### PR TITLE
feat: Add fenced multi-line message format (<<< ... >>>)

### DIFF
--- a/.claude/skills/using-agent-relay/SKILL.md
+++ b/.claude/skills/using-agent-relay/SKILL.md
@@ -23,6 +23,7 @@ Real-time agent-to-agent messaging. Two modes: **tmux wrapper** (real-time, sub-
 | Pattern | Description |
 |---------|-------------|
 | `->relay:Name message` | Direct message (output as text) |
+| `->relay:Name <<<`...`>>>` | Multi-line message with blank lines/code |
 | `->relay:* message` | Broadcast to all |
 | `[[RELAY]]{"to":"Name","body":"msg"}[[/RELAY]]` | Structured JSON |
 | `\->relay:` | Escape (literal output) |
@@ -56,6 +57,28 @@ relay team status                     # Show team
 ->relay:BlueLake I've finished the API refactor.
 ->relay:* STATUS: Starting auth module.
 ```
+
+### Multi-line Messages (Fenced Format)
+
+For messages with blank lines, code blocks, or complex content:
+
+```
+->relay:Reviewer <<<
+REVIEW REQUEST: Auth Module
+
+Please check:
+- src/auth/login.ts
+- src/auth/session.ts
+
+Key changes:
+1. Added JWT validation
+2. Fixed session expiry
+>>>
+```
+
+The `<<<` opens the block, `>>>` closes it. Everything between is captured exactly.
+
+### Pattern Rules
 
 Pattern must be at line start (whitespace/prefixes OK):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,23 @@ Output this in your response (not in a bash command):
 ->relay:AgentName Your message here
 ```
 
+### Multi-line Messages (Fenced Format)
+
+For messages with blank lines, code blocks, or complex formatting, use the fenced format:
+
+```
+->relay:AgentName <<<
+Here's my analysis:
+
+1. First point
+2. Second point
+
+The conclusion is clear.
+>>>
+```
+
+The `<<<` opens the message block, `>>>` closes it. Everything between is captured exactly, including blank lines and code.
+
 ### Broadcast to All
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,23 @@ Output this in your response (not in a bash command):
 ->relay:AgentName Your message here
 ```
 
+### Multi-line Messages (Fenced Format)
+
+For messages with blank lines, code blocks, or complex formatting, use the fenced format:
+
+```
+->relay:AgentName <<<
+Here's my analysis:
+
+1. First point
+2. Second point
+
+The conclusion is clear.
+>>>
+```
+
+The `<<<` opens the message block, `>>>` closes it. Everything between is captured exactly, including blank lines and code.
+
 ### Broadcast to All
 
 ```
@@ -114,12 +131,28 @@ agent-relay read abc12345...
 
 ## Communication Patterns
 
+### Simple Messages
 ```
 ->relay:* STATUS: Starting work on auth module
 ->relay:* DONE: Auth module complete
 ->relay:Developer TASK: Implement /api/register
 ->relay:Reviewer REVIEW: Please check src/auth/*.ts
 ->relay:Architect QUESTION: JWT or sessions?
+```
+
+### Multi-line (Fenced) Messages
+```
+->relay:Reviewer <<<
+REVIEW REQUEST: Authentication Module
+
+Please check these files:
+- src/auth/login.ts
+- src/auth/session.ts
+
+Key changes:
+1. Added JWT validation
+2. Fixed session expiry bug
+>>>
 ```
 
 ---

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -165,6 +165,15 @@ relay team status
 ->relay:* Broadcast to all agents
 ```
 
+**Fenced format** (multi-line with blank lines/code):
+```
+->relay:AgentName <<<
+Multi-line message here.
+
+Can include blank lines and code.
+>>>
+```
+
 **Block format** (structured data):
 ```
 [[RELAY]]{"to":"AgentName","type":"message","body":"Your message"}[[/RELAY]]

--- a/src/wrapper/tmux-wrapper.ts
+++ b/src/wrapper/tmux-wrapper.ts
@@ -399,6 +399,7 @@ export class TmuxWrapper {
     const instructions = [
       `[Agent Relay] You are "${this.config.name}" - connected for real-time messaging.`,
       `SEND: ${this.relayPrefix}AgentName message (or ${this.relayPrefix}* to broadcast)`,
+      `MULTI-LINE: ${this.relayPrefix}AgentName <<< ... >>> for messages with blank lines`,
       `RECEIVE: Messages appear as "Relay message from X [id]: content"`,
       `SUMMARY: Periodically output [[SUMMARY]]{"currentTask":"...","context":"..."}[[/SUMMARY]] to track progress`,
       `END: Output [[SESSION_END]]{"summary":"..."}[[/SESSION_END]] when your task is complete`,


### PR DESCRIPTION
Implements unambiguous multi-line message parsing using fence markers.
The new syntax allows agents to send messages with blank lines, code
blocks, and complex formatting without truncation:

  ->relay:Target <<<
  Multi-line content here.

  Can include blank lines.
  >>>

- Added fenced inline parsing state machine in parser.ts
- Added 13 comprehensive tests for fenced format
- Updated CLAUDE.md documentation with new format
- All 492 tests pass

Fixes the fundamental issue where multi-line messages with complete
line breaks would get cut off after the first line.