### PR TITLE
Improve LogViewer mobile scrolling

### DIFF
--- a/src/dashboard/react-components/XTermLogViewer.tsx
+++ b/src/dashboard/react-components/XTermLogViewer.tsx
@@ -355,6 +355,13 @@ export function XTermLogViewer({
         .xterm-log-viewer .xterm-rows {
           touch-action: pan-y !important;
         }
+        /* Let touch scroll events reach the viewport on mobile Safari */
+        @media (pointer: coarse) {
+          .xterm-log-viewer .xterm-screen,
+          .xterm-log-viewer .xterm-screen canvas {
+            pointer-events: none;
+          }
+        }
       `}</style>
       {/* Header */}
       {showHeader && (


### PR DESCRIPTION
## Summary\n- allow touch scroll gestures to reach the xterm viewport on coarse pointers\n- avoid canvas intercepting scroll on mobile devices\n\n## Testing\n- not run