### PR TITLE
fix: resolve platform-specific broker binary in SDK

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -476,7 +476,10 @@ jobs:
 
       - name: Make broker binaries executable (SDK only)
         if: matrix.package == 'sdk'
-        run: chmod +x packages/sdk/bin/agent-relay-broker-*
+        run: |
+          chmod +x packages/sdk/bin/agent-relay-broker-*
+          # Remove stale generic binary — SDK resolves platform-specific names at runtime
+          rm -f packages/sdk/bin/agent-relay-broker
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest
@@ -524,7 +527,10 @@ jobs:
           merge-multiple: true
 
       - name: Make broker binaries executable
-        run: chmod +x packages/sdk/bin/agent-relay-broker-*
+        run: |
+          chmod +x packages/sdk/bin/agent-relay-broker-*
+          # Remove stale generic binary — SDK resolves platform-specific names at runtime
+          rm -f packages/sdk/bin/agent-relay-broker
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

The CI publish was downloading fresh platform-specific binaries (`agent-relay-broker-darwin-arm64`, etc.) into `packages/sdk/bin/`, but the SDK's `resolveDefaultBinaryPath()` only looked for the generic `agent-relay-broker` name — which was still the stale binary from git.

- **SDK `client.ts`**: `resolveDefaultBinaryPath()` now checks for `agent-relay-broker-{platform}-{arch}` before falling back to the generic name
- **CI `publish.yml`**: Remove the stale generic binary during publish so it can't shadow fresh platform-specific ones

## Test plan

- [ ] Merge and publish — verify `npx tsx poc.ts` shows the observer URL
- [ ] Verify `npm pack @agent-relay/sdk` tarball contains platform-specific binaries but not the stale generic one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
