### PR TITLE
fix: cloud dashboard message duplication and attribution

### DIFF
--- a/src/dashboard/react-components/AgentList.tsx
+++ b/src/dashboard/react-components/AgentList.tsx
@@ -40,10 +40,13 @@ export function AgentList({
   const [allExpanded, setAllExpanded] = useState(true);
 
   // Filter out setup agents (temporary agents for provider auth)
-  // and then apply search filtering
+  // and system agents like _DashboardUI (used for dashboard message sending)
+  // then apply search filtering
   const filteredAgents = useMemo(() => {
-    const nonSetupAgents = agents.filter(a => !a.name.startsWith('__setup__'));
-    return filterAgents(nonSetupAgents, searchQuery);
+    const nonSystemAgents = agents.filter(a =>
+      !a.name.startsWith('__setup__') && a.name !== '_DashboardUI'
+    );
+    return filterAgents(nonSystemAgents, searchQuery);
   }, [agents, searchQuery]);
 
   const groups = useMemo(

--- a/src/dashboard/react-components/hooks/useMessages.ts
+++ b/src/dashboard/react-components/hooks/useMessages.ts
@@ -72,20 +72,22 @@ export function useMessages({
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
 
   // Clean up optimistic messages when they appear in the real messages list
-  // Match by content + from + to (since IDs will be different)
+  // Match by to + content only (not from, since server may use different sender like '_DashboardUI')
   useEffect(() => {
     if (optimisticMessages.length === 0) return;
 
     // Create a set of "fingerprints" for real messages (recent ones only)
+    // Use to + content only - the 'from' field may differ between optimistic (user's name)
+    // and real message (server may use '_DashboardUI' as relay client name)
     const recentMessages = messages.slice(-50); // Only check recent messages for performance
     const realFingerprints = new Set(
-      recentMessages.map((m) => `${m.from}:${m.to}:${m.content.slice(0, 100)}`)
+      recentMessages.map((m) => `${m.to}:${m.content.slice(0, 100)}`)
     );
 
     // Remove optimistic messages that now exist in real messages
     setOptimisticMessages((prev) =>
       prev.filter((opt) => {
-        const fingerprint = `${opt.from}:${opt.to}:${opt.content.slice(0, 100)}`;
+        const fingerprint = `${opt.to}:${opt.content.slice(0, 100)}`;
         return !realFingerprints.has(fingerprint);
       })
     );


### PR DESCRIPTION
## Summary

Fixes message duplication and incorrect attribution when sending messages from the cloud dashboard.

**Before:**
- Messages appeared twice in history
- First instance showed "_DashboardUI" as sender (incorrect)
- Second instance showed correct logged-in username
- "_DashboardUI" appeared in agent sidebar

**After:**
- Single message per send
- Messages show logged-in username
- "_DashboardUI" hidden from sidebar

## Root Cause

Optimistic messages created by frontend used logged-in username (e.g., "khaliqgant"), while server-confirmed messages used relay client name ("_DashboardUI"). The deduplication fingerprint included the 'from' field, causing mismatch and displaying both messages.

## Changes

1. **Frontend Deduplication** (`useMessages.ts`)
   - Changed fingerprint to match on `to + content` only
   - Excludes `from` field to handle server/client sender differences

2. **Backend Attribution** (`server.ts`)
   - Added `senderName` to message data field in `/api/send`
   - Updated `mapStoredMessages` to use `data.senderName` for display when sender is `_DashboardUI`

3. **Sidebar Filtering** (`AgentList.tsx`)
   - Explicitly filters out `_DashboardUI` from agent list

## Test Plan

- [ ] Send message from cloud dashboard
- [ ] Verify single message appears (no duplicate)
- [ ] Verify message shows logged-in username as sender
- [ ] Verify "_DashboardUI" does not appear in sidebar
- [ ] Verify other agents can reply to the actual user

🤖 Generated with [Claude Code](https://claude.com/claude-code)