### PR TITLE
feat: add hidden spawn CLI command for container environments

### DIFF
--- a/src/dashboard-server/server.ts
+++ b/src/dashboard-server/server.ts
@@ -3319,7 +3319,7 @@ export async function startDashboard(
 
   /**
    * POST /api/spawn - Spawn a new agent
-   * Body: { name: string, cli?: string, task?: string, team?: string, shadowMode?, shadowAgent?, shadowOf?, shadowTriggers?, shadowSpeakOn? }
+   * Body: { name: string, cli?: string, task?: string, team?: string, spawnerName?, cwd?, interactive?, shadowMode?, shadowAgent?, shadowOf?, shadowTriggers?, shadowSpeakOn? }
    */
   app.post('/api/spawn', async (req, res) => {
     if (!spawner) {
@@ -3334,6 +3334,8 @@ export async function startDashboard(
       cli = 'claude',
       task = '',
       team,
+      spawnerName,
+      cwd,
       interactive,
       shadowMode,
       shadowAgent,
@@ -3355,6 +3357,8 @@ export async function startDashboard(
         cli,
         task,
         team: team || undefined, // Optional team name
+        spawnerName: spawnerName || undefined, // For policy enforcement
+        cwd: cwd || undefined, // Working directory
         interactive, // Disables auto-accept for auth setup flows
         shadowMode,
         shadowAgent,


### PR DESCRIPTION
## Summary
- Adds `agent-relay spawn` CLI command that uses dashboard API instead of tmux
- Works in container environments (cloud) where tmux is not available
- Command is hidden from help since agents should use `->relay:spawn` pattern

## Problem
When agents in cloud containers ran `agent-relay spawn DeveloperProvisioner claude << 'EOF'`, they got `TmuxNotFoundError` because:
1. No explicit `spawn` command existed in CLI
2. Default action interpreted `spawn` as a command to wrap with TmuxWrapper
3. TmuxWrapper requires tmux, which isn't in containers

## Solution
Added a proper `spawn` command that uses `POST /api/spawn` (PtyWrapper-based, no tmux required).

## Test plan
- [x] Build passes
- [x] Tests pass (1197 passed)
- [x] Command hidden from `--help`
- [x] Command accessible via `agent-relay spawn --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)