### PR TITLE
feat(ci): add lightweight prerelease CLI workflow

### DIFF
--- a/.github/workflows/prerelease-cli.yml
+++ b/.github/workflows/prerelease-cli.yml
@@ -1,0 +1,174 @@
+name: Prerelease CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - prerelease
+          - prepatch
+          - preminor
+        default: "prerelease"
+      preid:
+        description: "Prerelease identifier"
+        required: true
+        type: choice
+        options:
+          - beta
+          - alpha
+          - rc
+          - next
+        default: "beta"
+      tag:
+        description: "NPM dist-tag"
+        required: true
+        type: choice
+        options:
+          - beta
+          - next
+          - alpha
+        default: "beta"
+      dry_run:
+        description: "Dry run (do not actually publish)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-package
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  NPM_CONFIG_FUND: false
+
+jobs:
+  publish:
+    name: Prerelease CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure rollup optional dependencies are installed
+        run: npm install --no-save rollup || true
+
+      - name: Version bump
+        id: bump
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+
+          npm version "${{ github.event.inputs.version }}" --no-git-tag-version --preid="${{ github.event.inputs.preid }}"
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+          # Sync all sub-package versions (needed for internal dependency resolution)
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const version = '$NEW_VERSION';
+            const rootPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            for (const depType of ['dependencies', 'devDependencies']) {
+              for (const dep of Object.keys(rootPkg[depType] || {})) {
+                if (dep.startsWith('@agent-relay/')) {
+                  rootPkg[depType][dep] = version;
+                }
+              }
+            }
+            fs.writeFileSync('package.json', JSON.stringify(rootPkg, null, 2) + '\n');
+            const packagesDir = 'packages';
+            for (const dir of fs.readdirSync(packagesDir)) {
+              const pkgPath = path.join(packagesDir, dir, 'package.json');
+              if (fs.existsSync(pkgPath)) {
+                const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+                pkg.version = version;
+                for (const depType of ['dependencies', 'devDependencies']) {
+                  for (const dep of Object.keys(pkg[depType] || {})) {
+                    if (dep.startsWith('@agent-relay/')) {
+                      pkg[depType][dep] = version;
+                    }
+                  }
+                }
+                fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+              }
+            }
+          "
+
+      - name: Clean reinstall after version bump
+        run: |
+          npm cache clean --force
+          rm -rf node_modules packages/*/node_modules package-lock.json
+          npm install
+
+      - name: Ensure rollup optional dependencies are installed
+        run: npm install --no-save rollup || true
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "Dry run - would publish agent-relay@${{ steps.bump.outputs.new_version }}"
+          npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish to NPM
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          npm install -g npm@latest
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Tag and push
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add package.json package-lock.json packages/*/package.json
+          git commit -m "chore(prerelease): v${NEW_VERSION}" || true
+          git tag -a "v${NEW_VERSION}" -m "Prerelease v${NEW_VERSION}"
+          git push origin HEAD:staging
+          git push origin "v${NEW_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "## CLI Prerelease Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: \`${{ steps.bump.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**NPM Tag**: \`${{ github.event.inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Dry Run**: \`${{ github.event.inputs.dry_run }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Install" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "npm install -g agent-relay@${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "# or by tag:" >> $GITHUB_STEP_SUMMARY
+          echo "npm install -g agent-relay@${{ github.event.inputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> Only the main \`agent-relay\` CLI package was published. Sub-packages and binaries were **not** updated." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds a new `Prerelease CLI` GitHub Actions workflow for publishing only the main `agent-relay` CLI package
- Skips Rust binary builds, standalone binary builds, and full verification — much faster than the full release pipeline
- Supports workflow_dispatch with inputs for version bump type (prerelease/prepatch/preminor), preid (beta/alpha/rc/next), npm dist-tag, and dry run

## Test plan
- [ ] Trigger the workflow manually from GitHub Actions with `dry_run: true` to verify it runs end-to-end
- [ ] Publish a real beta prerelease and verify it appears on npm with the correct tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
