### PR TITLE
fix(build): Fix Turbo and TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "packageManager": "npm@10.5.1",
   "overrides": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "npm run build:server && npm run build:ui",
     "build:server": "tsc",
-    "build:ui": "cd ui && npm ci && npm run build && mv out ../ui-dist",
+    "build:ui": "cd ui && npm ci && npm run build && rm -rf ../ui-dist && mv out ../ui-dist",
     "clean": "rm -rf dist ui-dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/wrapper/src/shared.ts
+++ b/packages/wrapper/src/shared.ts
@@ -89,7 +89,7 @@ export const INJECTION_CONSTANTS = {
  */
 export class AdaptiveThrottle {
   private consecutiveFailures = 0;
-  private currentDelay = INJECTION_CONSTANTS.QUEUE_PROCESS_DELAY_MS;
+  private currentDelay: number = INJECTION_CONSTANTS.QUEUE_PROCESS_DELAY_MS;
 
   /** Get current delay in milliseconds */
   getDelay(): number {


### PR DESCRIPTION
## Summary
- Add `packageManager` field to package.json (required by Turbo 2.7.5)
- Fix TypeScript literal type error in `AdaptiveThrottle` class
- Fix dashboard ui-dist directory cleanup before move

## Test plan
- [x] `npm run build` completes successfully
- [x] `npm run dev:local` should work after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
