### PR TITLE
fix: comprehensive mobile touch scrolling for log viewer

### DIFF
--- a/src/dashboard/react-components/LogViewer.tsx
+++ b/src/dashboard/react-components/LogViewer.tsx
@@ -135,7 +135,11 @@ export function LogViewer({
         </div>
         <div
           className="font-mono text-xs leading-relaxed p-3 overflow-y-auto touch-pan-y"
-          style={{ maxHeight: '150px', WebkitOverflowScrolling: 'touch' }}
+          style={{
+            maxHeight: '150px',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+          }}
           ref={scrollContainerRef}
           onScroll={handleScroll}
         >

--- a/src/dashboard/react-components/XTermLogViewer.tsx
+++ b/src/dashboard/react-components/XTermLogViewer.tsx
@@ -326,15 +326,30 @@ export function XTermLogViewer({
         boxShadow: `0 0 60px -15px ${colors.primary}25, 0 25px 50px -12px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(255,255,255,0.02)`,
       }}
     >
-      {/* Mobile touch scroll fix for xterm.js */}
+      {/* Mobile touch scroll fix for xterm.js
+          xterm.js intercepts touch events on multiple elements (canvas, viewport, screen).
+          We need to allow vertical panning on all of them while still permitting taps. */}
       <style>{`
+        .xterm-log-viewer .xterm {
+          touch-action: pan-y !important;
+        }
         .xterm-log-viewer .xterm-viewport {
-          -webkit-overflow-scrolling: touch;
-          touch-action: pan-y;
+          -webkit-overflow-scrolling: touch !important;
+          touch-action: pan-y !important;
           overscroll-behavior: contain;
         }
         .xterm-log-viewer .xterm-screen {
-          touch-action: pan-y;
+          touch-action: pan-y !important;
+        }
+        .xterm-log-viewer .xterm-screen canvas {
+          touch-action: pan-y !important;
+        }
+        .xterm-log-viewer .xterm-helper-textarea {
+          touch-action: pan-y !important;
+        }
+        /* Ensure the xterm rows don't block scrolling */
+        .xterm-log-viewer .xterm-rows {
+          touch-action: pan-y !important;
         }
       `}</style>
       {/* Header */}
@@ -463,15 +478,13 @@ export function XTermLogViewer({
         </div>
       )}
 
-      {/* Terminal container */}
+      {/* Terminal container - don't use overflow-auto here, xterm-viewport handles scrolling */}
       <div
         ref={containerRef}
-        className="flex-1 overflow-auto touch-pan-y"
+        className="flex-1 touch-pan-y"
         style={{
           maxHeight,
           minHeight: '200px',
-          WebkitOverflowScrolling: 'touch',
-          overscrollBehavior: 'contain',
         }}
       />
 


### PR DESCRIPTION
## Summary

Fixes mobile touch scrolling in the log viewer that PR #153 attempted to fix but didn't fully resolve.

## Root Cause Analysis

The previous fix (#153) only partially addressed the issue:

1. **Incomplete element targeting**: xterm.js has multiple DOM elements that can intercept touch events - the canvas, helper-textarea, and rows div were not targeted
2. **Nested scrollable containers**: The container div had `overflow-auto`, creating TWO scrollable containers (the container AND xterm-viewport). This confuses mobile touch handling because the browser doesn't know which container should scroll
3. **CSS specificity**: Without `!important`, xterm.js inline styles could override our touch-action rules

## Changes

### XTermLogViewer.tsx
- Extended `touch-action: pan-y` to ALL xterm elements: `.xterm`, `.xterm-viewport`, `.xterm-screen`, `canvas`, `.xterm-helper-textarea`, `.xterm-rows`
- Added `!important` to ensure rules override xterm's inline styles
- **Key fix**: Removed `overflow-auto` from container div - let xterm-viewport be the sole scrollable element

### LogViewer.tsx (inline mode)
- Added `overscrollBehavior: 'contain'` to prevent iOS page bounce

## Test plan

- [ ] Open log viewer panel on mobile (iOS Safari)
- [ ] Open log viewer panel on mobile (Android Chrome)
- [ ] Verify touch scrolling works in both directions
- [ ] Verify scrolling doesn't trigger page scroll when reaching bounds
- [ ] Verify desktop scroll (mouse wheel) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)