### PR TITLE
fix: use macos-12 runner for Intel x64 verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -420,7 +420,7 @@ jobs:
           - os: macos-latest
             arch: arm64
             binary: relay-pty-darwin-arm64
-          - os: macos-15-large  # Intel runner (macos-13 is retired)
+          - os: macos-12  # Intel runner (macos-13 retired, macos-12 deprecated but available)
             arch: x64
             binary: relay-pty-darwin-x64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -314,7 +314,7 @@ jobs:
         include:
           - os: macos-latest
             arch: arm64
-          - os: macos-15-large  # Intel runner (macos-13 is retired)
+          - os: macos-12  # Intel runner (macos-13 retired, macos-12 deprecated but available)
             arch: x64
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
macos-15-large is not a valid public runner. Use macos-12 instead (deprecated but available).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/332">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
