### PR TITLE
fix(security): add workspace token auth to CLI auth endpoints

### DIFF
--- a/.trajectories/active/traj_7ludwvz45veh.json
+++ b/.trajectories/active/traj_7ludwvz45veh.json
@@ -191,6 +191,18 @@
             "reasoning": "Hamburger menu visibility, logs button always visible on mobile, responsive padding throughout"
           },
           "significance": "high"
+        },
+        {
+          "ts": 1767636873294,
+          "type": "decision",
+          "content": "Starting work on bd-critical-016: Workspace Daemon Auth security fix: Starting work on bd-critical-016: Workspace Daemon Auth security fix",
+          "raw": {
+            "question": "Starting work on bd-critical-016: Workspace Daemon Auth security fix",
+            "chosen": "Starting work on bd-critical-016: Workspace Daemon Auth security fix",
+            "alternatives": [],
+            "reasoning": ""
+          },
+          "significance": "high"
         }
       ]
     }

--- a/.trajectories/active/traj_7ludwvz45veh.json
+++ b/.trajectories/active/traj_7ludwvz45veh.json
@@ -203,6 +203,30 @@
             "reasoning": ""
           },
           "significance": "high"
+        },
+        {
+          "ts": 1767637700734,
+          "type": "decision",
+          "content": "Implemented workspace token auth for CLI endpoints: Implemented workspace token auth for CLI endpoints",
+          "raw": {
+            "question": "Implemented workspace token auth for CLI endpoints",
+            "chosen": "Implemented workspace token auth for CLI endpoints",
+            "alternatives": [],
+            "reasoning": "Added HMAC-based token validation to prevent unauthorized access to auth sessions"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1767637829693,
+          "type": "decision",
+          "content": "bd-critical-016: Chose HMAC-SHA256 token validation over simpler approaches: bd-critical-016: Chose HMAC-SHA256 token validation over simpler approaches",
+          "raw": {
+            "question": "bd-critical-016: Chose HMAC-SHA256 token validation over simpler approaches",
+            "chosen": "bd-critical-016: Chose HMAC-SHA256 token validation over simpler approaches",
+            "alternatives": [],
+            "reasoning": "Matches existing provisioner token generation, cryptographically secure, no additional dependencies needed"
+          },
+          "significance": "high"
         }
       ]
     }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-01-05T17:59:19.223Z",
+  "lastUpdated": "2026-01-05T18:14:33.532Z",
   "trajectories": {
     "traj_ozd98si6a7ns": {
       "title": "Fix thinking indicator showing on all messages",

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-01-05T18:14:33.532Z",
+  "lastUpdated": "2026-01-05T18:30:29.700Z",
   "trajectories": {
     "traj_ozd98si6a7ns": {
       "title": "Fix thinking indicator showing on all messages",


### PR DESCRIPTION
Fixes bd-critical-016: Workspace Daemon Auth - Unauthenticated Endpoints

The workspace daemon's CLI auth endpoints were exposed without authentication. In cloud mode, attackers could potentially:
- Submit malicious codes to active auth sessions
- Enumerate active sessions
- DoS the PTY processes
- Hijack OAuth flows mid-completion

Changes:
- Add validateWorkspaceToken middleware to dashboard-server
- Apply middleware to all /auth/cli/* endpoints
- Skip auth in local mode (no WORKSPACE_TOKEN set)
- Update cloud server onboarding.ts to send Authorization header
- Add generateWorkspaceToken() helper matching provisioner logic
- Store workspaceId in session for subsequent requests

The workspace token is an HMAC-SHA256 hash of the workspace ID, signed with the session secret. This matches the token generation in the provisioner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)