### PR TITLE
fix: add /api/bridge endpoint to cloud server

### DIFF
--- a/src/cloud/server.ts
+++ b/src/cloud/server.ts
@@ -1038,6 +1038,13 @@ export async function createServer(): Promise<CloudServer> {
     await proxyToLocalDashboard(req, res, '/api/channels/users');
   });
 
+  // Bridge API - returns empty state in cloud mode
+  // Bridge is for local multi-project coordination; cloud workspaces are already separate
+  // MUST be before teamsRouter to avoid auth interception
+  app.get('/api/bridge', requireAuth, (_req, res) => {
+    res.json({ projects: [], messages: [], connected: false });
+  });
+
   // Test helper routes (only available in non-production)
   // MUST be before teamsRouter to avoid auth interception
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
The dashboard frontend calls /api/bridge on mount before workspaces load, causing a race condition where the request falls through to teamsRouter and fails with 401/404.

Add the endpoint before teamsRouter to return empty bridge state in cloud mode, since bridge is for local multi-project coordination.