### PR TITLE
Fix agent token fetch and add seamless gh CLI support

### DIFF
--- a/.trajectories/completed/2026-01/traj_78ffm31jn3uk.json
+++ b/.trajectories/completed/2026-01/traj_78ffm31jn3uk.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_78ffm31jn3uk",
+  "version": 1,
+  "task": {
+    "title": "Fix agent token fetch and seamless gh CLI",
+    "source": {
+      "system": "plain",
+      "id": "fix-agent-token-and-gh-cli"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-01-06T16:24:13.901Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-01-06T16:24:28.434Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_0lvfxdqzt4wm",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-01-06T16:24:28.434Z",
+      "events": [
+        {
+          "ts": 1767716668436,
+          "type": "decision",
+          "content": "Enhanced verifyWorkspaceToken to return detailed failure reasons: Enhanced verifyWorkspaceToken to return detailed failure reasons",
+          "raw": {
+            "question": "Enhanced verifyWorkspaceToken to return detailed failure reasons",
+            "chosen": "Enhanced verifyWorkspaceToken to return detailed failure reasons",
+            "alternatives": [],
+            "reasoning": "Helps diagnose missing token, wrong format, or session secret mismatch"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1767716674696,
+          "type": "decision",
+          "content": "Added error codes and actionable hints to all API error responses: Added error codes and actionable hints to all API error responses",
+          "raw": {
+            "question": "Added error codes and actionable hints to all API error responses",
+            "chosen": "Added error codes and actionable hints to all API error responses",
+            "alternatives": [],
+            "reasoning": "Enables git-credential-relay to show specific guidance to users"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1767716680011,
+          "type": "decision",
+          "content": "Created auto-refreshing gh wrapper at /usr/local/bin/gh: Created auto-refreshing gh wrapper at /usr/local/bin/gh",
+          "raw": {
+            "question": "Created auto-refreshing gh wrapper at /usr/local/bin/gh",
+            "chosen": "Created auto-refreshing gh wrapper at /usr/local/bin/gh",
+            "alternatives": [],
+            "reasoning": "Transparent to agents - gh just works without any token management"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-01-06T16:24:50.235Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/home/user/relay",
+  "tags": [],
+  "completedAt": "2026-01-06T16:24:50.235Z",
+  "retrospective": {
+    "summary": "Fixed agent token fetch with better error handling and added auto-refreshing gh wrapper for seamless GitHub CLI usage",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-01/traj_78ffm31jn3uk.md
+++ b/.trajectories/completed/2026-01/traj_78ffm31jn3uk.md
@@ -1,0 +1,42 @@
+# Trajectory: Fix agent token fetch and seamless gh CLI
+
+> **Status:** ✅ Completed
+> **Task:** fix-agent-token-and-gh-cli
+> **Confidence:** 90%
+> **Started:** January 6, 2026 at 04:24 PM
+> **Completed:** January 6, 2026 at 04:24 PM
+
+---
+
+## Summary
+
+Fixed agent token fetch with better error handling and added auto-refreshing gh wrapper for seamless GitHub CLI usage
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Enhanced verifyWorkspaceToken to return detailed failure reasons
+- **Chose:** Enhanced verifyWorkspaceToken to return detailed failure reasons
+- **Reasoning:** Helps diagnose missing token, wrong format, or session secret mismatch
+
+### Added error codes and actionable hints to all API error responses
+- **Chose:** Added error codes and actionable hints to all API error responses
+- **Reasoning:** Enables git-credential-relay to show specific guidance to users
+
+### Created auto-refreshing gh wrapper at /usr/local/bin/gh
+- **Chose:** Created auto-refreshing gh wrapper at /usr/local/bin/gh
+- **Reasoning:** Transparent to agents - gh just works without any token management
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Enhanced verifyWorkspaceToken to return detailed failure reasons: Enhanced verifyWorkspaceToken to return detailed failure reasons
+- Added error codes and actionable hints to all API error responses: Added error codes and actionable hints to all API error responses
+- Created auto-refreshing gh wrapper at /usr/local/bin/gh: Created auto-refreshing gh wrapper at /usr/local/bin/gh

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-01-06T12:58:24.029Z",
+  "lastUpdated": "2026-01-06T16:24:50.254Z",
   "trajectories": {
     "traj_ozd98si6a7ns": {
       "title": "Fix thinking indicator showing on all messages",
@@ -351,6 +351,13 @@
       "startedAt": "2026-01-06T12:27:13.004Z",
       "completedAt": "2026-01-06T12:58:24.003Z",
       "path": "/Users/khaliqgant/Projects/agent-workforce/relay/.trajectories/completed/2026-01/traj_xy9vifpqet80.json"
+    },
+    "traj_78ffm31jn3uk": {
+      "title": "Fix agent token fetch and seamless gh CLI",
+      "status": "completed",
+      "startedAt": "2026-01-06T16:24:13.901Z",
+      "completedAt": "2026-01-06T16:24:50.235Z",
+      "path": "/home/user/relay/.trajectories/completed/2026-01/traj_78ffm31jn3uk.json"
     }
   }
 }


### PR DESCRIPTION
## Token Fetch Improvements
- Enhanced verifyWorkspaceToken to return detailed failure reasons
- Added error codes (INVALID_WORKSPACE_TOKEN, NO_GITHUB_APP_CONNECTION, etc.)
- Added actionable hints in all error responses
- Wrapped Nango token fetch with specific error handling
- Updated git-credential-relay to display detailed error info

## Seamless gh CLI
- Created auto-refreshing gh wrapper at /usr/local/bin/gh
- Wrapper fetches fresh token from cloud API on each invocation
- Transparent to agents - gh commands just work without token management
- Falls back to installation token if user OAuth unavailable

Fixes token fetch issues where:
- Workspace token is missing (container not configured)
- Session secret changed (workspace needs reprovisioning)
- Nango connection expired or revoked
- Repository has no GitHub App connection