### PR TITLE
fix: show all accessible workspaces in selector dropdown

### DIFF
--- a/src/dashboard/lib/cloudApi.ts
+++ b/src/dashboard/lib/cloudApi.ts
@@ -398,6 +398,32 @@ export const cloudApi = {
   },
 
   /**
+   * Get all accessible workspaces (owned + member + contributor via GitHub repos)
+   * This is the preferred method for the workspace selector dropdown
+   */
+  async getAccessibleWorkspaces() {
+    return cloudFetch<{
+      workspaces: Array<{
+        id: string;
+        name: string;
+        status: string;
+        publicUrl?: string;
+        providers?: string[];
+        repositories?: string[];
+        accessType: 'owner' | 'member' | 'contributor';
+        permission: 'admin' | 'write' | 'read';
+        createdAt: string;
+      }>;
+      summary: {
+        owned: number;
+        member: number;
+        contributor: number;
+        total: number;
+      };
+    }>('/api/workspaces/accessible');
+  },
+
+  /**
    * Get workspace status (live polling from compute provider)
    */
   async getWorkspaceStatus(id: string) {


### PR DESCRIPTION
## Summary

Fixes the workspace selector dropdown to show ALL accessible workspaces, including contributor workspaces (accessible via GitHub repository permissions).

**Before:**
- Workspace dropdown used `/api/workspaces/summary`
- Only showed workspaces where user is OWNER or MEMBER
- Missing workspaces accessible via GitHub repo contributor access
- Users couldn't see or switch to contributor workspaces

**After:**
- Workspace dropdown uses `/api/workspaces/accessible`
- Shows owned + member + contributor workspaces
- Complete list of all accessible workspaces displayed
- Users can see and switch to any workspace they have access to

## Changes

1. **New API Method: `cloudApi.getAccessibleWorkspaces()`** (`cloudApi.ts`)
   - Calls `/api/workspaces/accessible` endpoint
   - Returns workspaces with `accessType` (owner/member/contributor)
   - Includes `permission` level (admin/write/read)

2. **Updated Workspace Fetching** (`App.tsx`)
   - Changed from `getWorkspaceSummary()` to `getAccessibleWorkspaces()`
   - Updated workspace state type to include `accessType` and `permission`
   - Changed from `path` to `publicUrl` for workspace URLs

## Behavior

**Workspace Access Types:**
- **Owner:** User created the workspace
- **Member:** User was invited to the workspace
- **Contributor:** User has access via GitHub repository permissions

**Result:** Workspace selector dropdown now displays complete list of accessible workspaces across all access types.

## Test Plan

- [ ] Open dashboard in cloud mode
- [ ] Check workspace dropdown (top left)
- [ ] Verify all accessible workspaces are listed (owned + member + contributor)
- [ ] Verify can switch between workspaces
- [ ] Verify workspace data loads correctly after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)