### PR TITLE
Handle undefined bridge config content in tests

### DIFF
--- a/packages/config/src/bridge-config.test.ts
+++ b/packages/config/src/bridge-config.test.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import {
+  loadBridgeConfig,
   resolvePath,
   getDefaultLeadName,
   resolveProjects,
@@ -62,6 +63,18 @@ describe('Bridge Config', () => {
   });
 
   describe('resolveProjects', () => {
+    it('ignores non-string config file content', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(undefined as unknown as string);
+
+      const config = loadBridgeConfig();
+
+      expect(config).toBeNull();
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
     it('creates project configs from CLI paths', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
 

--- a/packages/config/src/bridge-config.ts
+++ b/packages/config/src/bridge-config.ts
@@ -42,7 +42,16 @@ export function loadBridgeConfig(): BridgeConfigFile | null {
     if (fs.existsSync(configPath)) {
       try {
         const content = fs.readFileSync(configPath, 'utf-8');
-        return JSON.parse(content);
+        if (typeof content !== 'string') {
+          continue;
+        }
+
+        const trimmed = content.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        return JSON.parse(trimmed);
       } catch (err) {
         console.error(`[bridge] Failed to parse ${configPath}:`, err);
       }


### PR DESCRIPTION
## Summary
- make  skip non-string and empty file content before JSON parsing
- prevent noisy parse errors when mocked fs returns undefined in tests
- add a regression test to ensure non-string bridge config content is ignored without logging parse errors

## Validation
- ran 
> @agent-relay/config@2.3.14 test
> vitest run


 RUN  v3.2.4 /Users/will/Projects/relay/packages/config

 ✓ src/relay-config.test.ts (4 tests) 2ms
 ✓ src/bridge-config.test.ts (11 tests) 5ms
 ✓ src/agent-config.test.ts (16 tests) 16ms
 ✓ src/schemas.test.ts (7 tests) 3ms
 ✓ src/relay-file-writer.test.ts (27 tests) 32ms

 Test Files  5 passed (5)
      Tests  65 passed (65)
   Start at  08:58:29
   Duration  299ms (transform 172ms, setup 0ms, collect 287ms, tests 58ms, environment 0ms, prepare 294ms)
- all tests pass (65/65)
