### PR TITLE
fix: update macOS x64 runners from macos-13 to macos-15-large

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -420,7 +420,7 @@ jobs:
           - os: macos-latest
             arch: arm64
             binary: relay-pty-darwin-arm64
-          - os: macos-13
+          - os: macos-15-large  # Intel runner (macos-13 is retired)
             arch: x64
             binary: relay-pty-darwin-x64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -314,7 +314,7 @@ jobs:
         include:
           - os: macos-latest
             arch: arm64
-          - os: macos-13
+          - os: macos-15-large  # Intel runner (macos-13 is retired)
             arch: x64
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
Updates deprecated macos-13 runners to macos-15-large for Intel x64 binary verification.

## Problem
The publish workflow was being cancelled because macos-13 runners are retired:
> The macOS-13 based runner images are now retired.

## Solution
Switch to `macos-15-large` which provides Intel x64 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
