### PR TITLE
Fix publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             binary_name: relay-pty-darwin-arm64
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: relay-pty-darwin-x64
           - os: ubuntu-latest
@@ -63,13 +63,15 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Build relay-pty
         working-directory: relay-pty
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Copy binary with platform name
-        run: cp relay-pty/target/release/relay-pty bin/${{ matrix.binary_name }}
+        run: cp relay-pty/target/${{ matrix.target }}/release/relay-pty bin/${{ matrix.binary_name }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.trajectories/completed/2026-01/traj_2zk4ndzdr5te.json
+++ b/.trajectories/completed/2026-01/traj_2zk4ndzdr5te.json
@@ -1,0 +1,49 @@
+{
+  "id": "traj_2zk4ndzdr5te",
+  "version": 1,
+  "task": {
+    "title": "Fix publish workflow macos runner"
+  },
+  "status": "completed",
+  "startedAt": "2026-01-16T13:31:46.311Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-01-16T13:31:49.805Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_6uvou47axdll",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-01-16T13:31:49.805Z",
+      "events": [
+        {
+          "ts": 1768570309806,
+          "type": "decision",
+          "content": "Build x86_64-apple-darwin on macos-latest: Build x86_64-apple-darwin on macos-latest",
+          "raw": {
+            "question": "Build x86_64-apple-darwin on macos-latest",
+            "chosen": "Build x86_64-apple-darwin on macos-latest",
+            "alternatives": [],
+            "reasoning": "macos-13 runners are retired; use macos-latest with explicit Rust target"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-01-16T13:31:52.700Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relay",
+  "tags": [],
+  "completedAt": "2026-01-16T13:31:52.700Z",
+  "retrospective": {
+    "summary": "Updated publish workflow to use macos-latest and explicit Rust targets",
+    "approach": "Standard approach",
+    "confidence": 0.76
+  }
+}

--- a/.trajectories/completed/2026-01/traj_2zk4ndzdr5te.md
+++ b/.trajectories/completed/2026-01/traj_2zk4ndzdr5te.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix publish workflow macos runner
+
+> **Status:** ✅ Completed
+> **Confidence:** 76%
+> **Started:** January 16, 2026 at 08:31 AM
+> **Completed:** January 16, 2026 at 08:31 AM
+
+---
+
+## Summary
+
+Updated publish workflow to use macos-latest and explicit Rust targets
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Build x86_64-apple-darwin on macos-latest
+- **Chose:** Build x86_64-apple-darwin on macos-latest
+- **Reasoning:** macos-13 runners are retired; use macos-latest with explicit Rust target
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Build x86_64-apple-darwin on macos-latest: Build x86_64-apple-darwin on macos-latest

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-01-16T10:28:28.644Z",
+  "lastUpdated": "2026-01-16T13:31:52.725Z",
   "trajectories": {
     "traj_ozd98si6a7ns": {
       "title": "Fix thinking indicator showing on all messages",
@@ -680,6 +680,13 @@
       "startedAt": "2026-01-16T10:27:59.063Z",
       "completedAt": "2026-01-16T10:28:28.633Z",
       "path": "/Users/khaliqgant/Projects/agent-workforce/relay/.trajectories/completed/2026-01/traj_e68cbt5rmmbp.json"
+    },
+    "traj_2zk4ndzdr5te": {
+      "title": "Fix publish workflow macos runner",
+      "status": "completed",
+      "startedAt": "2026-01-16T13:31:46.311Z",
+      "completedAt": "2026-01-16T13:31:52.700Z",
+      "path": "/Users/will/Projects/relay/.trajectories/completed/2026-01/traj_2zk4ndzdr5te.json"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the GitHub Actions publish workflow to address issues with the macOS runner and Rust cross-compilation. The main change is switching the x86_64 macOS build from the now-retired `macos-13` runner to `macos-latest`, and ensuring Rust targets are installed and referenced explicitly during the build process. Additionally, a new completed trajectory is recorded to document the workflow update.

**Workflow improvements:**

* Changed the x86_64 macOS build in `.github/workflows/publish.yml` to use `macos-latest` instead of the deprecated `macos-13` runner, ensuring compatibility with current GitHub-hosted runners.
* Updated the workflow to explicitly install the required Rust target and use it in the build and copy steps, improving reliability for cross-compilation.

**Trajectory tracking:**

* Added a new trajectory `.trajectories/completed/2026-01/traj_2zk4ndzdr5te.json` and its summary `.trajectories/completed/2026-01/traj_2zk4ndzdr5te.md` documenting the decision to update the workflow for macOS runners. [[1]](diffhunk://#diff-64cd8a93e3af39104f40c38ecbe4e9fd7fbdac62201a91e415db9d05c20bb433R1-R49) [[2]](diffhunk://#diff-49dfbb0e019abee9c27750665ae21da2f01cbcca86698b37e768807854f9f199R1-R31)
* Updated `.trajectories/index.json` to include the new completed trajectory and its metadata. [[1]](diffhunk://#diff-31ffbf000e8b51651e5b61210d5a77f77e7189a60b655b7990b66ba815982a0eL3-R3) [[2]](diffhunk://#diff-31ffbf000e8b51651e5b61210d5a77f77e7189a60b655b7990b66ba815982a0eR683-R689)