### PR TITLE
feat: integrate browser-use for web automation

### DIFF
--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -1,0 +1,118 @@
+# Browser Agent (browser-use integration)
+
+This module integrates [browser-use](https://github.com/browser-use/browser-use) into agent-relay,
+allowing any relay agent to request web automation tasks.
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────────┐
+│   Agent A   │────>│   Relay     │────>│  BrowserAgent   │
+│             │     │   Daemon    │     │  (this module)  │
+└─────────────┘     └─────────────┘     └────────┬────────┘
+                                                  │
+                                         ┌────────┴────────┐
+                                         │  browser-use    │
+                                         │  (Python)       │
+                                         └────────┬────────┘
+                                                  │
+                                         ┌────────┴────────┐
+                                         │   Chromium      │
+                                         └─────────────────┘
+```
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   # Using uv (recommended)
+   uv add browser-use
+   uvx browser-use install
+
+   # Or using pip
+   pip install browser-use
+   playwright install chromium
+   ```
+
+2. Set your LLM API key:
+   ```bash
+   export OPENAI_API_KEY=sk-...
+   # or
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+## Usage
+
+### Start a browser agent:
+
+```bash
+# Start the relay with a browser agent
+agent-relay browser
+
+# Or start standalone
+agent-relay create-agent --name Browser python src/browser/python/browser_agent.py
+```
+
+### Send tasks from other agents:
+
+Any relay agent can send tasks to the browser agent:
+
+```
+TO: Browser
+
+Navigate to https://news.ycombinator.com and get the titles of the top 5 posts
+```
+
+### Message Format
+
+**Request:**
+```
+TO: Browser
+THREAD: optional-thread-id
+
+<natural language task description>
+```
+
+**Response:**
+```
+DONE: <result summary>
+
+<detailed results or extracted data>
+```
+
+## Configuration
+
+Environment variables:
+- `BROWSER_USE_MODEL` - LLM model to use (default: gpt-4o)
+- `BROWSER_USE_HEADLESS` - Run browser headless (default: true)
+- `BROWSER_USE_TIMEOUT` - Task timeout in seconds (default: 300)
+
+## Examples
+
+### Web scraping
+```
+TO: Browser
+
+Go to https://example.com/products and extract all product names and prices into a JSON array
+```
+
+### Form filling
+```
+TO: Browser
+
+Go to https://example.com/contact, fill in the form with:
+- Name: John Doe
+- Email: john@example.com
+- Message: Hello, I have a question about your services
+Then submit the form.
+```
+
+### Multi-step workflow
+```
+TO: Browser
+
+1. Go to https://github.com
+2. Search for "agent-relay"
+3. Click on the first repository result
+4. Get the star count and description
+```

--- a/src/browser/browser-wrapper.ts
+++ b/src/browser/browser-wrapper.ts
@@ -1,0 +1,353 @@
+/**
+ * BrowserWrapper - Wraps the Python browser-use agent for relay integration
+ *
+ * This wrapper:
+ * 1. Spawns the Python browser agent process
+ * 2. Connects to the relay daemon as a client
+ * 3. Forwards messages to/from the Python process
+ * 4. Handles process lifecycle and reconnection
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RelayClient } from '../wrapper/client.js';
+import type { SendPayload, SendMeta } from '../protocol/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface BrowserWrapperConfig {
+  /** Agent name (default: Browser) */
+  name?: string;
+  /** Python executable path */
+  pythonPath?: string;
+  /** LLM model to use (default: gpt-4o) */
+  model?: string;
+  /** Run browser headless (default: true) */
+  headless?: boolean;
+  /** Task timeout in seconds (default: 300) */
+  timeout?: number;
+  /** Relay daemon socket path */
+  socketPath?: string;
+  /** Working directory */
+  cwd?: string;
+  /** Additional environment variables */
+  env?: Record<string, string>;
+}
+
+export class BrowserWrapper extends EventEmitter {
+  private config: Required<BrowserWrapperConfig>;
+  private process: ChildProcess | null = null;
+  private client: RelayClient | null = null;
+  private running = false;
+  private outputBuffer = '';
+
+  constructor(config: BrowserWrapperConfig = {}) {
+    super();
+
+    this.config = {
+      name: config.name ?? 'Browser',
+      pythonPath: config.pythonPath ?? 'python3',
+      model: config.model ?? process.env.BROWSER_USE_MODEL ?? 'gpt-4o',
+      headless: config.headless ?? (process.env.BROWSER_USE_HEADLESS !== 'false'),
+      timeout: config.timeout ?? parseInt(process.env.BROWSER_USE_TIMEOUT ?? '300', 10),
+      socketPath: config.socketPath ?? '',
+      cwd: config.cwd ?? process.cwd(),
+      env: config.env ?? {},
+    };
+  }
+
+  /**
+   * Start the browser wrapper
+   */
+  async start(): Promise<void> {
+    if (this.running) {
+      throw new Error('BrowserWrapper is already running');
+    }
+
+    // Connect to relay daemon
+    this.client = new RelayClient({
+      agentName: this.config.name,
+      socketPath: this.config.socketPath || undefined,
+      cli: 'browser-use',
+      task: 'Browser automation agent powered by browser-use',
+      quiet: true,
+    });
+
+    // Handle incoming messages using callback
+    this.client.onMessage = (from: string, payload: SendPayload, messageId: string, meta?: SendMeta) => {
+      this.handleRelayMessage(from, payload, messageId, meta);
+    };
+
+    await this.client.connect();
+    console.error(`[${this.config.name}] Connected to relay daemon`);
+
+    // Spawn Python browser agent
+    await this.spawnPythonAgent();
+
+    this.running = true;
+    this.emit('ready');
+  }
+
+  /**
+   * Stop the browser wrapper
+   */
+  async stop(): Promise<void> {
+    this.running = false;
+
+    if (this.process) {
+      this.process.kill('SIGTERM');
+      this.process = null;
+    }
+
+    if (this.client) {
+      this.client.disconnect();
+      this.client = null;
+    }
+
+    this.emit('stopped');
+  }
+
+  /**
+   * Spawn the Python browser agent process
+   */
+  private async spawnPythonAgent(): Promise<void> {
+    const scriptPath = path.resolve(__dirname, 'python', 'browser_agent.py');
+
+    const args = [
+      scriptPath,
+      '--name', this.config.name,
+      '--model', this.config.model,
+      '--timeout', this.config.timeout.toString(),
+    ];
+
+    if (this.config.headless) {
+      args.push('--headless');
+    }
+
+    const env = {
+      ...process.env,
+      ...this.config.env,
+      AGENT_RELAY_NAME: this.config.name,
+    };
+
+    this.process = spawn(this.config.pythonPath, args, {
+      cwd: this.config.cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    // Handle stdout - look for relay triggers
+    this.process.stdout?.on('data', (data: Buffer) => {
+      const text = data.toString();
+      this.outputBuffer += text;
+
+      // Process complete lines
+      const lines = this.outputBuffer.split('\n');
+      this.outputBuffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        this.handlePythonOutput(line);
+      }
+    });
+
+    // Handle stderr - log it
+    this.process.stderr?.on('data', (data: Buffer) => {
+      const text = data.toString().trim();
+      if (text) {
+        console.error(`[${this.config.name}] ${text}`);
+      }
+    });
+
+    // Handle process exit
+    this.process.on('exit', (code, signal) => {
+      console.error(`[${this.config.name}] Python process exited (code: ${code}, signal: ${signal})`);
+      this.emit('process-exit', { code, signal });
+
+      // Attempt restart if still running
+      if (this.running) {
+        console.error(`[${this.config.name}] Restarting Python process...`);
+        setTimeout(() => this.spawnPythonAgent(), 1000);
+      }
+    });
+
+    this.process.on('error', (err) => {
+      console.error(`[${this.config.name}] Process error: ${err.message}`);
+      this.emit('error', err);
+    });
+
+    console.error(`[${this.config.name}] Python browser agent started (pid: ${this.process.pid})`);
+  }
+
+  /**
+   * Handle output from the Python agent
+   */
+  private handlePythonOutput(line: string): void {
+    // Check for relay file triggers
+    if (line.startsWith('->relay-file:')) {
+      const filename = line.substring('->relay-file:'.length).trim();
+      this.handleRelayFileTrigger(filename);
+    }
+  }
+
+  /**
+   * Handle relay file trigger from Python
+   */
+  private async handleRelayFileTrigger(filename: string): Promise<void> {
+    const fs = await import('node:fs/promises');
+    const os = await import('node:os');
+
+    const outboxDir = path.join(os.tmpdir(), 'relay-outbox', this.config.name);
+    const filePath = path.join(outboxDir, filename);
+
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      this.sendRelayMessage(content);
+      // Clean up the file
+      await fs.unlink(filePath);
+    } catch (err) {
+      console.error(`[${this.config.name}] Failed to read relay file: ${err}`);
+    }
+  }
+
+  /**
+   * Send a message via the relay client
+   */
+  private sendRelayMessage(content: string): void {
+    if (!this.client) {
+      console.error(`[${this.config.name}] Cannot send - not connected`);
+      return;
+    }
+
+    // Parse the message content
+    const lines = content.split('\n');
+    let to = '';
+    let thread = '';
+    let bodyStart = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.startsWith('TO: ')) {
+        to = line.substring(4).trim();
+      } else if (line.startsWith('THREAD: ')) {
+        thread = line.substring(8).trim();
+      } else if (line === '') {
+        bodyStart = i + 1;
+        break;
+      } else {
+        bodyStart = i;
+        break;
+      }
+    }
+
+    const body = lines.slice(bodyStart).join('\n').trim();
+
+    if (!to) {
+      console.error(`[${this.config.name}] Message missing TO field`);
+      return;
+    }
+
+    try {
+      if (to === '*') {
+        this.client.broadcast(body);
+      } else {
+        this.client.sendMessage(to, body, 'message', undefined, thread || undefined);
+      }
+    } catch (err) {
+      console.error(`[${this.config.name}] Failed to send message: ${err}`);
+    }
+  }
+
+  /**
+   * Handle incoming relay message
+   */
+  private handleRelayMessage(from: string, payload: SendPayload, messageId: string, _meta?: SendMeta): void {
+    if (!this.process?.stdin) {
+      console.error(`[${this.config.name}] Cannot forward message - process not running`);
+      return;
+    }
+
+    const thread = payload.thread ?? '';
+    const body = payload.body;
+
+    // Format message for Python agent
+    const message = `Relay message from ${from} [${messageId}]${thread ? ` [thread:${thread}]` : ''}: ${body}\n`;
+
+    try {
+      this.process.stdin.write(message);
+    } catch (err) {
+      console.error(`[${this.config.name}] Failed to forward message: ${err}`);
+    }
+  }
+
+  /**
+   * Send a task directly (programmatic API)
+   */
+  async sendTask(task: string): Promise<void> {
+    if (!this.process?.stdin) {
+      throw new Error('Browser agent not running');
+    }
+
+    this.process.stdin.write(`FROM: API\n\n${task}\n\n`);
+  }
+
+  /**
+   * Check if browser-use is available
+   */
+  static async checkDependencies(pythonPath = 'python3'): Promise<{
+    available: boolean;
+    pythonVersion?: string;
+    browserUseVersion?: string;
+    error?: string;
+  }> {
+    const { exec } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const execAsync = promisify(exec);
+
+    try {
+      // Check Python version
+      const { stdout: pythonVersion } = await execAsync(`${pythonPath} --version`);
+
+      // Check browser-use installation
+      const checkScript = `
+import sys
+try:
+    import browser_use
+    print(f"browser_use:{browser_use.__version__ if hasattr(browser_use, '__version__') else 'installed'}")
+except ImportError:
+    print("browser_use:not_installed")
+    sys.exit(1)
+`;
+      const { stdout: browserUseCheck } = await execAsync(
+        `${pythonPath} -c "${checkScript.replace(/"/g, '\\"').replace(/\n/g, '; ')}"`
+      );
+
+      const browserUseVersion = browserUseCheck.includes(':')
+        ? browserUseCheck.split(':')[1].trim()
+        : undefined;
+
+      if (browserUseCheck.includes('not_installed')) {
+        return {
+          available: false,
+          pythonVersion: pythonVersion.trim(),
+          error: 'browser-use is not installed. Run: pip install browser-use',
+        };
+      }
+
+      return {
+        available: true,
+        pythonVersion: pythonVersion.trim(),
+        browserUseVersion,
+      };
+    } catch (err) {
+      return {
+        available: false,
+        error: `Failed to check dependencies: ${err}`,
+      };
+    }
+  }
+}
+
+export default BrowserWrapper;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Browser Agent Module
+ *
+ * Integrates browser-use (https://github.com/browser-use/browser-use)
+ * with agent-relay for web automation capabilities.
+ *
+ * @example
+ * ```typescript
+ * import { BrowserWrapper } from 'agent-relay/browser';
+ *
+ * const browser = new BrowserWrapper({
+ *   name: 'Browser',
+ *   model: 'gpt-4o',
+ *   headless: true,
+ * });
+ *
+ * await browser.start();
+ * ```
+ */
+
+export { BrowserWrapper, type BrowserWrapperConfig } from './browser-wrapper.js';

--- a/src/browser/python/browser_agent.py
+++ b/src/browser/python/browser_agent.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Browser Agent Bridge for Agent Relay
+
+This script bridges browser-use with the agent-relay file-based protocol.
+It watches for incoming messages and executes browser automation tasks.
+
+Usage:
+    python browser_agent.py [--name NAME] [--headless] [--model MODEL]
+
+Environment variables:
+    AGENT_RELAY_NAME - Agent name (default: Browser)
+    BROWSER_USE_MODEL - LLM model to use (default: gpt-4o)
+    BROWSER_USE_HEADLESS - Run headless (default: true)
+    OPENAI_API_KEY - OpenAI API key
+    ANTHROPIC_API_KEY - Anthropic API key (alternative)
+"""
+
+import asyncio
+import json
+import os
+import sys
+import signal
+import argparse
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Optional
+from datetime import datetime
+
+# Check for browser-use installation
+try:
+    from browser_use import Agent
+    from langchain_openai import ChatOpenAI
+    from langchain_anthropic import ChatAnthropic
+    BROWSER_USE_AVAILABLE = True
+except ImportError:
+    BROWSER_USE_AVAILABLE = False
+    print("Warning: browser-use not installed. Install with: pip install browser-use langchain-openai langchain-anthropic", file=sys.stderr)
+
+
+class RelayProtocol:
+    """File-based relay protocol handler"""
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+        self.outbox_dir = Path(tempfile.gettempdir()) / "relay-outbox" / agent_name
+        self.outbox_dir.mkdir(parents=True, exist_ok=True)
+
+    def send_message(self, to: str, body: str, thread: Optional[str] = None):
+        """Send a message via the relay file protocol"""
+        msg_file = self.outbox_dir / "msg"
+
+        content = f"TO: {to}\n"
+        if thread:
+            content += f"THREAD: {thread}\n"
+        content += f"\n{body}"
+
+        msg_file.write_text(content)
+        # Output the trigger that the relay wrapper watches for
+        print(f"->relay-file:msg", flush=True)
+
+    def send_ack(self, to: str, description: str):
+        """Send an acknowledgment"""
+        self.send_message(to, f"ACK: {description}")
+
+    def send_done(self, to: str, summary: str, details: Optional[str] = None):
+        """Send completion message"""
+        body = f"DONE: {summary}"
+        if details:
+            body += f"\n\n{details}"
+        self.send_message(to, body)
+
+    def send_error(self, to: str, error: str):
+        """Send error message"""
+        self.send_message(to, f"ERROR: {error}")
+
+
+class BrowserAgentBridge:
+    """Bridge between relay messages and browser-use"""
+
+    def __init__(
+        self,
+        agent_name: str = "Browser",
+        model: str = "gpt-4o",
+        headless: bool = True,
+        timeout: int = 300
+    ):
+        self.agent_name = agent_name
+        self.model = model
+        self.headless = headless
+        self.timeout = timeout
+        self.relay = RelayProtocol(agent_name)
+        self.running = False
+        self._current_task: Optional[asyncio.Task] = None
+
+        # Initialize LLM
+        self.llm = self._create_llm()
+
+    def _create_llm(self):
+        """Create the LLM instance based on available API keys"""
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            return ChatAnthropic(model="claude-sonnet-4-20250514")
+        elif os.environ.get("OPENAI_API_KEY"):
+            return ChatOpenAI(model=self.model)
+        else:
+            raise ValueError(
+                "No LLM API key found. Set OPENAI_API_KEY or ANTHROPIC_API_KEY"
+            )
+
+    async def execute_task(self, task: str, sender: str, thread: Optional[str] = None) -> str:
+        """Execute a browser automation task"""
+        if not BROWSER_USE_AVAILABLE:
+            return "ERROR: browser-use is not installed"
+
+        try:
+            # Create browser-use agent
+            agent = Agent(
+                task=task,
+                llm=self.llm,
+            )
+
+            # Run the task with timeout
+            result = await asyncio.wait_for(
+                agent.run(),
+                timeout=self.timeout
+            )
+
+            # Extract the final result
+            if hasattr(result, 'final_result'):
+                return result.final_result()
+            return str(result)
+
+        except asyncio.TimeoutError:
+            return f"ERROR: Task timed out after {self.timeout} seconds"
+        except Exception as e:
+            return f"ERROR: {str(e)}\n{traceback.format_exc()}"
+
+    def parse_message(self, raw_input: str) -> tuple[Optional[str], Optional[str], str]:
+        """Parse incoming relay message
+
+        Returns: (sender, thread, body)
+        """
+        lines = raw_input.strip().split('\n')
+        sender = None
+        thread = None
+        body_start = 0
+
+        # Parse headers
+        for i, line in enumerate(lines):
+            if line.startswith("FROM: "):
+                sender = line[6:].strip()
+            elif line.startswith("THREAD: "):
+                thread = line[8:].strip()
+            elif line == "":
+                body_start = i + 1
+                break
+            else:
+                # No more headers
+                body_start = i
+                break
+
+        body = '\n'.join(lines[body_start:]).strip()
+        return sender, thread, body
+
+    async def handle_message(self, raw_input: str):
+        """Handle an incoming message"""
+        sender, thread, task = self.parse_message(raw_input)
+
+        if not sender:
+            print(f"Warning: Message without sender, using 'Unknown'", file=sys.stderr)
+            sender = "Unknown"
+
+        if not task:
+            self.relay.send_error(sender, "Empty task received")
+            return
+
+        # Send acknowledgment
+        self.relay.send_ack(sender, f"Starting browser task: {task[:50]}...")
+
+        # Execute the task
+        print(f"[{datetime.now().isoformat()}] Executing task from {sender}: {task[:100]}...", file=sys.stderr)
+        result = await self.execute_task(task, sender, thread)
+
+        # Send result
+        if result.startswith("ERROR:"):
+            self.relay.send_error(sender, result[7:])
+        else:
+            self.relay.send_done(sender, "Browser task completed", result)
+
+    async def run_interactive(self):
+        """Run in interactive mode, reading from stdin"""
+        print(f"Browser agent '{self.agent_name}' ready.", file=sys.stderr)
+        print(f"Model: {self.model}, Headless: {self.headless}", file=sys.stderr)
+        print("Waiting for tasks via stdin or relay messages...", file=sys.stderr)
+
+        self.running = True
+
+        # Set up signal handlers
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, self._handle_shutdown)
+
+        # Read from stdin
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+
+        buffer = ""
+        while self.running:
+            try:
+                line = await asyncio.wait_for(reader.readline(), timeout=1.0)
+                if not line:
+                    # EOF
+                    break
+
+                line = line.decode('utf-8')
+
+                # Check for relay message format (injected by wrapper)
+                if line.startswith("Relay message from "):
+                    # Parse: "Relay message from Alice [abc123]: <content>"
+                    # Extract sender and content
+                    import re
+                    match = re.match(r"Relay message from (\w+) \[([^\]]+)\](?:\s*\[#[^\]]+\])?: (.*)", line)
+                    if match:
+                        sender = match.group(1)
+                        # msg_id = match.group(2)
+                        content = match.group(3)
+                        # Wrap in relay format
+                        raw_msg = f"FROM: {sender}\n\n{content}"
+                        await self.handle_message(raw_msg)
+                elif line.strip():
+                    # Accumulate for multi-line input
+                    buffer += line
+
+                    # Check if we have a complete message (empty line terminates)
+                    if buffer.endswith("\n\n") or (buffer.strip() and not line.strip()):
+                        await self.handle_message(buffer)
+                        buffer = ""
+
+            except asyncio.TimeoutError:
+                continue
+            except Exception as e:
+                print(f"Error reading input: {e}", file=sys.stderr)
+
+    def _handle_shutdown(self):
+        """Handle shutdown signal"""
+        print("\nShutting down browser agent...", file=sys.stderr)
+        self.running = False
+        if self._current_task:
+            self._current_task.cancel()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Browser Agent for Agent Relay")
+    parser.add_argument(
+        "--name", "-n",
+        default=os.environ.get("AGENT_RELAY_NAME", "Browser"),
+        help="Agent name (default: Browser)"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default=os.environ.get("BROWSER_USE_MODEL", "gpt-4o"),
+        help="LLM model to use (default: gpt-4o)"
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        default=os.environ.get("BROWSER_USE_HEADLESS", "true").lower() == "true",
+        help="Run browser in headless mode"
+    )
+    parser.add_argument(
+        "--timeout", "-t",
+        type=int,
+        default=int(os.environ.get("BROWSER_USE_TIMEOUT", "300")),
+        help="Task timeout in seconds (default: 300)"
+    )
+
+    args = parser.parse_args()
+
+    if not BROWSER_USE_AVAILABLE:
+        print("Error: browser-use is not installed.", file=sys.stderr)
+        print("Install with: pip install browser-use langchain-openai langchain-anthropic", file=sys.stderr)
+        sys.exit(1)
+
+    bridge = BrowserAgentBridge(
+        agent_name=args.name,
+        model=args.model,
+        headless=args.headless,
+        timeout=args.timeout
+    )
+
+    asyncio.run(bridge.run_interactive())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/browser/python/requirements.txt
+++ b/src/browser/python/requirements.txt
@@ -1,0 +1,7 @@
+# Browser-use dependencies for agent-relay
+# Install with: pip install -r requirements.txt
+
+browser-use>=0.1.0
+langchain-openai>=0.1.0
+langchain-anthropic>=0.1.0
+playwright>=1.40.0

--- a/src/browser/python/setup.sh
+++ b/src/browser/python/setup.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Setup script for browser-use integration with agent-relay
+#
+# This script installs the required Python dependencies for the browser agent.
+#
+# Usage:
+#   ./setup.sh           # Install using pip
+#   ./setup.sh --uv      # Install using uv (faster)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
+
+echo "====================================="
+echo "  Browser Agent Setup (browser-use)"
+echo "====================================="
+echo ""
+
+# Check for Python
+if ! command -v python3 &> /dev/null; then
+    echo "Error: Python 3 is required but not found."
+    echo "Please install Python 3.11 or higher."
+    exit 1
+fi
+
+PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+echo "Found Python: $PYTHON_VERSION"
+
+# Check Python version (need 3.11+)
+MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
+MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
+if [ "$MAJOR" -lt 3 ] || ([ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 11 ]); then
+    echo ""
+    echo "Warning: browser-use requires Python 3.11+, you have $PYTHON_VERSION"
+    echo "Some features may not work correctly."
+    echo ""
+fi
+
+# Determine installation method
+if [ "$1" == "--uv" ] || command -v uv &> /dev/null; then
+    echo "Installing with uv..."
+    echo ""
+
+    if ! command -v uv &> /dev/null; then
+        echo "Installing uv first..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        source $HOME/.cargo/env 2>/dev/null || true
+    fi
+
+    uv pip install -r "$REQUIREMENTS_FILE"
+
+    # Install Chromium for Playwright
+    echo ""
+    echo "Installing Chromium browser..."
+    uvx playwright install chromium
+else
+    echo "Installing with pip..."
+    echo ""
+
+    pip install -r "$REQUIREMENTS_FILE"
+
+    # Install Chromium for Playwright
+    echo ""
+    echo "Installing Chromium browser..."
+    python3 -m playwright install chromium
+fi
+
+echo ""
+echo "====================================="
+echo "  Setup Complete!"
+echo "====================================="
+echo ""
+echo "Next steps:"
+echo ""
+echo "1. Set your LLM API key:"
+echo "   export OPENAI_API_KEY=sk-..."
+echo "   # or"
+echo "   export ANTHROPIC_API_KEY=sk-ant-..."
+echo ""
+echo "2. Start the browser agent:"
+echo "   agent-relay browser"
+echo ""
+echo "3. Send tasks from other agents:"
+echo "   TO: Browser"
+echo "   "
+echo "   Navigate to https://example.com and get the page title"
+echo ""


### PR DESCRIPTION
Add browser agent capability that allows any relay agent to request
web automation tasks via the browser-use Python library.

Components:
- BrowserWrapper: TypeScript wrapper that bridges Python browser-use
  with the relay protocol
- browser_agent.py: Python bridge that receives relay messages and
  executes browser automation tasks
- CLI command: `agent-relay browser` to start a browser agent
- Setup script and requirements for easy installation

Usage:
  # Start browser agent
  agent-relay browser

  # Send task from any agent
  TO: Browser

  Navigate to https://example.com and extract all links

Requires: Python 3.11+, browser-use, langchain-openai/langchain-anthropic