### PR TITLE
Fix: Handle direct_message events in dashboard presence handler

### DIFF
--- a/src/dashboard/react-components/App.tsx
+++ b/src/dashboard/react-components/App.tsx
@@ -452,6 +452,27 @@ export function App({ wsUrl, orchestratorUrl }: AppProps) {
         isRead: selectedChannelId === channelId,
       };
       appendChannelMessage(channelId, msg, { incrementUnread: selectedChannelId !== channelId });
+    } else if (event?.type === 'direct_message') {
+      // Handle direct messages sent to the user's GitHub username
+      const sender = event.from || 'unknown';
+      const recipient = currentUser?.displayName;
+      if (!recipient) return;
+
+      // Create DM channel ID with sorted participants for consistency
+      const participants = [sender, recipient].sort();
+      const dmChannelId = `dm:${participants.join(':')}`;
+
+      const msg: ChannelApiMessage = {
+        id: event.id ?? `dm-${Date.now()}`,
+        channelId: dmChannelId,
+        from: sender,
+        fromEntityType: 'agent', // DMs to user are typically from agents
+        content: event.body ?? '',
+        timestamp: event.timestamp || new Date().toISOString(),
+        threadId: event.thread,
+        isRead: selectedChannelId === dmChannelId,
+      };
+      appendChannelMessage(dmChannelId, msg, { incrementUnread: selectedChannelId !== dmChannelId });
     }
   }, [appendChannelMessage, currentUser?.displayName, selectedChannelId]);
 


### PR DESCRIPTION
## Summary
- Fix message routing bug where messages sent to GitHub username (e.g., `khaliqgant`) were not received in dashboard UI
- Messages sent to `_DashboardUI` worked because they were fetched from storage, but real-time direct messages were silently discarded

## Root Cause
`handlePresenceEvent` in `App.tsx` only handled `channel_message` events and ignored `direct_message` events:

\`\`\`typescript
// Before: Only handled channel_message
const handlePresenceEvent = useCallback((event: any) => {
  if (event?.type === 'channel_message') {
    // ... process channel message
  }
  // direct_message events were silently ignored!
}, [...]);
\`\`\`

When UserBridge forwarded DMs via WebSocket as `{ type: 'direct_message', from: 'Agent', body: '...' }`, they were discarded.

## Fix
Added handling for `direct_message` events that:
1. Creates a consistent DM channel ID (`dm:user1:user2` with sorted participants)
2. Appends the message to the channel messages state
3. Handles unread state like channel messages

## Changes
This PR contains **only** the direct_message event handling fix in `App.tsx`. No relay-pty or Rust changes included.

Based on main, which already has the _DashboardUI display fixes from PR #193.

## Test plan
- [ ] Send message from agent to GitHub username - verify it appears in dashboard
- [ ] Verify existing `_DashboardUI` routing still works
- [ ] Verify channel messages still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)