### PR TITLE
fix(ci): fix npm auth in prerelease CLI workflow

### DIFF
--- a/.github/workflows/prerelease-cli.yml
+++ b/.github/workflows/prerelease-cli.yml
@@ -123,13 +123,6 @@ jobs:
           rm -rf node_modules packages/*/node_modules package-lock.json
           npm install
 
-      # Re-setup Node.js registry auth (clean reinstall clobbers .npmrc)
-      - name: Re-setup Node.js registry
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Ensure rollup optional dependencies are installed
         run: npm install --no-save rollup || true
 
@@ -138,6 +131,14 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Re-setup registry auth immediately before publish (matching publish.yml pattern).
+      # npm ci / npm install / build / test can clobber the .npmrc that setup-node creates.
+      - name: Setup registry for publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- Move `setup-node` with `registry-url` to **immediately before** `npm publish`, matching the `publish.yml` pattern exactly
- The previous placement had `npm install`, build, and test steps between `setup-node` and `npm publish` which clobber the `.npmrc` OIDC auth
- Pattern now matches publish.yml: `setup-node` → `npm install -g npm@latest` → `npm publish` with nothing in between

## Test plan
- [ ] Trigger "Prerelease CLI" workflow with `dry_run: true` to verify npm auth works
- [ ] Publish a real beta prerelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
