### PR TITLE
fix: correct @agent-relay/utils CJS exports for CommonJS compatibility

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,68 +3,68 @@
   "version": "2.0.29",
   "description": "Shared utilities for agent-relay: logging, name generation, command resolution, update checking",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./logger": {
       "types": "./dist/logger.d.ts",
-      "import": "./dist/logger.js",
       "require": "./dist/cjs/logger.js",
-      "default": "./dist/logger.js"
+      "import": "./dist/logger.js",
+      "default": "./dist/cjs/logger.js"
     },
     "./name-generator": {
       "types": "./dist/name-generator.d.ts",
-      "import": "./dist/name-generator.js",
       "require": "./dist/cjs/name-generator.js",
-      "default": "./dist/name-generator.js"
+      "import": "./dist/name-generator.js",
+      "default": "./dist/cjs/name-generator.js"
     },
     "./command-resolver": {
       "types": "./dist/command-resolver.d.ts",
-      "import": "./dist/command-resolver.js",
       "require": "./dist/cjs/command-resolver.js",
-      "default": "./dist/command-resolver.js"
+      "import": "./dist/command-resolver.js",
+      "default": "./dist/cjs/command-resolver.js"
     },
     "./update-checker": {
       "types": "./dist/update-checker.d.ts",
-      "import": "./dist/update-checker.js",
       "require": "./dist/cjs/update-checker.js",
-      "default": "./dist/update-checker.js"
+      "import": "./dist/update-checker.js",
+      "default": "./dist/cjs/update-checker.js"
     },
     "./git-remote": {
       "types": "./dist/git-remote.d.ts",
-      "import": "./dist/git-remote.js",
       "require": "./dist/cjs/git-remote.js",
-      "default": "./dist/git-remote.js"
+      "import": "./dist/git-remote.js",
+      "default": "./dist/cjs/git-remote.js"
     },
     "./precompiled-patterns": {
       "types": "./dist/precompiled-patterns.d.ts",
-      "import": "./dist/precompiled-patterns.js",
       "require": "./dist/cjs/precompiled-patterns.js",
-      "default": "./dist/precompiled-patterns.js"
+      "import": "./dist/precompiled-patterns.js",
+      "default": "./dist/cjs/precompiled-patterns.js"
     },
     "./error-tracking": {
       "types": "./dist/error-tracking.d.ts",
-      "import": "./dist/error-tracking.js",
       "require": "./dist/cjs/error-tracking.js",
-      "default": "./dist/error-tracking.js"
+      "import": "./dist/error-tracking.js",
+      "default": "./dist/cjs/error-tracking.js"
     },
     "./model-mapping": {
       "types": "./dist/model-mapping.d.ts",
-      "import": "./dist/model-mapping.js",
       "require": "./dist/cjs/model-mapping.js",
-      "default": "./dist/model-mapping.js"
+      "import": "./dist/model-mapping.js",
+      "default": "./dist/cjs/model-mapping.js"
     },
     "./relay-pty-path": {
       "types": "./dist/relay-pty-path.d.ts",
-      "import": "./dist/relay-pty-path.js",
       "require": "./dist/cjs/relay-pty-path.js",
-      "default": "./dist/relay-pty-path.js"
+      "import": "./dist/relay-pty-path.js",
+      "default": "./dist/cjs/relay-pty-path.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary

**Root Cause**: The Docker 18 spawn infrastructure test fails because `require('@agent-relay/utils')` receives the ES module instead of the CommonJS version.

**Issue**: `@agent-relay/utils/package.json` had:
- `"main": "dist/index.js"` (ES module)
- `"default": "./dist/index.js"` in exports (ES module)

When CommonJS code tries to `require()` the package, Node.js gets the ES module path, causing:
```
ERROR: require() of ES Module .../dist/src/index.js not supported
```

## Solution

Updated `@agent-relay/utils/package.json`:
- Changed `"main"` from `dist/index.js` → `dist/cjs/index.js`
- Reordered exports conditions: `require` before `import`
- Changed all `"default"` fields to point to `dist/cjs/*` versions

This matches the fix from PR #325 applied to the root package and ensures CommonJS compatibility.

## Testing

- [ ] Local npm install test with `require('agent-relay')`
- [ ] Docker 18 spawn infrastructure test passes
- [ ] Docker 20/22 tests pass
- [ ] Verify Node tests pass
- [ ] Linux/Docker tests pass

## Files Changed

- `packages/utils/package.json`: Updated main and exports fields for CJS compatibility

🤖 Generated with Claude Code

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
