### PR TITLE
fix: Enable cross-machine routing for users (not just agents)

### DIFF
--- a/.trajectories/completed/2026-01/traj_mjec54pveknf.json
+++ b/.trajectories/completed/2026-01/traj_mjec54pveknf.json
@@ -1,0 +1,25 @@
+{
+  "id": "traj_mjec54pveknf",
+  "version": 1,
+  "task": {
+    "title": "Stuck detection - heuristics for idle, error loop, output loop detection",
+    "source": {
+      "system": "plain",
+      "id": "agent-relay-501"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-01-17T08:39:56.033Z",
+  "agents": [],
+  "chapters": [],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/data/repos/relay",
+  "tags": [],
+  "completedAt": "2026-01-17T08:48:47.638Z",
+  "retrospective": {
+    "summary": "Created StuckDetector for extended idle, error loop, and output loop detection. Integrated with BaseWrapper. Emits stuck/unstuck events.",
+    "approach": "Standard approach",
+    "confidence": 0.85
+  }
+}

--- a/.trajectories/completed/2026-01/traj_mjec54pveknf.md
+++ b/.trajectories/completed/2026-01/traj_mjec54pveknf.md
@@ -1,0 +1,15 @@
+# Trajectory: Stuck detection - heuristics for idle, error loop, output loop detection
+
+> **Status:** ✅ Completed
+> **Task:** agent-relay-501
+> **Confidence:** 85%
+> **Started:** January 17, 2026 at 08:39 AM
+> **Completed:** January 17, 2026 at 08:48 AM
+
+---
+
+## Summary
+
+Created StuckDetector for extended idle, error loop, and output loop detection. Integrated with BaseWrapper. Emits stuck/unstuck events.
+
+**Approach:** Standard approach

--- a/.trajectories/completed/2026-01/traj_y8qkatv78zc4.json
+++ b/.trajectories/completed/2026-01/traj_y8qkatv78zc4.json
@@ -1,0 +1,25 @@
+{
+  "id": "traj_y8qkatv78zc4",
+  "version": 1,
+  "task": {
+    "title": "Workspace cleanup - clean /tmp/relay/{id}/ on workspace deletion",
+    "source": {
+      "system": "plain",
+      "id": "agent-relay-491"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-01-17T08:32:37.797Z",
+  "agents": [],
+  "chapters": [],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/data/repos/relay",
+  "tags": [],
+  "completedAt": "2026-01-17T08:35:04.279Z",
+  "retrospective": {
+    "summary": "Created role prompts (planner, worker, reviewer) and prompt-composer.ts with caching, fallback, and composition",
+    "approach": "Standard approach",
+    "confidence": 0.85
+  }
+}

--- a/.trajectories/completed/2026-01/traj_y8qkatv78zc4.md
+++ b/.trajectories/completed/2026-01/traj_y8qkatv78zc4.md
@@ -1,0 +1,15 @@
+# Trajectory: Workspace cleanup - clean /tmp/relay/{id}/ on workspace deletion
+
+> **Status:** ✅ Completed
+> **Task:** agent-relay-491
+> **Confidence:** 85%
+> **Started:** January 17, 2026 at 08:32 AM
+> **Completed:** January 17, 2026 at 08:35 AM
+
+---
+
+## Summary
+
+Created role prompts (planner, worker, reviewer) and prompt-composer.ts with caching, fallback, and composition
+
+**Approach:** Standard approach


### PR DESCRIPTION
## Summary
- Enables cross-machine message routing for **users** (humans connected via cloud dashboard)
- Previously only **agents** could be routed across machines; users would fail with "Target not found"

## Problem
When agent "Lead" on a local machine sends a message TO "khaliqgant" (a user connected via cloud dashboard):
1. Router checks `agents.get('khaliqgant')` → NOT FOUND
2. Router checks `users.get('khaliqgant')` → NOT FOUND (user is on cloud daemon)
3. Router checks `isRemoteAgent('khaliqgant')` → NOT FOUND (only tracks agents)
4. **Message dropped**: `Target "khaliqgant" not found`

Meanwhile, messages TO `_DashboardUI` worked because it's registered as an agent.

## Solution
- Added `isRemoteUser()` to `CrossMachineHandler` interface
- Added `remoteUsers` tracking in daemon server
- Added `remote-users-updated` event handling from cloud sync
- Router now checks `isRemoteUser()` when local lookup fails

## Files Changed
- `src/daemon/router.ts` - Added interface method and router lookup
- `src/daemon/server.ts` - Added remoteUsers tracking and isRemoteUser method
- `src/daemon/cloud-sync.ts` - Added remoteUsers and event emission

## Test plan
- [ ] Send DM from local agent to cloud-connected user
- [ ] Verify message routes via cloud to user's dashboard
- [ ] Confirm backward compatibility with agent routing

## Note
This fix complements PR #209 (DM channel formatting). They fix different layers:
- PR #209: Channel message formatting (`dm:` prefix)
- This PR: Daemon router cross-machine user lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)