### PR TITLE
fix: Add Drizzle migrations journal and copy migrations in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y \
 # Copy built artifacts
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/dashboard/out ./src/dashboard/out
+COPY --from=builder /app/src/cloud/db/migrations ./src/cloud/db/migrations
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 

--- a/src/cloud/db/migrations/meta/_journal.json
+++ b/src/cloud/db/migrations/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1735689600000,
+      "tag": "0001_initial",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1735776000000,
+      "tag": "0002_agent_sessions",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
- Create meta/_journal.json required by Drizzle ORM migrator
- Copy migrations folder to Docker production image

Fixes: Can't find meta/_journal.json file error on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)