### PR TITLE
fix: sync devDependencies in publish workflow version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -355,11 +355,13 @@ jobs:
             const path = require('path');
             const version = '$NEW_VERSION';
 
-            // Update root package internal dependencies
+            // Update root package internal dependencies (both regular and dev)
             const rootPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            for (const dep of Object.keys(rootPkg.dependencies || {})) {
-              if (dep.startsWith('@agent-relay/')) {
-                rootPkg.dependencies[dep] = version;
+            for (const depType of ['dependencies', 'devDependencies']) {
+              for (const dep of Object.keys(rootPkg[depType] || {})) {
+                if (dep.startsWith('@agent-relay/')) {
+                  rootPkg[depType][dep] = version;
+                }
               }
             }
             fs.writeFileSync('package.json', JSON.stringify(rootPkg, null, 2) + '\n');
@@ -376,10 +378,12 @@ jobs:
                 console.log('@agent-relay/' + dir);
                 console.log('v' + version);
 
-                // Update internal dependencies
-                for (const dep of Object.keys(pkg.dependencies || {})) {
-                  if (dep.startsWith('@agent-relay/')) {
-                    pkg.dependencies[dep] = version;
+                // Update internal dependencies (both regular and dev)
+                for (const depType of ['dependencies', 'devDependencies']) {
+                  for (const dep of Object.keys(pkg[depType] || {})) {
+                    if (dep.startsWith('@agent-relay/')) {
+                      pkg[depType][dep] = version;
+                    }
                   }
                 }
                 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');


### PR DESCRIPTION
## Summary
- Fix publish workflow to sync `devDependencies` in addition to `dependencies` during version bumps

## Problem
The version sync script in `.github/workflows/publish.yml` only updated `dependencies` but not `devDependencies`. This caused the staging build to fail when `@agent-relay/mcp` (which has `@agent-relay/sdk` as a devDependency) couldn't find the `setWorkerModel` method - npm was resolving to the older published version (2.1.22) instead of the workspace version.

## Solution
Updated both the root package and sub-package version sync loops to iterate over both `dependencies` and `devDependencies`.

## Test plan
- [ ] Re-run the publish workflow on staging to verify the build passes
- [ ] Verify that `@agent-relay/mcp` can now access the `setWorkerModel` method from the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
