### PR TITLE
Fix Cargo.lock v4 compatibility by updating Rust to 1.83

### DIFF
--- a/deploy/workspace/Dockerfile.base
+++ b/deploy/workspace/Dockerfile.base
@@ -5,7 +5,7 @@
 # ============================================================================
 # Stage 1: Build Rust relay-pty binary
 # ============================================================================
-FROM rust:1.75-slim AS rust-builder
+FROM rust:1.83-slim AS rust-builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Cargo.lock version 4 was introduced in Rust 1.83. The Docker build was
failing because rust:1.75-slim doesn't understand the v4 lock file format.