### PR TITLE
fix: Add cloud spawning support to daemon server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Daemon Constants
+ * Shared constants for the daemon module.
+ * Extracted to a separate file to avoid circular imports.
+ */
+
+export const DEFAULT_SOCKET_PATH = '/tmp/agent-relay.sock';

--- a/src/wrapper/client.ts
+++ b/src/wrapper/client.ts
@@ -37,7 +37,7 @@ import type {
   MessageAttachment,
 } from '../protocol/channels.js';
 import { encodeFrameLegacy, FrameParser } from '../protocol/framing.js';
-import { DEFAULT_SOCKET_PATH } from '../daemon/server.js';
+import { DEFAULT_SOCKET_PATH } from '../daemon/constants.js';
 
 export type ClientState = 'DISCONNECTED' | 'CONNECTING' | 'HANDSHAKING' | 'READY' | 'BACKOFF';
 


### PR DESCRIPTION
The daemon server was receiving cloud-triggered spawn commands
(sent to __spawner__) but had no code to process them. This caused
cloud spawning to silently fail with a "Target agent not found" warning.

Changes:
- Add handleSpawnCommand() method to process __spawner__ messages
- Initialize AgentSpawner when cloud sync is enabled (hasEnvApiKey)
- Extract DEFAULT_SOCKET_PATH to constants.ts to avoid circular imports
- Add cloudSpawning and projectRoot config options

The fix enables the full cloud spawning flow:
1. Cloud webhook receives event -> queues spawn command
2. Daemon fetches message via /api/daemons/messages
3. handleCrossMachineMessage detects __spawner__ target
4. handleSpawnCommand parses JSON and calls spawner.spawn()