### PR TITLE
Fix LogViewer mobile scroll containment

### DIFF
--- a/src/dashboard/react-components/LogViewerPanel.tsx
+++ b/src/dashboard/react-components/LogViewerPanel.tsx
@@ -69,15 +69,21 @@ export function LogViewerPanel({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, onClose]);
 
-  // Prevent body scroll when fullscreen
+  // Prevent body scroll when panel is open (fix mobile scroll capture)
   useEffect(() => {
-    if (isOpen && position === 'fullscreen') {
-      document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = '';
-      };
-    }
-  }, [isOpen, position]);
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const previousOverscroll = document.body.style.overscrollBehavior;
+
+    document.body.style.overflow = 'hidden';
+    document.body.style.overscrollBehavior = 'none';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.body.style.overscrollBehavior = previousOverscroll;
+    };
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -280,7 +286,7 @@ export function LogViewerPanel({
         </div>
 
         {/* Log viewer */}
-        <div className="flex-1 min-h-0">
+        <div className="flex-1 min-h-0 overflow-hidden">
           <LogViewer
             agentName={agent.name}
             mode="panel"

--- a/src/dashboard/react-components/XTermLogViewer.tsx
+++ b/src/dashboard/react-components/XTermLogViewer.tsx
@@ -549,17 +549,20 @@ export function XTermLogViewer({
         </div>
       )}
 
-      {/* Terminal container - don't use overflow-auto here, xterm-viewport handles scrolling */}
+      {/* Terminal container - keep a dedicated scroll boundary for mobile */}
       <div
-        ref={containerRef}
-        className="flex-1 touch-pan-y"
-        style={{
-          maxHeight,
-          minHeight: '200px',
-          overscrollBehavior: 'contain',
-          touchAction: 'pan-y',
-        }}
-      />
+        className="flex-1 min-h-0 overflow-hidden"
+        style={{ maxHeight, minHeight: '200px' }}
+      >
+        <div
+          ref={containerRef}
+          className="h-full w-full touch-pan-y"
+          style={{
+            overscrollBehavior: 'contain',
+            touchAction: 'pan-y',
+          }}
+        />
+      </div>
 
       {/* Footer status bar */}
       <div


### PR DESCRIPTION
## Summary\n- lock body scroll while LogViewer panel is open to prevent page capture on mobile\n- add overflow boundary around xterm container for stable touch scrolling\n\n## Testing\n- not run (UI change)