### PR TITLE
Fix migration 0008: remove duplicate DROP COLUMN statements

### DIFF
--- a/src/cloud/db/migrations/0008_stripe_customer_id.sql
+++ b/src/cloud/db/migrations/0008_stripe_customer_id.sql
@@ -1,4 +1,1 @@
-ALTER TABLE "users" ADD COLUMN "stripe_customer_id" varchar(255);--> statement-breakpoint
-ALTER TABLE "workspaces" DROP COLUMN "ssh_host";--> statement-breakpoint
-ALTER TABLE "workspaces" DROP COLUMN "ssh_port";--> statement-breakpoint
-ALTER TABLE "workspaces" DROP COLUMN "ssh_password";
+ALTER TABLE "users" ADD COLUMN "stripe_customer_id" varchar(255);


### PR DESCRIPTION
Migration 0007 already dropped ssh_host, ssh_port, and ssh_password
columns from workspaces table. Migration 0008 incorrectly tried to
drop them again without IF EXISTS, causing the migration to fail.