### PR TITLE
Dashboard cleanup: agent list labeling

### DIFF
--- a/src/dashboard/lib/agent-merge.test.ts
+++ b/src/dashboard/lib/agent-merge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '../types';
+import { mergeAgentsForDashboard } from './agent-merge.js';
+
+describe('mergeAgentsForDashboard', () => {
+  it('filters out the Dashboard user', () => {
+    const agents: Agent[] = [
+      { name: 'Dashboard', status: 'online' },
+      { name: 'Lead', status: 'online' },
+    ];
+
+    const merged = mergeAgentsForDashboard({ agents });
+
+    expect(merged.map((agent) => agent.name)).toEqual(['Lead']);
+  });
+
+  it('keeps cloud agents from being marked as local on name collision', () => {
+    const agents: Agent[] = [
+      { name: 'Lead', status: 'online' },
+    ];
+    const localAgents: Agent[] = [
+      { name: 'Lead', status: 'online', isLocal: true, daemonName: 'local-daemon' },
+    ];
+
+    const merged = mergeAgentsForDashboard({ agents, localAgents });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe('Lead');
+    expect(merged[0].isLocal).toBe(false);
+  });
+
+  it('preserves local agents when no cloud agent exists', () => {
+    const localAgents: Agent[] = [
+      { name: 'Worker', status: 'online', isLocal: true, daemonName: 'local-daemon' },
+    ];
+
+    const merged = mergeAgentsForDashboard({ localAgents });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe('Worker');
+    expect(merged[0].isLocal).toBe(true);
+  });
+});

--- a/src/dashboard/lib/agent-merge.ts
+++ b/src/dashboard/lib/agent-merge.ts
@@ -1,0 +1,35 @@
+import type { Agent } from '../types';
+
+export interface MergeAgentsInput {
+  agents?: Agent[];
+  users?: Agent[];
+  localAgents?: Agent[];
+}
+
+export function mergeAgentsForDashboard({
+  agents = [],
+  users = [],
+  localAgents = [],
+}: MergeAgentsInput): Agent[] {
+  const merged = [...agents, ...users, ...localAgents]
+    .filter((agent) => agent.name.toLowerCase() !== 'dashboard');
+  const byName = new Map<string, Agent>();
+
+  for (const agent of merged) {
+    const key = agent.name.toLowerCase();
+    const existing = byName.get(key);
+    // Prefer non-local agents when names collide to avoid cloud agents showing as local.
+    if (existing) {
+      const keepNonLocal = !existing.isLocal && agent.isLocal;
+      byName.set(key, {
+        ...existing,
+        ...agent,
+        isLocal: keepNonLocal ? false : Boolean(agent.isLocal),
+      });
+    } else {
+      byName.set(key, agent);
+    }
+  }
+
+  return Array.from(byName.values());
+}

--- a/src/dashboard/react-components/App.tsx
+++ b/src/dashboard/react-components/App.tsx
@@ -45,6 +45,7 @@ import { useCloudSessionOptional } from './CloudSessionProvider';
 import { WorkspaceProvider } from './WorkspaceContext';
 import { api, convertApiDecision, setActiveWorkspaceId as setApiWorkspaceId } from '../lib/api';
 import { cloudApi } from '../lib/cloudApi';
+import { mergeAgentsForDashboard } from '../lib/agent-merge';
 import type { CurrentUser } from './MessageList';
 
 /**
@@ -461,27 +462,11 @@ export function App({ wsUrl, orchestratorUrl }: AppProps) {
 
   // Merge AI agents, human users, and local agents from linked daemons
   const combinedAgents = useMemo(() => {
-    const merged = [...(data?.agents ?? []), ...(data?.users ?? []), ...localAgents]
-      .filter((agent) => agent.name.toLowerCase() !== 'dashboard');
-    const byName = new Map<string, Agent>();
-
-    for (const agent of merged) {
-      const key = agent.name.toLowerCase();
-      const existing = byName.get(key);
-      // Prefer non-local agents when names collide to avoid cloud agents showing as local.
-      if (existing) {
-        const keepNonLocal = !existing.isLocal && agent.isLocal;
-        byName.set(key, {
-          ...existing,
-          ...agent,
-          isLocal: keepNonLocal ? false : Boolean(agent.isLocal),
-        });
-      } else {
-        byName.set(key, agent);
-      }
-    }
-
-    return Array.from(byName.values());
+    return mergeAgentsForDashboard({
+      agents: data?.agents,
+      users: data?.users,
+      localAgents,
+    });
   }, [data?.agents, data?.users, localAgents]);
 
   // Mark a DM conversation as seen (used for unread badges)


### PR DESCRIPTION
## Summary\n- filter out Dashboard from agents list\n- avoid marking cloud agents as local on name collision\n\n## Testing\n- not run (not requested)\n