### PR TITLE
Add workflow to track GitHub stars in PostHog

### DIFF
--- a/.github/workflows/github-stars-posthog.yml
+++ b/.github/workflows/github-stars-posthog.yml
@@ -1,0 +1,78 @@
+name: Track GitHub Stars in PostHog
+
+on:
+  schedule:
+    # Every 6 hours
+    - cron: "15 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-stars-posthog
+  cancel-in-progress: false
+
+jobs:
+  capture-stars:
+    name: Capture GitHub stars snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch repository metrics and send snapshot to PostHog
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${POSTHOG_PROJECT_API_KEY:-}" ]; then
+            echo "POSTHOG_PROJECT_API_KEY is not set. Add it as a repository secret."
+            exit 1
+          fi
+
+          posthog_api_key="${POSTHOG_PROJECT_API_KEY}"
+          posthog_host="https://us.i.posthog.com"
+          github_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY_NAME}"
+
+          repo_json="$(curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "User-Agent: agent-relay-stars-tracker" \
+            "${github_api_url}")"
+
+          stars="$(echo "${repo_json}" | jq -r '.stargazers_count')"
+          forks="$(echo "${repo_json}" | jq -r '.forks_count')"
+          open_issues="$(echo "${repo_json}" | jq -r '.open_issues_count')"
+          subscribers="$(echo "${repo_json}" | jq -r '.subscribers_count')"
+          captured_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          payload="$(jq -n \
+            --arg api_key "${posthog_api_key}" \
+            --arg event "github_repo_stars_snapshot" \
+            --arg distinct_id "github_repo:${GITHUB_REPOSITORY_NAME}" \
+            --arg repo "${GITHUB_REPOSITORY_NAME}" \
+            --arg captured_at "${captured_at}" \
+            --argjson star_count "${stars}" \
+            --argjson fork_count "${forks}" \
+            --argjson open_issue_count "${open_issues}" \
+            --argjson subscriber_count "${subscribers}" \
+            '{
+              api_key: $api_key,
+              event: $event,
+              distinct_id: $distinct_id,
+              timestamp: $captured_at,
+              properties: {
+                source: "github_actions",
+                repository: $repo,
+                star_count: $star_count,
+                fork_count: $fork_count,
+                open_issue_count: $open_issue_count,
+                subscriber_count: $subscriber_count
+              }
+            }'
+          )"
+
+          curl -fsSL -X POST "${posthog_host}/capture/" \
+            -H "Content-Type: application/json" \
+            -d "${payload}"
+
+          echo "Sent github_repo_stars_snapshot for ${GITHUB_REPOSITORY_NAME} (star_count=${stars})"

