### PR TITLE
fix: pass all spawn fields through SDK client to daemon

### DIFF
--- a/packages/wrapper/src/client.ts
+++ b/packages/wrapper/src/client.ts
@@ -713,6 +713,16 @@ export class RelayClient {
     task: string;
     model?: string;
     cwd?: string;
+    team?: string;
+    interactive?: boolean;
+    spawnerName?: string;
+    userId?: string;
+    includeWorkflowConventions?: boolean;
+    shadowMode?: 'subagent' | 'process';
+    shadowOf?: string;
+    shadowAgent?: string;
+    shadowTriggers?: SpeakOnTrigger[];
+    shadowSpeakOn?: SpeakOnTrigger[];
   }): Promise<SpawnResult> {
     if (this._state !== 'READY') {
       return { success: false, error: 'Client not ready' };
@@ -725,7 +735,16 @@ export class RelayClient {
         task: options.task,
         model: options.model,
         cwd: options.cwd,
-        spawnerName: this.config.agentName,
+        team: options.team,
+        interactive: options.interactive,
+        spawnerName: options.spawnerName || this.config.agentName,
+        userId: options.userId,
+        includeWorkflowConventions: options.includeWorkflowConventions,
+        shadowMode: options.shadowMode,
+        shadowOf: options.shadowOf,
+        shadowAgent: options.shadowAgent,
+        shadowTriggers: options.shadowTriggers,
+        shadowSpeakOn: options.shadowSpeakOn,
       };
 
       const result = await this.requestResponse<SpawnResultPayload>(


### PR DESCRIPTION
## Summary
- The SDK client's `spawn()` method was only forwarding `name`, `cli`, `task`, `model`, `cwd`, and `spawnerName` to the daemon protocol payload
- All other `SpawnPayload` fields (`interactive`, `team`, `userId`, `shadowMode`, `shadowOf`, `shadowAgent`, `shadowTriggers`, `shadowSpeakOn`, `includeWorkflowConventions`) were silently dropped
- This caused `--dangerously-skip-permissions` to always be added for Claude agents in cloud workspaces, because `interactive: true` from the cloud API never reached the bridge spawner — the spawner saw `interactive: undefined`, treated it as falsy, and added the flag

## Test plan
- [ ] Deploy to staging workspace and verify Claude agents spawn without the bypass permissions prompt
- [ ] Verify shadow agent spawning still works (shadowMode, shadowOf, etc. now forwarded)
- [ ] Verify team assignment works for daemon-routed spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
