### PR TITLE
fix(ci): re-setup npm registry auth in prerelease workflow

### DIFF
--- a/.github/workflows/prerelease-cli.yml
+++ b/.github/workflows/prerelease-cli.yml
@@ -123,6 +123,13 @@ jobs:
           rm -rf node_modules packages/*/node_modules package-lock.json
           npm install
 
+      # Re-setup Node.js registry auth (clean reinstall clobbers .npmrc)
+      - name: Re-setup Node.js registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Ensure rollup optional dependencies are installed
         run: npm install --no-save rollup || true
 
@@ -132,6 +139,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         run: |
@@ -140,9 +150,7 @@ jobs:
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
-        run: |
-          npm install -g npm@latest
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
       - name: Tag and push
         if: github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Summary
- Re-run `actions/setup-node` after the clean reinstall step to restore `.npmrc` with OIDC registry auth
- Move `npm install -g npm@latest` to its own step before publish (matching the main publish workflow pattern)
- Fixes "Access token expired or revoked" / 404 error when publishing prereleases

## Test plan
- [ ] Trigger "Prerelease CLI" workflow with `dry_run: true` to verify npm auth works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
