### PR TITLE
fix(cloud): Fix dashboard static file path resolution

### DIFF
--- a/packages/cloud/src/server.ts
+++ b/packages/cloud/src/server.ts
@@ -1306,8 +1306,9 @@ export async function createServer(): Promise<CloudServer> {
   app.use('/api', teamsRouter);
 
   // Serve static dashboard files (Next.js static export)
-  // Path: dist/cloud/server.js -> ../../src/dashboard/out
-  const dashboardPath = path.join(__dirname, '../../src/dashboard/out');
+  // Path: packages/cloud/dist/server.js -> ../../../src/dashboard/out
+  // In Docker: /app/packages/cloud/dist -> /app/src/dashboard/out
+  const dashboardPath = path.join(__dirname, '../../../src/dashboard/out');
 
   // Serve static files (JS, CSS, images, etc.)
   app.use(express.static(dashboardPath));


### PR DESCRIPTION
The dashboard path was incorrectly resolving to
/app/packages/src/dashboard/out instead of /app/src/dashboard/out in the Docker production environment.

Changed from ../../src/dashboard/out to ../../../src/dashboard/out to correctly navigate from packages/cloud/dist up to the app root.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/274">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
