### PR TITLE
Fix trajectory viewer showing wrong data by using unique step IDs

### DIFF
--- a/src/trajectory/integration.ts
+++ b/src/trajectory/integration.ts
@@ -582,10 +582,13 @@ export async function listTrajectorySteps(trajectoryId?: string): Promise<{
     }
 
     // Extract events from all chapters
+    // Include trajectory ID in step IDs to ensure uniqueness across trajectories
+    // This prevents React key collisions when switching between trajectories
+    const trajId = trajectory.id || 'unknown';
     for (const chapter of trajectory.chapters || []) {
       for (const event of chapter.events || []) {
         steps.push({
-          id: `step-${stepIndex++}`,
+          id: `${trajId}-step-${stepIndex++}`,
           timestamp: event.ts || Date.now(),
           type: mapEventType(event.type),
           title: event.content?.slice(0, 50) || event.type || 'Event',


### PR DESCRIPTION
## Summary

- Root cause: Step IDs were generated as `step-0`, `step-1`, etc. regardless of trajectory
- This caused React key collisions when switching between trajectories
- React reused DOM elements with the same keys, displaying stale data

## Technical Details

When viewing trajectory A and switching to trajectory B:
- Trajectory A steps: `step-0`, `step-1`, `step-2`
- Trajectory B steps: `step-0`, `step-1`, `step-2` (same keys!)

React sees the same keys and reuses the existing DOM elements, potentially displaying old data from trajectory A instead of the new data from trajectory B.

## Fix

Include trajectory ID in step IDs to ensure uniqueness:
- Trajectory A steps: `traj_abc-step-0`, `traj_abc-step-1`
- Trajectory B steps: `traj_xyz-step-0`, `traj_xyz-step-1` (different keys!)

Now React properly unmounts old steps and mounts new ones when switching trajectories.

## Test plan

- [x] Open trajectory panel
- [x] View steps for trajectory A
- [x] Click on trajectory B
- [x] Verify trajectory B's steps are displayed (not A's)
- [x] Switch back to A, verify A's steps shown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)