### PR TITLE
feat: add force update workspaces GitHub workflow

### DIFF
--- a/.github/workflows/force-update-workspaces.yml
+++ b/.github/workflows/force-update-workspaces.yml
@@ -1,0 +1,42 @@
+name: Force Update Workspaces
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-workspaces:
+    name: Force Update Workspaces
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update workspace images
+        env:
+          CLOUD_API_URL: ${{ secrets.CLOUD_API_URL }}
+          ADMIN_API_SECRET: ${{ secrets.ADMIN_API_SECRET }}
+        run: |
+          if [ -z "$CLOUD_API_URL" ] || [ -z "$ADMIN_API_SECRET" ]; then
+            echo "❌ CLOUD_API_URL or ADMIN_API_SECRET not configured"
+            exit 1
+          fi
+
+          echo "🔄 Force updating workspaces to ghcr.io/agentworkforce/relay-workspace:latest"
+
+          # Remove trailing slash from CLOUD_API_URL if present
+          API_URL="${CLOUD_API_URL%/}"
+
+          response=$(curl -s -w "\n%{http_code}" -X POST "${API_URL}/api/admin/workspaces/update-image" \
+            -H "x-admin-secret: ${ADMIN_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"image": "ghcr.io/agentworkforce/relay-workspace:latest", "skipRestart": false}')
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "✅ Workspace update initiated successfully"
+            echo "$body" | jq . 2>/dev/null || echo "$body"
+          else
+            echo "❌ Failed to update workspaces (HTTP $http_code)"
+            echo "$body"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a manually triggered workflow to force update all running
workspaces to the latest Docker image via the admin API.

https://claude.ai/code/session_0126GPB8ZbCwpYJSqmZyNpCE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
