### PR TITLE
fix: bundle Rust broker binary for SDK programmatic usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,64 @@ jobs:
           path: bin/${{ matrix.binary_name }}
           retention-days: 1
 
+  # Build Rust broker binary for all platforms (needed by SDK's AgentRelayClient)
+  build-broker:
+    name: Build broker (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main'
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: agent-relay-broker-darwin-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary_name: agent-relay-broker-darwin-x64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_name: agent-relay-broker-linux-x64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary_name: agent-relay-broker-linux-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: broker-${{ matrix.target }}
+
+      - name: Build broker binary
+        run: cargo build --release --bin agent-relay --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      - name: Copy binary with platform name
+        run: |
+          mkdir -p release-binaries
+          cp target/${{ matrix.target }}/release/agent-relay release-binaries/${{ matrix.binary_name }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.binary_name }}
+          path: release-binaries/${{ matrix.binary_name }}
+          retention-days: 1
+
   # Build standalone binaries using bun compile (cross-platform, no Node.js required)
   build-standalone:
     name: Build standalone (${{ matrix.target }})
@@ -899,7 +957,7 @@ jobs:
   # Create git tag and release
   create-release:
     name: Create Release
-    needs: [build, build-binaries, build-standalone, build-acp-standalone, verify-binaries, publish-main]
+    needs: [build, build-binaries, build-broker, build-standalone, build-acp-standalone, verify-binaries, publish-main]
     runs-on: ubuntu-latest
     if: |
       always() &&
@@ -938,6 +996,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: relay-acp-*
+          path: release-binaries/
+          merge-multiple: true
+
+      - name: Download broker binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: agent-relay-broker-*
           path: release-binaries/
           merge-multiple: true
 
@@ -1066,6 +1131,13 @@ jobs:
             - `relay-pty-darwin-x64` - macOS Intel
             - `relay-pty-darwin-arm64` - macOS Apple Silicon
 
+            ### Broker binaries (SDK programmatic usage)
+            Rust broker binary for `new AgentRelay()` / workflow orchestration:
+            - `agent-relay-broker-linux-x64` - Linux x86_64
+            - `agent-relay-broker-linux-arm64` - Linux ARM64
+            - `agent-relay-broker-darwin-x64` - macOS Intel
+            - `agent-relay-broker-darwin-arm64` - macOS Apple Silicon
+
             ### relay-acp binaries (Zed editor integration)
             ACP bridge for Zed editor:
             - `relay-acp-linux-x64` - Linux x86_64
@@ -1138,7 +1210,7 @@ jobs:
 
   summary:
     name: Summary
