### PR TITLE
Fix Gemini API key input opening OAuth modal on focus

### DIFF
--- a/src/dashboard/react-components/settings/WorkspaceSettingsPanel.tsx
+++ b/src/dashboard/react-components/settings/WorkspaceSettingsPanel.tsx
@@ -602,7 +602,7 @@ export function WorkspaceSettingsPanel({
 
                   {!providerStatus[provider.id] && (
                     <div className="mt-5 pt-5 border-t border-border-subtle">
-                      {connectingProvider === provider.id ? (
+                      {connectingProvider === provider.id && !showApiKeyFallback[provider.id] ? (
                         useTerminalSetup[provider.id] ? (
                           <TerminalProviderSetup
                             provider={{


### PR DESCRIPTION
## Summary

- Fixes bug where clicking/focusing the API key input field for Gemini opens the OAuth popup
- Issue: User clicks "Or enter API key manually", then focuses the input, and OAuth modal appears

## Root Cause

In `WorkspaceSettingsPanel.tsx`, the render logic checked conditions in this order:
1. `connectingProvider === provider.id` → shows ProviderAuthFlow (OAuth)
2. `showApiKeyFallback[provider.id]` → shows API key input

When the user focused the API key input, `onFocus` set `connectingProvider` to the provider ID. This made condition 1 true, causing `ProviderAuthFlow` to render. Since `ProviderAuthFlow` auto-starts OAuth on mount, the popup would open.

## Fix

Changed the condition from:
```tsx
connectingProvider === provider.id
```
to:
```tsx
connectingProvider === provider.id && !showApiKeyFallback[provider.id]
```

Now, when the user is in API key fallback mode, the OAuth flow won't render even if `connectingProvider` is set.

## Test plan

- [x] Open Workspace Settings > AI Providers
- [x] Click "Or enter API key manually" for Gemini
- [x] Click/focus the API key input field
- [x] Verify no popup opens, input field works normally
- [x] Type/paste an API key
- [x] Verify Connect button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)