### PR TITLE
fix: include broker binary in all SDK publish paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
   build-broker:
     name: Build broker (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
-    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main'
+    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main' || github.event.inputs.package == 'sdk'
     strategy:
       matrix:
         include:
@@ -430,7 +430,7 @@ jobs:
   # Publish all packages in parallel (npm publish doesn't need deps published first)
   publish-packages:
     name: Publish ${{ matrix.package }}
-    needs: build
+    needs: [build, build-broker]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'all'
     strategy:
@@ -465,6 +465,18 @@ jobs:
         with:
           name: build-output
           path: .
+
+      - name: Download broker binaries (SDK only)
+        if: matrix.package == 'sdk'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: agent-relay-broker-*
+          path: packages/sdk/bin/
+          merge-multiple: true
+
+      - name: Make broker binaries executable (SDK only)
+        if: matrix.package == 'sdk'
+        run: chmod +x packages/sdk/bin/agent-relay-broker-*
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

- Add `sdk` to `build-broker` job's `if` condition so broker builds actually run for standalone SDK publishes
- Add broker binary download steps to `publish-packages` matrix job (conditional on `matrix.package == 'sdk'`) so `package: all` also ships fresh binaries
- `publish-sdk-only` already had the download steps from #461, but was dead because `build-broker` was skipped for `package == 'sdk'`

Fixes the issue where every SDK publish shipped a stale broker binary checked into `packages/sdk/bin/`.

## Test plan

- [ ] Publish with `package: all` — verify "Publish sdk" job shows "Download broker binaries" step
- [ ] Publish with `package: sdk` — verify `publish-sdk-only` runs (not skipped) and downloads binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
