### PR TITLE
fix(sidebar): Filter DMs from channels list

### DIFF
--- a/src/dashboard/react-components/App.tsx
+++ b/src/dashboard/react-components/App.tsx
@@ -2370,18 +2370,22 @@ export function App({ wsUrl, orchestratorUrl }: AppProps) {
           activeThreads={activeThreads}
           currentThread={currentThread}
           totalUnreadThreadCount={totalUnreadThreadCount}
-          channels={channelsList.map(c => ({
-            id: c.id,
-            name: c.name,
-            unreadCount: c.unreadCount,
-            hasMentions: c.hasMentions,
-          }))}
-          archivedChannels={archivedChannelsList.map((c) => ({
-            id: c.id,
-            name: c.name,
-            unreadCount: c.unreadCount ?? 0,
-            hasMentions: c.hasMentions,
-          }))}
+          channels={channelsList
+            .filter(c => !c.isDm && !c.id.startsWith('dm:'))
+            .map(c => ({
+              id: c.id,
+              name: c.name,
+              unreadCount: c.unreadCount,
+              hasMentions: c.hasMentions,
+            }))}
+          archivedChannels={archivedChannelsList
+            .filter(c => !c.isDm && !c.id.startsWith('dm:'))
+            .map((c) => ({
+              id: c.id,
+              name: c.name,
+              unreadCount: c.unreadCount ?? 0,
+              hasMentions: c.hasMentions,
+            }))}
           selectedChannelId={selectedChannelId}
           isActivitySelected={selectedChannelId === ACTIVITY_FEED_ID}
           activityUnreadCount={0}


### PR DESCRIPTION
## Summary

- DMs (`dm:*`) were incorrectly appearing in the CHANNELS section of the sidebar
- Added filter to exclude channels where `isDm` is true or `id` starts with `dm:` before passing to the Sidebar component

## Screenshot

Before: DM `dm:Lead:khaliqgant` was showing up in the Channels section with a `#` prefix

## Changes

- Filter applied to both `channels` and `archivedChannels` props passed to `Sidebar`

## Test plan

- [ ] Verify DMs no longer appear in the CHANNELS section
- [ ] Verify regular channels still display correctly
- [ ] Verify archived channels still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)