-    needs: [build, build-binaries, build-standalone, build-acp-standalone, verify-binaries, verify-standalone-linux, verify-standalone-macos, verify-acp-linux, verify-acp-macos, publish-packages, publish-main, verify-publish]
+    needs: [build, build-binaries, build-broker, build-standalone, build-acp-standalone, verify-binaries, verify-standalone-linux, verify-standalone-macos, verify-acp-linux, verify-acp-macos, publish-packages, publish-main, verify-publish]
     runs-on: ubuntu-latest
     if: always()
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -359,7 +359,8 @@ async function installRelayPtyBinary() {
 
 /**
  * Get the platform-specific binary name for the broker binary.
- * The broker binary is needed by the SDK (packages/broker-sdk) for programmatic
+ * The broker binary is the Rust-compiled broker (not the Bun-compiled CLI).
+ * It is needed by the SDK (packages/broker-sdk) for programmatic
  * agent orchestration via `new AgentRelay()`.
  * Returns null if platform is not supported.
  */
@@ -377,7 +378,8 @@ function getBrokerBinaryName() {
     return null;
   }
 
-  return `agent-relay-${targetPlatform}-${targetArch}`;
+  // Use the broker-specific release asset name (Rust binary, not Bun CLI)
+  return `agent-relay-broker-${targetPlatform}-${targetArch}`;
 }
 
 /**
@@ -399,12 +401,18 @@ async function installBrokerBinary() {
   const binaryFilename = isWindows ? 'agent-relay.exe' : 'agent-relay';
   const targetPath = path.join(sdkBinDir, binaryFilename);
 
-  // 1. Already installed?
+  // 1. Already installed? Verify it's the Rust broker (supports --name flag)
   if (fs.existsSync(targetPath)) {
     try {
-      execSync(`"${targetPath}" init --help`, { stdio: 'pipe' });
-      info('Broker binary already installed in SDK');
-      return true;
+      const helpOutput = execSync(`"${targetPath}" init --help`, { stdio: 'pipe' }).toString();
+      // The Rust broker shows "--name <NAME>" in init --help
+      // The Bun-compiled Node.js CLI shows "First-time setup wizard"
+      if (helpOutput.includes('--name')) {
+        info('Broker binary already installed in SDK (Rust broker verified)');
+        return true;
+      }
+      // Wrong binary (Bun CLI instead of Rust broker) — reinstall
+      warn('Broker binary exists but is the CLI, not the Rust broker — reinstalling');
     } catch {
       // Binary exists but doesn't work — reinstall
     }
@@ -433,17 +441,19 @@ async function installBrokerBinary() {
     }
   }
 
-  // 3. Dev fallback — check for local Rust build
-  const debugBinary = path.join(pkgRoot, 'target', 'debug', binaryFilename);
-  if (fs.existsSync(debugBinary)) {
-    try {
-      fs.copyFileSync(debugBinary, targetPath);
-      fs.chmodSync(targetPath, 0o755);
-      resignBinaryForMacOS(targetPath);
-      success('Installed broker binary from local Rust debug build');
-      return true;
-    } catch (err) {
-      warn(`Failed to copy debug broker binary: ${err.message}`);
+  // 3. Dev fallback — check for local Rust build (release first, then debug)
+  for (const profile of ['release', 'debug']) {
+    const localBinary = path.join(pkgRoot, 'target', profile, binaryFilename);
+    if (fs.existsSync(localBinary)) {
+      try {
+        fs.copyFileSync(localBinary, targetPath);
+        fs.chmodSync(targetPath, 0o755);
+        resignBinaryForMacOS(targetPath);
+        success(`Installed broker binary from local Rust ${profile} build`);
+        return true;
+      } catch (err) {
+        warn(`Failed to copy ${profile} broker binary: ${err.message}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- The SDK's `AgentRelayClient` spawns `agent-relay init --name broker --channels <channel>` which requires the **Rust broker binary**, not the Bun-compiled Node.js CLI
- The publish workflow was uploading the CLI as `agent-relay-{platform}-{arch}` and `postinstall.js` was downloading it into `sdk-ts/bin/`, causing **"broker exited (code=1)"** for all workflow runs
- Additionally, the Rust broker requires a Relaycast workspace API key but there was no auto-provisioning, requiring manual `RELAY_API_KEY` setup

## Changes

### CI: Add `build-broker` job (`publish.yml`)
- Builds the Rust broker from `src/main.rs` via `cargo build --release` for all 4 platforms
- Uploads as `agent-relay-broker-{platform}-{arch}` (distinct from CLI's `agent-relay-{platform}-{arch}`)
- Adds broker binaries to GitHub release assets

### Postinstall: Download correct binary (`postinstall.js`)
- `getBrokerBinaryName()` now returns `agent-relay-broker-{platform}-{arch}` instead of `agent-relay-{platform}-{arch}`
- Adds validation to distinguish the Rust broker from the Bun CLI (checks for `--name` flag in `init --help`)
- Checks `target/release` before `target/debug` in dev fallback

### WorkflowRunner: Auto-provision Relaycast (`runner.ts`)
- `ensureRelaycastApiKey()` runs before broker startup
- Resolution order: `RELAY_API_KEY` env var → cached `~/.agent-relay/relaycast.json` → auto-create workspace
- Auto-created workspaces use unique names (`relay-{channel}-{hex}`) to avoid 409 conflicts

## Test plan
- [ ] Verify `npm run build` passes (sdk-ts compiles cleanly)
- [ ] Verify postinstall detects wrong binary and reinstalls
- [ ] Run `agent-relay run workflows/example.yaml` — broker should start without manual API key setup
- [ ] Verify CI `build-broker` job produces valid Rust binaries for all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
