### PR TITLE
Add automated volume snapshots for workspace resilience

### DIFF
--- a/deploy/workspace/fly.toml
+++ b/deploy/workspace/fly.toml
@@ -32,6 +32,13 @@ primary_region = "sjc"
   cpus = 1
   memory_mb = 512
 
+# NOTE: Volumes are now created explicitly via the provisioner API
+# with automatic daily snapshots enabled and configurable retention.
+# This mount config is kept for documentation but the provisioner
+# creates volumes with: auto_backup_enabled=true, snapshot_retention=14 days
+#
+# To customize retention, set FLY_SNAPSHOT_RETENTION_DAYS (1-60, default 14)
+# To customize volume size, set FLY_VOLUME_SIZE_GB (default 10)
 [mounts]
   source = "workspace_data"
   destination = "/data"

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -47,6 +47,9 @@ export interface CloudConfig {
         username: string;
         password: string;
       };
+      // Volume snapshot settings
+      snapshotRetentionDays?: number; // 1-60, default 14
+      volumeSizeGb?: number; // default 10
     };
     railway?: {
       apiToken: string;
@@ -136,6 +139,8 @@ export function loadConfig(): CloudConfig {
                   password: optionalEnv('GHCR_TOKEN')!,
                 }
               : undefined,
+            snapshotRetentionDays: parseInt(optionalEnv('FLY_SNAPSHOT_RETENTION_DAYS') || '14', 10),
+            volumeSizeGb: parseInt(optionalEnv('FLY_VOLUME_SIZE_GB') || '10', 10),
           }
         : undefined,
       railway: optionalEnv('RAILWAY_API_TOKEN')


### PR DESCRIPTION
- Create Fly.io volumes explicitly with auto_backup_enabled=true
- Configure 14-day snapshot retention (configurable via FLY_SNAPSHOT_RETENTION_DAYS)
- Add volume size configuration (FLY_VOLUME_SIZE_GB, default 10GB)
- Add snapshot management methods to WorkspaceProvisioner:
  - createSnapshot(): On-demand snapshots before risky operations
  - listSnapshots(): View available recovery points
  - getVolumeId(): Get volume ID for restore operations
- Mount volumes explicitly in machine config

Cost impact: ~$0.08/GB/month for snapshot storage (first 10GB free).
Incremental snapshots mean typical workspace costs ~$0.50-1.50/month extra.