--- a/.trajectories/completed/2026-02/traj_qeucn3159q6x.json
+++ b/.trajectories/completed/2026-02/traj_qeucn3159q6x.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_qeucn3159q6x",
+  "version": 1,
+  "task": {
+    "title": "Require PostHog key as GitHub secret for stars tracking"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-12T02:58:20.021Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-12T02:58:38.839Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_y3oyydgygp34",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-12T02:58:38.839Z",
+      "events": [
+        {
+          "ts": 1770865118840,
+          "type": "decision",
+          "content": "Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow: Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow",
+          "raw": {
+            "question": "Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow",
+            "chosen": "Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow",
+            "alternatives": [],
+            "reasoning": "Prevents easy misuse when the workflow is copied/forked and keeps tracking configuration explicit per repository"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-12T02:58:39.017Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8",
+    "endRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8"
+  },
+  "completedAt": "2026-02-12T02:58:39.017Z",
+  "retrospective": {
+    "summary": "Updated stars workflow to require POSTHOG_PROJECT_API_KEY secret and updated README setup steps",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  }
+}

--- a/.trajectories/completed/2026-02/traj_qeucn3159q6x.md
+++ b/.trajectories/completed/2026-02/traj_qeucn3159q6x.md
@@ -1,0 +1,31 @@
+# Trajectory: Require PostHog key as GitHub secret for stars tracking
+
+> **Status:** ✅ Completed
+> **Confidence:** 94%
+> **Started:** February 11, 2026 at 09:58 PM
+> **Completed:** February 11, 2026 at 09:58 PM
+
+---
+
+## Summary
+
+Updated stars workflow to require POSTHOG_PROJECT_API_KEY secret and updated README setup steps
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow
+- **Chose:** Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow
+- **Reasoning:** Prevents easy misuse when the workflow is copied/forked and keeps tracking configuration explicit per repository
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow: Require POSTHOG_PROJECT_API_KEY as GitHub secret for stars workflow

--- a/.trajectories/completed/2026-02/traj_xxcra8ywee78.json
+++ b/.trajectories/completed/2026-02/traj_xxcra8ywee78.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_xxcra8ywee78",
+  "version": 1,
+  "task": {
+    "title": "Force default PostHog host for stars tracking"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-13T03:18:03.210Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-13T03:18:21.060Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_jmyiuwysegfr",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-13T03:18:21.060Z",
+      "events": [
+        {
+          "ts": 1770952701061,
+          "type": "decision",
+          "content": "Hardcode PostHog host to US ingest for stars workflow: Hardcode PostHog host to US ingest for stars workflow",
+          "raw": {
+            "question": "Hardcode PostHog host to US ingest for stars workflow",
+            "chosen": "Hardcode PostHog host to US ingest for stars workflow",
+            "alternatives": [],
+            "reasoning": "User requested fixed default host; removing host override keeps configuration simple and consistent"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-13T03:18:21.245Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8",
+    "endRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8"
+  },
+  "completedAt": "2026-02-13T03:18:21.245Z",
+  "retrospective": {
+    "summary": "Removed POSTHOG_HOST override and set stars workflow to always post to https://us.i.posthog.com; updated README setup steps",
+    "approach": "Standard approach",
+    "confidence": 0.97
+  }
+}

--- a/.trajectories/completed/2026-02/traj_xxcra8ywee78.md
+++ b/.trajectories/completed/2026-02/traj_xxcra8ywee78.md
@@ -1,0 +1,31 @@
+# Trajectory: Force default PostHog host for stars tracking
+
+> **Status:** ✅ Completed
+> **Confidence:** 97%
+> **Started:** February 12, 2026 at 10:18 PM
+> **Completed:** February 12, 2026 at 10:18 PM
+
+---
+
+## Summary
+
+Removed POSTHOG_HOST override and set stars workflow to always post to https://us.i.posthog.com; updated README setup steps
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Hardcode PostHog host to US ingest for stars workflow
+- **Chose:** Hardcode PostHog host to US ingest for stars workflow
+- **Reasoning:** User requested fixed default host; removing host override keeps configuration simple and consistent
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Hardcode PostHog host to US ingest for stars workflow: Hardcode PostHog host to US ingest for stars workflow

--- a/.trajectories/completed/2026-02/traj_yo9tijj0e8sn.json
+++ b/.trajectories/completed/2026-02/traj_yo9tijj0e8sn.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_yo9tijj0e8sn",
+  "version": 1,
+  "task": {
+    "title": "Track GitHub stars in PostHog"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-12T02:55:15.064Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-12T02:55:48.743Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_d6zaufarl601",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-12T02:55:48.743Z",
+      "events": [
+        {
+          "ts": 1770864948745,
+          "type": "decision",
+          "content": "Use a daily GitHub Action snapshot to send star counts to PostHog: Use a daily GitHub Action snapshot to send star counts to PostHog",
+          "raw": {
+            "question": "Use a daily GitHub Action snapshot to send star counts to PostHog",
+            "chosen": "Use a daily GitHub Action snapshot to send star counts to PostHog",
+            "alternatives": [],
+            "reasoning": "No webhook backend required; simple, reliable time-series metric with minimal maintenance"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-12T02:56:30.520Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8",
+    "endRef": "9a7ba4ea8f429f540a330de83d836dd694fd06e8"
+  },
+  "completedAt": "2026-02-12T02:56:30.520Z",
+  "retrospective": {
+    "summary": "Added scheduled GitHub Action to capture repository star snapshots into PostHog and documented required secrets and event schema in README",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-02/traj_yo9tijj0e8sn.md
+++ b/.trajectories/completed/2026-02/traj_yo9tijj0e8sn.md
@@ -1,0 +1,31 @@
+# Trajectory: Track GitHub stars in PostHog
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** February 11, 2026 at 09:55 PM
+> **Completed:** February 11, 2026 at 09:56 PM
+
+---
+
+## Summary
+
+Added scheduled GitHub Action to capture repository star snapshots into PostHog and documented required secrets and event schema in README
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use a daily GitHub Action snapshot to send star counts to PostHog
+- **Chose:** Use a daily GitHub Action snapshot to send star counts to PostHog
+- **Reasoning:** No webhook backend required; simple, reliable time-series metric with minimal maintenance
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use a daily GitHub Action snapshot to send star counts to PostHog: Use a daily GitHub Action snapshot to send star counts to PostHog

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-02-06T08:42:23.316Z",
+  "lastUpdated": "2026-02-13T03:18:21.324Z",
   "trajectories": {
     "traj_1b1dj40sl6jl": {
       "title": "Revert aggressive retry logic in relay-pty-orchestrator",
@@ -253,6 +253,27 @@
       "startedAt": "2026-02-06T08:33:52.113Z",
       "completedAt": "2026-02-06T08:42:23.268Z",
       "path": "/Users/khaliqgant/Projects/agent-workforce/relay/.trajectories/completed/2026-02/traj_fjarwwxhil8i.json"
+    },
+    "traj_yo9tijj0e8sn": {
+      "title": "Track GitHub stars in PostHog",
+      "status": "completed",
+      "startedAt": "2026-02-12T02:55:15.064Z",
+      "completedAt": "2026-02-12T02:56:30.520Z",
+      "path": "/Users/will/Projects/relay/.trajectories/completed/2026-02/traj_yo9tijj0e8sn.json"
+    },
+    "traj_qeucn3159q6x": {
+      "title": "Require PostHog key as GitHub secret for stars tracking",
+      "status": "completed",
+      "startedAt": "2026-02-12T02:58:20.021Z",
+      "completedAt": "2026-02-12T02:58:39.017Z",
+      "path": "/Users/will/Projects/relay/.trajectories/completed/2026-02/traj_qeucn3159q6x.json"
+    },
+    "traj_xxcra8ywee78": {
+      "title": "Force default PostHog host for stars tracking",
+      "status": "completed",
+      "startedAt": "2026-02-13T03:18:03.210Z",
+      "completedAt": "2026-02-13T03:18:21.245Z",
+      "path": "/Users/will/Projects/relay/.trajectories/completed/2026-02/traj_xxcra8ywee78.json"
     }
   }
 }


### PR DESCRIPTION
Add a scheduled GitHub Actions workflow (runs every 6 hours) that fetches repository metrics and posts a github_repo_stars_snapshot event to PostHog (US ingest). The action collects stargazers, forks, open issues, and subscribers, requires the POSTHOG_PROJECT_API_KEY repository secret, and uses curl/jq to build and send the payload to https://us.i.posthog.com. Also add completed trajectory metadata files and update .trajectories/index.json with three new trajectories and an updated lastUpdated timestamp.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
