### PR TITLE
fix: global install fails with ERR_MODULE_NOT_FOUND for workspace packages

### DIFF
--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -43,7 +43,11 @@ jobs:
 
       - name: Install deps for pack (PR only)
         if: github.event_name == 'pull_request'
-        run: npm ci --ignore-scripts
+        run: npm ci
+
+      - name: Build packages (PR only)
+        if: github.event_name == 'pull_request'
+        run: npm run build
 
       - name: Pack local tarball (PR only)
         if: github.event_name == 'pull_request'
@@ -329,7 +333,11 @@ jobs:
 
       - name: Install deps for pack (PR only)
         if: github.event_name == 'pull_request'
-        run: npm ci --ignore-scripts
+        run: npm ci
+
+      - name: Build packages (PR only)
+        if: github.event_name == 'pull_request'
+        run: npm run build
 
       - name: Pack local tarball (PR only)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Fix verify-publish workflow to build packages before npm pack on PRs
- Add workspace package symlink setup in postinstall.js for global installs

## Problem
When globally installing agent-relay, the CLI fails with:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@agent-relay/daemon' imported from dist/src/cli/index.js
```

This happens because:
1. The verify-publish workflow was running `npm ci --ignore-scripts` then `npm pack` without building
2. Without building, the `packages/*/dist/` folders don't exist
3. When globally installed, Node.js can't resolve the workspace package imports

## Solution
1. Remove `--ignore-scripts` from `npm ci` in verify-publish workflow
2. Add explicit `npm run build` step before `npm pack` on PRs
3. Add `setupWorkspacePackageLinks()` in postinstall.js as a fallback to create symlinks from `node_modules/@agent-relay/*` to `packages/*` for bundled/global installs

## Test plan
- [ ] PR workflow verify-publish passes
- [ ] Global install test: `npm install -g agent-relay` then `agent-relay --version`
- [ ] npx test: `npx agent-relay --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
