### PR TITLE
fix(ci): Clean reinstall node_modules after version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,8 +187,10 @@ jobs:
             }
           "
 
-      - name: Update package-lock.json and reinstall
-        run: npm install
+      - name: Clean reinstall after version bump
+        run: |
+          rm -rf node_modules packages/*/node_modules
+          npm install
 
       - name: Build all packages
         run: npm run build


### PR DESCRIPTION
After version bumping changes all package.json files, npm install may not properly re-link workspace dependencies. Delete node_modules and reinstall fresh to ensure all dependencies are correctly resolved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
