### PR TITLE
fix(channels): Fix invite buttons and messages endpoint

### DIFF
--- a/src/cloud/server.ts
+++ b/src/cloud/server.ts
@@ -1058,6 +1058,7 @@ export async function createServer(): Promise<CloudServer> {
     const params = new URLSearchParams();
     if (req.query.limit) params.set('limit', req.query.limit as string);
     if (req.query.before) params.set('before', req.query.before as string);
+    if (req.query.workspaceId) params.set('workspaceId', req.query.workspaceId as string);
     const queryString = params.toString() ? `?${params.toString()}` : '';
     await proxyToLocalDashboard(req, res, `/api/channels/${channel}/messages${queryString}`);
   });


### PR DESCRIPTION
## Summary

- Fix both "Invite Member" buttons in the channels UI not working (missing click handlers and API endpoint issues)
- Fix `/api/channels/:channel/messages` endpoint not forwarding `workspaceId` query parameter when proxying to local dashboard

## Changes

1. **Invite member buttons** (`65daf1a`): Added missing functionality to invite member buttons in channels
2. **Messages endpoint** (`831dc57`): Forward `workspaceId` param in the cloud proxy so messages are properly filtered by workspace

## Test plan

- [ ] Verify invite member buttons work in channel settings
- [ ] Verify channel messages load correctly with workspaceId filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)