### PR TITLE
fix: improve error handling for unreachable workspaces during image updates

### DIFF
--- a/src/cloud/api/admin.ts
+++ b/src/cloud/api/admin.ts
@@ -205,7 +205,9 @@ adminRouter.get('/workspaces/:id/agents', async (req: Request, res: Response) =>
     }
 
     try {
-      const response = await fetch(`${baseUrl}/api/agents`, {
+      // Use /api/data endpoint which returns { agents: [...], ... }
+      // Note: /api/agents doesn't exist on the workspace dashboard-server
+      const response = await fetch(`${baseUrl}/api/data`, {
         method: 'GET',
         headers: { 'Accept': 'application/json' },
         signal: AbortSignal.timeout(10_000),

--- a/src/cloud/provisioner/index.ts
+++ b/src/cloud/provisioner/index.ts
@@ -1187,7 +1187,9 @@ class FlyProvisioner implements ComputeProvisioner {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), 10_000);
 
-        const response = await fetch(`${baseUrl}/api/agents`, {
+        // Use /api/data endpoint which returns { agents: [...], ... }
+        // Note: /api/agents doesn't exist on the workspace dashboard-server
+        const response = await fetch(`${baseUrl}/api/data`, {
           method: 'GET',
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
- Change SKIPPED_VERIFICATION_FAILED from "error" to "reason" since this is
  expected behavior for workspaces that are waking up from auto-stop
- Update error message to be more informative: "Workspace unreachable - will
  update on next restart or when accessible"
- Add skippedVerificationFailed to the summary return type for completeness
- Add reason field to return types for non-error skip conditions