### PR TITLE
fix: make sidebar agent card buttons always visible

### DIFF
--- a/src/dashboard/react-components/AgentCard.tsx
+++ b/src/dashboard/react-components/AgentCard.tsx
@@ -192,7 +192,7 @@ export function AgentCard({
               <button
                 className="relative bg-transparent border border-transparent text-text-dim p-1.5 cursor-pointer
                            flex items-center justify-center rounded-md transition-all duration-200
-                           opacity-100 md:opacity-0 md:group-hover:opacity-100
+                           opacity-100
                            hover:bg-[#a855f7]/10 hover:border-[#a855f7]/30 hover:text-[#a855f7]
                            hover:shadow-[0_0_12px_rgba(168,85,247,0.25)]"
                 onClick={handleProfileClick}
@@ -205,7 +205,7 @@ export function AgentCard({
               <button
                 className="relative bg-transparent border border-transparent text-text-dim p-1.5 cursor-pointer
                            flex items-center justify-center rounded-md transition-all duration-200
-                           opacity-100 md:opacity-0 md:group-hover:opacity-100
+                           opacity-100
                            hover:bg-accent-cyan/10 hover:border-accent-cyan/30 hover:text-accent-cyan
                            hover:shadow-[0_0_12px_rgba(0,217,255,0.25)]"
                 onClick={handleLogsClick}
@@ -218,7 +218,7 @@ export function AgentCard({
               <button
                 className="relative bg-transparent border border-transparent text-text-dim p-1.5 cursor-pointer
                            flex items-center justify-center rounded-md transition-all duration-200
-                           opacity-100 md:opacity-0 md:group-hover:opacity-100
+                           opacity-100
                            hover:bg-error/10 hover:border-error/30 hover:text-error
                            hover:shadow-[0_0_12px_rgba(255,68,68,0.25)]"
                 onClick={handleReleaseClick}


### PR DESCRIPTION
## Summary
- Removed hover-dependent opacity classes from action buttons in compact sidebar view
- Profile, logs, and release buttons now always visible (no longer hidden until hover)
- Keeps buttons consistently visible across all screen sizes

## Changes
- Modified `src/dashboard/react-components/AgentCard.tsx`
- Removed `md:opacity-0 md:group-hover:opacity-100` from three button classes
- Buttons maintain `opacity-100` for consistent visibility

## Testing
- Verify buttons are visible in sidebar agent cards without hovering
- Confirm buttons still function correctly (click handlers work)
- Test on mobile and desktop views