### PR TITLE
chore(ci): auto-generate CHANGELOG on stable release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1214,6 +1214,7 @@ jobs:
           lines.push('');
           lines.push('---');
           lines.push('');
+          lines.push('');
 
           const newEntry = lines.join('\n');
           const changelog = readFileSync('CHANGELOG.md', 'utf-8');


### PR DESCRIPTION
## Summary

- Adds `Setup Node.js for changelog` and `Generate changelog entry` steps to the `create-release` job in `.github/workflows/publish.yml`
- On each stable release, parses conventional commits since the last tag and generates a versioned CHANGELOG entry in relay's format
- Skips automatically for prereleases

## How it works

A Node.js script maps conventional commit types to relay's Product/Technical Perspective sections:

| Commit prefix | Section |
|---|---|
| `feat:` | Product → User-Facing Features & Improvements |
| `fix:` | Product → User-Impacting Fixes |
| `refactor:/perf:/build:` | Technical → Architecture & API Changes |
| `test:/ci:` | Technical → Performance & Reliability |
| `chore:` | Technical → Dependencies & Tooling |

The new entry is inserted after `## [Unreleased]` and before the previous versioned release, so hand-curated `[Unreleased]` content remains intact.

`CHANGELOG.md` is included in the version bump commit so it ships with every release.

## Test plan

- [ ] Trigger a dry-run publish to confirm the changelog step runs without errors
- [ ] Verify the generated entry format matches the existing `## [2.1.x]` entries
- [ ] Confirm prereleases skip changelog generation cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
