### PR TITLE
fix: Broadcast messages should show [broadcast] not [#general]

### DIFF
--- a/src/wrapper/shared.test.ts
+++ b/src/wrapper/shared.test.ts
@@ -98,7 +98,7 @@ describe('buildInjectionString', () => {
         originalTo: '*',
       };
       const result = buildInjectionString(msg);
-      expect(result).toContain('[#general]');
+      expect(result).toContain('[broadcast]');
     });
 
     it('includes channel hint for channel messages', () => {

--- a/src/wrapper/shared.ts
+++ b/src/wrapper/shared.ts
@@ -143,7 +143,7 @@ export function buildInjectionString(msg: QueuedMessage): string {
   // Channel indicator for channel messages and broadcasts
   // originalTo will be '*' for broadcasts or the channel name (e.g., '#general') for channel messages
   const channelHint = msg.originalTo === '*'
-    ? ' [#general]'
+    ? ' [broadcast]'
     : msg.originalTo?.startsWith('#')
       ? ` [${msg.originalTo}]`
       : '';


### PR DESCRIPTION
## Summary

Fixed incorrect channel label for broadcast messages. When messages are sent to broadcast (`originalTo === '*'`), they were being displayed with `[#general]` label, which confused routing information. Now correctly displays `[broadcast]`.

## Changes

- Updated `buildInjectionString()` in `src/wrapper/shared.ts` to show `[broadcast]` for broadcasts
- Updated test expectation in `src/wrapper/shared.test.ts` to match correct behavior
- Aligns with existing behavior in `tmux-wrapper.ts` line 1498

## Why This Matters

Broadcasts go to ALL agents/users in the workspace. Showing `[#general]` incorrectly implies they only went to the #general channel. The label is important for agents to understand message routing in their terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)