### PR TITLE
fix: enable mobile touch scrolling in log viewer

### DIFF
--- a/src/dashboard/react-components/XTermLogViewer.tsx
+++ b/src/dashboard/react-components/XTermLogViewer.tsx
@@ -326,6 +326,17 @@ export function XTermLogViewer({
         boxShadow: `0 0 60px -15px ${colors.primary}25, 0 25px 50px -12px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(255,255,255,0.02)`,
       }}
     >
+      {/* Mobile touch scroll fix for xterm.js */}
+      <style>{`
+        .xterm-log-viewer .xterm-viewport {
+          -webkit-overflow-scrolling: touch;
+          touch-action: pan-y;
+          overscroll-behavior: contain;
+        }
+        .xterm-log-viewer .xterm-screen {
+          touch-action: pan-y;
+        }
+      `}</style>
       {/* Header */}
       {showHeader && (
         <div
@@ -455,8 +466,13 @@ export function XTermLogViewer({
       {/* Terminal container */}
       <div
         ref={containerRef}
-        className="flex-1 overflow-auto md:overflow-hidden touch-pan-y"
-        style={{ maxHeight, minHeight: '200px', WebkitOverflowScrolling: 'touch' }}
+        className="flex-1 overflow-auto touch-pan-y"
+        style={{
+          maxHeight,
+          minHeight: '200px',
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehavior: 'contain',
+        }}
       />
 
       {/* Footer status bar */}


### PR DESCRIPTION
## Summary

- **Bug:** Log viewer couldn't be scrolled on mobile phones
- **Cause:** xterm.js captures touch events for selection, blocking scroll gestures
- **Fix:** Add CSS to enable touch scrolling in xterm viewport

## Changes

1. Removed `md:overflow-hidden` from terminal container - allows scroll on all screen sizes
2. Added `touch-action: pan-y` to `.xterm-viewport` and `.xterm-screen` elements
3. Added `-webkit-overflow-scrolling: touch` for iOS momentum scrolling
4. Added `overscroll-behavior: contain` to prevent page bounce during scroll

## Test plan

- [ ] Open log viewer on mobile device
- [ ] Verify scrolling works with touch gestures
- [ ] Verify scrolling still works on desktop
- [ ] Test on both iOS and Android if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)