### PR TITLE
fix: clear npm cache before reinstall in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,7 +200,9 @@ jobs:
 
       - name: Clean reinstall after version bump
         run: |
-          rm -rf node_modules packages/*/node_modules
+          # Clear npm cache and node_modules to ensure fresh platform-specific deps
+          npm cache clean --force
+          rm -rf node_modules packages/*/node_modules package-lock.json
           npm install
 
       - name: Build all packages


### PR DESCRIPTION
## Summary
- Fixes rollup optional dependency resolution issue on Linux runners
- Clears npm cache before reinstall to remove platform-incorrect cached deps
- Removes package-lock.json to force fresh resolution of optional deps

## Problem
The publish workflow was failing with:
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu
```

This happens because:
1. package-lock.json was generated on macOS
2. npm cache from setup-node action has macOS-specific optional deps
3. `npm install` uses cached deps instead of resolving fresh

## Solution
Before reinstall, clear npm cache and remove lockfile to ensure Linux-specific optional deps are properly installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
