### PR TITLE
Add team and spawner tracking to daemon/bridge/sdk

### DIFF
--- a/packages/bridge/src/spawner.ts
+++ b/packages/bridge/src/spawner.ts
@@ -1213,6 +1213,7 @@ export class AgentSpawner {
             cli,
             task,
             team,
+            spawnerName,
             userId,
             spawnedAt: Date.now(),
             pid: openCodeWrapper.pid,
@@ -1409,6 +1410,7 @@ export class AgentSpawner {
         cli,
         task,
         team,
+        spawnerName,
         userId,
         spawnedAt: Date.now(),
         pid: pty.pid,
@@ -1636,6 +1638,7 @@ export class AgentSpawner {
       cli: w.cli,
       task: w.task,
       team: w.team,
+      spawnerName: w.spawnerName,
       spawnedAt: w.spawnedAt,
       pid: w.pid,
     }));

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -88,6 +88,8 @@ export interface WorkerInfo {
   task: string;
   /** Optional team name this agent belongs to */
   team?: string;
+  /** Name of the agent that spawned this worker */
+  spawnerName?: string;
   spawnedAt: number;
   /** PID of the pty process */
   pid?: number;

--- a/packages/daemon/src/connection.ts
+++ b/packages/daemon/src/connection.ts
@@ -78,6 +78,7 @@ export class Connection {
   private _model?: string;
   private _task?: string;
   private _workingDirectory?: string;
+  private _team?: string;
   private _displayName?: string;
   private _avatarUrl?: string;
   private _sessionId: string;
@@ -149,6 +150,10 @@ export class Connection {
 
   get workingDirectory(): string | undefined {
     return this._workingDirectory;
+  }
+
+  get team(): string | undefined {
+    return this._team;
   }
 
   get displayName(): string | undefined {
@@ -251,6 +256,7 @@ export class Connection {
     this._model = envelope.payload.model;
     this._task = envelope.payload.task;
     this._workingDirectory = envelope.payload.workingDirectory;
+    this._team = envelope.payload.team;
     this._displayName = envelope.payload.displayName;
     this._avatarUrl = envelope.payload.avatarUrl;
 

--- a/packages/daemon/src/router.ts
+++ b/packages/daemon/src/router.ts
@@ -41,6 +41,7 @@ export interface RoutableConnection {
   model?: string;
   task?: string;
   workingDirectory?: string;
+  team?: string;
   sessionId: string;
   close(): void;
   send(envelope: Envelope): boolean;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -960,6 +960,7 @@ export class Daemon {
           model: connection.model,
           task: connection.task,
           workingDirectory: connection.workingDirectory,
+          team: connection.team,
         });
 
         // Auto-join all agents to #general channel
@@ -1348,17 +1349,24 @@ export class Daemon {
         const registryAgents = this.registry?.getAgents() ?? [];
         const registryMap = new Map(registryAgents.map(a => [a.name, a]));
 
+        // Get active workers from spawn manager for PID lookup
+        const activeWorkers = this.spawnManager?.getActiveWorkers() ?? [];
+        const workerMap = new Map(activeWorkers.map(w => [w.name, w]));
+
         // Build agent list from connected agents
         const agents = connectedAgents
           .filter(name => !this.isInternalAgent(name))
           .map(name => {
             const registryAgent = registryMap.get(name);
+            const conn = this.router.getConnection(name);
+            const worker = workerMap.get(name);
             return {
               name,
-              cli: registryAgent?.cli,
+              cli: conn?.cli ?? registryAgent?.cli,
               idle: false, // Connected agents are not idle
-              // TODO: Add proper parent tracking via spawner relationship
-              parent: undefined,
+              parent: worker?.spawnerName,
+              team: conn?.team ?? worker?.team,
+              pid: worker?.pid,
             };
           });
 
@@ -1371,6 +1379,8 @@ export class Daemon {
                 cli: agent.cli,
                 idle: true,
                 parent: undefined,
+                team: agent.team,
+                pid: undefined,
               });
             }
           }
@@ -1389,20 +1399,27 @@ export class Daemon {
 
       case 'LIST_CONNECTED_AGENTS': {
         // Returns only currently connected agents (not historical/registered agents)
-        const connectedAgents = this.router.getAgents();
+        const connectedAgentNames = this.router.getAgents();
         const registryAgents = this.registry?.getAgents() ?? [];
         const registryMap = new Map(registryAgents.map(a => [a.name, a]));
 
-        const agents = connectedAgents
+        // Get active workers from spawn manager for PID lookup
+        const workers = this.spawnManager?.getActiveWorkers() ?? [];
+        const workersByName = new Map(workers.map(w => [w.name, w]));
+
+        const agents = connectedAgentNames
           .filter(name => !this.isInternalAgent(name))
           .map(name => {
             const registryAgent = registryMap.get(name);
+            const conn = this.router.getConnection(name);
+            const worker = workersByName.get(name);
             return {
               name,
-              cli: registryAgent?.cli,
+              cli: conn?.cli ?? registryAgent?.cli,
               idle: false,
-              // TODO: Add proper parent tracking via spawner relationship
-              parent: undefined,
+              parent: worker?.spawnerName,
+              team: conn?.team ?? worker?.team,
+              pid: worker?.pid,
             };
           });
 

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -118,6 +118,8 @@ export interface HelloPayload {
   task?: string;
   /** Working directory */
   workingDirectory?: string;
+  /** Team name */
+  team?: string;
   /** Display name for human users */
   displayName?: string;
   /** Avatar URL for human users */
@@ -598,6 +600,8 @@ export interface ListAgentsResponsePayload {
     cli?: string;
     idle?: boolean;
     parent?: string;
+    team?: string;
+    pid?: number;
   }>;
 }
 
@@ -620,6 +624,8 @@ export interface ListConnectedAgentsResponsePayload {
     cli?: string;
     idle?: boolean;
     parent?: string;
+    team?: string;
+    pid?: number;
   }>;
 }
 
@@ -810,6 +816,8 @@ export interface AgentInfo {
   idle?: boolean;
   parent?: string;
   task?: string;
+  team?: string;
+  pid?: number;
   connectedAt?: number;
 }
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -83,6 +83,8 @@ export interface ClientConfig {
   task?: string;
   /** Working directory */
   workingDirectory?: string;
+  /** Team name */
+  team?: string;
   /** Display name for human users */
   displayName?: string;
   /** Avatar URL for human users */
@@ -1082,6 +1084,7 @@ export class RelayClient {
         model: this.config.model,
         task: this.config.task,
         workingDirectory: this.config.workingDirectory,
+        team: this.config.team,
         displayName: this.config.displayName,
         avatarUrl: this.config.avatarUrl,
         capabilities: {


### PR DESCRIPTION
Introduce team and spawnerName propagation across bridge, daemon, protocol, and SDK to surface agent parent/team/pid metadata. Key changes:

- Bridge: include spawnerName in WorkerInfo and attach it when spawning workers.
- Protocol: extend Hello and agent/list response types to include team and pid fields.
- SDK: send config.team in Hello payload.
- Daemon: track connection.team on Connection and RoutableConnection; use spawnManager.getActiveWorkers() to enrich agent lists with parent (spawnerName), team and pid; prefer live connection values (cli/team) when available and fall back to registry data.

These updates allow the system to report which agent spawned a worker, the worker PID, and team membership in agent listings and connection handshake data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/348">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
