### PR TITLE
feat: Add screenshot attachment support for dashboard messages

### DIFF
--- a/src/dashboard/react-components/MessageList.tsx
+++ b/src/dashboard/react-components/MessageList.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import type { Message, Agent } from '../types';
+import type { Message, Agent, Attachment } from '../types';
 import { MessageStatusIndicator } from './MessageStatusIndicator';
 import { ThinkingIndicator } from './ThinkingIndicator';
 
@@ -271,8 +271,101 @@ function MessageItem({ message, isHighlighted, onThreadClick, recipientProcessin
         <div className="text-sm leading-relaxed text-text-primary whitespace-pre-wrap break-words">
           {formatMessageBody(message.content)}
         </div>
+
+        {/* Attachments */}
+        {message.attachments && message.attachments.length > 0 && (
+          <MessageAttachments attachments={message.attachments} />
+        )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Message Attachments Component
+ * Displays image attachments with lightbox functionality
+ */
+interface MessageAttachmentsProps {
+  attachments: Attachment[];
+}
+
+function MessageAttachments({ attachments }: MessageAttachmentsProps) {
+  const [lightboxImage, setLightboxImage] = useState<Attachment | null>(null);
+
+  const imageAttachments = attachments.filter(a =>
+    a.mimeType.startsWith('image/')
+  );
+
+  if (imageAttachments.length === 0) return null;
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 mt-2">
+        {imageAttachments.map((attachment) => (
+          <button
+            key={attachment.id}
+            type="button"
+            onClick={() => setLightboxImage(attachment)}
+            className="relative group cursor-pointer bg-transparent border-0 p-0"
+            title={`View ${attachment.filename}`}
+          >
+            <img
+              src={attachment.url}
+              alt={attachment.filename}
+              className="max-h-48 max-w-xs rounded-lg border border-border-subtle object-cover transition-all duration-150 group-hover:border-accent-cyan/50 group-hover:shadow-[0_0_8px_rgba(0,217,255,0.2)]"
+              loading="lazy"
+            />
+            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 rounded-lg transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                strokeWidth="2"
+                className="drop-shadow-lg"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                <line x1="11" y1="8" x2="11" y2="14" />
+                <line x1="8" y1="11" x2="14" y2="11" />
+              </svg>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Lightbox Modal */}
+      {lightboxImage && (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={() => setLightboxImage(null)}
+        >
+          <div className="relative max-w-[90vw] max-h-[90vh]">
+            <img
+              src={lightboxImage.url}
+              alt={lightboxImage.filename}
+              className="max-w-full max-h-[90vh] rounded-lg shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            />
+            <button
+              type="button"
+              onClick={() => setLightboxImage(null)}
+              className="absolute -top-3 -right-3 w-8 h-8 bg-bg-tertiary border border-border-subtle rounded-full flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-card transition-colors shadow-lg"
+              title="Close"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+            <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-black/60 to-transparent rounded-b-lg">
+              <p className="text-white text-sm truncate">{lightboxImage.filename}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/dashboard/react-components/ThreadPanel.tsx
+++ b/src/dashboard/react-components/ThreadPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
-import type { Message } from '../types';
+import type { Message, Attachment } from '../types';
 import { getAgentColor, getAgentInitials } from '../lib/colors';
 
 export interface ThreadPanelProps {
@@ -170,8 +170,101 @@ function ThreadMessage({ message, isOriginal }: ThreadMessageProps) {
         <div className="text-sm leading-relaxed text-text-primary whitespace-pre-wrap break-words">
           {formatMessageBody(message.content)}
         </div>
+
+        {/* Attachments */}
+        {message.attachments && message.attachments.length > 0 && (
+          <ThreadAttachments attachments={message.attachments} />
+        )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Thread Attachments Component
+ * Displays image attachments with lightbox functionality
+ */
+interface ThreadAttachmentsProps {
+  attachments: Attachment[];
+}
+
+function ThreadAttachments({ attachments }: ThreadAttachmentsProps) {
+  const [lightboxImage, setLightboxImage] = useState<Attachment | null>(null);
+
+  const imageAttachments = attachments.filter(a =>
+    a.mimeType.startsWith('image/')
+  );
+
+  if (imageAttachments.length === 0) return null;
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 mt-2">
+        {imageAttachments.map((attachment) => (
+          <button
+            key={attachment.id}
+            type="button"
+            onClick={() => setLightboxImage(attachment)}
+            className="relative group cursor-pointer bg-transparent border-0 p-0"
+            title={`View ${attachment.filename}`}
+          >
+            <img
+              src={attachment.url}
+              alt={attachment.filename}
+              className="max-h-32 max-w-[200px] rounded-lg border border-border object-cover transition-all duration-150 group-hover:border-accent/50 group-hover:shadow-md"
+              loading="lazy"
+            />
+            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 rounded-lg transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                strokeWidth="2"
+                className="drop-shadow-lg"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                <line x1="11" y1="8" x2="11" y2="14" />
+                <line x1="8" y1="11" x2="14" y2="11" />
+              </svg>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Lightbox Modal */}
+      {lightboxImage && (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={() => setLightboxImage(null)}
+        >
+          <div className="relative max-w-[90vw] max-h-[90vh]">
+            <img
+              src={lightboxImage.url}
+              alt={lightboxImage.filename}
+              className="max-w-full max-h-[90vh] rounded-lg shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            />
+            <button
+              type="button"
+              onClick={() => setLightboxImage(null)}
+              className="absolute -top-3 -right-3 w-8 h-8 bg-bg-primary border border-border rounded-full flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-colors shadow-lg"
+              title="Close"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+            <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-black/60 to-transparent rounded-b-lg">
+              <p className="text-white text-sm truncate">{lightboxImage.filename}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/dashboard/react-components/hooks/useMessages.ts
+++ b/src/dashboard/react-components/hooks/useMessages.ts
@@ -38,7 +38,7 @@ export interface UseMessagesReturn {
   totalUnreadThreadCount: number;
 
   // Message actions
-  sendMessage: (to: string, content: string, thread?: string) => Promise<boolean>;
+  sendMessage: (to: string, content: string, thread?: string, attachmentIds?: string[]) => Promise<boolean>;
   isSending: boolean;
   sendError: string | null;
 
@@ -188,7 +188,7 @@ export function useMessages({
 
   // Send message function
   const sendMessage = useCallback(
-    async (to: string, content: string, thread?: string): Promise<boolean> => {
+    async (to: string, content: string, thread?: string, attachmentIds?: string[]): Promise<boolean> => {
       setIsSending(true);
       setSendError(null);
 
@@ -197,6 +197,7 @@ export function useMessages({
           to,
           message: content,
           thread,
+          attachments: attachmentIds,
         };
 
         const response = await fetch('/api/send', {

--- a/src/dashboard/types/index.ts
+++ b/src/dashboard/types/index.ts
@@ -34,6 +34,26 @@ export interface AgentSummary {
 // Message Status
 export type MessageStatus = 'unread' | 'read' | 'acked' | 'sending';
 
+// Attachment Types
+export interface Attachment {
+  /** Unique identifier for the attachment */
+  id: string;
+  /** Original filename */
+  filename: string;
+  /** MIME type (e.g., 'image/png', 'image/jpeg') */
+  mimeType: string;
+  /** Size in bytes */
+  size: number;
+  /** URL to access the attachment */
+  url: string;
+  /** Width for images */
+  width?: number;
+  /** Height for images */
+  height?: number;
+  /** Base64-encoded data (for inline display, optional) */
+  data?: string;
+}
+
 // Message Types
 export interface Message {
   id: string;
@@ -47,6 +67,8 @@ export interface Message {
   replyCount?: number;
   /** Message delivery status: sending → acked (received by agent) */
   status?: MessageStatus;
+  /** Attachments (images, files) */
+  attachments?: Attachment[];
 }
 
 export interface Thread {
@@ -175,6 +197,8 @@ export interface SendMessageRequest {
   to: string;
   message: string;
   thread?: string;
+  /** Attachment IDs to include with the message */
+  attachments?: string[];
 }
 
 export type SpeakOnTrigger = 'SESSION_END' | 'CODE_WRITTEN' | 'REVIEW_REQUEST' | 'EXPLICIT_ASK' | 'ALL_MESSAGES';


### PR DESCRIPTION
Add the ability to include screenshots/images when sending messages from
the dashboard to agents. This enables users to share visual context with
agents directly from the dashboard UI.

Changes:
- Add Attachment type and extend Message type to support attachments
- Add POST /api/upload endpoint for image uploads (stored in data/uploads)
- Extend POST /api/send to include attachments in message data
- Add uploadAttachment() API function to frontend
- Update MessageComposer with image upload button and paste support
- Display image attachments in MessageList with lightbox preview
- Display image attachments in ThreadPanel with lightbox preview

Features:
- Click image button or paste from clipboard to attach screenshots
- Preview attachments before sending
- Remove attachments before sending
- Click images to view full-size in lightbox modal
- Base64 data included in message for agents without URL access