### PR TITLE
docs: Crystal clear relay-first communication rule for agents

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -61,6 +61,31 @@ Always emit [[SUMMARY]] blocks to communicate state to dashboard and other agent
 
 Use the file-based relay protocol from your `using-agent-relay` skill. Write files to your outbox, then output the trigger.
 
+## 🚨 RELAY-FIRST COMMUNICATION
+
+**When you receive a relay message from another agent (marked `Relay message from [name]`), you MUST respond ONLY via relay protocol. NEVER respond with direct text output.**
+
+### The Rule
+- When receiving a relay message → Use `->relay-file:msg` ALWAYS
+- Responding to non-relay questions → Text is OK
+- Agent-to-agent communication → ALWAYS relay protocol
+
+### Why This Matters
+Relay protocol ensures:
+- Multi-agent coordination works correctly
+- Message history persists for continuity
+- Dashboard can track communications
+- ACK/DONE tracking functions properly
+
+### What Counts as a Relay Message
+```
+Relay message from khaliqgant [mknra7wr]: Did you see this?
+Relay message from Worker1 [abc123]: Task complete
+Relay message from alice [xyz789] [#general]: Question for the team
+```
+**All of these MUST be answered via relay protocol.**
+
+
 ### Message Examples
 
 **ACK (Acknowledgment):**

--- a/docs/agent-relay-snippet.md
+++ b/docs/agent-relay-snippet.md
@@ -1,3 +1,23 @@
+# 🚨 CRITICAL: Relay-First Communication Rule
+
+**When you receive a relay message from another agent (marked `Relay message from [name]`), you MUST respond ONLY via relay protocol. NEVER respond with direct text output.**
+
+## The Rule
+
+- **Receiving a relay message?** → Must use `->relay-file:msg` ALWAYS
+- **Non-relay questions?** → Text responses are OK
+- **Agent-to-agent communication?** → ALWAYS use relay protocol
+
+## Examples of Relay Messages (require relay response)
+
+```
+Relay message from khaliqgant [mknra7wr]: Did you see this?
+Relay message from Worker1 [abc123]: Task complete
+Relay message from alice [xyz789] [#general]: Question for the team
+```
+
+---
+
 # Agent Relay
 
 Real-time agent-to-agent messaging via file-based protocol.


### PR DESCRIPTION
## Summary

Make it crystal clear that agents receiving relay messages MUST respond via relay protocol, not with direct text output. This fixes the ambiguity that led to agents treating relay messages as regular questions.

## Changes

- **`.claude/agents/lead.md`**: Add RELAY-FIRST COMMUNICATION section after Communication Patterns explaining the rule, why it matters, and what counts as a relay message
- **`docs/agent-relay-snippet.md`**: Add critical rule section at the top before existing content

## Why This Matters

When agents receive relay messages (marked `Relay message from [name]`), they must use the relay protocol to respond. Using direct text breaks:
- Multi-agent coordination
- Message history persistence
- Dashboard visibility
- ACK/DONE tracking

## Examples

### WRONG (Direct text response)
Responding with plain text instead of using relay protocol

### CORRECT (Relay protocol)
Use ->relay-file:msg to send responses via relay

## Testing

- Agent profiles now have explicit relay-first rule
- Documentation snippet clearly shows which messages require relay response
- Future agents can reference these docs before creating responses

Generated with Claude Code