### PR TITLE
fix: Add success() check to update-workspaces job condition

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push]
     # Only run on main branch pushes, not releases or manual runs
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Update workspace images
         env:


### PR DESCRIPTION
## Problem

The `update-workspaces` job has **never run** despite being configured to run on every push to main. 

Investigation showed:
- All recent runs were push events to main ✓
- All had `build-and-push` succeed ✓  
- But `update-workspaces` was skipped in every case ✗

## Root Cause

GitHub Actions skips jobs when any upstream dependency is skipped, even if the direct dependency succeeds. 

The flow was:
1. `build-base` → skipped (only runs when Dockerfile.base changes)
2. `build-and-push` → runs (has `if: always() && !cancelled()`)
3. `update-workspaces` → **skipped** (sees skipped job in dependency chain)

## Solution

Added `success()` to the job condition:

```yaml
if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
```

This makes the job check only its direct dependency (`build-and-push`), not the entire chain.

## Impact

- Workspaces will now be updated automatically after PR merges to main
- Fixes silent deployment failure that's been happening since this workflow was added
- No behavior change for releases or manual runs (still skipped as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)