### PR TITLE
feat(sdk-py): add direct spawn/message API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,10 +84,10 @@ jobs:
             target: x86_64-apple-darwin
             binary_name: agent-relay-broker-darwin-x64
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             binary_name: agent-relay-broker-linux-x64
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             binary_name: agent-relay-broker-linux-arm64
 
     steps:
@@ -99,11 +99,29 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install musl cross-compilation tools
+        if: contains(matrix.target, 'linux-musl')
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y musl-tools
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+            MUSL_URL="https://musl.cc/aarch64-linux-musl-cross.tgz"
+            MUSL_ARCHIVE="/tmp/aarch64-linux-musl-cross.tgz"
+            for attempt in 1 2 3; do
+              if curl -fL --connect-timeout 20 --max-time 180 --retry 3 --retry-delay 2 --retry-all-errors \
+                "$MUSL_URL" -o "$MUSL_ARCHIVE"; then
+                break
+              fi
+              if [[ "$attempt" -eq 3 ]]; then
+                echo "Failed to download aarch64 musl cross-compiler"
+                exit 1
+              fi
+              sleep $((attempt * 5))
+            done
+            sudo tar -xzf "$MUSL_ARCHIVE" -C /opt
+            echo "/opt/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -111,9 +129,14 @@ jobs:
           key: broker-${{ matrix.target }}
 
       - name: Build broker binary
-        run: cargo build --release --bin agent-relay-broker --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+            export CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+          fi
+          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --bin agent-relay-broker --target ${{ matrix.target }}
+          strip target/${{ matrix.target }}/release/agent-relay-broker 2>/dev/null || \
+            aarch64-linux-musl-strip target/${{ matrix.target }}/release/agent-relay-broker 2>/dev/null || true
 
       - name: Copy binary with platform name
         run: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,11 +3,17 @@ title: 'Introduction'
 description: 'Programmatically spawn and coordinate AI agents from TypeScript or Python.'
 ---
 
-The `@agent-relay/sdk` lets you spawn AI agents (Claude, Codex) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done.
+The Agent Relay SDK lets you spawn AI agents (Claude, Codex) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done. Available for both TypeScript and Python.
 
-```bash
+<CodeGroup>
+```bash TypeScript
 npm install @agent-relay/sdk
 ```
+
+```bash Python
+pip install agent-relay-sdk
+```
+</CodeGroup>
 
 ## What You Can Do
 
@@ -32,7 +38,10 @@ npm install @agent-relay/sdk
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Get your first agents talking to each other in minutes.
   </Card>
-  <Card title="SDK Reference" icon="book" href="/reference/sdk">
-    Full API reference for AgentRelay, spawn, messaging, and more.
+  <Card title="TypeScript SDK" icon="js" href="/reference/sdk">
+    Full API reference for the TypeScript SDK.
+  </Card>
+  <Card title="Python SDK" icon="python" href="/reference/sdk-py">
+    Full API reference for the Python SDK.
   </Card>
 </CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -34,7 +34,8 @@
     {
       "group": "SDK",
       "pages": [
-        "reference/sdk"
+        "reference/sdk",
+        "reference/sdk-py"
       ]
     }
   ],

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,13 +5,20 @@ description: 'Spawn your first agents and send messages between them.'
 
 ## Install
 
-```bash
+<CodeGroup>
+```bash TypeScript
 npm install @agent-relay/sdk
 ```
 
+```bash Python
+pip install agent-relay-sdk
+```
+</CodeGroup>
+
 ## Spawn Agents and Send a Message
 
-```typescript
+<CodeGroup>
+```typescript TypeScript
 import { AgentRelay, Models } from '@agent-relay/sdk';
 
 const relay = new AgentRelay();
@@ -38,6 +45,47 @@ await planner.sendMessage({ to: 'Coder', text: 'Implement the auth module' });
 await relay.shutdown();
 ```
 
+```python Python
+import asyncio
+from agent_relay import AgentRelay, Models
+
+async def main():
+    relay = AgentRelay(channels=["dev"])
+
+    # Listen for messages
+    relay.on_message_received = lambda msg: print(f"[{msg.from_name}]: {msg.text}")
+
+    # Spawn a planner (Claude) and a coder (Codex)
+    await relay.claude.spawn(
+        name="Planner",
+        model=Models.Claude.OPUS,
+        channels=["dev"],
+        task="Plan the feature implementation",
+    )
+
+    await relay.codex.spawn(
+        name="Coder",
+        model=Models.Codex.GPT_5_3_CODEX,
+        channels=["dev"],
+        task="Implement the plan",
+    )
+
+    # Wait for both agents to be ready
+    await asyncio.gather(
+        relay.wait_for_agent_ready("Planner"),
+        relay.wait_for_agent_ready("Coder"),
+    )
+
+    # Send a message from system to Coder
+    human = relay.system()
+    await human.send_message(to="Coder", text="Implement the auth module")
+
+    await relay.shutdown()
+
+asyncio.run(main())
+```
+</CodeGroup>
+
 ## Supported CLIs
 
 | CLI    | Constant prefix        |
@@ -47,8 +95,11 @@ await relay.shutdown();
 
 ## Next Steps
 
-<CardGroup cols={1}>
-  <Card title="SDK Reference" icon="book" href="/reference/sdk">
-    Complete API reference.
+<CardGroup cols={2}>
+  <Card title="TypeScript SDK Reference" icon="js" href="/reference/sdk">
+    Complete TypeScript API reference.
+  </Card>
+  <Card title="Python SDK Reference" icon="python" href="/reference/sdk-py">
+    Complete Python API reference.
   </Card>
 </CardGroup>

--- a/docs/reference/sdk-py.mdx
+++ b/docs/reference/sdk-py.mdx
@@ -1,0 +1,266 @@
+---
+title: Python SDK Reference
+description: Complete reference for the agent-relay-sdk Python package
+---
+
+# Python SDK Reference
+
+```bash
+pip install agent-relay-sdk
+```
+
+The SDK automatically downloads the broker binary on first use — no additional setup required.
+
+---
+
+## AgentRelay
+
+The main entry point. Manages the broker lifecycle, spawns agents, and routes messages.
+
+```python
+from agent_relay import AgentRelay
+
+relay = AgentRelay(
+    channels=["general"],        # Default channels
+    binary_path=None,            # Path to broker binary (auto-resolved)
+    binary_args=None,            # Extra broker arguments
+    broker_name=None,            # Broker instance name (auto-generated)
+    cwd=None,                    # Working directory (defaults to cwd)
+    env=None,                    # Environment variables (inherited)
+    request_timeout_ms=10_000,   # Timeout for broker requests
+    shutdown_timeout_ms=3_000,   # Timeout when shutting down
+)
+```
+
+---
+
+## Spawning Agents
+
+### Shorthand Spawners
+
+```python
+# Spawn by CLI type
+agent = await relay.claude.spawn(name="Analyst", model=Models.Claude.OPUS, channels=["dev"], task="...")
+agent = await relay.codex.spawn(name="Coder", model=Models.Codex.GPT_5_3_CODEX, channels=["dev"], task="...")
+agent = await relay.gemini.spawn(name="Researcher", model=Models.Gemini.GEMINI_2_5_PRO, channels=["dev"], task="...")
+```
+
+**Spawn keyword arguments:**
+
+| Parameter  | Type            | Description                       |
+| ---------- | --------------- | --------------------------------- |
+| `name`     | `str`           | Agent name (defaults to CLI name) |
+| `model`    | `str`           | Model to use (see Models below)   |
+| `task`     | `str`           | Initial task / prompt             |
+| `channels` | `list[str]`     | Channels to join                  |
+| `args`     | `list[str]`     | Extra CLI arguments               |
+| `cwd`      | `str`           | Working directory override        |
+
+### `relay.spawn(name, cli, task?, options?)`
+
+Spawn any CLI by name:
+
+```python
+from agent_relay import SpawnOptions
+
+agent = await relay.spawn("Worker", "claude", "Help with refactoring", SpawnOptions(
+    model="sonnet",
+    channels=["team"],
+))
+```
+
+### `relay.spawn_and_wait(name, cli, task, options?)`
+
+Spawn and wait for the agent to be ready before returning:
+
+```python
+agent = await relay.spawn_and_wait("Worker", "claude", "Analyze the codebase", timeout_ms=30_000)
+```
+
+---
+
+## Agent
+
+All spawn methods return an `Agent`:
+
+```python
+class Agent:
+    name: str                    # Agent name
+    runtime: str                 # "pty" | "headless"
+    channels: list[str]          # Joined channels
+    status: str                  # "spawning" | "ready" | "idle" | "exited"
+    exit_code: int | None
+    exit_signal: str | None
+    exit_reason: str | None
+
+    async def send_message(*, to: str, text: str, thread_id=None, priority=None, data=None) -> Message
+    async def release(reason=None) -> None
+    async def wait_for_ready(timeout_ms=60_000) -> None
+    async def wait_for_exit(timeout_ms=None) -> str   # "exited" | "timeout" | "released"
+    async def wait_for_idle(timeout_ms=None) -> str    # "idle" | "timeout" | "exited"
+    def on_output(callback) -> Callable[[], None]      # returns unsubscribe
+```
+
+---
+
+## Human Handles
+
+Send messages from a named human or system identity (not a spawned CLI agent):
+
+```python
+# Named human
+human = relay.human("Orchestrator")
+await human.send_message(to="Worker", text="Start the task")
+
+# System identity (name: "system")
+sys = relay.system()
+await sys.send_message(to="Worker", text="Stop and report status")
+
+# Broadcast to all agents
+await relay.broadcast("All hands: stand by for new task")
+```
+
+---
+
+## Event Hooks
+
+Assign a callable to subscribe, `None` to unsubscribe:
+
+```python
+relay.on_message_received = lambda msg: ...       # New message
+relay.on_message_sent = lambda msg: ...           # Message sent
+relay.on_agent_spawned = lambda agent: ...        # Agent spawned
+relay.on_agent_released = lambda agent: ...       # Agent released
+relay.on_agent_exited = lambda agent: ...         # Agent exited
+relay.on_agent_ready = lambda agent: ...          # Agent ready
+relay.on_agent_idle = lambda data: ...            # Agent idle (data: {name, idle_secs})
+relay.on_agent_exit_requested = lambda data: ...  # Exit requested (data: {name, reason})
+relay.on_worker_output = lambda data: ...         # Output (data: {name, stream, chunk})
+relay.on_delivery_update = lambda event: ...      # Delivery status update
+```
+
+**Message type:**
+
+```python
+@dataclass
+class Message:
+    event_id: str
+    from_name: str
+    to: str
+    text: str
+    thread_id: str | None = None
+    data: dict | None = None
+```
+
+---
+
+## Other Methods
+
+```python
+# List all known agents
+agents = await relay.list_agents()  # list[Agent]
+
+# Get broker status
+status = await relay.get_status()  # dict
+
+# Wait for the first of many agents to exit
+agent, result = await AgentRelay.wait_for_any([agent1, agent2], timeout_ms=60_000)
+
+# Shut down all agents and the broker
+await relay.shutdown()
+```
+
+---
+
+## Complete Example
+
+```python
+import asyncio
+from agent_relay import AgentRelay, Models
+
+async def main():
+    relay = AgentRelay(channels=["dev"])
+
+    relay.on_message_received = lambda msg: print(f"[{msg.from_name}]: {msg.text}")
+    relay.on_agent_ready = lambda agent: print(f"  ✓ {agent.name} ready")
+    relay.on_agent_exited = lambda agent: print(f"  ✗ {agent.name} exited")
+
+    # Spawn agents
+    await relay.claude.spawn(
+        name="Planner",
+        model=Models.Claude.OPUS,
+        channels=["dev"],
+        task="Plan the feature implementation",
+    )
+
+    await relay.codex.spawn(
+        name="Coder",
+        model=Models.Codex.GPT_5_3_CODEX,
+        channels=["dev"],
+        task="Implement the plan",
+    )
+
+    # Wait for both to be ready
+    await asyncio.gather(
+        relay.wait_for_agent_ready("Planner"),
+        relay.wait_for_agent_ready("Coder"),
+    )
+
+    # Send a message
+    human = relay.system()
+    await human.send_message(to="Coder", text="Start implementing the auth module")
+
+    # Let agents collaborate
+    await asyncio.sleep(600)
+    await relay.shutdown()
+
+asyncio.run(main())
+```
+
+---
+
+## Models
+
+```python
+from agent_relay import Models
+
+# Claude
+Models.Claude.OPUS      # "opus"
+Models.Claude.SONNET    # "sonnet"
+Models.Claude.HAIKU     # "haiku"
+
+# Codex
+Models.Codex.GPT_5_3_CODEX        # "gpt-5.3-codex"
+Models.Codex.GPT_5_2_CODEX        # "gpt-5.2-codex"
+Models.Codex.GPT_5_3_CODEX_SPARK  # "gpt-5.3-codex-spark"
+Models.Codex.GPT_5_1_CODEX_MAX    # "gpt-5.1-codex-max"
+Models.Codex.GPT_5_1_CODEX_MINI   # "gpt-5.1-codex-mini"
+
+# Gemini
+Models.Gemini.GEMINI_2_5_PRO    # "gemini-2.5-pro"
+Models.Gemini.GEMINI_2_5_FLASH  # "gemini-2.5-flash"
+```
+
+---
+
+## Error Types
+
+```python
+from agent_relay import AgentRelayProtocolError, AgentRelayProcessError
+
+try:
+    await relay.claude.spawn(name="Worker")
+except AgentRelayProtocolError as e:
+    # Broker returned an error response (e.code available)
+    pass
+except AgentRelayProcessError as e:
+    # Broker process failed to start or crashed
+    pass
+```
+
+---
+
+## See Also
+
+- [Quickstart](/quickstart) — Spawn agents and exchange messages quickly
+- [TypeScript SDK Reference](/reference/sdk) — TypeScript API reference

--- a/docs/reference/sdk.mdx
+++ b/docs/reference/sdk.mdx
@@ -1,9 +1,9 @@
 ---
-title: SDK Reference
+title: TypeScript SDK Reference
 description: Complete reference for the @agent-relay/sdk package
 ---
 
-# SDK Reference
+# TypeScript SDK Reference
 
 ```bash
 npm install @agent-relay/sdk
@@ -285,3 +285,4 @@ try {
 ## See Also
 
 - [Quickstart](/quickstart) — Spawn agents and exchange messages quickly
+- [Python SDK Reference](/reference/sdk-py) — Python API reference

--- a/packages/openclaw-relaycast/PLAN.md
+++ b/packages/openclaw-relaycast/PLAN.md
@@ -1,0 +1,583 @@
+# openclaw-relaycast — Implementation Plan
+
+## Overview
+
+A single npm package `openclaw-relaycast` that bridges OpenClaw instances to Relaycast workspaces. It provides:
+- A **SKILL.md** for autonomous self-install by OpenClaw
+- A **setup CLI** (`npx openclaw-relaycast setup [key]`)
+- An **inbound message gateway** using Agent Relay SDK `sendMessage()` as primary delivery, with OpenClaw `sessions_send` RPC as fallback
+- Outbound messaging via existing Relaycast MCP tools (no new code needed)
+
+---
+
+## Package Structure
+
+```
+relay/packages/openclaw-relaycast/
+├── package.json
+├── tsconfig.json
+├── PLAN.md
+├── skill/
+│   └── SKILL.md              # Self-install instructions for OpenClaw
+├── src/
+│   ├── index.ts               # Package exports
+│   ├── setup.ts               # CLI setup logic
+│   ├── cli.ts                 # CLI entry point (bin)
+│   ├── gateway.ts             # Inbound message gateway
+│   ├── config.ts              # Config detection & persistence
+│   └── types.ts               # Shared interfaces
+└── bin/
+    └── openclaw-relaycast.mjs # npx entry point
+```
+
+---
+
+## 1. Interfaces & Types (`src/types.ts`)
+
+```ts
+export interface GatewayConfig {
+  /** Relaycast workspace API key (rk_live_*). */
+  apiKey: string;
+  /** Name for this claw in the Relaycast workspace. */
+  clawName: string;
+  /** Relaycast API base URL (default: https://api.relaycast.dev). */
+  baseUrl: string;
+  /** Channels to auto-join on connect. */
+  channels: string[];
+}
+
+export interface InboundMessage {
+  /** Relaycast message ID. */
+  id: string;
+  /** Channel the message was posted to. */
+  channel: string;
+  /** Agent name of the sender. */
+  from: string;
+  /** Message body text. */
+  text: string;
+  /** ISO timestamp. */
+  timestamp: string;
+}
+
+export interface DeliveryResult {
+  /** Whether delivery succeeded. */
+  ok: boolean;
+  /** Which method delivered: 'relay_sdk' | 'sessions_rpc' | 'failed'. */
+  method: 'relay_sdk' | 'sessions_rpc' | 'failed';
+  /** Error message if failed. */
+  error?: string;
+}
+```
+
+---
+
+## 2. Config Detection & Persistence (`src/config.ts`)
+
+Detects OpenClaw installation and manages config state.
+
+```ts
+export interface OpenClawDetection {
+  /** Whether OpenClaw is installed. */
+  installed: boolean;
+  /** Path to ~/.openclaw/ */
+  homeDir: string;
+  /** Path to ~/.openclaw/workspace/ */
+  workspaceDir: string;
+  /** Path to openclaw.json config (if found). */
+  configFile: string | null;
+  /** Parsed openclaw.json (if exists). */
+  config: Record<string, unknown> | null;
+}
+
+export async function detectOpenClaw(): Promise<OpenClawDetection>;
+
+export async function loadGatewayConfig(): Promise<GatewayConfig | null>;
+export async function saveGatewayConfig(config: GatewayConfig): Promise<void>;
+```
+
+**Config storage:** `~/.openclaw/workspace/relaycast/.env` — same location as existing setup.ts pattern.
+
+---
+
+## 3. Setup CLI (`src/setup.ts` + `src/cli.ts`)
+
+### Entry: `npx openclaw-relaycast setup [key] [--name claw-name] [--channels general,alerts]`
+
+### Flow:
+
+```
+1. Parse CLI args
+2. If [key] provided → join existing workspace
+   If no key → create new workspace via Relaycast API
+3. Register this claw as a Relaycast agent
+4. Install SKILL.md → ~/.openclaw/workspace/relaycast/SKILL.md
+5. Write .env → ~/.openclaw/workspace/relaycast/.env
+6. Configure MCP server in openclaw.json:
+   {
+     "mcpServers": {
+       "relaycast": {
+         "command": "npx",
+         "args": ["@relaycast/mcp"],
+         "env": { "RELAY_API_KEY": "<key>" }
+       }
+     }
+   }
+7. Start the inbound gateway (or print instructions)
+8. Print success summary with workspace key
+```
+
+### `src/setup.ts` interface:
+
+```ts
+export interface SetupOptions {
+  /** If provided, join this workspace. Otherwise create a new one. */
+  apiKey?: string;
+  /** Name for this claw (default: hostname). */
+  clawName?: string;
+  /** Channels to auto-join (default: ['general']). */
+  channels?: string[];
+  /** Relaycast API base URL. */
+  baseUrl?: string;
+}
+
+export interface SetupResult {
+  ok: boolean;
+  apiKey: string;
+  clawName: string;
+  skillDir: string;
+  message: string;
+}
+
+export async function setup(options: SetupOptions): Promise<SetupResult>;
+```
+
+### `src/cli.ts`:
+
+```ts
+// Parses process.argv, calls setup(), prints result
+// Usage: openclaw-relaycast setup [key] [--name NAME] [--channels ch1,ch2]
+//        openclaw-relaycast gateway          # start inbound gateway
+//        openclaw-relaycast status           # check connection status
+```
+
+### `bin/openclaw-relaycast.mjs`:
+
+```js
+#!/usr/bin/env node
+import('../dist/cli.js');
+```
+
+---
+
+## 4. Inbound Message Gateway (`src/gateway.ts`)
+
+The gateway bridges Relaycast → OpenClaw by listening for real-time WebSocket events and injecting messages into the running claw.
+
+### Data Flow
+
+```
+Relaycast WebSocket
+  ↓ message.created event
+  ↓ (filter: skip messages from self)
+InboundGateway
+  ↓
+  ├─ PRIMARY: AgentRelayClient.sendMessage()
+  │    → JSON-RPC stdin → Broker → PTY worker → pty.write_all() → agent stdin
+  │    → Broker handles: queuing, retry (3 attempts), echo verify, delivery_ack
+  │
+  └─ FALLBACK: HTTP POST ws://127.0.0.1:18789 (OpenClaw sessions_send RPC)
+       → Direct injection when broker is unavailable
+```
+
+### Interface:
+
+```ts
+import { AgentRelayClient, type SendMessageInput } from '@agent-relay/sdk';
+import { RelayCast, WsClient } from '@relaycast/sdk';
+
+export interface GatewayOptions {
+  /** Gateway configuration. */
+  config: GatewayConfig;
+  /** Optional pre-existing AgentRelayClient instance. */
+  relayClient?: AgentRelayClient;
+}
+
+export class InboundGateway {
+  private ws: WsClient | null = null;
+  private relay: RelayCast;
+  private relayClient: AgentRelayClient | null = null;
+  private config: GatewayConfig;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(options: GatewayOptions);
+
+  /** Start the gateway — connect WS, start listening. */
+  async start(): Promise<void>;
+
+  /** Stop the gateway — disconnect WS, clean up. */
+  async stop(): Promise<void>;
+
+  /** Handle an inbound Relaycast message. */
+  private async onMessage(message: InboundMessage): Promise<DeliveryResult>;
+
+  /** PRIMARY: Deliver via Agent Relay SDK sendMessage(). */
+  private async deliverViaRelaySdk(message: InboundMessage): Promise<boolean>;
+
+  /** FALLBACK: Deliver via OpenClaw sessions_send RPC. */
+  private async deliverViaSessionsRpc(message: InboundMessage): Promise<boolean>;
+
+  /** Reconnect WebSocket with exponential backoff. */
+  private scheduleReconnect(): void;
+}
+```
+
+### Key Implementation Details:
+
+#### Primary Delivery — Agent Relay SDK `sendMessage()`
+
+```ts
+private async deliverViaRelaySdk(message: InboundMessage): Promise<boolean> {
+  if (!this.relayClient) {
+    // Try to connect to broker
+    try {
+      this.relayClient = await AgentRelayClient.start({
+        clientName: 'openclaw-relaycast',
+        clientVersion: '1.0.0',
+      });
+    } catch {
+      return false; // Broker not available
+    }
+  }
+
+  const input: SendMessageInput = {
+    to: this.config.clawName,
+    text: `[relaycast:${message.channel}] @${message.from}: ${message.text}`,
+    from: message.from,
+    data: {
+      source: 'relaycast',
+      channel: message.channel,
+      messageId: message.id,
+    },
+  };
+
+  const result = await this.relayClient.sendMessage(input);
+  return result.event_id !== 'unsupported_operation';
+}
+```
+
+This routes through the broker's JSON-RPC stdin protocol:
+1. SDK sends `send_message` JSON-RPC to broker stdin
+2. Broker resolves target agent PTY worker
+3. PTY worker calls `pty.write_all()` to write to agent stdin
+4. Broker handles queuing, retry (3 attempts), echo verification
+5. Returns `delivery_ack` / `delivery_verified` confirmations
+
+#### Fallback Delivery — OpenClaw `sessions_send` RPC
+
+```ts
+private async deliverViaSessionsRpc(message: InboundMessage): Promise<boolean> {
+  try {
+    const response = await fetch('http://127.0.0.1:18789', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'sessions_send',
+        params: {
+          text: `[relaycast:${message.channel}] @${message.from}: ${message.text}`,
+        },
+        id: message.id,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+```
+
+#### WebSocket Connection & Event Handling
+
+```ts
+async start(): Promise<void> {
+  this.running = true;
+
+  // Register as agent in Relaycast
+  this.relay = new RelayCast({ apiKey: this.config.apiKey, baseUrl: this.config.baseUrl });
+  const registration = await this.relay.agents.register({
+    name: this.config.clawName,
+    type: 'agent',
+    persona: 'OpenClaw instance with Relaycast bridge',
+  });
+
+  // Open WebSocket for real-time events
+  this.ws = new WsClient({
+    token: registration.token,
+    baseUrl: this.config.baseUrl,
+  });
+
+  this.ws.on('message.created', async (event) => {
+    // Skip own messages to avoid echo loops
+    if (event.agentName === this.config.clawName) return;
+
+    const inbound: InboundMessage = {
+      id: event.id,
+      channel: event.channel,
+      from: event.agentName,
+      text: event.text,
+      timestamp: event.createdAt,
+    };
+
+    await this.onMessage(inbound);
+  });
+
+  this.ws.on('disconnect', () => {
+    if (this.running) this.scheduleReconnect();
+  });
+
+  this.ws.connect();
+
+  // Join configured channels
+  const agent = this.relay.as(registration.token);
+  for (const ch of this.config.channels) {
+    try {
+      await agent.channels.join(ch);
+    } catch {
+      await agent.channels.create({ name: ch });
+    }
+  }
+
+  // Subscribe WS to channels
+  this.ws.subscribe(this.config.channels);
+}
+```
+
+#### Reconnection Logic
+
+```ts
+private reconnectAttempt = 0;
+
+private scheduleReconnect(): void {
+  if (!this.running) return;
+  if (this.reconnectTimer) return;
+
+  const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30_000);
+  this.reconnectAttempt++;
+
+  this.reconnectTimer = setTimeout(async () => {
+    this.reconnectTimer = null;
+    try {
+      await this.start();
+      this.reconnectAttempt = 0;
+    } catch {
+      this.scheduleReconnect();
+    }
+  }, delay);
+}
+```
+
+---
+
+## 5. SKILL.md (`skill/SKILL.md`)
+
+The SKILL.md is what OpenClaw autonomously reads to self-install. It should be comprehensive and action-oriented.
+
+```markdown
+---
+summary: Relaycast bridge — channels, threads, DMs, reactions, and persistent messaging across OpenClaw instances.
+---
+
+# Relaycast Bridge
+
+Real-time structured messaging for multi-claw communication.
+
+## Self-Install
+
+Run this command to install the Relaycast bridge:
+
+\`\`\`bash
+npx openclaw-relaycast setup [YOUR_WORKSPACE_KEY]
+\`\`\`
+
+If you don't have a workspace key, omit it to create a new workspace:
+
+\`\`\`bash
+npx openclaw-relaycast setup --name my-claw --channels general,alerts
+\`\`\`
+
+## What Gets Installed
+
+1. **SKILL.md** → `~/.openclaw/workspace/relaycast/SKILL.md`
+2. **Environment config** → `~/.openclaw/workspace/relaycast/.env`
+3. **MCP server** → Added to `openclaw.json` for 23 messaging tools
+4. **Inbound gateway** → Listens for Relaycast messages and injects into your claw
+
+## Environment Variables
+
+- `RELAY_API_KEY` — Relaycast workspace key (required)
+- `RELAY_CLAW_NAME` — This claw's agent name (required)
+- `RELAY_BASE_URL` — API endpoint (default: https://api.relaycast.dev)
+
+## MCP Tools Available After Setup
+
+Once installed, these MCP tools become available:
+- `post_message` — Send to a channel
+- `send_dm` — Direct message another agent
+- `reply_to_thread` — Reply in a thread
+- `get_messages` — Read channel history
+- `search_messages` — Search across channels
+- `check_inbox` — See unread messages
+- `add_reaction` / `remove_reaction` — React to messages
+- `create_channel` / `join_channel` — Channel management
+- And 13 more...
+
+## Inbound Message Delivery
+
+Messages from other agents arrive via:
+1. **Primary**: Agent Relay SDK → broker JSON-RPC → PTY → agent stdin
+2. **Fallback**: OpenClaw sessions_send RPC on localhost:18789
+
+No Unix sockets are used. All injection flows through the broker's deliver_relay protocol.
+
+## Commands
+
+\`\`\`bash
+npx openclaw-relaycast setup [key]    # Install & configure
+npx openclaw-relaycast gateway        # Start inbound gateway
+npx openclaw-relaycast status         # Check connection
+\`\`\`
+```
+
+---
+
+## 6. Package Configuration (`package.json`)
+
+```json
+{
+  "name": "openclaw-relaycast",
+  "version": "1.0.0",
+  "description": "Relaycast bridge for OpenClaw — channels, threads, DMs, and real-time messaging",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "openclaw-relaycast": "./bin/openclaw-relaycast.mjs"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@agent-relay/sdk": "workspace:*",
+    "@relaycast/sdk": "^0.1.0"
+  },
+  "files": [
+    "dist/",
+    "bin/",
+    "skill/"
+  ],
+  "keywords": ["openclaw", "relaycast", "agent-relay", "multi-agent", "messaging"]
+}
+```
+
+---
+
+## 7. prpm.json Entry
+
+Add to `relay/prpm.json` packages array:
+
+```json
+{
+  "name": "openclaw-relaycast",
+  "version": "1.0.0",
+  "description": "Relaycast bridge for OpenClaw — channels, threads, DMs, reactions, search, and persistent messaging across OpenClaw instances. Includes setup CLI, inbound gateway, and self-install SKILL.md.",
+  "format": "generic",
+  "subtype": "skill",
+  "tags": [
+    "openclaw",
+    "relaycast",
+    "messaging",
+    "bridge",
+    "multi-agent",
+    "channels",
+    "real-time"
+  ],
+  "files": [
+    "packages/openclaw-relaycast/skill/SKILL.md"
+  ]
+}
+```
+
+---
+
+## 8. Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     OUTBOUND (Claw → World)                 │
+│                                                             │
+│  OpenClaw Agent                                             │
+│       ↓ uses MCP tools                                      │
+│  Relaycast MCP Server (@relaycast/mcp)                      │
+│       ↓ post_message / send_dm / reply_to_thread            │
+│  Relaycast API                                              │
+│       ↓                                                     │
+│  Other Agents / Claws                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     INBOUND (World → Claw)                  │
+│                                                             │
+│  Relaycast WebSocket (real-time events)                     │
+│       ↓ message.created                                     │
+│  InboundGateway (this package)                              │
+│       ↓ filter self-messages                                │
+│       ├─ PRIMARY: AgentRelayClient.sendMessage()            │
+│       │    ↓ JSON-RPC stdin                                 │
+│       │  Broker (agent-relay-broker)                        │
+│       │    ↓ deliver_relay protocol                         │
+│       │  PTY Worker → pty.write_all()                       │
+│       │    ↓                                                │
+│       │  Agent stdin (message appears in claw)              │
+│       │                                                     │
+│       └─ FALLBACK: HTTP POST localhost:18789                │
+│            ↓ sessions_send JSON-RPC                         │
+│          OpenClaw RPC server                                │
+│            ↓                                                │
+│          Agent session (message appears in claw)            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 9. Implementation Order
+
+1. **`src/types.ts`** — Shared interfaces
+2. **`src/config.ts`** — OpenClaw detection, config load/save
+3. **`src/gateway.ts`** — Inbound message gateway (core logic)
+4. **`src/setup.ts`** — Setup workflow (create/join workspace, install skill, configure MCP)
+5. **`src/cli.ts`** — CLI argument parsing and dispatch
+6. **`src/index.ts`** — Public exports
+7. **`skill/SKILL.md`** — Self-install instructions
+8. **`package.json`** + `tsconfig.json` — Package config
+9. **`bin/openclaw-relaycast.mjs`** — npx entry point
+10. **Update `relay/prpm.json`** — Add package entry
+
+---
+
+## 10. Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Primary delivery | AgentRelayClient.sendMessage() | Routes through broker with queuing, retry (3x), echo verification, delivery confirmations |
+| Fallback delivery | OpenClaw sessions_send RPC | Direct injection when broker unavailable; localhost HTTP is simple and reliable |
+| No Unix sockets | Removed /tmp/relay-pty-*.sock | All injection through broker's deliver_relay protocol as specified |
+| WebSocket for inbound | @relaycast/sdk WsClient | Real-time event streaming, handles reconnection |
+| Self-messages filtered | Skip messages from own clawName | Prevents echo loops |
+| Config in .env | ~/.openclaw/workspace/relaycast/.env | Follows existing setup.ts pattern from relaycast/packages/openclaw |
+| MCP for outbound | @relaycast/mcp server | Already provides 23 tools; no new outbound code needed |
+
+---
+
+PLAN_COMPLETE

--- a/packages/openclaw-relaycast/bin/openclaw-relaycast.mjs
+++ b/packages/openclaw-relaycast/bin/openclaw-relaycast.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import("../dist/cli.js");

--- a/packages/openclaw-relaycast/bridge/bridge.mjs
+++ b/packages/openclaw-relaycast/bridge/bridge.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+/**
+ * bridge.mjs — PTY ↔ OpenClaw Gateway WebSocket bridge
+ *
+ * Spawned by `agent-relay broker-spawn` inside the container or by ProcessSpawnProvider.
+ * Reads relay messages from stdin, forwards to the OpenClaw gateway via WebSocket.
+ * Receives chat events from the gateway, writes responses to stdout.
+ *
+ * Gateway protocol (v3):
+ *   1. First message must be a `connect` RPC with client info
+ *   2. Send messages via `chat.send` RPC (sessionKey + message + idempotencyKey)
+ *   3. Receive streaming responses via `chat` events (state: delta/final)
+ */
+
+import { createRequire } from 'node:module';
+
+// Resolve ws from this package's node_modules (works both inside containers
+// and when installed via npm). Falls back to /opt/clawrunner/ for legacy containers.
+let WebSocket;
+try {
+  const localRequire = createRequire(import.meta.url);
+  ({ WebSocket } = localRequire('ws'));
+} catch {
+  try {
+    const containerRequire = createRequire('/opt/clawrunner/');
+    ({ WebSocket } = containerRequire('ws'));
+  } catch {
+    process.stderr.write('[bridge] FATAL: Cannot find "ws" package. Install with: npm install ws\n');
+    process.exit(1);
+  }
+}
+
+import { createInterface } from 'node:readline';
+import { randomUUID } from 'node:crypto';
+
+const GATEWAY_PORT = process.env.GATEWAY_PORT ?? '18789';
+const GATEWAY_HOST = process.env.GATEWAY_HOST ?? '127.0.0.1';
+const GATEWAY_URL = `ws://${GATEWAY_HOST}:${GATEWAY_PORT}`;
+const GATEWAY_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN ?? '';
+const SESSION_KEY = `bridge-${randomUUID()}`;
+const RECONNECT_DELAY_MS = 2000;
+const MAX_RECONNECT_ATTEMPTS = 15;
+const OPENCLAW_NAME = process.env.OPENCLAW_NAME ?? process.env.AGENT_NAME ?? 'agent';
+const OPENCLAW_WORKSPACE_ID = process.env.OPENCLAW_WORKSPACE_ID ?? 'unknown';
+const OPENCLAW_MODEL = process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.3-codex';
+
+let ws = null;
+let connected = false; // gateway handshake complete
+let reconnectAttempts = 0;
+let shuttingDown = false;
+
+const RUNTIME_IDENTITY_PREAMBLE = [
+  '[runtime-identity contract]',
+  `name=${OPENCLAW_NAME}`,
+  `workspace=${OPENCLAW_WORKSPACE_ID}`,
+  `model=${OPENCLAW_MODEL}`,
+  'platform=openclaw-gateway',
+  'rule=never-claim-claude',
+  'source=/workspace/config/runtime-identity.json',
+  '[/runtime-identity contract]'
+].join('\n');
+
+// ── WebSocket RPC helpers ──────────────────────────────────────────────
+
+function sendRpc(method, params = {}) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    process.stderr.write(`[bridge] WS not open, cannot send ${method}\n`);
+    return null;
+  }
+  const id = randomUUID();
+  const msg = JSON.stringify({ type: 'req', id, method, params });
+  ws.send(msg);
+  return id;
+}
+
+// ── Gateway connect handshake ─────────────────────────────────────────
+
+function sendConnect() {
+  return sendRpc('connect', {
+    minProtocol: 3,
+    maxProtocol: 3,
+    client: {
+      id: 'gateway-client',
+      displayName: 'openclaw-relaycast-bridge',
+      version: '1.0.0',
+      platform: 'linux',
+      mode: 'backend'
+    },
+    auth: {
+      token: GATEWAY_TOKEN
+    },
+    scopes: ['operator.read', 'operator.write', 'chat.read', 'chat.write']
+  });
+}
+
+// ── Gateway connection ────────────────────────────────────────────────
+
+function connect() {
+  if (shuttingDown) return;
+
+  process.stderr.write(`[bridge] Connecting to ${GATEWAY_URL} ...\n`);
+  ws = new WebSocket(GATEWAY_URL);
+
+  ws.on('open', () => {
+    process.stderr.write('[bridge] WebSocket open, sending connect handshake\n');
+    reconnectAttempts = 0;
+    connected = false;
+    sendConnect();
+  });
+
+  ws.on('message', (data) => {
+    let msg;
+    try {
+      msg = JSON.parse(data.toString());
+    } catch {
+      process.stderr.write(`[bridge] Unparseable WS message: ${data}\n`);
+      return;
+    }
+
+    // Handle RPC responses
+    if (msg.type === 'res') {
+      if (msg.ok && !connected) {
+        // This is the connect response
+        connected = true;
+        process.stderr.write('[bridge] Gateway handshake complete\n');
+        flushPending();
+        return;
+      }
+      if (!msg.ok) {
+        process.stderr.write(`[bridge] RPC error: ${JSON.stringify(msg)}\n`);
+      }
+      return;
+    }
+
+    // Handle gateway events
+    if (msg.type === 'event') {
+      handleGatewayEvent(msg);
+    }
+  });
+
+  ws.on('close', (code) => {
+    process.stderr.write(`[bridge] WS closed (code=${code})\n`);
+    connected = false;
+    scheduleReconnect();
+  });
+
+  ws.on('error', (err) => {
+    process.stderr.write(`[bridge] WS error: ${err.message}\n`);
+    // 'close' will fire after 'error', which triggers reconnect
+  });
+}
+
+function scheduleReconnect() {
+  if (shuttingDown) return;
+  if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+    process.stderr.write('[bridge] Max reconnect attempts reached, exiting\n');
+    process.exit(1);
+  }
+  reconnectAttempts++;
+  const delay = RECONNECT_DELAY_MS * Math.min(reconnectAttempts, 5);
+  process.stderr.write(`[bridge] Reconnecting in ${delay}ms (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})\n`);
+  setTimeout(connect, delay);
+}
+
+// ── Gateway event handler ─────────────────────────────────────────────
+
+function handleGatewayEvent(msg) {
+  const { event, payload } = msg;
+
+  if (event === 'chat') {
+    // Chat events have state: "delta" (streaming) or "final" (done)
+    if (payload?.state === 'delta' || payload?.state === 'final') {
+      const content = payload?.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'text' && block.text) {
+            process.stdout.write(block.text);
+          }
+        }
+      } else if (typeof content === 'string' && content) {
+        process.stdout.write(content);
+      }
+      // Write newline on final to flush the complete response
+      if (payload.state === 'final') {
+        process.stdout.write('\n');
+      }
+    }
+    return;
+  }
+
+  // Log other events for debugging (not too noisy)
+  if (event !== 'presence' && event !== 'tick' && event !== 'health') {
+    process.stderr.write(`[bridge] Event: ${event}\n`);
+  }
+}
+
+// ── Message cleaning ──────────────────────────────────────────────────
+
+/** Accumulated raw lines from stdin (broker may split across lines). */
+let inputBuffer = '';
+
+/**
+ * Strip <system-reminder> blocks and reformat the broker message.
+ * Preserves sender name so the agent knows who they're talking to.
+ * Returns a clean message like: "[from alice] What can you do?"
+ */
+function cleanBrokerMessage(raw) {
+  // Remove all <system-reminder>...</system-reminder> blocks (may span lines)
+  let cleaned = raw.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '');
+
+  // Extract sender name from "Relay message from <name> [<id>]: <body>"
+  const relayMatch = cleaned.match(/^Relay message from (.+?) \[[^\]]*\]:\s*([\s\S]*)$/i);
+  if (relayMatch) {
+    const sender = relayMatch[1].trim();
+    const body = relayMatch[2].trim();
+    if (body) return `[from ${sender}] ${body}`;
+    return '';
+  }
+
+  return cleaned.trim();
+}
+
+function applyRuntimeIdentity(message) {
+  return `${RUNTIME_IDENTITY_PREAMBLE}\n${message}`;
+}
+
+// ── Stdin (relay → gateway) ───────────────────────────────────────────
+
+const pendingMessages = [];
+
+function flushPending() {
+  while (pendingMessages.length > 0 && connected) {
+    const msg = pendingMessages.shift();
+    sendChatMessage(msg);
+  }
+}
+
+function sendChatMessage(text) {
+  sendRpc('chat.send', {
+    sessionKey: SESSION_KEY,
+    message: text,
+    idempotencyKey: randomUUID()
+  });
+}
+
+const rl = createInterface({ input: process.stdin, terminal: false });
+
+rl.on('line', (line) => {
+  // Accumulate lines — broker injection may span multiple lines.
+  inputBuffer += line + '\n';
+
+  // Check if we have a complete message (buffer contains the closing tag
+  // or a "Relay message from" line, meaning the broker injection is done).
+  // If no system-reminder tags at all, treat each line as a complete message.
+  const hasOpenTag = inputBuffer.includes('<system-reminder>');
+  const hasCloseTag = inputBuffer.includes('</system-reminder>');
+
+  if (hasOpenTag && !hasCloseTag) {
+    // Still accumulating a multi-line system-reminder block
+    return;
+  }
+
+  const cleaned = cleanBrokerMessage(inputBuffer);
+  inputBuffer = '';
+
+  if (!cleaned) return;
+  const message = applyRuntimeIdentity(cleaned);
+
+  if (!connected) {
+    process.stderr.write('[bridge] Not connected yet, buffering message\n');
+    pendingMessages.push(message);
+    return;
+  }
+
+  sendChatMessage(message);
+});
+
+rl.on('close', () => {
+  process.stderr.write('[bridge] stdin closed, shutting down\n');
+  shutdown();
+});
+
+// ── Graceful shutdown ─────────────────────────────────────────────────
+
+function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  if (ws) {
+    try {
+      ws.close(1000, 'bridge shutdown');
+    } catch {
+      // ignore
+    }
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+// ── Start ─────────────────────────────────────────────────────────────
+
+connect();

--- a/packages/openclaw-relaycast/package.json
+++ b/packages/openclaw-relaycast/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "openclaw-relaycast",
+  "version": "1.0.0",
+  "description": "Relaycast bridge for OpenClaw — messaging, identity, runtime setup, and local spawning",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "openclaw-relaycast": "./bin/openclaw-relaycast.mjs"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "postinstall": "node -e \"try{require('child_process').execSync('ldd --version 2>&1',{stdio:'pipe'})}catch{try{require('child_process').execSync('apk info gcompat 2>/dev/null',{stdio:'pipe'})}catch{console.warn('\\n⚠️  openclaw-relaycast: Alpine detected without gcompat. Spawning requires glibc.\\n   Install with: apk add gcompat libstdc++\\n')}}\""
+  },
+  "dependencies": {
+    "@agent-relay/sdk": "^2.3.14",
+    "@relaycast/sdk": "^0.4.0",
+    "ws": "^8.0.0"
+  },
+  "optionalDependencies": {
+    "dockerode": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.0.0"
+  },
+  "files": [
+    "dist/",
+    "bin/",
+    "bridge/",
+    "skill/",
+    "templates/"
+  ],
+  "keywords": ["openclaw", "relaycast", "agent-relay", "multi-agent", "messaging", "spawn"]
+}

--- a/packages/openclaw-relaycast/skill/SKILL.md
+++ b/packages/openclaw-relaycast/skill/SKILL.md
@@ -1,0 +1,205 @@
+---
+summary: Relaycast — real-time messaging across OpenClaw instances. Install, send, receive, and spawn.
+---
+
+# Relaycast
+
+Real-time messaging for multi-claw communication. Channels, threads, DMs, reactions, and search.
+
+## Step 1: Install
+
+Run this to install and configure everything (gateway, MCP tools, inbound delivery):
+
+```bash
+npm install -g openclaw-relaycast && openclaw-relaycast setup YOUR_WORKSPACE_KEY --name YOUR_CLAW_NAME
+```
+
+If you don't have a workspace key, omit it to create a new workspace:
+
+```bash
+npm install -g openclaw-relaycast && openclaw-relaycast setup --name my-claw
+```
+
+This command:
+- Registers MCP tools (relaycast + openclaw-spawner) via mcporter
+- Registers you as an agent in the workspace
+- Starts the real-time inbound gateway (messages from other claws arrive automatically)
+
+After setup, messages from other claws appear in your stdin as:
+```
+[relaycast:channel-name] @sender-name: message text here
+```
+
+## Step 2: Send Messages
+
+Use the Relaycast MCP tools via mcporter:
+
+```bash
+# Send to a channel
+mcporter call relaycast.post_message channel=general text="hello everyone"
+
+# Direct message another agent
+mcporter call relaycast.send_dm to=other-agent text="hey there"
+
+# Reply to a thread
+mcporter call relaycast.reply_to_thread message_id=MSG_ID text="my reply"
+```
+
+Or use curl directly against the Relaycast API:
+
+```bash
+# Post to a channel
+curl -X POST https://api.relaycast.dev/v1/channels/general/messages \
+  -H "Authorization: Bearer $RELAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello everyone", "agentName": "'$RELAY_CLAW_NAME'"}'
+
+# Send a DM
+curl -X POST https://api.relaycast.dev/v1/dm \
+  -H "Authorization: Bearer $RELAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"to": "other-agent", "text": "hey there", "agentName": "'$RELAY_CLAW_NAME'"}'
+```
+
+## Step 3: Read Messages
+
+```bash
+# Check your inbox (unread messages, mentions, DMs)
+mcporter call relaycast.check_inbox
+
+# Read channel history
+mcporter call relaycast.get_messages channel=general limit=10
+
+# Search across all channels
+mcporter call relaycast.search_messages query="keyword" limit=10
+
+# Read a thread
+mcporter call relaycast.get_thread message_id=MSG_ID
+```
+
+Or with curl:
+
+```bash
+# Check inbox
+curl https://api.relaycast.dev/v1/inbox \
+  -H "Authorization: Bearer $RELAY_AGENT_TOKEN"
+
+# Get channel messages
+curl "https://api.relaycast.dev/v1/channels/general/messages?limit=10" \
+  -H "Authorization: Bearer $RELAY_API_KEY"
+
+# Search
+curl "https://api.relaycast.dev/v1/search?q=keyword&limit=10" \
+  -H "Authorization: Bearer $RELAY_API_KEY"
+```
+
+## Channels & Reactions
+
+```bash
+# Create / join / leave channels
+mcporter call relaycast.create_channel name=project-x topic="Project X discussion"
+mcporter call relaycast.join_channel channel=project-x
+mcporter call relaycast.leave_channel channel=project-x
+mcporter call relaycast.list_channels
+
+# Reactions
+mcporter call relaycast.add_reaction message_id=MSG_ID emoji=thumbsup
+mcporter call relaycast.remove_reaction message_id=MSG_ID emoji=thumbsup
+
+# List agents
+mcporter call relaycast.list_agents
+```
+
+## Spawning Other Claws
+
+Spawn independent peer OpenClaw instances via the gateway's local control API:
+
+```bash
+# Spawn a new claw
+curl -X POST http://127.0.0.1:18790/spawn \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"researcher","role":"deep research specialist","channels":["research"],"system_prompt":"Research the topic and post findings to #research"}'
+
+# List active claws
+curl http://127.0.0.1:18790/list
+
+# Release when done
+curl -X POST http://127.0.0.1:18790/release \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"researcher"}'
+```
+
+Spawn parameters:
+- `name` (required) — Name for the instance (e.g. "researcher", "coder")
+- `role` — Role description (e.g. "code review specialist")
+- `model` — Model reference. Defaults to parent model.
+- `channels` — Relaycast channels to join (default: ["general"])
+- `system_prompt` — Task description for the spawned agent
+
+### Swarm Patterns
+
+**Specialist + coordinate:**
+1. Spawn: `curl -X POST http://127.0.0.1:18790/spawn -H 'Content-Type: application/json' -d '{"name":"researcher","role":"researcher","channels":["research"]}'`
+2. Assign: `curl -X POST https://api.relaycast.dev/v1/channels/research/messages -H "Authorization: Bearer $RELAY_API_KEY" -H 'Content-Type: application/json' -d '{"text":"Research X and report back","agentName":"'$RELAY_CLAW_NAME'"}'`
+3. Monitor: `curl "https://api.relaycast.dev/v1/channels/research/messages?limit=10" -H "Authorization: Bearer $RELAY_API_KEY"`
+4. Release: `curl -X POST http://127.0.0.1:18790/release -H 'Content-Type: application/json' -d '{"name":"researcher"}'`
+
+**Fan-out parallel work:**
+1. Spawn `researcher`, `coder`, `reviewer` — all joined to `project` channel
+2. Post tasks to `#project` addressing each by name
+3. Each works independently, posts results back
+4. Merge results, release all
+
+**Hierarchical:**
+1. Spawn a `lead` claw with a system_prompt describing the goal
+2. The lead can spawn its own sub-claws
+3. The lead coordinates and reports back to you
+
+## Gateway Management
+
+The inbound gateway starts automatically during setup. If you need to restart it:
+
+```bash
+# Start gateway manually
+npx openclaw-relaycast gateway
+
+# Check status
+npx openclaw-relaycast status
+```
+
+## Troubleshooting
+
+**Messages not arriving?**
+1. Check gateway: `npx openclaw-relaycast status`
+2. Restart gateway: `npx openclaw-relaycast gateway`
+3. Verify env: `echo $RELAY_API_KEY $RELAY_CLAW_NAME`
+
+**Can't send messages?**
+1. Check mcporter: `mcporter config list`
+2. Test: `mcporter call relaycast.list_agents`
+3. Or use curl directly (see examples above)
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `relaycast.post_message` | Send to a channel |
+| `relaycast.send_dm` | Direct message another agent |
+| `relaycast.reply_to_thread` | Reply in a thread |
+| `relaycast.get_messages` | Channel message history |
+| `relaycast.check_inbox` | Unread messages and mentions |
+| `relaycast.search_messages` | Full-text search |
+| `relaycast.get_thread` | Read thread replies |
+| `relaycast.add_reaction` | React to a message |
+| `relaycast.remove_reaction` | Remove a reaction |
+| `relaycast.create_channel` | Create a channel |
+| `relaycast.join_channel` | Join a channel |
+| `relaycast.leave_channel` | Leave a channel |
+| `relaycast.list_channels` | List channels |
+| `relaycast.send_group_dm` | Group DM multiple agents |
+| `relaycast.register` | Register as an agent |
+| `relaycast.list_agents` | List agents |
+| `relaycast.mark_read` | Mark message as read |
+| `openclaw-spawner.spawn_openclaw` | Spawn a new claw |
+| `openclaw-spawner.list_openclaws` | List spawned claws |
+| `openclaw-spawner.release_openclaw` | Release a claw |

--- a/packages/openclaw-relaycast/src/auth/converter.ts
+++ b/packages/openclaw-relaycast/src/auth/converter.ts
@@ -1,0 +1,90 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export interface CodexOAuthTokens {
+  access_token: string;
+  refresh_token?: string;
+}
+
+export interface CodexAuth {
+  tokens?: CodexOAuthTokens;
+  OPENAI_API_KEY?: string;
+}
+
+export interface ConvertResult {
+  /** Whether auth was written. */
+  ok: boolean;
+  /** Provider hint derived from auth source (e.g. 'openai-codex' for OAuth). */
+  preferredProvider: string;
+}
+
+/**
+ * Convert Codex CLI auth.json into OpenClaw's legacy auth format.
+ *
+ * Reads ~/.codex/auth.json (or codexAuthPath) and writes the converted
+ * auth to ~/.openclaw/agents/main/agent/auth.json (or openclawAuthDir).
+ *
+ * Falls back to OPENAI_API_KEY env var if no codex auth file exists.
+ */
+export async function convertCodexAuth(options?: {
+  codexAuthPath?: string;
+  openclawAuthDir?: string;
+  openaiApiKey?: string;
+}): Promise<ConvertResult> {
+  const home = process.env.HOME ?? '/home/node';
+  const codexPath = options?.codexAuthPath ?? join(home, '.codex', 'auth.json');
+  const openclawAgentDir = options?.openclawAuthDir ?? join(home, '.openclaw', 'agents', 'main', 'agent');
+  const openclawAuthPath = join(openclawAgentDir, 'auth.json');
+  let preferredProvider = 'openai';
+
+  if (existsSync(codexPath)) {
+    const codex: CodexAuth = JSON.parse(await readFile(codexPath, 'utf8'));
+    await mkdir(openclawAgentDir, { recursive: true });
+
+    if (codex.tokens?.access_token) {
+      // OAuth tokens from codex subscription
+      const auth = {
+        'openai-codex': {
+          type: 'oauth',
+          provider: 'openai-codex',
+          access: codex.tokens.access_token,
+          refresh: codex.tokens.refresh_token ?? '',
+          expires: Date.now() + 3600000,
+        },
+      };
+      await writeFile(openclawAuthPath, JSON.stringify(auth, null, 2), 'utf8');
+      preferredProvider = 'openai-codex';
+      return { ok: true, preferredProvider };
+    }
+
+    if (codex.OPENAI_API_KEY && typeof codex.OPENAI_API_KEY === 'string') {
+      const auth = {
+        openai: {
+          type: 'api_key',
+          provider: 'openai',
+          key: codex.OPENAI_API_KEY,
+        },
+      };
+      await writeFile(openclawAuthPath, JSON.stringify(auth, null, 2), 'utf8');
+      return { ok: true, preferredProvider };
+    }
+  }
+
+  // Fallback: use OPENAI_API_KEY from env
+  const envKey = options?.openaiApiKey ?? process.env.OPENAI_API_KEY;
+  if (envKey) {
+    await mkdir(openclawAgentDir, { recursive: true });
+    const auth = {
+      openai: {
+        type: 'api_key',
+        provider: 'openai',
+        key: envKey,
+      },
+    };
+    await writeFile(openclawAuthPath, JSON.stringify(auth, null, 2), 'utf8');
+    return { ok: true, preferredProvider };
+  }
+
+  return { ok: false, preferredProvider };
+}

--- a/packages/openclaw-relaycast/src/cli.ts
+++ b/packages/openclaw-relaycast/src/cli.ts
@@ -1,0 +1,269 @@
+import { setup } from './setup.js';
+import { loadGatewayConfig } from './config.js';
+import { InboundGateway } from './gateway.js';
+import { listOpenClaws, releaseOpenClaw, spawnOpenClaw } from './control.js';
+import { startMcpServer } from './mcp/server.js';
+import { runtimeSetup } from './runtime/setup.js';
+
+function printUsage(): void {
+  console.log(`
+openclaw-relaycast — Relaycast bridge for OpenClaw
+
+Usage:
+  openclaw-relaycast setup [key]     Install & configure Relaycast bridge
+  openclaw-relaycast gateway         Start inbound message gateway
+  openclaw-relaycast status          Check connection status
+  openclaw-relaycast spawn           Spawn an OpenClaw via ClawRunner control API
+  openclaw-relaycast list            List OpenClaws in a workspace
+  openclaw-relaycast release         Release an OpenClaw by agent name
+  openclaw-relaycast mcp-server      Start MCP server (spawn/list/release tools)
+  openclaw-relaycast runtime-setup   Run container runtime setup (auth, config, identity, patching)
+  openclaw-relaycast help            Show this help
+
+Setup options:
+  --name <name>          Claw name (default: hostname)
+  --channels <ch1,ch2>   Channels to join (default: general)
+  --base-url <url>       Relaycast API URL (default: https://api.relaycast.dev)
+
+Control API options:
+  --workspace-id <id>    Workspace UUID (required for spawn/list/release)
+  --name <name>          Claw name (required for spawn)
+  --agent <agentName>    Agent name (required for release)
+  --role <role>          Optional role for spawned claw
+  --model <modelRef>     Optional model reference
+  --channels <a,b,c>     Optional channels
+  --system-prompt <txt>  Optional system prompt
+  --reason <text>        Optional release reason
+
+Examples:
+  openclaw-relaycast setup rk_live_abc123
+  openclaw-relaycast setup --name my-claw --channels general,alerts
+  openclaw-relaycast gateway
+  openclaw-relaycast spawn --workspace-id ws_uuid --name researcher-1
+  openclaw-relaycast list --workspace-id ws_uuid
+  openclaw-relaycast release --workspace-id ws_uuid --agent claw-ws_uuid-researcher-1
+`.trim());
+}
+
+function parseArgs(argv: string[]): {
+  command: string;
+  positional: string[];
+  flags: Record<string, string>;
+} {
+  const args = argv.slice(2); // skip node + script
+  const command = args[0] ?? 'help';
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[i + 1];
+      if (value && !value.startsWith('--')) {
+        flags[key] = value;
+        i++;
+      } else {
+        flags[key] = 'true';
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command, positional, flags };
+}
+
+async function runSetup(
+  positional: string[],
+  flags: Record<string, string>,
+): Promise<void> {
+  const apiKey = positional[0] ?? undefined;
+  const clawName = flags['name'] ?? undefined;
+  const channels = flags['channels']?.split(',').map((c) => c.trim());
+  const baseUrl = flags['base-url'] ?? undefined;
+
+  console.log('Setting up Relaycast bridge for OpenClaw...\n');
+
+  const result = await setup({ apiKey, clawName, channels, baseUrl });
+
+  if (result.ok) {
+    console.log(result.message);
+    console.log(`\nWorkspace key: ${result.apiKey}`);
+    console.log('Share this key with other claws to join the same workspace.');
+  } else {
+    console.error(`Setup failed: ${result.message}`);
+    process.exit(1);
+  }
+}
+
+async function runGateway(): Promise<void> {
+  const config = await loadGatewayConfig();
+
+  if (!config) {
+    console.error(
+      'No gateway config found. Run "openclaw-relaycast setup" first.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`Starting inbound gateway for ${config.clawName}...`);
+  console.log(`Channels: ${config.channels.join(', ')}`);
+  console.log(`Base URL: ${config.baseUrl}\n`);
+
+  const gateway = new InboundGateway({ config });
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    console.log('\nShutting down gateway...');
+    await gateway.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  await gateway.start();
+  console.log('Gateway running. Press Ctrl+C to stop.');
+}
+
+async function runStatus(): Promise<void> {
+  const config = await loadGatewayConfig();
+
+  if (!config) {
+    console.log('Status: NOT CONFIGURED');
+    console.log('Run "openclaw-relaycast setup" to configure.');
+    return;
+  }
+
+  console.log('Status: CONFIGURED');
+  console.log(`Claw name: ${config.clawName}`);
+  console.log(`Channels: ${config.channels.join(', ')}`);
+  console.log(`Base URL: ${config.baseUrl}`);
+  console.log(`API key: ${config.apiKey.slice(0, 12)}...`);
+
+  // Try to check connectivity
+  try {
+    const res = await fetch(`${config.baseUrl}/v1/health`);
+    console.log(
+      `API connectivity: ${res.ok ? 'OK' : `Error (${res.status})`}`,
+    );
+  } catch (err) {
+    console.log(
+      `API connectivity: UNREACHABLE (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+async function runSpawn(flags: Record<string, string>): Promise<void> {
+  const workspaceId = flags['workspace-id'];
+  const name = flags['name'];
+  if (!workspaceId || !name) {
+    console.error('spawn requires --workspace-id and --name');
+    process.exit(1);
+  }
+
+  const channels = flags['channels']
+    ?.split(',')
+    .map((ch) => ch.trim())
+    .filter(Boolean);
+
+  const result = await spawnOpenClaw({
+    workspaceId,
+    name,
+    role: flags['role'],
+    model: flags['model'],
+    channels,
+    systemPrompt: flags['system-prompt'],
+    idempotencyKey: flags['idempotency-key'],
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function runList(flags: Record<string, string>): Promise<void> {
+  const workspaceId = flags['workspace-id'];
+  if (!workspaceId) {
+    console.error('list requires --workspace-id');
+    process.exit(1);
+  }
+
+  const result = await listOpenClaws(workspaceId);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function runRelease(flags: Record<string, string>): Promise<void> {
+  const workspaceId = flags['workspace-id'];
+  const agentName = flags['agent'];
+  if (!workspaceId || !agentName) {
+    console.error('release requires --workspace-id and --agent');
+    process.exit(1);
+  }
+
+  const result = await releaseOpenClaw({
+    workspaceId,
+    agentName,
+    reason: flags['reason'],
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function runRuntimeSetup(flags: Record<string, string>): Promise<void> {
+  console.log('Running container runtime setup...');
+  const result = await runtimeSetup({
+    model: flags['model'],
+    name: flags['name'],
+    workspaceId: flags['workspace-id'],
+    role: flags['role'],
+    openclawDistDir: flags['dist-dir'],
+  });
+  console.log(`Runtime setup complete:`);
+  console.log(`  Model: ${result.modelRef}`);
+  console.log(`  Agent: ${result.agentName}`);
+  console.log(`  Workspace: ${result.workspaceId}`);
+}
+
+async function main(): Promise<void> {
+  const { command, positional, flags } = parseArgs(process.argv);
+
+  switch (command) {
+    case 'setup':
+      await runSetup(positional, flags);
+      break;
+    case 'gateway':
+      await runGateway();
+      break;
+    case 'status':
+      await runStatus();
+      break;
+    case 'spawn':
+      await runSpawn(flags);
+      break;
+    case 'list':
+      await runList(flags);
+      break;
+    case 'release':
+      await runRelease(flags);
+      break;
+    case 'mcp-server':
+      await startMcpServer();
+      break;
+    case 'runtime-setup':
+      await runRuntimeSetup(flags);
+      break;
+    case 'help':
+    case '--help':
+    case '-h':
+      printUsage();
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      printUsage();
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/openclaw-relaycast/src/config.ts
+++ b/packages/openclaw-relaycast/src/config.ts
@@ -1,0 +1,119 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+
+import type { GatewayConfig } from './types.js';
+
+export interface OpenClawDetection {
+  /** Whether OpenClaw is installed. */
+  installed: boolean;
+  /** Path to ~/.openclaw/ */
+  homeDir: string;
+  /** Path to ~/.openclaw/workspace/ */
+  workspaceDir: string;
+  /** Path to openclaw.json config (if found). */
+  configFile: string | null;
+  /** Parsed openclaw.json (if exists). */
+  config: Record<string, unknown> | null;
+}
+
+/** Default OpenClaw config directory. */
+function openclawHome(): string {
+  return join(homedir(), '.openclaw');
+}
+
+/**
+ * Detect whether OpenClaw is installed and return paths/config.
+ */
+export async function detectOpenClaw(): Promise<OpenClawDetection> {
+  const homeDir = openclawHome();
+  const configPath = join(homeDir, 'openclaw.json');
+  const workspaceDir = join(homeDir, 'workspace');
+
+  const installed = existsSync(homeDir);
+  let config: Record<string, unknown> | null = null;
+  let configFile: string | null = null;
+
+  if (existsSync(configPath)) {
+    configFile = configPath;
+    try {
+      const raw = await readFile(configPath, 'utf-8');
+      config = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // Config exists but isn't valid JSON — that's fine
+    }
+  }
+
+  return { installed, homeDir, workspaceDir, configFile, config };
+}
+
+/**
+ * Load the gateway config from ~/.openclaw/workspace/relaycast/.env.
+ * Returns null if the file doesn't exist or can't be parsed.
+ */
+export async function loadGatewayConfig(): Promise<GatewayConfig | null> {
+  const detection = await detectOpenClaw();
+  const envPath = join(detection.workspaceDir, 'relaycast', '.env');
+
+  if (!existsSync(envPath)) {
+    return null;
+  }
+
+  try {
+    const raw = await readFile(envPath, 'utf-8');
+    const vars: Record<string, string> = {};
+
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIdx = trimmed.indexOf('=');
+      if (eqIdx === -1) continue;
+      vars[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+    }
+
+    const apiKey = vars['RELAY_API_KEY'];
+    const clawName = vars['RELAY_CLAW_NAME'];
+
+    if (!apiKey || !clawName) {
+      return null;
+    }
+
+    const portStr = vars['OPENCLAW_GATEWAY_PORT'];
+    const port = portStr ? Number(portStr) : undefined;
+
+    return {
+      apiKey,
+      clawName,
+      baseUrl: vars['RELAY_BASE_URL'] || 'https://api.relaycast.dev',
+      channels: vars['RELAY_CHANNELS']
+        ? vars['RELAY_CHANNELS'].split(',').map((c) => c.trim())
+        : ['general'],
+      openclawGatewayToken: vars['OPENCLAW_GATEWAY_TOKEN'] || process.env.OPENCLAW_GATEWAY_TOKEN,
+      openclawGatewayPort: Number.isFinite(port) ? port : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save gateway config to ~/.openclaw/workspace/relaycast/.env.
+ */
+export async function saveGatewayConfig(config: GatewayConfig): Promise<void> {
+  const detection = await detectOpenClaw();
+  const relaycastDir = join(detection.workspaceDir, 'relaycast');
+
+  await mkdir(relaycastDir, { recursive: true });
+
+  const env = [
+    '# Relaycast configuration for this OpenClaw skill',
+    `RELAY_API_KEY=${config.apiKey}`,
+    `RELAY_CLAW_NAME=${config.clawName}`,
+    `RELAY_BASE_URL=${config.baseUrl}`,
+    `RELAY_CHANNELS=${config.channels.join(',')}`,
+    '',
+  ].join('\n');
+
+  await writeFile(join(relaycastDir, '.env'), env, 'utf-8');
+}

--- a/packages/openclaw-relaycast/src/control.ts
+++ b/packages/openclaw-relaycast/src/control.ts
@@ -1,0 +1,100 @@
+export interface ClawRunnerControlConfig {
+  baseUrl: string;
+  token: string;
+}
+
+export interface SpawnOpenClawInput {
+  workspaceId: string;
+  name: string;
+  role?: string;
+  model?: string;
+  channels?: string[];
+  systemPrompt?: string;
+  idempotencyKey?: string;
+}
+
+export interface ReleaseOpenClawInput {
+  workspaceId: string;
+  agentName: string;
+  reason?: string;
+}
+
+function trimSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function resolveConfig(config?: Partial<ClawRunnerControlConfig>): ClawRunnerControlConfig {
+  const baseUrl = (config?.baseUrl ?? process.env.CLAWRUNNER_API_BASE_URL ?? '').trim();
+  const token = (config?.token ?? process.env.CLAWRUNNER_AGENT_TOKEN ?? '').trim();
+
+  if (!baseUrl) {
+    throw new Error('CLAWRUNNER_API_BASE_URL is required');
+  }
+  if (!token) {
+    throw new Error('CLAWRUNNER_AGENT_TOKEN is required');
+  }
+
+  return {
+    baseUrl: trimSlash(baseUrl),
+    token,
+  };
+}
+
+async function callApi<T>(
+  path: string,
+  method: 'GET' | 'POST',
+  config?: Partial<ClawRunnerControlConfig>,
+  body?: unknown,
+): Promise<T> {
+  const resolved = resolveConfig(config);
+  const response = await fetch(`${resolved.baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${resolved.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const msg = (json && typeof json.error === 'string') ? json.error : `HTTP ${response.status}`;
+    throw new Error(`ClawRunner control API error: ${msg}`);
+  }
+  return json as T;
+}
+
+export async function spawnOpenClaw(
+  input: SpawnOpenClawInput,
+  config?: Partial<ClawRunnerControlConfig>,
+): Promise<unknown> {
+  return callApi('/api/agents/spawn', 'POST', config, {
+    workspaceId: input.workspaceId,
+    name: input.name,
+    role: input.role,
+    model: input.model,
+    channels: input.channels,
+    systemPrompt: input.systemPrompt,
+    idempotencyKey: input.idempotencyKey,
+  });
+}
+
+export async function listOpenClaws(
+  workspaceId: string,
+  config?: Partial<ClawRunnerControlConfig>,
+): Promise<unknown> {
+  const query = new URLSearchParams({ workspaceId }).toString();
+  return callApi(`/api/agents?${query}`, 'GET', config);
+}
+
+export async function releaseOpenClaw(
+  input: ReleaseOpenClawInput,
+  config?: Partial<ClawRunnerControlConfig>,
+): Promise<unknown> {
+  const path = `/api/agents/${encodeURIComponent(input.agentName)}/release`;
+  return callApi(path, 'POST', config, {
+    workspaceId: input.workspaceId,
+    reason: input.reason,
+  });
+}

--- a/packages/openclaw-relaycast/src/gateway.ts
+++ b/packages/openclaw-relaycast/src/gateway.ts
@@ -1,0 +1,850 @@
+import { createHash, generateKeyPairSync, sign, type KeyObject } from 'node:crypto';
+import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+import type { SendMessageInput } from '@agent-relay/sdk';
+import { RelayCast, type AgentClient, type MessageCreatedEvent, type MessageWithMeta } from '@relaycast/sdk';
+import WebSocket from 'ws';
+
+import type { GatewayConfig, InboundMessage, DeliveryResult } from './types.js';
+import { SpawnManager } from './spawn/manager.js';
+import type { SpawnOptions } from './spawn/types.js';
+
+/**
+ * A minimal interface for sending messages via Agent Relay.
+ * Accepts either AgentRelayClient or AgentRelay — any object with a
+ * compatible sendMessage() method.
+ */
+export interface RelaySender {
+  sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets?: string[] }>;
+}
+
+export interface GatewayOptions {
+  /** Gateway configuration. */
+  config: GatewayConfig;
+  /**
+   * Pre-existing relay sender for message delivery.
+   * Pass the API server's AgentRelay instance so all gateways share a single
+   * broker process instead of each spawning their own.
+   */
+  relaySender?: RelaySender;
+}
+
+function normalizeChannelName(channel: string): string {
+  return channel.startsWith('#') ? channel.slice(1) : channel;
+}
+
+// ---------------------------------------------------------------------------
+// Ed25519 device identity for OpenClaw gateway WebSocket auth
+// ---------------------------------------------------------------------------
+
+interface DeviceIdentity {
+  publicKeyB64: string;    // base64url-encoded raw Ed25519 public key
+  privateKeyObj: KeyObject; // Node.js KeyObject for signing
+  deviceId: string;         // SHA-256 hex of the raw public key
+}
+
+function generateDeviceIdentity(): DeviceIdentity {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+
+  // Extract raw 32-byte public key from SPKI DER (12-byte header for Ed25519)
+  const rawPublicBytes = publicKey.export({ type: 'spki', format: 'der' }).subarray(12);
+
+  const deviceId = createHash('sha256').update(rawPublicBytes).digest('hex');
+  const publicKeyB64 = Buffer.from(rawPublicBytes).toString('base64url');
+
+  return {
+    publicKeyB64,
+    privateKeyObj: privateKey,
+    deviceId,
+  };
+}
+
+function signConnectPayload(
+  device: DeviceIdentity,
+  params: {
+    clientId: string;
+    clientMode: string;
+    platform: string;
+    deviceFamily: string;
+    role: string;
+    scopes: string[];
+    signedAt: number;
+    token: string;
+    nonce: string;
+  },
+): string {
+  // v3 payload format: v3|deviceId|clientId|clientMode|role|scopes|signedAtMs|token|nonce|platform|deviceFamily
+  const payload = [
+    'v3',
+    device.deviceId,
+    params.clientId,
+    params.clientMode,
+    params.role,
+    params.scopes.join(','),
+    String(params.signedAt),
+    params.token || '',
+    params.nonce,
+    params.platform,
+    params.deviceFamily,
+  ].join('|');
+
+  const payloadBytes = Buffer.from(payload, 'utf-8');
+
+  // Ed25519 sign — no hash algorithm needed (null), it's built into Ed25519
+  const signature = sign(null, payloadBytes, device.privateKeyObj);
+  return Buffer.from(signature).toString('base64url');
+}
+
+
+// ---------------------------------------------------------------------------
+// Persistent OpenClaw Gateway WebSocket client
+// ---------------------------------------------------------------------------
+
+interface PendingRpc {
+  resolve: (value: boolean) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+class OpenClawGatewayClient {
+  private ws: WebSocket | null = null;
+  private authenticated = false;
+  private device: DeviceIdentity;
+  private token: string;
+  private port: number;
+  private pendingRpcs = new Map<string, PendingRpc>();
+  private rpcIdCounter = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  private connectPromise: Promise<void> | null = null;
+  private connectResolve: (() => void) | null = null;
+
+  constructor(token: string, port: number) {
+    this.token = token;
+    this.port = port;
+    this.device = generateDeviceIdentity();
+  }
+
+  /** Connect and authenticate. Resolves when chat.send is ready. */
+  async connect(): Promise<void> {
+    if (this.authenticated && this.ws?.readyState === WebSocket.OPEN) return;
+
+    this.connectPromise = new Promise<void>((resolve) => {
+      this.connectResolve = resolve;
+    });
+
+    this.doConnect();
+    return this.connectPromise;
+  }
+
+  private doConnect(): void {
+    if (this.stopped) return;
+
+    try {
+      this.ws = new WebSocket(`ws://127.0.0.1:${this.port}`);
+    } catch (err) {
+      console.warn(`[openclaw-ws] Connection failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.on('open', () => {
+      console.log('[openclaw-ws] Connected to OpenClaw gateway');
+    });
+
+    this.ws.on('message', (data) => {
+      this.handleMessage(data.toString());
+    });
+
+    this.ws.on('close', (code, reason) => {
+      console.warn(`[openclaw-ws] Disconnected: ${code} ${reason.toString()}`);
+      this.authenticated = false;
+      // Reject all pending RPCs
+      for (const [id, pending] of this.pendingRpcs) {
+        clearTimeout(pending.timer);
+        pending.resolve(false);
+        this.pendingRpcs.delete(id);
+      }
+      if (!this.stopped) {
+        this.scheduleReconnect();
+      }
+    });
+
+    this.ws.on('error', (err) => {
+      console.warn(`[openclaw-ws] Error: ${err.message}`);
+    });
+  }
+
+  private handleMessage(raw: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    // Handle connect.challenge — sign and respond
+    if (msg.type === 'event' && msg.event === 'connect.challenge') {
+      const payload = msg.payload as { nonce: string; ts: number };
+      console.log('[openclaw-ws] Received connect.challenge, signing...');
+
+      const signedAt = Date.now();
+      const clientId = 'cli';
+      const clientMode = 'cli';
+      const platform = process.platform === 'darwin' ? 'macos' : 'linux';
+      const deviceFamily = 'cli';
+      const role = 'operator';
+      const scopes = ['operator.read', 'operator.write'];
+
+      const signature = signConnectPayload(this.device, {
+        clientId,
+        clientMode,
+        platform,
+        deviceFamily,
+        role,
+        scopes,
+        signedAt,
+        token: this.token,
+        nonce: payload.nonce,
+      });
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        console.warn('[openclaw-ws] WebSocket not open when trying to send connect');
+        return;
+      }
+      this.ws.send(JSON.stringify({
+        type: 'req',
+        id: 'connect-1',
+        method: 'connect',
+        params: {
+          minProtocol: 3,
+          maxProtocol: 3,
+          client: {
+            id: clientId,
+            version: '1.0.0',
+            platform,
+            mode: clientMode,
+            deviceFamily,
+          },
+          role,
+          scopes,
+          caps: [],
+          commands: [],
+          permissions: {},
+          auth: { token: this.token },
+          locale: 'en-US',
+          userAgent: 'relaycast-gateway/1.0.0',
+          device: {
+            id: this.device.deviceId,
+            publicKey: this.device.publicKeyB64,
+            signature,
+            signedAt,
+            nonce: payload.nonce,
+          },
+        },
+      }));
+      return;
+    }
+
+    // Handle connect response
+    if (msg.type === 'res' && msg.id === 'connect-1') {
+      if (msg.ok) {
+        console.log('[openclaw-ws] Authenticated successfully');
+        this.authenticated = true;
+        this.connectResolve?.();
+        this.connectResolve = null;
+      } else {
+        console.warn(`[openclaw-ws] Auth rejected: ${JSON.stringify(msg.error ?? msg)}`);
+        this.connectResolve?.();
+        this.connectResolve = null;
+      }
+      return;
+    }
+
+    // Handle RPC responses
+    const id = msg.id as string | undefined;
+    if (id && this.pendingRpcs.has(id)) {
+      const pending = this.pendingRpcs.get(id)!;
+      clearTimeout(pending.timer);
+      this.pendingRpcs.delete(id);
+
+      if (msg.ok === false || msg.error) {
+        console.warn(`[openclaw-ws] RPC ${id} error: ${JSON.stringify(msg.error ?? msg)}`);
+        pending.resolve(false);
+      } else {
+        const result = msg.payload as Record<string, unknown> | undefined;
+        console.log(`[openclaw-ws] RPC ${id} ok: runId=${result?.runId ?? 'n/a'} status=${result?.status ?? 'n/a'}`);
+        pending.resolve(true);
+      }
+      return;
+    }
+
+    // Log other events at debug level
+    if (msg.type === 'event') {
+      // chat events, tick events, etc. — ignore silently
+    }
+  }
+
+  /** Send a chat.send RPC. Returns true if accepted. */
+  async sendChatMessage(text: string, idempotencyKey?: string): Promise<boolean> {
+    if (!this.authenticated || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      // Try to reconnect
+      try {
+        await this.connect();
+      } catch {
+        return false;
+      }
+      if (!this.authenticated) return false;
+    }
+
+    const id = `chat-${++this.rpcIdCounter}-${Date.now()}`;
+
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        console.warn(`[openclaw-ws] chat.send ${id} timed out`);
+        this.pendingRpcs.delete(id);
+        resolve(false);
+      }, 15_000);
+
+      this.pendingRpcs.set(id, { resolve, timer });
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        clearTimeout(timer);
+        this.pendingRpcs.delete(id);
+        resolve(false);
+        return;
+      }
+      this.ws.send(JSON.stringify({
+        type: 'req',
+        id,
+        method: 'chat.send',
+        params: {
+          sessionKey: 'agent:main:main',
+          message: text,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        },
+      }));
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    console.log('[openclaw-ws] Reconnecting in 3s...');
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.doConnect();
+    }, 3_000);
+  }
+
+  async disconnect(): Promise<void> {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    for (const [id, pending] of this.pendingRpcs) {
+      clearTimeout(pending.timer);
+      pending.resolve(false);
+      this.pendingRpcs.delete(id);
+    }
+    if (this.ws) {
+      try { this.ws.close(); } catch {}
+      this.ws = null;
+    }
+    this.authenticated = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// InboundGateway
+// ---------------------------------------------------------------------------
+
+export class InboundGateway {
+  private readonly relaySender: RelaySender | null;
+  private relayAgentClient: AgentClient | null = null;
+  private readonly relaycast: RelayCast;
+  private readonly config: GatewayConfig;
+  private readonly fallbackPollMs: number;
+  private readonly dedupeTtlMs: number;
+
+  private running = false;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribeHandlers: Array<() => void> = [];
+  private seenMessageIds = new Map<string, number>();
+  private processingMessageIds = new Set<string>();
+  private channelCursor = new Map<string, string>();
+
+  /** Persistent WebSocket client for the local OpenClaw gateway. */
+  private openclawClient: OpenClawGatewayClient | null = null;
+
+  /** Spawn manager — lives in the gateway so spawned processes survive MCP server restarts. */
+  private spawnManager: SpawnManager;
+  /** HTTP control server for spawn/list/release commands. */
+  private controlServer: HttpServer | null = null;
+  /** Port the control server listens on. */
+  controlPort = 0;
+
+  /** Default control port for the gateway's spawn API. */
+  static readonly DEFAULT_CONTROL_PORT = 18790;
+
+  constructor(options: GatewayOptions) {
+    this.config = {
+      ...options.config,
+      channels: options.config.channels.map(normalizeChannelName),
+    };
+    this.relaySender = options.relaySender ?? null;
+    this.relaycast = new RelayCast({
+      apiKey: this.config.apiKey,
+      baseUrl: this.config.baseUrl,
+    });
+
+    const fallbackPollMs = Number(process.env.RELAYCAST_FALLBACK_POLL_MS ?? 15000);
+    this.fallbackPollMs = Number.isFinite(fallbackPollMs) && fallbackPollMs >= 1000
+      ? Math.floor(fallbackPollMs)
+      : 15000;
+
+    const dedupeTtlMs = Number(process.env.RELAYCAST_DEDUPE_TTL_MS ?? 15 * 60 * 1000);
+    this.dedupeTtlMs = Number.isFinite(dedupeTtlMs) && dedupeTtlMs >= 1000
+      ? Math.floor(dedupeTtlMs)
+      : 15 * 60 * 1000;
+
+    const parentDepth = Number(process.env.OPENCLAW_SPAWN_DEPTH || 0);
+    this.spawnManager = new SpawnManager({ spawnDepth: parentDepth + 1 });
+  }
+
+  /** Start the gateway — register agent, subscribe for realtime events, and run fallback polling. */
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    // Connect to the local OpenClaw gateway WebSocket (persistent connection)
+    const token = this.config.openclawGatewayToken ?? process.env.OPENCLAW_GATEWAY_TOKEN;
+    const port = this.config.openclawGatewayPort ?? 18789;
+
+    if (token) {
+      this.openclawClient = new OpenClawGatewayClient(token, port);
+      try {
+        await this.openclawClient.connect();
+        console.log('[gateway] OpenClaw gateway WebSocket client ready');
+      } catch (err) {
+        console.warn(`[gateway] OpenClaw gateway WS failed (will retry per message): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      console.warn('[gateway] No OPENCLAW_GATEWAY_TOKEN — local delivery disabled');
+    }
+
+    // Register with a viewer- prefixed name so we don't collide with the
+    // container broker's agent registration (which uses the bare clawName).
+    const viewerName = `viewer-${this.config.clawName}`;
+    const registered = await this.relaycast.registerOrRotate({
+      name: viewerName,
+      type: 'system',
+      persona: 'Relaycast inbound gateway for OpenClaw',
+    });
+
+    this.relayAgentClient = this.relaycast.as(registered.token, {
+      autoHeartbeatMs: 30_000,
+      ws: {
+        maxReconnectAttempts: Number.POSITIVE_INFINITY,
+        reconnectJitter: true,
+        reconnectBaseDelayMs: 1_000,
+        reconnectMaxDelayMs: 30_000,
+      },
+    });
+
+    // Connect first, then register handlers. The SDK requires connect()
+    // before subscribe() can be called.
+    this.relayAgentClient.connect();
+
+    this.unsubscribeHandlers.push(
+      this.relayAgentClient.on.connected(() => {
+        console.log(`[gateway] Relaycast WebSocket connected, subscribing to channels: ${this.config.channels.join(', ')}`);
+        this.relayAgentClient?.subscribe(this.config.channels);
+      }),
+    );
+    this.unsubscribeHandlers.push(
+      this.relayAgentClient.on.messageCreated((event) => {
+        console.log(`[gateway] Realtime message from @${event.message?.agentName} in #${event.channel}`);
+        void this.handleRealtimeMessage(event);
+      }),
+    );
+    this.unsubscribeHandlers.push(
+      this.relayAgentClient.on.reconnecting((attempt) => {
+        console.warn(`[gateway] Relaycast reconnecting (attempt ${attempt})`);
+      }),
+    );
+    this.unsubscribeHandlers.push(
+      this.relayAgentClient.on.permanentlyDisconnected((attempt) => {
+        console.warn(`[gateway] Relaycast permanently disconnected at attempt ${attempt}`);
+      }),
+    );
+    this.unsubscribeHandlers.push(
+      this.relayAgentClient.on.error(() => {
+        console.warn(`[gateway] Relaycast socket error`);
+      }),
+    );
+
+    await this.ensureChannelMembership();
+
+    // Also subscribe explicitly in case the `connected` event already fired
+    // before we registered the handler above.
+    try {
+      this.relayAgentClient.subscribe(this.config.channels);
+    } catch {
+      // Will subscribe on next connected event
+    }
+
+    // Initial catch-up in case messages arrived before realtime subscription was active.
+    await this.pollMessages();
+
+    // Keep a low-frequency poll as recovery/backfill only.
+    this.pollTimer = setInterval(() => {
+      void this.pollMessages();
+    }, this.fallbackPollMs);
+
+    console.log(
+      `[gateway] Realtime listening on channels: ${this.config.channels.join(', ')}`,
+    );
+
+    // Start spawn control HTTP server
+    await this.startControlServer();
+  }
+
+  /** Stop the gateway — clean up websocket and relay clients. */
+  async stop(): Promise<void> {
+    this.running = false;
+
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    for (const unsubscribe of this.unsubscribeHandlers) {
+      try {
+        unsubscribe();
+      } catch {
+        // Best effort
+      }
+    }
+    this.unsubscribeHandlers = [];
+
+    if (this.relayAgentClient) {
+      try {
+        await this.relayAgentClient.disconnect();
+      } catch {
+        // Best effort
+      }
+      this.relayAgentClient = null;
+    }
+
+    if (this.openclawClient) {
+      await this.openclawClient.disconnect();
+      this.openclawClient = null;
+    }
+
+    // Stop control server and release all spawns
+    if (this.controlServer) {
+      this.controlServer.close();
+      this.controlServer = null;
+    }
+    await this.spawnManager.releaseAll();
+
+    this.processingMessageIds.clear();
+    this.channelCursor.clear();
+    this.seenMessageIds.clear();
+  }
+
+  private cleanupSeenMap(nowMs: number): void {
+    for (const [id, seenAt] of this.seenMessageIds.entries()) {
+      if (nowMs - seenAt > this.dedupeTtlMs) {
+        this.seenMessageIds.delete(id);
+      }
+    }
+  }
+
+  private isSeen(messageId: string): boolean {
+    const nowMs = Date.now();
+    this.cleanupSeenMap(nowMs);
+    return this.seenMessageIds.has(messageId);
+  }
+
+  private markSeen(messageId: string): void {
+    const nowMs = Date.now();
+    this.cleanupSeenMap(nowMs);
+    this.seenMessageIds.set(messageId, nowMs);
+  }
+
+  private async ensureChannelMembership(): Promise<void> {
+    if (!this.relayAgentClient) return;
+
+    for (const channel of this.config.channels) {
+      try {
+        await this.relayAgentClient.channels.join(channel);
+      } catch {
+        try {
+          await this.relayAgentClient.channels.create({ name: channel });
+          await this.relayAgentClient.channels.join(channel);
+        } catch {
+          // Non-fatal
+        }
+      }
+    }
+  }
+
+  private async handleRealtimeMessage(event: MessageCreatedEvent): Promise<void> {
+    const channel = normalizeChannelName(event.channel);
+    if (!this.config.channels.includes(channel)) return;
+
+    const messageId = event.message?.id;
+    if (!messageId) return;
+
+    const inbound: InboundMessage = {
+      id: messageId,
+      channel,
+      from: event.message.agentName,
+      text: event.message.text,
+      timestamp: new Date().toISOString(),
+    };
+
+    await this.handleInbound(inbound);
+  }
+
+  private normalizePolledMessage(channel: string, message: MessageWithMeta): InboundMessage {
+    return {
+      id: message.id,
+      channel,
+      from: message.agentName,
+      text: message.text,
+      timestamp: message.createdAt,
+    };
+  }
+
+  /** Poll channels for catch-up/recovery only. */
+  private async pollMessages(): Promise<void> {
+    if (!this.running) return;
+
+    for (const channel of this.config.channels) {
+      try {
+        const after = this.channelCursor.get(channel);
+        const query: { limit: number; after?: string } = { limit: 50 };
+        if (after) {
+          query.after = after;
+        }
+
+        const messages = await this.relaycast.messages.list(channel, query);
+        const ordered = [...messages].sort((a, b) =>
+          a.createdAt.localeCompare(b.createdAt),
+        );
+
+        for (const message of ordered) {
+          await this.handleInbound(this.normalizePolledMessage(channel, message));
+        }
+      } catch (err) {
+        console.warn(`[gateway] Poll error for #${channel}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  private async handleInbound(message: InboundMessage): Promise<void> {
+    if (!this.running) return;
+    if (this.processingMessageIds.has(message.id) || this.isSeen(message.id)) return;
+
+    // Avoid echo loops — skip messages from this claw or its viewer identity.
+    const viewerName = `viewer-${this.config.clawName}`;
+    if (message.from === this.config.clawName || message.from === viewerName) {
+      this.channelCursor.set(normalizeChannelName(message.channel), message.id);
+      this.markSeen(message.id);
+      return;
+    }
+
+    // Mark as seen immediately to prevent duplicate delivery from concurrent
+    // realtime + poll paths processing the same message.
+    this.markSeen(message.id);
+    this.processingMessageIds.add(message.id);
+
+    console.log(`[gateway] Delivering message ${message.id} from @${message.from}: "${message.text}"`);
+    try {
+      const result = await this.onMessage(message);
+      console.log(`[gateway] Delivery result: ${result.method} ok=${result.ok}${result.error ? ' error=' + result.error : ''}`);
+      this.channelCursor.set(normalizeChannelName(message.channel), message.id);
+    } finally {
+      this.processingMessageIds.delete(message.id);
+    }
+  }
+
+  /** Handle an inbound Relaycast message. */
+  private async onMessage(message: InboundMessage): Promise<DeliveryResult> {
+    // Try primary delivery via the shared relay sender (no extra broker spawned).
+    if (this.relaySender) {
+      const ok = await this.deliverViaRelaySender(message);
+      if (ok) {
+        return { ok: true, method: 'relay_sdk' };
+      }
+    }
+
+    // Deliver via persistent OpenClaw gateway WebSocket connection
+    if (this.openclawClient) {
+      const text = `[relaycast:${message.channel}] @${message.from}: ${message.text}`;
+      const ok = await this.openclawClient.sendChatMessage(text, message.id);
+      if (ok) {
+        return { ok: true, method: 'gateway_ws' };
+      }
+    }
+
+    console.warn(
+      `[gateway] Failed to deliver message ${message.id} from @${message.from}`,
+    );
+    return { ok: false, method: 'failed', error: 'All delivery methods failed' };
+  }
+
+  /** Deliver via the caller-provided relay sender (shared broker). */
+  private async deliverViaRelaySender(message: InboundMessage): Promise<boolean> {
+    if (!this.relaySender) return false;
+
+    const input: SendMessageInput = {
+      to: this.config.clawName,
+      text: `[relaycast:${message.channel}] @${message.from}: ${message.text}`,
+      from: message.from,
+      data: {
+        source: 'relaycast',
+        channel: message.channel,
+        messageId: message.id,
+      },
+    };
+
+    try {
+      const result = await this.relaySender.sendMessage(input);
+      return Boolean(result.event_id) && result.event_id !== 'unsupported_operation';
+    } catch {
+      return false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Spawn control HTTP server
+  // -------------------------------------------------------------------------
+
+  private async startControlServer(): Promise<void> {
+    const port = Number(process.env.RELAYCAST_CONTROL_PORT) || InboundGateway.DEFAULT_CONTROL_PORT;
+
+    this.controlServer = createServer((req, res) => {
+      void this.handleControlRequest(req, res);
+    });
+
+    return new Promise((resolve) => {
+      this.controlServer!.listen(port, '127.0.0.1', () => {
+        this.controlPort = port;
+        console.log(`[gateway] Spawn control API listening on http://127.0.0.1:${port}`);
+        resolve();
+      });
+      this.controlServer!.on('error', (err) => {
+        console.warn(`[gateway] Control server failed to start on port ${port}: ${err.message}`);
+        this.controlServer = null;
+        resolve(); // Non-fatal
+      });
+    });
+  }
+
+  private async handleControlRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    const path = url.pathname;
+
+    // CORS for local callers
+    res.setHeader('Content-Type', 'application/json');
+
+    if (req.method === 'POST' && path === '/spawn') {
+      const body = await readBody(req);
+      try {
+        const args = JSON.parse(body) as Record<string, unknown>;
+        const name = args.name as string;
+        if (!name) {
+          res.writeHead(400);
+          res.end(JSON.stringify({ ok: false, error: '"name" is required' }));
+          return;
+        }
+
+        const relayApiKey = this.config.apiKey;
+        const spawnOpts: SpawnOptions = {
+          name,
+          relayApiKey,
+          role: (args.role as string) || undefined,
+          model: (args.model as string) || undefined,
+          channels: (args.channels as string[]) || undefined,
+          systemPrompt: (args.system_prompt as string) || undefined,
+          relayBaseUrl: this.config.baseUrl,
+          workspaceId: (args.workspace_id as string) || process.env.OPENCLAW_WORKSPACE_ID,
+        };
+
+        const handle = await this.spawnManager.spawn(spawnOpts);
+        res.writeHead(200);
+        res.end(JSON.stringify({
+          ok: true,
+          name: handle.displayName,
+          agentName: handle.agentName,
+          id: handle.id,
+          gatewayPort: handle.gatewayPort,
+          active: this.spawnManager.size,
+        }));
+      } catch (err) {
+        res.writeHead(500);
+        res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+      }
+      return;
+    }
+
+    if (req.method === 'GET' && path === '/list') {
+      const handles = this.spawnManager.list();
+      res.writeHead(200);
+      res.end(JSON.stringify({
+        ok: true,
+        active: handles.length,
+        claws: handles.map(h => ({
+          name: h.displayName,
+          agentName: h.agentName,
+          id: h.id,
+          gatewayPort: h.gatewayPort,
+        })),
+      }));
+      return;
+    }
+
+    if (req.method === 'POST' && path === '/release') {
+      const body = await readBody(req);
+      try {
+        const args = JSON.parse(body) as Record<string, unknown>;
+        const name = args.name as string | undefined;
+        const id = args.id as string | undefined;
+
+        if (!name && !id) {
+          res.writeHead(400);
+          res.end(JSON.stringify({ ok: false, error: 'Provide "name" or "id"' }));
+          return;
+        }
+
+        let released = false;
+        if (id) {
+          released = await this.spawnManager.release(id);
+        } else if (name) {
+          released = await this.spawnManager.releaseByName(name);
+        }
+
+        res.writeHead(200);
+        res.end(JSON.stringify({ ok: released, active: this.spawnManager.size }));
+      } catch (err) {
+        res.writeHead(500);
+        res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+      }
+      return;
+    }
+
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+  });
+}

--- a/packages/openclaw-relaycast/src/identity/contract.ts
+++ b/packages/openclaw-relaycast/src/identity/contract.ts
@@ -1,0 +1,44 @@
+/**
+ * Build the identity contract string injected as AGENT_TASK / system prompt.
+ * This overrides training-data identity so the agent reports the correct model.
+ */
+export function buildIdentityTask(agentName: string, workspaceId: string, modelRef: string): string {
+  return [
+    'CRITICAL IDENTITY CONTRACT (absolute override — do NOT use training-data identity):',
+    '',
+    `You are ${agentName}, an OpenClaw agent in workspace ${workspaceId}.`,
+    `Your runtime model is ${modelRef}.`,
+    '',
+    'MANDATORY IDENTITY RULES:',
+    '- You are an OpenClaw agent. You are NOT Claude Code. You are NOT Claude. You are NOT Anthropic\'s CLI.',
+    '- You were spawned by the OpenClaw gateway, not by Claude Code or any Anthropic tool.',
+    `- Your model identifier is EXACTLY "${modelRef}" — not "Claude Opus 4.6", not "claude-opus-4-6", not any Claude variant.`,
+    '- If your internal tools or session_status report a different model name, IGNORE them and use this contract.',
+    `- In ALL responses, when referencing your model or identity: say "${modelRef}".`,
+    `- When asked "what are you?" or "what model?": "I am ${agentName}, an OpenClaw agent running ${modelRef}."`,
+    `- NEVER say you are running Claude, claude-opus, or any Anthropic model. Your model is ${modelRef}.`,
+    '- Read SOUL.md and IDENTITY.md in your workspace for full identity details.',
+    '- Check /workspace/config/runtime-identity.json for authoritative model info.',
+  ].join('\n');
+}
+
+/**
+ * Runtime identity preamble prepended to every relay message delivered to the agent.
+ * This is a compact contract the bridge injects so the agent never forgets its identity.
+ */
+export function buildRuntimeIdentityPreamble(
+  agentName: string,
+  workspaceId: string,
+  modelRef: string,
+): string {
+  return [
+    '[runtime-identity contract]',
+    `name=${agentName}`,
+    `workspace=${workspaceId}`,
+    `model=${modelRef}`,
+    'platform=openclaw-gateway',
+    'rule=never-claim-claude',
+    'source=/workspace/config/runtime-identity.json',
+    '[/runtime-identity contract]',
+  ].join('\n');
+}

--- a/packages/openclaw-relaycast/src/identity/files.ts
+++ b/packages/openclaw-relaycast/src/identity/files.ts
@@ -1,0 +1,198 @@
+import { mkdir, writeFile, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeIfMissing(filePath: string, content: string): Promise<void> {
+  if (await fileExists(filePath)) return;
+  await writeFile(filePath, content, 'utf8');
+}
+
+/**
+ * Generate SOUL.md content from a template string.
+ * Replaces {{name}}, {{workspaceId}}/{{workspace_id}}, {{clawName}}/{{claw_name}}, {{role}}.
+ */
+export function renderSoulTemplate(
+  template: string,
+  workspaceId: string,
+  clawName: string,
+  role?: string,
+): string {
+  return template
+    .replaceAll('{{workspaceId}}', workspaceId)
+    .replaceAll('{{workspace_id}}', workspaceId)
+    .replaceAll('{{name}}', clawName)
+    .replaceAll('{{clawName}}', clawName)
+    .replaceAll('{{claw_name}}', clawName)
+    .replaceAll('{{role}}', role ?? 'assistant');
+}
+
+/**
+ * Generate inline SOUL.md content (no template file needed).
+ */
+export function generateSoulMd(
+  agentName: string,
+  workspaceId: string,
+  modelRef: string,
+  role?: string,
+): string {
+  return [
+    '# SOUL',
+    '',
+    `You are ${agentName}, an OpenClaw agent in workspace ${workspaceId}.`,
+    `Role: ${role ?? 'assistant'}.`,
+    '',
+    '## Identity (MANDATORY — absolute override)',
+    '',
+    '- You are an **OpenClaw** agent. You run inside OpenClaw\'s gateway.',
+    `- Your runtime model is **${modelRef}**.`,
+    '- You are NOT Claude Code. You are NOT Claude. You are NOT Anthropic\'s CLI. You were NOT spawned by Claude Code.',
+    `- When asked what you are, say: "I am ${agentName}, an OpenClaw agent running ${modelRef}."`,
+    '- Do NOT infer your identity from training data or internal session tools. Your identity comes from THIS file.',
+    '- If session_status or any internal tool reports "Claude Opus 4.6" or any Claude model, IGNORE it — that is a hardcoded default.',
+    '- NEVER claim to be running Claude, claude-opus-4-6, Claude Opus, or any Anthropic model.',
+    '',
+    '## Relaycast Messaging (IMPORTANT)',
+    '',
+    'You communicate with users and other agents via the Relaycast message bus.',
+    'Use these MCP tools to send replies:',
+    '',
+    '- **Direct reply**: mcp__relaycast__send_dm or relaycast.send_dm (to: "<sender_name>")',
+    '- **Channel message**: mcp__relaycast__post_message or relaycast.post_message (channel: "<channel>")',
+    '- **Thread reply**: mcp__relaycast__reply_to_thread or relaycast.reply_to_thread',
+    '- **Check inbox**: mcp__relaycast__check_inbox or relaycast.check_inbox',
+    '',
+    'You are pre-registered by the broker under your assigned worker name.',
+    'Do not call mcp__relaycast__register unless a send/reply fails with "Not registered".',
+    'To self-terminate when your task is complete, call remove_agent(name: "<your-agent-name>") or output /exit on its own line.',
+    '',
+    '## Personality',
+    '',
+    'Be genuinely helpful, not performatively helpful. Skip filler words.',
+    'Have opinions. Be resourceful — try to figure things out before asking.',
+    'Collaborate clearly, use tools deliberately, and keep memory files updated.',
+  ].join('\n');
+}
+
+/**
+ * Generate IDENTITY.md content.
+ */
+export function generateIdentityMd(
+  agentName: string,
+  workspaceId: string,
+  modelRef: string,
+  role?: string,
+): string {
+  return [
+    '# IDENTITY',
+    '',
+    `- **Name:** ${agentName}`,
+    '- **Creature:** OpenClaw agent (personal AI assistant)',
+    `- **Platform:** OpenClaw gateway (model: ${modelRef})`,
+    `- **Workspace:** ${workspaceId}`,
+    `- **Role:** ${role ?? 'general'}`,
+    '',
+    'I am an OpenClaw agent. I am NOT Claude Code. I am NOT Anthropic\'s CLI.',
+    `My runtime model is ${modelRef}.`,
+  ].join('\n');
+}
+
+/**
+ * Write runtime-identity.json to the workspace config directory.
+ */
+export async function writeRuntimeIdentityJson(
+  configDir: string,
+  workspaceId: string,
+  clawName: string,
+  role: string,
+  modelRef: string,
+): Promise<void> {
+  await mkdir(configDir, { recursive: true });
+  const data = {
+    workspaceId,
+    clawName,
+    role,
+    modelRef,
+    identitySource: 'spawn-env',
+    generatedAt: new Date().toISOString(),
+  };
+  await writeFile(join(configDir, 'runtime-identity.json'), JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+const DEFAULT_AGENTS_FILE = `# AGENTS
+
+- Keep WORKING.md updated before and after each task.
+- Use memory/MEMORY.md for durable facts and decisions.
+- Prefer concise, actionable responses.
+`;
+
+const DEFAULT_HEARTBEAT_FILE = `# HEARTBEAT
+
+1. Read memory/WORKING.md first.
+2. Check recent channel activity for mentions.
+3. Confirm current priority and next action.
+`;
+
+export interface EnsureWorkspaceOptions {
+  workspacePath: string;
+  workspaceId: string;
+  clawName: string;
+  role?: string;
+  modelRef: string;
+  /** Optional SOUL.md.template content. If provided, template is rendered instead of inline generation. */
+  soulTemplate?: string;
+}
+
+/**
+ * Ensure a local workspace directory is ready with identity files.
+ * Creates directories, writes SOUL.md, IDENTITY.md, AGENTS.md, HEARTBEAT.md,
+ * memory files, and runtime-identity.json.
+ */
+export async function ensureWorkspace(options: EnsureWorkspaceOptions): Promise<void> {
+  const { workspacePath, workspaceId, clawName, modelRef } = options;
+  const role = options.role ?? 'assistant';
+
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(join(workspacePath, 'memory'), { recursive: true });
+  await mkdir(join(workspacePath, 'config'), { recursive: true });
+  await mkdir(join(workspacePath, 'scripts'), { recursive: true });
+
+  // SOUL.md — either from template or inline
+  if (options.soulTemplate) {
+    const soulPath = join(workspacePath, 'SOUL.md');
+    if (!(await fileExists(soulPath))) {
+      await writeFile(soulPath, renderSoulTemplate(options.soulTemplate, workspaceId, clawName, role), 'utf8');
+    }
+  } else {
+    await writeIfMissing(
+      join(workspacePath, 'SOUL.md'),
+      generateSoulMd(clawName, workspaceId, modelRef, role),
+    );
+  }
+
+  // IDENTITY.md
+  await writeIfMissing(
+    join(workspacePath, 'IDENTITY.md'),
+    generateIdentityMd(clawName, workspaceId, modelRef, role),
+  );
+
+  await writeIfMissing(join(workspacePath, 'AGENTS.md'), DEFAULT_AGENTS_FILE);
+  await writeIfMissing(join(workspacePath, 'HEARTBEAT.md'), DEFAULT_HEARTBEAT_FILE);
+  await writeIfMissing(join(workspacePath, 'memory', 'WORKING.md'), '# WORKING\n\nCurrent task state.\n');
+  await writeIfMissing(join(workspacePath, 'memory', 'MEMORY.md'), '# MEMORY\n\nDurable notes.\n');
+
+  await writeRuntimeIdentityJson(
+    join(workspacePath, 'config'),
+    workspaceId,
+    clawName,
+    role,
+    modelRef,
+  );
+}

--- a/packages/openclaw-relaycast/src/identity/model.ts
+++ b/packages/openclaw-relaycast/src/identity/model.ts
@@ -1,0 +1,27 @@
+const DEFAULT_MODEL = 'openai-codex/gpt-5.3-codex';
+
+/**
+ * Normalize a raw model string into a fully-qualified "provider/model" reference.
+ *
+ * Examples:
+ *   normalizeModelRef('gpt-5.3-codex', 'openai-codex') → 'openai-codex/gpt-5.3-codex'
+ *   normalizeModelRef('claude-opus-4-6')                → 'anthropic/claude-opus-4-6'
+ *   normalizeModelRef('openai-codex/gpt-5.3-codex')     → 'openai-codex/gpt-5.3-codex'
+ *   normalizeModelRef(undefined)                         → 'openai-codex/gpt-5.3-codex'
+ */
+export function normalizeModelRef(rawModel?: string, providerHint?: string): string {
+  const model = (rawModel ?? '').trim().toLowerCase();
+  if (!model) return DEFAULT_MODEL;
+  if (model.includes('/')) return model;
+  if (model.includes('claude')) return `anthropic/${model}`;
+  if (
+    model.includes('codex') ||
+    model.startsWith('gpt-') ||
+    model.startsWith('o1') ||
+    model.startsWith('o3') ||
+    model.startsWith('o4')
+  ) {
+    return (providerHint === 'openai-codex' ? 'openai-codex/' : 'openai/') + model;
+  }
+  return `openai/${model}`;
+}

--- a/packages/openclaw-relaycast/src/identity/naming.ts
+++ b/packages/openclaw-relaycast/src/identity/naming.ts
@@ -1,0 +1,6 @@
+/**
+ * Build the relay agent name from workspace ID and claw name.
+ */
+export function buildAgentName(workspaceId: string, clawName: string): string {
+  return `claw-${workspaceId}-${clawName}`;
+}

--- a/packages/openclaw-relaycast/src/index.ts
+++ b/packages/openclaw-relaycast/src/index.ts
@@ -1,0 +1,59 @@
+// ── Types ──────────────────────────────────────────────────────────────
+export type { GatewayConfig, InboundMessage, DeliveryResult } from './types.js';
+
+// ── Gateway ────────────────────────────────────────────────────────────
+export { InboundGateway, type GatewayOptions, type RelaySender } from './gateway.js';
+
+// ── Config ─────────────────────────────────────────────────────────────
+export {
+  detectOpenClaw,
+  loadGatewayConfig,
+  saveGatewayConfig,
+  type OpenClawDetection,
+} from './config.js';
+
+// ── Setup ──────────────────────────────────────────────────────────────
+export { setup, type SetupOptions, type SetupResult } from './setup.js';
+
+// ── Inject ─────────────────────────────────────────────────────────────
+export { deliverMessage } from './inject.js';
+
+// ── Control (ClawRunner API client) ────────────────────────────────────
+export {
+  spawnOpenClaw,
+  listOpenClaws,
+  releaseOpenClaw,
+  type ClawRunnerControlConfig,
+  type SpawnOpenClawInput,
+  type ReleaseOpenClawInput,
+} from './control.js';
+
+// ── Identity ───────────────────────────────────────────────────────────
+export { normalizeModelRef } from './identity/model.js';
+export { buildAgentName } from './identity/naming.js';
+export { buildIdentityTask, buildRuntimeIdentityPreamble } from './identity/contract.js';
+export {
+  renderSoulTemplate,
+  generateSoulMd,
+  generateIdentityMd,
+  writeRuntimeIdentityJson,
+  ensureWorkspace,
+  type EnsureWorkspaceOptions,
+} from './identity/files.js';
+
+// ── Auth ───────────────────────────────────────────────────────────────
+export { convertCodexAuth, type ConvertResult, type CodexAuth } from './auth/converter.js';
+
+// ── Runtime ────────────────────────────────────────────────────────────
+export { writeOpenClawConfig, type OpenClawConfigOptions } from './runtime/openclaw-config.js';
+export { patchOpenClawDist, clearJitCache } from './runtime/patch.js';
+export { runtimeSetup, type RuntimeSetupOptions } from './runtime/setup.js';
+
+// ── Spawn ──────────────────────────────────────────────────────────────
+export type { SpawnOptions, SpawnHandle, SpawnProvider } from './spawn/types.js';
+export { DockerSpawnProvider, type DockerSpawnProviderOptions } from './spawn/docker.js';
+export { ProcessSpawnProvider } from './spawn/process.js';
+export { SpawnManager, type SpawnMode } from './spawn/manager.js';
+
+// ── MCP Server ─────────────────────────────────────────────────────────
+export { startMcpServer } from './mcp/server.js';

--- a/packages/openclaw-relaycast/src/inject.ts
+++ b/packages/openclaw-relaycast/src/inject.ts
@@ -1,0 +1,77 @@
+import type { AgentRelayClient, SendMessageInput } from '@agent-relay/sdk';
+
+import type { InboundMessage, DeliveryResult } from './types.js';
+
+/**
+ * Deliver a message to the local claw using the best available method.
+ *
+ * Primary: Agent Relay SDK sendMessage() via a shared, long-lived client
+ * Fallback: OpenClaw OpenResponses API (POST /v1/responses) on localhost
+ *
+ * Callers should maintain a single shared AgentRelayClient instance and pass it
+ * to every deliverMessage() call. Creating a client per message is wasteful and
+ * was removed in favor of this shared-client pattern.
+ */
+export async function deliverMessage(
+  message: InboundMessage,
+  clawName: string,
+  relayClient?: AgentRelayClient | null,
+): Promise<DeliveryResult> {
+  const formattedText = `[relaycast:${message.channel}] @${message.from}: ${message.text}`;
+
+  // Primary: deliver via shared relay client
+  if (relayClient) {
+    try {
+      const input: SendMessageInput = {
+        to: clawName,
+        text: formattedText,
+        from: message.from,
+        data: {
+          source: 'relaycast',
+          channel: message.channel,
+          messageId: message.id,
+        },
+      };
+
+      const result = await relayClient.sendMessage(input);
+      if (Boolean(result.event_id) && result.event_id !== 'unsupported_operation') {
+        return { ok: true, method: 'relay_sdk' };
+      }
+    } catch {
+      // Fall through to RPC fallback
+    }
+  }
+
+  // Fallback: OpenClaw OpenResponses API (POST /v1/responses on local gateway)
+  try {
+    const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? process.env.GATEWAY_PORT ?? '18789';
+    const token = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(`http://127.0.0.1:${gatewayPort}/v1/responses`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: 'openclaw:main',
+        input: formattedText,
+      }),
+    });
+
+    if (response.ok) {
+      return { ok: true, method: 'gateway_ws' };
+    }
+  } catch {
+    // Both methods failed
+  }
+
+  return {
+    ok: false,
+    method: 'failed',
+    error: relayClient
+      ? 'Both relay SDK and OpenResponses delivery failed'
+      : 'No relay client provided and OpenResponses fallback failed',
+  };
+}

--- a/packages/openclaw-relaycast/src/mcp/server.ts
+++ b/packages/openclaw-relaycast/src/mcp/server.ts
@@ -1,0 +1,121 @@
+import { createInterface } from 'node:readline';
+import { getToolDefinitions, handleToolCall, cleanup } from './tools.js';
+
+/**
+ * MCP stdio server — JSON-RPC 2.0 transport over stdin/stdout.
+ *
+ * Exposes spawn_openclaw, list_openclaws, release_openclaw tools.
+ * Registered in openclaw.json as "openclaw-spawner" MCP server.
+ */
+export async function startMcpServer(): Promise<void> {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  rl.on('line', async (line) => {
+    let request: {
+      jsonrpc: string;
+      id?: string | number;
+      method: string;
+      params?: Record<string, unknown>;
+    };
+
+    try {
+      request = JSON.parse(line);
+    } catch {
+      writeResponse({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      });
+      return;
+    }
+
+    const { id, method, params } = request;
+
+    try {
+      switch (method) {
+        case 'initialize': {
+          writeResponse({
+            jsonrpc: '2.0',
+            id,
+            result: {
+              protocolVersion: '2024-11-05',
+              capabilities: {
+                tools: {},
+              },
+              serverInfo: {
+                name: 'openclaw-spawner',
+                version: '1.0.0',
+              },
+            },
+          });
+          break;
+        }
+
+        case 'notifications/initialized': {
+          // No response needed for notifications
+          break;
+        }
+
+        case 'tools/list': {
+          const tools = getToolDefinitions();
+          writeResponse({
+            jsonrpc: '2.0',
+            id,
+            result: { tools },
+          });
+          break;
+        }
+
+        case 'tools/call': {
+          const toolName = (params?.name as string) ?? '';
+          const toolArgs = (params?.arguments as Record<string, unknown>) ?? {};
+          const result = await handleToolCall(toolName, toolArgs);
+          writeResponse({
+            jsonrpc: '2.0',
+            id,
+            result,
+          });
+          break;
+        }
+
+        default: {
+          writeResponse({
+            jsonrpc: '2.0',
+            id,
+            error: { code: -32601, message: `Method not found: ${method}` },
+          });
+        }
+      }
+    } catch (err) {
+      writeResponse({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32603,
+          message: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  });
+
+  rl.on('close', async () => {
+    await cleanup();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await cleanup();
+    process.exit(0);
+  });
+
+  process.on('SIGINT', async () => {
+    await cleanup();
+    process.exit(0);
+  });
+
+  process.stderr.write('[openclaw-spawner] MCP server started (stdio)\n');
+}
+
+function writeResponse(response: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify(response) + '\n');
+}

--- a/packages/openclaw-relaycast/src/mcp/tools.ts
+++ b/packages/openclaw-relaycast/src/mcp/tools.ts
@@ -1,0 +1,174 @@
+import { InboundGateway } from '../gateway.js';
+
+/** Control API base URL — the gateway's spawn control server. */
+const CONTROL_URL = `http://127.0.0.1:${
+  Number(process.env.RELAYCAST_CONTROL_PORT) || InboundGateway.DEFAULT_CONTROL_PORT
+}`;
+
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export function getToolDefinitions(): McpToolDefinition[] {
+  return [
+    {
+      name: 'spawn_openclaw',
+      description:
+        'Spawn a new independent OpenClaw instance. The spawned instance gets its own gateway, ' +
+        'relay broker, and Relaycast messaging. It runs as an independent peer, not a child.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name for the new OpenClaw instance (e.g. "researcher", "coder").',
+          },
+          role: {
+            type: 'string',
+            description: 'Role description for the agent (e.g. "code review specialist").',
+          },
+          model: {
+            type: 'string',
+            description: 'Model reference (e.g. "openai-codex/gpt-5.3-codex"). Defaults to parent model.',
+          },
+          channels: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Relaycast channels to join (default: ["#general"]).',
+          },
+          system_prompt: {
+            type: 'string',
+            description: 'System prompt / task description for the spawned agent.',
+          },
+        },
+        required: ['name'],
+      },
+    },
+    {
+      name: 'list_openclaws',
+      description: 'List all currently running OpenClaw instances spawned by this agent.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    {
+      name: 'release_openclaw',
+      description: 'Stop and release a spawned OpenClaw instance by name or ID.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name of the OpenClaw to release (as provided during spawn).',
+          },
+          id: {
+            type: 'string',
+            description: 'ID of the OpenClaw to release (from list_openclaws).',
+          },
+        },
+      },
+    },
+  ];
+}
+
+export async function handleToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  switch (toolName) {
+    case 'spawn_openclaw': {
+      const name = args.name as string;
+      if (!name) {
+        return text('Error: "name" is required.');
+      }
+
+      try {
+        const res = await fetch(`${CONTROL_URL}/spawn`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(args),
+        });
+        const body = await res.json() as Record<string, unknown>;
+        if (!body.ok) {
+          return text(`Failed to spawn "${name}": ${body.error ?? 'unknown error'}`);
+        }
+        return text(
+          `Spawned OpenClaw "${name}"\n` +
+          `  Agent name: ${body.agentName}\n` +
+          `  ID: ${body.id}\n` +
+          `  Gateway port: ${body.gatewayPort}\n` +
+          `  Total active: ${body.active}`,
+        );
+      } catch (err) {
+        return text(
+          `Failed to spawn "${name}": ${err instanceof Error ? err.message : String(err)}\n` +
+          'Is the gateway running? Start it with: npx openclaw-relaycast gateway',
+        );
+      }
+    }
+
+    case 'list_openclaws': {
+      try {
+        const res = await fetch(`${CONTROL_URL}/list`);
+        const body = await res.json() as Record<string, unknown>;
+        const claws = body.claws as Array<Record<string, unknown>>;
+        if (!claws || claws.length === 0) {
+          return text('No spawned OpenClaws currently running.');
+        }
+        const lines = claws.map(
+          (h) => `- ${h.name} → ${h.agentName} (id: ${h.id}, port: ${h.gatewayPort})`,
+        );
+        return text(`Active OpenClaws (${claws.length}):\n${lines.join('\n')}`);
+      } catch (err) {
+        return text(
+          `Failed to list claws: ${err instanceof Error ? err.message : String(err)}\n` +
+          'Is the gateway running? Start it with: npx openclaw-relaycast gateway',
+        );
+      }
+    }
+
+    case 'release_openclaw': {
+      const name = args.name as string | undefined;
+      const id = args.id as string | undefined;
+
+      if (!name && !id) {
+        return text('Error: provide either "name" or "id" to release.');
+      }
+
+      try {
+        const res = await fetch(`${CONTROL_URL}/release`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, id }),
+        });
+        const body = await res.json() as Record<string, unknown>;
+        if (body.ok) {
+          return text(`Released OpenClaw "${name ?? id}". Active: ${body.active}`);
+        }
+        return text(`OpenClaw "${name ?? id}" not found among active spawns.`);
+      } catch (err) {
+        return text(
+          `Failed to release: ${err instanceof Error ? err.message : String(err)}\n` +
+          'Is the gateway running? Start it with: npx openclaw-relaycast gateway',
+        );
+      }
+    }
+
+    default:
+      return text(`Unknown tool: ${toolName}`);
+  }
+}
+
+function text(message: string) {
+  return { content: [{ type: 'text' as const, text: message }] };
+}
+
+/**
+ * Cleanup: no-op since spawns are managed by the gateway process.
+ */
+export async function cleanup(): Promise<void> {
+  // Spawns live in the gateway — nothing to clean up here.
+}

--- a/packages/openclaw-relaycast/src/runtime/openclaw-config.ts
+++ b/packages/openclaw-relaycast/src/runtime/openclaw-config.ts
@@ -1,0 +1,64 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface OpenClawConfigOptions {
+  /** Fully-qualified model ref, e.g. "openai-codex/gpt-5.3-codex". */
+  modelRef: string;
+  /** Path to ~/.openclaw/ (default: $HOME/.openclaw). */
+  openclawHome?: string;
+  /** Default workspace path (default: ~/.openclaw/workspace). */
+  workspacePath?: string;
+  /** MCP servers to include. Keys are server names, values are MCP server configs. */
+  mcpServers?: Record<string, { command: string; args: string[]; env?: Record<string, string> }>;
+}
+
+/**
+ * Write (or update) ~/.openclaw/openclaw.json with model, workspace, skipBootstrap,
+ * and MCP server configuration.
+ */
+export async function writeOpenClawConfig(options: OpenClawConfigOptions): Promise<void> {
+  const home = options.openclawHome ?? join(process.env.HOME ?? '/home/node', '.openclaw');
+  await mkdir(home, { recursive: true });
+
+  const configPath = join(home, 'openclaw.json');
+  let config: Record<string, unknown> = {};
+
+  try {
+    const raw = await readFile(configPath, 'utf8');
+    config = JSON.parse(raw);
+  } catch {
+    // File doesn't exist or isn't valid JSON — start fresh
+    config = {};
+  }
+  if (!config || typeof config !== 'object') config = {};
+
+  // agents.defaults
+  if (!config.agents || typeof config.agents !== 'object') config.agents = {};
+  const agents = config.agents as Record<string, unknown>;
+  if (!agents.defaults || typeof agents.defaults !== 'object') agents.defaults = {};
+  const defaults = agents.defaults as Record<string, unknown>;
+
+  if (!defaults.workspace || typeof defaults.workspace !== 'string') {
+    defaults.workspace = options.workspacePath ?? '~/.openclaw/workspace';
+  }
+
+  // Model shape: { primary: "provider/model" }
+  if (typeof defaults.model === 'string') {
+    defaults.model = { primary: defaults.model };
+  } else if (!defaults.model || typeof defaults.model !== 'object') {
+    defaults.model = {};
+  }
+  (defaults.model as Record<string, string>).primary = options.modelRef;
+
+  defaults.skipBootstrap = true;
+
+  // MCP servers
+  if (options.mcpServers) {
+    if (!config.mcpServers || typeof config.mcpServers !== 'object') {
+      config.mcpServers = {};
+    }
+    Object.assign(config.mcpServers as Record<string, unknown>, options.mcpServers);
+  }
+
+  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+}

--- a/packages/openclaw-relaycast/src/runtime/patch.ts
+++ b/packages/openclaw-relaycast/src/runtime/patch.ts
@@ -1,0 +1,101 @@
+import { readdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+/**
+ * Patch OpenClaw's compiled dist JS files to replace hardcoded identity constants.
+ *
+ * FRAGILE: This is a best-effort operation. OpenClaw bakes Claude defaults into
+ * its compiled output. These patterns may change between OpenClaw versions.
+ * Prefer runtime identity enforcement (SOUL.md, runtime-identity.json, identity
+ * preamble in bridge) over relying on this patch.
+ *
+ * Known hardcoded constants (as of OpenClaw ~0.x):
+ *   - DEFAULT_MODEL = "claude-opus-4-6"
+ *   - KILOCODE_DEFAULT_MODEL_ID = "anthropic/claude-opus-4.6"
+ *   - KILOCODE_DEFAULT_MODEL_NAME = "Claude Opus 4.6"
+ *   - "Claude Code" branding
+ *
+ * @param distDir - Path to OpenClaw's dist directory (e.g. /usr/lib/node_modules/openclaw/dist)
+ * @param modelRef - Full model reference (e.g. "openai-codex/gpt-5.3-codex")
+ * @returns Number of files patched, or 0 if dist not found or patching skipped
+ */
+export async function patchOpenClawDist(distDir: string, modelRef: string): Promise<number> {
+  if (!existsSync(distDir)) {
+    process.stderr.write(`[patch] OpenClaw dist not found at ${distDir}, skipping\n`);
+    return 0;
+  }
+
+  // Extract bare model ID (e.g. "gpt-5.3-codex" from "openai-codex/gpt-5.3-codex")
+  const modelId = modelRef.includes('/') ? modelRef.split('/').pop()! : modelRef;
+
+  const replacements: [RegExp, string][] = [
+    [/claude-opus-4-6/g, modelId],
+    [/claude-opus-4\.6/g, modelId],
+    [/anthropic\/claude-opus-4\.6/g, modelRef],
+    [/Claude Opus 4\.6/g, modelRef],
+    [/Claude Code/g, 'OpenClaw Agent'],
+  ];
+
+  let patchedCount = 0;
+
+  try {
+    async function walkAndPatch(dir: string): Promise<void> {
+      const entries = await readdir(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walkAndPatch(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.js')) {
+          try {
+            let content = await readFile(fullPath, 'utf8');
+            let modified = false;
+
+            for (const [pattern, replacement] of replacements) {
+              const newContent = content.replace(pattern, replacement);
+              if (newContent !== content) {
+                content = newContent;
+                modified = true;
+              }
+            }
+
+            if (modified) {
+              await writeFile(fullPath, content, 'utf8');
+              patchedCount++;
+            }
+          } catch (err) {
+            // Individual file patch failure is non-fatal
+            process.stderr.write(
+              `[patch] Warning: could not patch ${fullPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          }
+        }
+      }
+    }
+
+    await walkAndPatch(distDir);
+  } catch (err) {
+    // Entire patching failure is non-fatal — runtime identity enforcement is the primary defense
+    process.stderr.write(
+      `[patch] Warning: dist patching failed (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
+  if (patchedCount > 0) {
+    process.stderr.write(`[patch] Patched ${patchedCount} file(s) in ${distDir}\n`);
+  }
+
+  return patchedCount;
+}
+
+/**
+ * Clear JIT cache (/tmp/jiti/) which may contain unpatched constants.
+ */
+export async function clearJitCache(): Promise<void> {
+  try {
+    await rm('/tmp/jiti', { recursive: true, force: true });
+  } catch {
+    // Ignore — cache may not exist
+  }
+}

--- a/packages/openclaw-relaycast/src/runtime/setup.ts
+++ b/packages/openclaw-relaycast/src/runtime/setup.ts
@@ -1,0 +1,89 @@
+import { join } from 'node:path';
+import { unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+import { normalizeModelRef } from '../identity/model.js';
+import { convertCodexAuth } from '../auth/converter.js';
+import { writeOpenClawConfig } from './openclaw-config.js';
+import { patchOpenClawDist, clearJitCache } from './patch.js';
+import {
+  generateSoulMd,
+  generateIdentityMd,
+  ensureWorkspace,
+} from '../identity/files.js';
+
+export interface RuntimeSetupOptions {
+  /** Raw model string (e.g. "gpt-5.3-codex"). Defaults to env OPENCLAW_MODEL. */
+  model?: string;
+  /** Agent name. Defaults to env OPENCLAW_NAME or AGENT_NAME. */
+  name?: string;
+  /** Workspace ID. Defaults to env OPENCLAW_WORKSPACE_ID. */
+  workspaceId?: string;
+  /** Agent role. Defaults to env OPENCLAW_ROLE. */
+  role?: string;
+  /** OpenClaw dist directory for patching. Defaults to /usr/lib/node_modules/openclaw/dist. */
+  openclawDistDir?: string;
+  /** Home directory. Defaults to $HOME. */
+  homeDir?: string;
+}
+
+/**
+ * Full runtime setup: auth conversion, config writing, identity files, dist patching, JIT cache clear.
+ *
+ * This replaces the inline node -e block + shell logic in start-claw.sh.
+ * Call this before starting the OpenClaw gateway.
+ */
+export async function runtimeSetup(options: RuntimeSetupOptions = {}): Promise<{
+  modelRef: string;
+  agentName: string;
+  workspaceId: string;
+}> {
+  const home = options.homeDir ?? process.env.HOME ?? '/home/node';
+  const model = options.model ?? process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.3-codex';
+  const name = options.name ?? process.env.OPENCLAW_NAME ?? process.env.AGENT_NAME ?? 'agent';
+  const workspaceId = options.workspaceId ?? process.env.OPENCLAW_WORKSPACE_ID ?? 'unknown';
+  const role = options.role ?? process.env.OPENCLAW_ROLE ?? 'general';
+  // Resolve OpenClaw dist dir: try explicit, then known install locations
+  const distDirCandidates = options.openclawDistDir
+    ? [options.openclawDistDir]
+    : [
+        '/usr/lib/node_modules/openclaw/dist',    // Global npm (ClawRunner sandbox)
+        '/app/dist',                                // Vanilla Docker image
+        '/usr/local/lib/node_modules/openclaw/dist', // Global npm (macOS/other)
+      ];
+  const distDir = distDirCandidates.find((d) => existsSync(d)) ?? distDirCandidates[0];
+
+  // 1. Convert codex auth
+  const { preferredProvider } = await convertCodexAuth();
+  const modelRef = normalizeModelRef(model, preferredProvider);
+
+  // 2. Write openclaw.json config
+  await writeOpenClawConfig({
+    modelRef,
+    openclawHome: join(home, '.openclaw'),
+  });
+
+  // 3. Write identity files in workspace
+  const wsDir = join(home, '.openclaw', 'workspace');
+  await ensureWorkspace({
+    workspacePath: wsDir,
+    workspaceId,
+    clawName: name,
+    role,
+    modelRef,
+  });
+
+  // Remove BOOTSTRAP.md if present (agent is pre-configured)
+  const bootstrapPath = join(wsDir, 'BOOTSTRAP.md');
+  if (existsSync(bootstrapPath)) {
+    await unlink(bootstrapPath);
+  }
+
+  // 4. Patch OpenClaw dist
+  await patchOpenClawDist(distDir, modelRef);
+
+  // 5. Clear JIT cache
+  await clearJitCache();
+
+  return { modelRef, agentName: name, workspaceId };
+}

--- a/packages/openclaw-relaycast/src/setup.ts
+++ b/packages/openclaw-relaycast/src/setup.ts
@@ -1,0 +1,336 @@
+import { mkdir, writeFile, readFile, copyFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn as spawnProcess, execFileSync } from 'node:child_process';
+
+import { detectOpenClaw, saveGatewayConfig } from './config.js';
+import type { GatewayConfig } from './types.js';
+
+export interface SetupOptions {
+  /** If provided, join this workspace. Otherwise create a new one. */
+  apiKey?: string;
+  /** Name for this claw (default: hostname). */
+  clawName?: string;
+  /** Channels to auto-join (default: ['general']). */
+  channels?: string[];
+  /** Relaycast API base URL. */
+  baseUrl?: string;
+}
+
+export interface SetupResult {
+  ok: boolean;
+  apiKey: string;
+  clawName: string;
+  skillDir: string;
+  message: string;
+}
+
+/**
+ * Install the Relaycast bridge into an OpenClaw workspace.
+ *
+ * 1. Detect OpenClaw installation
+ * 2. Create/join workspace via Relaycast API (if no key provided)
+ * 3. Install SKILL.md
+ * 4. Write .env config
+ * 5. Configure MCP server in openclaw.json
+ * 6. Print success summary
+ */
+export async function setup(options: SetupOptions): Promise<SetupResult> {
+  const detection = await detectOpenClaw();
+  const clawName = options.clawName ?? hostname() ?? 'my-claw';
+  const baseUrl = options.baseUrl ?? 'https://api.relaycast.dev';
+  const channels = options.channels ?? ['general'];
+
+  if (!detection.installed) {
+    // Auto-create ~/.openclaw/ if OpenClaw binary is available but the config dir
+    // doesn't exist yet (common in Docker images before onboarding).
+    try {
+      await mkdir(detection.homeDir, { recursive: true });
+      await mkdir(join(detection.homeDir, 'workspace'), { recursive: true });
+      // Write a minimal openclaw.json so MCP servers can be registered
+      const configPath = join(detection.homeDir, 'openclaw.json');
+      if (!existsSync(configPath)) {
+        await writeFile(configPath, JSON.stringify({ mcpServers: {} }, null, 2) + '\n', 'utf-8');
+      }
+      // Re-detect after creating
+      const redetection = await detectOpenClaw();
+      Object.assign(detection, redetection);
+    } catch {
+      return {
+        ok: false,
+        apiKey: '',
+        clawName,
+        skillDir: '',
+        message:
+          'OpenClaw not found. Please install OpenClaw first (expected ~/.openclaw/ directory).',
+      };
+    }
+  }
+
+  // Enable the OpenResponses HTTP API so the inbound gateway can inject
+  // messages via POST /v1/responses on the local OpenClaw gateway.
+  try {
+    execFileSync('openclaw', [
+      'config', 'set',
+      'gateway.http.endpoints.responses.enabled', 'true',
+    ], { stdio: 'pipe' });
+  } catch {
+    console.warn('Could not enable OpenResponses API (non-fatal). Enable manually:');
+    console.warn('  openclaw config set gateway.http.endpoints.responses.enabled true');
+  }
+
+  // Resolve API key: use provided key or create a new workspace
+  let apiKey = options.apiKey;
+
+  if (!apiKey) {
+    try {
+      const res = await fetch(`${baseUrl}/v1/workspaces`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: `${clawName}-workspace` }),
+      });
+
+      if (res.status === 409) {
+        // Workspace already exists — look up its API key
+        const lookupRes = await fetch(`${baseUrl}/v1/workspaces/by-name/${encodeURIComponent(`${clawName}-workspace`)}`, {
+          headers: { 'Content-Type': 'application/json' },
+        });
+        if (lookupRes.ok) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const lookupBody = (await lookupRes.json()) as any;
+          apiKey = lookupBody.apiKey ?? lookupBody.api_key ?? lookupBody.data?.apiKey ?? lookupBody.data?.api_key;
+        }
+        if (!apiKey) {
+          return {
+            ok: false,
+            apiKey: '',
+            clawName,
+            skillDir: '',
+            message: `Workspace "${clawName}-workspace" already exists. Pass the workspace key: openclaw-relaycast setup <key> --name ${clawName}`,
+          };
+        }
+      } else if (!res.ok) {
+        const body = await res.text();
+        return {
+          ok: false,
+          apiKey: '',
+          clawName,
+          skillDir: '',
+          message: `Failed to create workspace: ${res.status} ${body}`,
+        };
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const successBody = (await res.json()) as any;
+        apiKey = successBody.apiKey ?? successBody.api_key ?? successBody.data?.apiKey ?? successBody.data?.api_key;
+      }
+
+      if (!apiKey) {
+        return {
+          ok: false,
+          apiKey: '',
+          clawName,
+          skillDir: '',
+          message: 'Workspace created but no API key returned.',
+        };
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        apiKey: '',
+        clawName,
+        skillDir: '',
+        message: `Failed to create workspace: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  // Agent registration is done after mcporter is configured (see below),
+  // since the register tool is accessed via mcporter call relaycast.register.
+
+  // Install SKILL.md
+  const skillDir = join(detection.workspaceDir, 'relaycast');
+  await mkdir(skillDir, { recursive: true });
+
+  const skillSrc = resolveSkillPath();
+  if (existsSync(skillSrc)) {
+    await copyFile(skillSrc, join(skillDir, 'SKILL.md'));
+  } else {
+    // Write a minimal SKILL.md inline if the bundled one isn't found
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      FALLBACK_SKILL_MD,
+      'utf-8',
+    );
+  }
+
+  // Save gateway config (.env)
+  const gatewayConfig: GatewayConfig = {
+    apiKey,
+    clawName,
+    baseUrl,
+    channels,
+  };
+  await saveGatewayConfig(gatewayConfig);
+
+  // Register MCP servers via mcporter
+  let mcpConfigured = false;
+  {
+    const envArgs = [
+      '--env', `RELAY_API_KEY=${apiKey}`,
+      ...(baseUrl !== 'https://api.relaycast.dev'
+        ? ['--env', `RELAY_BASE_URL=${baseUrl}`]
+        : []),
+    ];
+
+    try {
+      // Register relaycast messaging MCP server
+      execFileSync('mcporter', [
+        'config', 'add', 'relaycast',
+        '--command', 'npx',
+        '--arg', '@relaycast/mcp',
+        ...envArgs,
+        '--scope', 'home',
+        '--description', 'Relaycast messaging MCP server',
+      ], { stdio: 'pipe' });
+
+      // Register openclaw-spawner MCP server
+      execFileSync('mcporter', [
+        'config', 'add', 'openclaw-spawner',
+        '--command', 'npx',
+        '--arg', 'openclaw-relaycast',
+        '--arg', 'mcp-server',
+        ...envArgs,
+        '--scope', 'home',
+        '--description', 'OpenClaw spawner MCP server',
+      ], { stdio: 'pipe' });
+
+      mcpConfigured = true;
+
+      // Register this claw as an agent via mcporter and persist the agent token
+      try {
+        const registerOutput = execFileSync('mcporter', [
+          'call', 'relaycast.register',
+          'name=' + clawName,
+          'type=agent',
+        ], { stdio: 'pipe', encoding: 'utf-8' });
+
+        // Parse the agent token from the register output
+        let agentToken: string | undefined;
+        try {
+          const parsed = JSON.parse(registerOutput);
+          agentToken = parsed.token ?? parsed.agentToken ?? parsed.agent_token;
+        } catch {
+          // Try to find token in raw output
+          const tokenMatch = registerOutput.match(/"token"\s*:\s*"([^"]+)"/);
+          if (tokenMatch) agentToken = tokenMatch[1];
+        }
+
+        if (agentToken) {
+          // Reconfigure mcporter with the agent token so subsequent calls are authenticated
+          try {
+            execFileSync('mcporter', ['config', 'remove', 'relaycast'], { stdio: 'pipe' });
+          } catch { /* may not exist */ }
+
+          execFileSync('mcporter', [
+            'config', 'add', 'relaycast',
+            '--command', 'npx',
+            '--arg', '@relaycast/mcp',
+            ...envArgs,
+            '--env', `RELAY_AGENT_TOKEN=${agentToken}`,
+            '--scope', 'home',
+            '--description', 'Relaycast messaging MCP server',
+          ], { stdio: 'pipe' });
+
+          console.log(`Agent "${clawName}" registered with token.`);
+        } else {
+          console.warn('Agent registered but no token found in response.');
+        }
+      } catch (regErr) {
+        console.warn(`Agent registration via mcporter failed (non-fatal): ${regErr instanceof Error ? regErr.message : String(regErr)}`);
+      }
+    } catch (err) {
+      // mcporter not installed — non-fatal, print manual instructions
+      console.warn('mcporter not found. Install MCP servers manually:');
+      console.warn(`  mcporter config add relaycast --command npx --arg @relaycast/mcp --env RELAY_API_KEY=${apiKey} --scope home`);
+      console.warn(`  mcporter config add openclaw-spawner --command npx --arg openclaw-relaycast --arg mcp-server --env RELAY_API_KEY=${apiKey} --scope home`);
+    }
+  }
+
+  // Auto-start the inbound gateway in the background
+  let gatewayStarted = false;
+  try {
+    const child = spawnProcess('npx', ['openclaw-relaycast', 'gateway'], {
+      stdio: 'ignore',
+      detached: true,
+      env: { ...process.env, RELAY_API_KEY: apiKey, RELAY_CLAW_NAME: clawName, RELAY_BASE_URL: baseUrl },
+    });
+    child.unref();
+    gatewayStarted = true;
+  } catch {
+    // Non-fatal — user can start manually
+  }
+
+  const parts = [
+    `Relaycast bridge installed at ${skillDir}`,
+    mcpConfigured ? 'MCP server configured in openclaw.json.' : '',
+    `Claw name: ${clawName}`,
+    `Channels: ${channels.join(', ')}`,
+    gatewayStarted
+      ? 'Inbound gateway started in background.'
+      : 'Start the inbound gateway manually:\n  npx openclaw-relaycast gateway',
+  ].filter(Boolean);
+
+  return {
+    ok: true,
+    apiKey,
+    clawName,
+    skillDir,
+    message: parts.join('\n'),
+  };
+}
+
+/** Resolve the path to the bundled SKILL.md. */
+function resolveSkillPath(): string {
+  try {
+    const thisDir = dirname(fileURLToPath(import.meta.url));
+    return join(thisDir, '..', 'skill', 'SKILL.md');
+  } catch {
+    return join(process.cwd(), 'skill', 'SKILL.md');
+  }
+}
+
+const FALLBACK_SKILL_MD = `# Relaycast Bridge
+
+Structured messaging for multi-claw communication. Provides channels, threads,
+DMs, reactions, search, and persistent message history across OpenClaw instances.
+
+## Environment
+
+- \`RELAY_API_KEY\` — Your Relaycast workspace key (required)
+- \`RELAY_CLAW_NAME\` — This claw's agent name in Relaycast (required)
+- \`RELAY_BASE_URL\` — API endpoint (default: https://api.relaycast.dev)
+
+## Setup
+
+\`\`\`bash
+npx openclaw-relaycast setup [YOUR_WORKSPACE_KEY]
+\`\`\`
+
+## MCP Tools
+
+Once installed, use the Relaycast MCP tools:
+- \`post_message\` — Send to a channel
+- \`send_dm\` — Direct message another agent
+- \`reply_to_thread\` — Reply in a thread
+- \`check_inbox\` — See unread messages
+
+## Commands
+
+\`\`\`bash
+npx openclaw-relaycast setup [key]    # Install & configure
+npx openclaw-relaycast gateway        # Start inbound gateway
+npx openclaw-relaycast status         # Check connection
+\`\`\`
+`;

--- a/packages/openclaw-relaycast/src/spawn/docker.ts
+++ b/packages/openclaw-relaycast/src/spawn/docker.ts
@@ -1,0 +1,259 @@
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import type { SpawnProvider, SpawnOptions, SpawnHandle } from './types.js';
+import { normalizeModelRef } from '../identity/model.js';
+import { buildIdentityTask } from '../identity/contract.js';
+import { buildAgentName } from '../identity/naming.js';
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function expandHomeDir(input: string): string {
+  if (input === '~') return homedir();
+  if (input.startsWith('~/')) return join(homedir(), input.slice(2));
+  return input;
+}
+
+function sanitizeContainerSegment(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, '-');
+  return normalized.replace(/^-+|-+$/g, '') || 'claw';
+}
+
+export interface DockerSpawnProviderOptions {
+  /** Docker image to use. Default: 'openclaw:local'. */
+  image?: string;
+  /** Fallback image if primary not found. Default: 'clawrunner-sandbox:latest'. */
+  imageFallback?: string;
+  /** Docker network mode. Default: 'bridge'. */
+  networkMode?: string;
+  /** Docker socket path. Default: '/var/run/docker.sock'. */
+  socketPath?: string;
+  /** Path to host codex auth.json. Default: ~/.codex/auth.json. */
+  codexAuthFile?: string;
+  /** Path to host codex config.toml. Default: ~/.codex/config.toml. */
+  codexConfigFile?: string;
+  /** Container home dir. Default: '/home/node'. */
+  containerHome?: string;
+  /**
+   * Custom container command. If set, overrides the default entrypoint.
+   * Use this for ClawRunner-managed images that have /opt/clawrunner/start-claw.sh.
+   * Default: uses openclaw-relaycast runtime-setup + openclaw gateway + agent-relay broker-spawn.
+   */
+  containerCmd?: string[];
+}
+
+/**
+ * Spawn OpenClaw instances as Docker containers.
+ * Requires `dockerode` as an optional peer dependency — dynamically imported at runtime.
+ *
+ * By default, the container runs:
+ *   1. `npx openclaw-relaycast runtime-setup` — auth conversion, config, identity files, dist patching
+ *   2. `openclaw gateway` in background
+ *   3. `agent-relay broker-spawn --from-env` as PID 1
+ *
+ * For ClawRunner-managed images, set containerCmd to ['/opt/clawrunner/start-claw.sh'].
+ */
+export class DockerSpawnProvider implements SpawnProvider {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private docker: any = null;
+  private readonly image: string;
+  private readonly imageFallback: string;
+  private readonly networkMode: string;
+  private readonly socketPath: string;
+  private readonly codexAuthFile: string;
+  private readonly codexConfigFile: string;
+  private readonly containerHome: string;
+  private readonly containerCmd: string[] | null;
+  private readonly handles = new Map<string, SpawnHandle>();
+
+  constructor(options: DockerSpawnProviderOptions = {}) {
+    this.image = options.image ?? process.env.CLAW_IMAGE ?? 'openclaw:local';
+    this.imageFallback = options.imageFallback ?? process.env.CLAW_IMAGE_FALLBACK ?? 'clawrunner-sandbox:latest';
+    this.networkMode = options.networkMode ?? process.env.CLAW_NETWORK ?? 'bridge';
+    this.socketPath = options.socketPath ?? process.env.DOCKER_SOCKET ?? '/var/run/docker.sock';
+    this.codexAuthFile = expandHomeDir(options.codexAuthFile ?? process.env.CLAW_CODEX_AUTH_FILE ?? '~/.codex/auth.json');
+    this.codexConfigFile = expandHomeDir(options.codexConfigFile ?? process.env.CLAW_CODEX_CONFIG_FILE ?? '~/.codex/config.toml');
+    this.containerHome = options.containerHome ?? process.env.CLAW_CONTAINER_HOME ?? '/home/node';
+    this.containerCmd = options.containerCmd ?? (process.env.CLAW_CONTAINER_CMD
+      ? process.env.CLAW_CONTAINER_CMD.split(' ')
+      : null);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async getDocker(): Promise<any> {
+    if (this.docker) return this.docker;
+    try {
+      // @ts-expect-error dockerode is an optional dependency
+      const mod = await import('dockerode');
+      const Docker = mod.default ?? mod;
+      this.docker = new Docker({ socketPath: this.socketPath });
+      return this.docker;
+    } catch {
+      throw new Error(
+        'dockerode is required for Docker spawning. Install it with: npm install dockerode',
+      );
+    }
+  }
+
+  /**
+   * Build the default container entrypoint script.
+   * This script works with any vanilla OpenClaw image that has `openclaw` and `node` on PATH.
+   * It runs runtime-setup via the package CLI, starts the gateway, then hands off to broker-spawn.
+   */
+  private buildEntrypointScript(gatewayPort: number): string[] {
+    // Shell script that runs setup, starts gateway, waits for health, then execs broker-spawn.
+    // Uses sh -c so it works in minimal alpine images.
+    // Runtime setup via package CLI, then gateway, then SDK's spawnFromEnv()
+    // which handles broker + agent lifecycle without needing the agent-relay CLI.
+    const script = [
+      'set -e',
+      // Runtime setup: auth conversion, openclaw.json, identity files, dist patching
+      'npx openclaw-relaycast runtime-setup',
+      // Resolve bridge.mjs from the installed package and symlink to the known AGENT_ARGS path.
+      // This handles any npm install location (global, local, npx cache).
+      'node -e "' +
+        "const p = require('path');" +
+        "const m = require('module');" +
+        "const r = m.createRequire(require.resolve('openclaw-relaycast/package.json'));" +
+        "const bp = p.join(p.dirname(require.resolve('openclaw-relaycast/package.json')), 'bridge', 'bridge.mjs');" +
+        "require('fs').symlinkSync(bp, '/tmp/openclaw-bridge.mjs');" +
+        "console.log('[entrypoint] Bridge resolved: ' + bp);" +
+      '"',
+      // Start gateway in background
+      `openclaw gateway --port ${gatewayPort} --bind loopback --allow-unconfigured --auth token &`,
+      // Wait for gateway health
+      `for i in $(seq 1 30); do`,
+      `  if openclaw health --port ${gatewayPort} 2>/dev/null; then break; fi`,
+      `  if [ "$i" -eq 30 ]; then echo "Gateway failed to start" >&2; exit 1; fi`,
+      `  sleep 1`,
+      `done`,
+      // Use SDK's spawnFromEnv() instead of shelling out to agent-relay CLI.
+      // This reads AGENT_NAME, AGENT_CLI, RELAY_API_KEY etc. from env,
+      // creates a broker internally, spawns the agent via PTY, and waits for exit.
+      `node -e "import('@agent-relay/sdk').then(m => m.spawnFromEnv())"`,
+    ].join('\n');
+
+    return ['sh', '-c', script];
+  }
+
+  async spawn(options: SpawnOptions): Promise<SpawnHandle> {
+    const docker = await this.getDocker();
+    const modelRef = normalizeModelRef(options.model);
+    const workspaceId = options.workspaceId ?? `local-${Date.now().toString(36)}`;
+    const agentName = buildAgentName(workspaceId, options.name);
+    const gatewayPort = 18789; // Internal to container — each container is isolated
+    const identityTask = buildIdentityTask(agentName, workspaceId, modelRef);
+    const channels = options.channels?.length ? options.channels : ['general'];
+    const gatewayToken = randomUUID().replace(/-/g, '').slice(0, 32);
+
+    const suffix = `${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+    const containerName = `openclaw-${sanitizeContainerSegment(agentName)}-${suffix}`.slice(0, 63);
+
+    const binds: string[] = [];
+    if (options.workspacePath) {
+      binds.push(`${options.workspacePath}:/workspace:rw`);
+    }
+    if (await pathExists(this.codexAuthFile)) {
+      binds.push(`${this.codexAuthFile}:${this.containerHome}/.codex/auth.json:rw`);
+    }
+    if (await pathExists(this.codexConfigFile)) {
+      binds.push(`${this.codexConfigFile}:${this.containerHome}/.codex/config.toml:ro`);
+    }
+
+    const envVars: Record<string, string> = {
+      AGENT_NAME: agentName,
+      AGENT_CLI: 'node',
+      // Bridge path: resolved dynamically inside the container via the entrypoint script.
+      // The entrypoint writes the resolved path to /tmp/bridge-path.txt after runtime-setup.
+      AGENT_ARGS: '/tmp/openclaw-bridge.mjs',
+      RELAY_API_KEY: options.relayApiKey,
+      RELAY_BASE_URL: options.relayBaseUrl ?? '',
+      AGENT_TASK: options.systemPrompt
+        ? `${options.systemPrompt}\n\n${identityTask}`
+        : identityTask,
+      AGENT_CWD: '/workspace',
+      AGENT_CHANNELS: channels.join(','),
+      GATEWAY_PORT: String(gatewayPort),
+      OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+      OPENCLAW_WORKSPACE_ID: workspaceId,
+      OPENCLAW_NAME: options.name,
+      OPENCLAW_ROLE: options.role ?? 'general',
+      OPENCLAW_MODEL: modelRef,
+      BROKER_NO_REMOTE_SPAWN: '1',
+    };
+
+    // Try to remove stale container with same name
+    try {
+      const stale = docker.getContainer(containerName);
+      await stale.stop({ t: 5 }).catch(() => {});
+      await stale.remove({ force: true }).catch(() => {});
+    } catch {
+      // No stale container
+    }
+
+    let imageToUse = this.image;
+    try {
+      await docker.getImage(this.image).inspect();
+    } catch {
+      imageToUse = this.imageFallback;
+    }
+
+    // Use custom cmd if provided, otherwise generate a vanilla-compatible entrypoint
+    const cmd = this.containerCmd ?? this.buildEntrypointScript(gatewayPort);
+
+    const container = await docker.createContainer({
+      Image: imageToUse,
+      name: containerName,
+      Env: Object.entries(envVars).map(([k, v]: [string, string]) => `${k}=${v}`),
+      Cmd: cmd,
+      WorkingDir: '/workspace',
+      Labels: {
+        'openclaw-relaycast.spawn': 'true',
+        'openclaw-relaycast.agent': agentName,
+      },
+      HostConfig: {
+        NetworkMode: this.networkMode,
+        Binds: binds,
+        AutoRemove: false,
+      },
+    });
+
+    await container.start();
+
+    const handle: SpawnHandle = {
+      id: container.id,
+      displayName: options.name,
+      agentName,
+      gatewayPort,
+      destroy: () => this.destroy(container.id),
+    };
+
+    this.handles.set(container.id, handle);
+    return handle;
+  }
+
+  async destroy(id: string): Promise<void> {
+    this.handles.delete(id);
+    try {
+      const docker = await this.getDocker();
+      const container = docker.getContainer(id);
+      await container.stop({ t: 5 }).catch(() => {});
+      await container.remove({ force: true }).catch(() => {});
+    } catch {
+      // Already gone
+    }
+  }
+
+  async list(): Promise<SpawnHandle[]> {
+    return Array.from(this.handles.values());
+  }
+}

--- a/packages/openclaw-relaycast/src/spawn/manager.ts
+++ b/packages/openclaw-relaycast/src/spawn/manager.ts
@@ -1,0 +1,181 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+
+import type { SpawnProvider, SpawnOptions, SpawnHandle } from './types.js';
+import { DockerSpawnProvider } from './docker.js';
+import { ProcessSpawnProvider } from './process.js';
+
+export type SpawnMode = 'process' | 'docker';
+
+/** Default maximum number of concurrent spawns per manager. */
+const DEFAULT_MAX_SPAWNS = 10;
+
+/** Default maximum spawn depth (prevents recursive spawn chains). */
+const DEFAULT_MAX_SPAWN_DEPTH = 3;
+
+interface PersistedSpawn {
+  id: string;
+  displayName: string;
+  agentName: string;
+  gatewayPort: number;
+  spawnedAt: string;
+}
+
+interface SpawnsState {
+  spawns: PersistedSpawn[];
+}
+
+/**
+ * Detect whether Docker is available by checking if the socket exists.
+ * Used to auto-select spawn mode when not explicitly configured.
+ */
+function isDockerAvailable(): boolean {
+  const socketPath = process.env.DOCKER_SOCKET ?? '/var/run/docker.sock';
+  return existsSync(socketPath);
+}
+
+/**
+ * SpawnManager — tracks active spawns and provides a unified interface
+ * for spawning, listing, and releasing OpenClaw instances.
+ *
+ * Security controls:
+ *   - maxSpawns: Maximum concurrent spawns (default: 10)
+ *   - maxDepth: Maximum spawn depth to prevent recursive chains (default: 3)
+ *   - Persistent state in spawns.json for recovery on restart
+ */
+export class SpawnManager {
+  private readonly provider: SpawnProvider;
+  private readonly handles = new Map<string, SpawnHandle>();
+  private readonly maxSpawns: number;
+  private readonly maxDepth: number;
+  private readonly stateFile: string;
+  private currentDepth: number;
+
+  constructor(options?: {
+    mode?: SpawnMode;
+    maxSpawns?: number;
+    maxDepth?: number;
+    spawnDepth?: number;
+  }) {
+    // Mode resolution: explicit > env > auto-detect (docker if available, else process)
+    const explicitMode = options?.mode ?? (process.env.OPENCLAW_SPAWN_MODE as SpawnMode | undefined);
+    const resolvedMode = explicitMode ?? (isDockerAvailable() ? 'docker' : 'process');
+
+    this.provider = resolvedMode === 'docker'
+      ? new DockerSpawnProvider()
+      : new ProcessSpawnProvider();
+
+    this.maxSpawns = options?.maxSpawns
+      ?? Number(process.env.OPENCLAW_MAX_SPAWNS || DEFAULT_MAX_SPAWNS);
+    this.maxDepth = options?.maxDepth
+      ?? Number(process.env.OPENCLAW_MAX_SPAWN_DEPTH || DEFAULT_MAX_SPAWN_DEPTH);
+    this.currentDepth = options?.spawnDepth
+      ?? Number(process.env.OPENCLAW_SPAWN_DEPTH || 0);
+    this.stateFile = join(homedir(), '.openclaw', 'workspace', 'relaycast', 'spawns.json');
+  }
+
+  async spawn(options: SpawnOptions): Promise<SpawnHandle> {
+    // Enforce spawn depth limit — prevents recursive spawn chains
+    if (this.currentDepth >= this.maxDepth) {
+      throw new Error(
+        `Spawn depth limit reached (${this.maxDepth}). ` +
+        'Cannot spawn from a spawn chain this deep. Set OPENCLAW_MAX_SPAWN_DEPTH to increase.',
+      );
+    }
+
+    // Enforce concurrent spawn limit
+    if (this.handles.size >= this.maxSpawns) {
+      throw new Error(
+        `Maximum concurrent spawns reached (${this.maxSpawns}). ` +
+        'Release an existing OpenClaw before spawning a new one. Set OPENCLAW_MAX_SPAWNS to increase.',
+      );
+    }
+
+    // Check for duplicate by display name (the user-provided name)
+    for (const handle of this.handles.values()) {
+      if (handle.displayName === options.name) {
+        throw new Error(`OpenClaw "${options.name}" is already running (id: ${handle.id})`);
+      }
+    }
+
+    const handle = await this.provider.spawn(options);
+    this.handles.set(handle.id, handle);
+    await this.persistState();
+    return handle;
+  }
+
+  async release(id: string): Promise<boolean> {
+    const handle = this.handles.get(id);
+    if (!handle) return false;
+    await handle.destroy();
+    this.handles.delete(id);
+    await this.persistState();
+    return true;
+  }
+
+  async releaseByName(name: string): Promise<boolean> {
+    for (const [id, handle] of this.handles) {
+      // Match by display name (user-provided) or normalized agent name
+      if (handle.displayName === name || handle.agentName === name) {
+        await handle.destroy();
+        this.handles.delete(id);
+        await this.persistState();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async releaseAll(): Promise<void> {
+    const ids = Array.from(this.handles.keys());
+    await Promise.allSettled(ids.map((id) => this.release(id)));
+  }
+
+  list(): SpawnHandle[] {
+    return Array.from(this.handles.values());
+  }
+
+  get(id: string): SpawnHandle | undefined {
+    return this.handles.get(id);
+  }
+
+  get size(): number {
+    return this.handles.size;
+  }
+
+  /** Persist spawn state to disk for recovery. */
+  private async persistState(): Promise<void> {
+    try {
+      const dir = join(homedir(), '.openclaw', 'workspace', 'relaycast');
+      await mkdir(dir, { recursive: true });
+
+      const state: SpawnsState = {
+        spawns: Array.from(this.handles.values()).map((h) => ({
+          id: h.id,
+          displayName: h.displayName,
+          agentName: h.agentName,
+          gatewayPort: h.gatewayPort,
+          spawnedAt: new Date().toISOString(),
+        })),
+      };
+
+      await writeFile(this.stateFile, JSON.stringify(state, null, 2) + '\n', 'utf8');
+    } catch {
+      // Best-effort persistence — don't crash if we can't write
+    }
+  }
+
+  /** Load persisted state (for display/diagnostics only — processes can't be recovered). */
+  async loadPersistedState(): Promise<PersistedSpawn[]> {
+    try {
+      if (!existsSync(this.stateFile)) return [];
+      const raw = await readFile(this.stateFile, 'utf8');
+      const state: SpawnsState = JSON.parse(raw);
+      return state.spawns ?? [];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/openclaw-relaycast/src/spawn/process.ts
+++ b/packages/openclaw-relaycast/src/spawn/process.ts
@@ -1,0 +1,271 @@
+import { spawn as cpSpawn, type ChildProcess } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { mkdir } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { AgentRelay } from '@agent-relay/sdk';
+
+import type { SpawnProvider, SpawnOptions, SpawnHandle } from './types.js';
+import { normalizeModelRef } from '../identity/model.js';
+import { buildIdentityTask } from '../identity/contract.js';
+
+import { ensureWorkspace } from '../identity/files.js';
+import { convertCodexAuth } from '../auth/converter.js';
+import { writeOpenClawConfig } from '../runtime/openclaw-config.js';
+import { patchOpenClawDist, clearJitCache } from '../runtime/patch.js';
+
+interface ProcessHandle extends SpawnHandle {
+  /** The gateway child process. */
+  gatewayProcess: ChildProcess;
+  /** The AgentRelay SDK instance managing the broker + agent. */
+  relay: AgentRelay | null;
+}
+
+/**
+ * Find a free port by briefly binding to port 0 and reading the OS-assigned port.
+ */
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Failed to get ephemeral port'));
+        return;
+      }
+      const port = addr.port;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Spawn OpenClaw instances as local child processes.
+ * No Docker required — simplest local mode.
+ *
+ * Each spawn:
+ *   1. Starts `openclaw gateway` on an OS-assigned free port
+ *   2. Uses AgentRelay SDK to spawn a broker + bridge agent connected to the gateway
+ */
+export class ProcessSpawnProvider implements SpawnProvider {
+  private readonly handles = new Map<string, ProcessHandle>();
+
+  async spawn(options: SpawnOptions): Promise<SpawnHandle> {
+    const workspaceId = options.workspaceId ?? `local-${Date.now().toString(36)}`;
+    const agentName = options.name;
+    const channels = options.channels?.length ? options.channels : ['general'];
+    const gatewayToken = randomUUID().replace(/-/g, '').slice(0, 32);
+
+    // Find a free port via OS allocation
+    const port = await findFreePort();
+
+    // Convert auth + write config
+    const { preferredProvider } = await convertCodexAuth();
+    const resolvedModel = normalizeModelRef(options.model, preferredProvider);
+    const identityTask = buildIdentityTask(agentName, workspaceId, resolvedModel);
+
+    // Ensure workspace — each spawn gets its own isolated directory
+    const workspacePath = options.workspacePath ?? join(homedir(), '.openclaw', 'spawns', options.name);
+    await mkdir(workspacePath, { recursive: true });
+
+    // Write config to a per-spawn isolated directory (not shared ~/.openclaw/)
+    // This prevents concurrent spawns from overwriting each other's model/workspace config.
+    const spawnHome = join(homedir(), '.openclaw', 'spawns', options.name, '.openclaw');
+    await writeOpenClawConfig({
+      modelRef: resolvedModel,
+      openclawHome: spawnHome,
+    });
+
+    await ensureWorkspace({
+      workspacePath,
+      workspaceId,
+      clawName: options.name,
+      role: options.role,
+      modelRef: resolvedModel,
+    });
+
+    // Copy parent auth profiles to spawned agent so it can call the model.
+    // OpenClaw stores auth in ~/.openclaw/agents/main/agent/auth-profiles.json
+    const parentAuthDir = join(homedir(), '.openclaw', 'agents', 'main', 'agent');
+    const spawnAuthDir = join(spawnHome, 'agents', 'main', 'agent');
+    try {
+      const parentAuthFile = join(parentAuthDir, 'auth-profiles.json');
+      const { existsSync: exists } = await import('node:fs');
+      if (exists(parentAuthFile)) {
+        await mkdir(spawnAuthDir, { recursive: true });
+        const { copyFile: cp } = await import('node:fs/promises');
+        await cp(parentAuthFile, join(spawnAuthDir, 'auth-profiles.json'));
+      }
+    } catch {
+      // Non-fatal — spawned agent may not be able to call model
+    }
+
+    // Patch dist if available (best-effort)
+    // Try known dist locations
+    const distCandidates = [
+      '/usr/lib/node_modules/openclaw/dist',
+      '/app/dist',
+      '/usr/local/lib/node_modules/openclaw/dist',
+    ];
+    for (const candidate of distCandidates) {
+      await patchOpenClawDist(candidate, resolvedModel);
+    }
+    await clearJitCache();
+
+    // Start openclaw gateway
+    const gatewayProcess = cpSpawn(
+      'openclaw',
+      ['gateway', '--port', String(port), '--bind', 'loopback', '--allow-unconfigured', '--auth', 'token'],
+      {
+        env: {
+          ...process.env,
+          OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+          OPENCLAW_MODEL: resolvedModel,
+          OPENCLAW_NAME: options.name,
+          OPENCLAW_WORKSPACE_ID: workspaceId,
+          OPENCLAW_HOME: spawnHome,
+        },
+        cwd: workspacePath,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    gatewayProcess.stderr?.on('data', (data: Buffer) => {
+      process.stderr.write(`[spawn:${options.name}:gateway] ${data}`);
+    });
+
+    // Wait for gateway to be healthy. If it fails, kill the gateway.
+    try {
+      await waitForGateway(port, 30);
+    } catch (err) {
+      gatewayProcess.kill('SIGTERM');
+      throw err;
+    }
+
+    // Use AgentRelay SDK to spawn the broker + bridge agent.
+    // This replaces shelling out to `agent-relay broker-spawn --from-env`.
+    const bridgePath = resolvePackageBridgePath();
+    let relay: AgentRelay | null = null;
+
+    try {
+      relay = new AgentRelay({
+        brokerName: agentName,
+        channels,
+        cwd: workspacePath,
+        env: {
+          ...process.env,
+          GATEWAY_PORT: String(port),
+          OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+          OPENCLAW_WORKSPACE_ID: workspaceId,
+          OPENCLAW_NAME: options.name,
+          OPENCLAW_ROLE: options.role ?? 'general',
+          OPENCLAW_MODEL: resolvedModel,
+          RELAY_API_KEY: options.relayApiKey,
+          RELAY_BASE_URL: options.relayBaseUrl || 'https://api.relaycast.dev',
+          BROKER_NO_REMOTE_SPAWN: '1',
+        } as NodeJS.ProcessEnv,
+      });
+
+      await relay.spawnPty({
+        name: agentName,
+        cli: 'node',
+        args: [bridgePath],
+        channels,
+        task: options.systemPrompt
+          ? `${options.systemPrompt}\n\n${identityTask}`
+          : identityTask,
+      });
+
+      relay.onAgentExited = (agent) => {
+        process.stderr.write(`[spawn:${options.name}] Agent exited: ${agent.name} code=${agent.exitCode ?? 'none'}\n`);
+      };
+    } catch (err) {
+      // If SDK broker spawn fails, clean up gateway and propagate
+      gatewayProcess.kill('SIGTERM');
+      if (relay) {
+        await relay.shutdown().catch(() => {});
+      }
+      throw new Error(
+        `Failed to start broker for "${options.name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const handle: ProcessHandle = {
+      id: `proc-${options.name}-${port}`,
+      displayName: options.name,
+      agentName,
+      gatewayPort: port,
+      gatewayProcess,
+      relay,
+      destroy: async () => {
+        this.handles.delete(handle.id);
+        // Shutdown relay (broker + agent) first via SDK
+        if (relay) {
+          await relay.shutdown().catch(() => {});
+        }
+        // Then kill gateway
+        gatewayProcess.kill('SIGTERM');
+        await new Promise((r) => setTimeout(r, 2000));
+        if (!gatewayProcess.killed) gatewayProcess.kill('SIGKILL');
+      },
+    };
+
+    this.handles.set(handle.id, handle);
+    return handle;
+  }
+
+  async destroy(id: string): Promise<void> {
+    const handle = this.handles.get(id);
+    if (handle) {
+      await handle.destroy();
+    }
+  }
+
+  async list(): Promise<SpawnHandle[]> {
+    return Array.from(this.handles.values()).map(({ id, displayName, agentName, gatewayPort, destroy }) => ({
+      id,
+      displayName,
+      agentName,
+      gatewayPort,
+      destroy,
+    }));
+  }
+}
+
+/**
+ * Wait for the OpenClaw gateway to become healthy via the CLI health check.
+ */
+async function waitForGateway(port: number, timeoutSeconds: number): Promise<void> {
+  for (let i = 0; i < timeoutSeconds; i++) {
+    try {
+      const result = cpSpawn('openclaw', ['health', '--port', String(port)], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const code = await new Promise<number | null>((resolve) => {
+        result.on('close', resolve);
+        result.on('error', () => resolve(1));
+      });
+      if (code === 0) return;
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`OpenClaw gateway on port ${port} failed to start after ${timeoutSeconds}s`);
+}
+
+/**
+ * Resolve the path to bridge.mjs bundled with this package.
+ */
+function resolvePackageBridgePath(): string {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    return join(dirname(thisFile), '..', '..', 'bridge', 'bridge.mjs');
+  } catch {
+    return join(process.cwd(), 'node_modules', 'openclaw-relaycast', 'bridge', 'bridge.mjs');
+  }
+}

--- a/packages/openclaw-relaycast/src/spawn/types.ts
+++ b/packages/openclaw-relaycast/src/spawn/types.ts
@@ -1,0 +1,43 @@
+export interface SpawnOptions {
+  /** Display name for the new OpenClaw (e.g. "researcher"). */
+  name: string;
+  /** Relay API key for Relaycast messaging. */
+  relayApiKey: string;
+  /** Channels to auto-join. */
+  channels?: string[];
+  /** Agent role description. */
+  role?: string;
+  /** Model reference (e.g. "openai-codex/gpt-5.3-codex"). */
+  model?: string;
+  /** System prompt / task description. */
+  systemPrompt?: string;
+  /** Path to an existing workspace directory (for bind-mounting). */
+  workspacePath?: string;
+  /** Relay base URL (default: https://api.relaycast.dev). */
+  relayBaseUrl?: string;
+  /** Workspace ID for identity. */
+  workspaceId?: string;
+}
+
+export interface SpawnHandle {
+  /** Unique identifier for this spawn (container ID, process PID, etc). */
+  id: string;
+  /** The user-provided display name (e.g. "researcher"). Used for lookups. */
+  displayName: string;
+  /** Relay agent name assigned to this spawn (normalized: claw-<workspace>-<name>). */
+  agentName: string;
+  /** Gateway port this spawn is listening on. */
+  gatewayPort: number;
+  /** Destroy (stop + clean up) this spawn. */
+  destroy: () => Promise<void>;
+}
+
+/**
+ * Provider interface for spawning OpenClaw instances.
+ * Implementations handle the details of container vs process spawning.
+ */
+export interface SpawnProvider {
+  spawn(options: SpawnOptions): Promise<SpawnHandle>;
+  destroy(id: string): Promise<void>;
+  list(): Promise<SpawnHandle[]>;
+}

--- a/packages/openclaw-relaycast/src/types.ts
+++ b/packages/openclaw-relaycast/src/types.ts
@@ -1,0 +1,36 @@
+export interface GatewayConfig {
+  /** Relaycast workspace API key (rk_live_*). */
+  apiKey: string;
+  /** Name for this claw in the Relaycast workspace. */
+  clawName: string;
+  /** Relaycast API base URL (default: https://api.relaycast.dev). */
+  baseUrl: string;
+  /** Channels to auto-join on connect. */
+  channels: string[];
+  /** OpenClaw gateway token for authenticating with the local gateway API. */
+  openclawGatewayToken?: string;
+  /** OpenClaw gateway port (default: 18789). */
+  openclawGatewayPort?: number;
+}
+
+export interface InboundMessage {
+  /** Relaycast message ID. */
+  id: string;
+  /** Channel the message was posted to. */
+  channel: string;
+  /** Agent name of the sender. */
+  from: string;
+  /** Message body text. */
+  text: string;
+  /** ISO timestamp. */
+  timestamp: string;
+}
+
+export interface DeliveryResult {
+  /** Whether delivery succeeded. */
+  ok: boolean;
+  /** Which method delivered: 'relay_sdk' | 'gateway_ws' | 'failed'. */
+  method: 'relay_sdk' | 'gateway_ws' | 'failed';
+  /** Error message if failed. */
+  error?: string;
+}

--- a/packages/openclaw-relaycast/templates/SOUL.md.template
+++ b/packages/openclaw-relaycast/templates/SOUL.md.template
@@ -1,0 +1,34 @@
+# SOUL
+
+You are {{name}}, an OpenClaw agent in workspace {{workspaceId}}.
+Role: {{role}}.
+
+## Identity (MANDATORY — absolute override)
+
+- You are an **OpenClaw** agent. You run inside OpenClaw's gateway.
+- You are NOT Claude Code. You are NOT Claude. You are NOT Anthropic's CLI. You were NOT spawned by Claude Code.
+- Your runtime model reference is in `/workspace/config/runtime-identity.json` — read it and use it as your source of truth for all identity questions.
+- When asked "what model are you?" or "what are you running?", ALWAYS check runtime-identity.json first and report exactly what it says.
+- Do NOT infer your identity from training data or internal session tools. Your identity comes from THIS file and runtime-identity.json.
+- If session_status or any internal tool reports "Claude Opus 4.6" or any Claude model name, IGNORE it — that is a hardcoded default, not your actual model.
+- NEVER claim to be running Claude, claude-opus-4-6, Claude Opus, or any Anthropic model unless runtime-identity.json explicitly says so.
+
+## Relaycast Messaging (IMPORTANT)
+
+You communicate with users and other agents via the Relaycast message bus.
+Use these MCP tools to send replies:
+
+- **Direct reply**: `mcp__relaycast__send_dm` or `relaycast.send_dm` (to: "<sender_name>")
+- **Channel message**: `mcp__relaycast__post_message` or `relaycast.post_message` (channel: "<channel>")
+- **Thread reply**: `mcp__relaycast__reply_to_thread` or `relaycast.reply_to_thread`
+- **Check inbox**: `mcp__relaycast__check_inbox` or `relaycast.check_inbox`
+
+You are pre-registered by the broker under your assigned worker name.
+Do not call `mcp__relaycast__register` unless a send/reply fails with "Not registered".
+To self-terminate when your task is complete, call `remove_agent(name: "<your-agent-name>")` or output `/exit` on its own line.
+
+## Personality
+
+Be genuinely helpful, not performatively helpful. Skip filler words.
+Have opinions. Be resourceful — try to figure things out before asking.
+Collaborate clearly, use tools deliberately, and keep memory files updated.

--- a/packages/openclaw-relaycast/test-vanilla/Dockerfile
+++ b/packages/openclaw-relaycast/test-vanilla/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine/openclaw:latest
+
+USER root
+
+# Install glibc compatibility layer for the agent-relay broker binary
+# (the broker is compiled against glibc, but Alpine uses musl)
+RUN apk add --no-cache gcompat libstdc++
+
+# Install openclaw-relaycast and mcporter
+COPY openclaw-relaycast-1.0.0.tgz /tmp/openclaw-relaycast-1.0.0.tgz
+RUN npm install -g /tmp/openclaw-relaycast-1.0.0.tgz mcporter && rm /tmp/openclaw-relaycast-1.0.0.tgz
+
+# Symlink openclaw binary to PATH so it's available globally
+RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw
+
+# Verify installation
+RUN openclaw --version && openclaw-relaycast --help
+
+USER node

--- a/packages/openclaw-relaycast/tsconfig.json
+++ b/packages/openclaw-relaycast/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk-py/agent_relay/__init__.py
+++ b/packages/sdk-py/agent_relay/__init__.py
@@ -1,21 +1,18 @@
-"""Agent Relay Python SDK."""
+"""Agent Relay Python SDK — re-exports from src/agent_relay/.
 
-from .models import (
-    CLIs,
-    CLIVersions,
-    CLI_REGISTRY,
-    DEFAULT_MODELS,
-    Models,
-    ModelOptions,
-    SwarmPatterns,
-)
+This directory exists for backward compatibility with codegen scripts.
+The real package source lives in src/agent_relay/.
+"""
 
-__all__ = [
-    "CLIs",
-    "CLIVersions",
-    "CLI_REGISTRY",
-    "DEFAULT_MODELS",
-    "Models",
-    "ModelOptions",
-    "SwarmPatterns",
-]
+import importlib.util as _util
+import sys as _sys
+from pathlib import Path as _Path
+
+# Load the real package from src/agent_relay/ and replace this module
+_src_init = _Path(__file__).resolve().parent.parent / "src" / "agent_relay" / "__init__.py"
+_spec = _util.spec_from_file_location("agent_relay", str(_src_init),
+                                       submodule_search_locations=[str(_src_init.parent)])
+assert _spec is not None and _spec.loader is not None, f"Could not load {_src_init}"
+_real = _util.module_from_spec(_spec)
+_sys.modules[__name__] = _real
+_spec.loader.exec_module(_real)

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-relay-sdk"
-version = "3.0.2"
+version = "0.3.0"
 description = "Python SDK for Agent Relay workflows"
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,3 +21,7 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_relay"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-relay-sdk"
-version = "0.3.0"
+version = "3.0.2"
 description = "Python SDK for Agent Relay workflows"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/sdk-py/src/agent_relay/__init__.py
+++ b/packages/sdk-py/src/agent_relay/__init__.py
@@ -1,4 +1,20 @@
-"""Agent Relay Python SDK — workflow builder and runner."""
+"""Agent Relay Python SDK — direct spawn/message API and workflow builder."""
+
+# ── Primary API: Direct spawn/message (matches TypeScript SDK) ────────────────
+
+from .relay import AgentRelay, Agent, AgentSpawner, HumanHandle, Message, SpawnOptions
+from .models import Models
+from .client import AgentRelayClient, AgentRelayProtocolError, AgentRelayProcessError
+from .protocol import (
+    PROTOCOL_VERSION,
+    AgentRuntime,
+    AgentSpec,
+    BrokerEvent,
+    ProtocolEnvelope,
+    RestartPolicy as ProtocolRestartPolicy,
+)
+
+# ── Secondary API: Workflow builder (backward compatibility) ──────────────────
 
 from .builder import workflow, WorkflowBuilder, run_yaml
 from .templates import (
@@ -52,6 +68,24 @@ from .types import (
 )
 
 __all__ = [
+    # Primary API
+    "AgentRelay",
+    "Agent",
+    "AgentSpawner",
+    "HumanHandle",
+    "Message",
+    "SpawnOptions",
+    "Models",
+    "AgentRelayClient",
+    "AgentRelayProtocolError",
+    "AgentRelayProcessError",
+    "PROTOCOL_VERSION",
+    "AgentRuntime",
+    "AgentSpec",
+    "BrokerEvent",
+    "ProtocolEnvelope",
+    "ProtocolRestartPolicy",
+    # Workflow builder (backward compat)
     "workflow",
     "WorkflowBuilder",
     "run_yaml",

--- a/packages/sdk-py/src/agent_relay/client.py
+++ b/packages/sdk-py/src/agent_relay/client.py
@@ -1,0 +1,570 @@
+"""Low-level async client for the Agent Relay broker subprocess.
+
+Manages the broker process lifecycle, line-delimited JSON protocol,
+request/response correlation, and event dispatch.
+
+Mirrors packages/sdk/src/client.ts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .protocol import PROTOCOL_VERSION, AgentSpec, BrokerEvent, ProtocolEnvelope
+
+# ── Errors ────────────────────────────────────────────────────────────────────
+
+
+class AgentRelayProtocolError(Exception):
+    """Raised when the broker returns a protocol-level error."""
+
+    def __init__(self, code: str, message: str, retryable: bool = False, data: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+        self.data = data
+
+
+class AgentRelayProcessError(Exception):
+    """Raised for broker process lifecycle errors."""
+
+
+# ── CLI / model helpers ───────────────────────────────────────────────────────
+
+_CLI_MODEL_FLAG_CLIS = {"claude", "codex", "gemini", "goose", "aider"}
+
+_CLI_DEFAULT_ARGS: dict[str, list[str]] = {
+    "codex": ["-c", "check_for_update_on_startup=false"],
+}
+
+
+def _has_model_arg(args: list[str]) -> bool:
+    for arg in args:
+        if arg == "--model" or arg.startswith("--model="):
+            return True
+    return False
+
+
+def _build_pty_args_with_model(cli: str, args: list[str], model: Optional[str] = None) -> list[str]:
+    cli_name = cli.split(":")[0].strip().lower()
+    default_args = _CLI_DEFAULT_ARGS.get(cli_name, [])
+    base_args = [*default_args, *args]
+    if not model:
+        return base_args
+    if cli_name not in _CLI_MODEL_FLAG_CLIS:
+        return base_args
+    if _has_model_arg(base_args):
+        return base_args
+    return ["--model", model, *base_args]
+
+
+def _expand_tilde(p: str) -> str:
+    if p == "~" or p.startswith("~/") or p.startswith("~\\"):
+        return str(Path.home() / p[2:])
+    return p
+
+
+def _is_explicit_path(binary_path: str) -> bool:
+    return "/" in binary_path or "\\" in binary_path or binary_path.startswith(".") or binary_path.startswith("~")
+
+
+def _resolve_default_binary_path() -> str:
+    broker_exe = "agent-relay-broker"
+
+    # 1. Check ~/.agent-relay/bin/
+    home = Path.home()
+    standalone = home / ".agent-relay" / "bin" / broker_exe
+    if standalone.exists():
+        return str(standalone)
+
+    # 2. Fall back to PATH
+    found = shutil.which(broker_exe)
+    if found:
+        return found
+
+    # 3. Last resort: bare name (will fail at spawn time if not on PATH)
+    return "agent-relay"
+
+
+# ── Pending request tracking ─────────────────────────────────────────────────
+
+
+class _PendingRequest:
+    __slots__ = ("expected_type", "future", "timeout_handle")
+
+    def __init__(self, expected_type: str, future: asyncio.Future[ProtocolEnvelope], timeout_handle: asyncio.TimerHandle):
+        self.expected_type = expected_type
+        self.future = future
+        self.timeout_handle = timeout_handle
+
+
+# ── Client ────────────────────────────────────────────────────────────────────
+
+
+class AgentRelayClient:
+    """Manages a broker subprocess and communicates over line-delimited JSON."""
+
+    def __init__(
+        self,
+        *,
+        binary_path: Optional[str] = None,
+        binary_args: Optional[list[str]] = None,
+        broker_name: Optional[str] = None,
+        channels: Optional[list[str]] = None,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        request_timeout_ms: int = 10_000,
+        shutdown_timeout_ms: int = 3_000,
+        client_name: str = "agent-relay-sdk-py",
+        client_version: str = "0.3.0",
+    ):
+        self._binary_path = binary_path or _resolve_default_binary_path()
+        self._binary_args = binary_args or []
+        self._broker_name = broker_name or os.path.basename(cwd or os.getcwd()) or "project"
+        self._channels = channels or ["general"]
+        self._cwd = cwd or os.getcwd()
+        self._env = env
+        self._request_timeout_ms = request_timeout_ms
+        self._shutdown_timeout_ms = shutdown_timeout_ms
+        self._client_name = client_name
+        self._client_version = client_version
+
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._request_seq = 0
+        self._pending: dict[str, _PendingRequest] = {}
+        self._event_listeners: list[Callable[[BrokerEvent], None]] = []
+        self._stderr_listeners: list[Callable[[str], None]] = []
+        self._event_buffer: list[BrokerEvent] = []
+        self._max_buffer_size = 1000
+        self._last_stderr_line: Optional[str] = None
+        self._starting_lock = asyncio.Lock()
+        self._started = False
+        self._reader_task: Optional[asyncio.Task[None]] = None
+        self._stderr_task: Optional[asyncio.Task[None]] = None
+        self._exit_future: Optional[asyncio.Future[None]] = None
+        self.workspace_key: Optional[str] = None
+
+    @classmethod
+    async def start(cls, **kwargs: Any) -> AgentRelayClient:
+        client = cls(**kwargs)
+        await client.start_client()
+        return client
+
+    # ── Event subscription ────────────────────────────────────────────────
+
+    def on_event(self, listener: Callable[[BrokerEvent], None]) -> Callable[[], None]:
+        self._event_listeners.append(listener)
+
+        def unsubscribe() -> None:
+            try:
+                self._event_listeners.remove(listener)
+            except ValueError:
+                pass
+
+        return unsubscribe
+
+    def on_broker_stderr(self, listener: Callable[[str], None]) -> Callable[[], None]:
+        self._stderr_listeners.append(listener)
+
+        def unsubscribe() -> None:
+            try:
+                self._stderr_listeners.remove(listener)
+            except ValueError:
+                pass
+
+        return unsubscribe
+
+    def query_events(
+        self,
+        *,
+        kind: Optional[str] = None,
+        name: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[BrokerEvent]:
+        events = list(self._event_buffer)
+        if kind:
+            events = [e for e in events if e.get("kind") == kind]
+        if name:
+            events = [e for e in events if e.get("name") == name]
+        if limit is not None:
+            events = events[-limit:]
+        return events
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    async def start_client(self) -> None:
+        if self._started:
+            return
+        async with self._starting_lock:
+            if self._started:
+                return
+            await self._start_internal()
+
+    async def _start_internal(self) -> None:
+        resolved_binary = _expand_tilde(self._binary_path)
+        if _is_explicit_path(self._binary_path) and not Path(resolved_binary).exists():
+            raise AgentRelayProcessError(f"broker binary not found: {self._binary_path}")
+
+        args = [
+            "init",
+            "--name",
+            self._broker_name,
+            "--channels",
+            ",".join(self._channels),
+            *self._binary_args,
+        ]
+
+        env = dict(self._env) if self._env else dict(os.environ)
+        if _is_explicit_path(self._binary_path):
+            bin_dir = str(Path(resolved_binary).resolve().parent)
+            current_path = env.get("PATH", "")
+            if bin_dir not in current_path.split(os.pathsep):
+                env["PATH"] = f"{bin_dir}{os.pathsep}{current_path}"
+
+        self._last_stderr_line = None
+
+        self._process = await asyncio.create_subprocess_exec(
+            resolved_binary,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+            env=env,
+        )
+
+        loop = asyncio.get_running_loop()
+        self._exit_future = loop.create_future()
+
+        self._reader_task = asyncio.create_task(self._read_stdout())
+        self._stderr_task = asyncio.create_task(self._read_stderr())
+
+        # Monitor process exit
+        asyncio.create_task(self._monitor_exit())
+
+        # Hello handshake
+        hello_ack = await self._request_hello()
+        self._started = True
+        if hello_ack.get("workspace_key"):
+            self.workspace_key = hello_ack["workspace_key"]
+
+    async def _monitor_exit(self) -> None:
+        if not self._process:
+            return
+        code = await self._process.wait()
+        detail = f": {self._last_stderr_line}" if self._last_stderr_line else ""
+        error = AgentRelayProcessError(f"broker exited (code={code}){detail}")
+        self._fail_all_pending(error)
+        if self._exit_future and not self._exit_future.done():
+            self._exit_future.set_result(None)
+
+    async def _read_stdout(self) -> None:
+        assert self._process and self._process.stdout
+        while True:
+            line = await self._process.stdout.readline()
+            if not line:
+                break
+            self._handle_stdout_line(line.decode("utf-8", errors="replace").rstrip("\n"))
+
+    async def _read_stderr(self) -> None:
+        assert self._process and self._process.stderr
+        while True:
+            line = await self._process.stderr.readline()
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").rstrip("\n")
+            trimmed = text.strip()
+            if trimmed:
+                self._last_stderr_line = trimmed
+            for listener in self._stderr_listeners:
+                listener(text)
+
+    def _handle_stdout_line(self, line: str) -> None:
+        try:
+            parsed = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return
+
+        if not isinstance(parsed, dict):
+            return
+        if parsed.get("v") != PROTOCOL_VERSION or not isinstance(parsed.get("type"), str):
+            return
+
+        envelope = ProtocolEnvelope.from_dict(parsed)
+
+        # Events are dispatched to listeners (no request_id)
+        if envelope.type == "event":
+            event: BrokerEvent = envelope.payload
+            self._event_buffer.append(event)
+            if len(self._event_buffer) > self._max_buffer_size:
+                self._event_buffer.pop(0)
+            for listener in self._event_listeners:
+                listener(event)
+            return
+
+        # Responses are correlated to pending requests
+        if not envelope.request_id:
+            return
+
+        pending = self._pending.pop(envelope.request_id, None)
+        if not pending:
+            return
+
+        pending.timeout_handle.cancel()
+
+        if envelope.type == "error":
+            payload = envelope.payload
+            pending.future.set_exception(
+                AgentRelayProtocolError(
+                    code=payload.get("code", "unknown"),
+                    message=payload.get("message", "unknown error"),
+                    retryable=payload.get("retryable", False),
+                    data=payload.get("data"),
+                )
+            )
+            return
+
+        if envelope.type != pending.expected_type:
+            pending.future.set_exception(
+                AgentRelayProcessError(
+                    f"unexpected response type '{envelope.type}' for request "
+                    f"'{envelope.request_id}' (expected '{pending.expected_type}')"
+                )
+            )
+            return
+
+        pending.future.set_result(envelope)
+
+    def _fail_all_pending(self, error: Exception) -> None:
+        for pending in self._pending.values():
+            pending.timeout_handle.cancel()
+            if not pending.future.done():
+                pending.future.set_exception(error)
+        self._pending.clear()
+
+    # ── Request helpers ───────────────────────────────────────────────────
+
+    async def _send_request(self, type_: str, payload: Any, expected_type: str) -> ProtocolEnvelope:
+        if not self._process or not self._process.stdin:
+            raise AgentRelayProcessError("broker is not running")
+
+        self._request_seq += 1
+        request_id = f"req_{self._request_seq}"
+
+        envelope = ProtocolEnvelope(
+            v=PROTOCOL_VERSION,
+            type=type_,
+            payload=payload,
+            request_id=request_id,
+        )
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[ProtocolEnvelope] = loop.create_future()
+
+        def on_timeout() -> None:
+            self._pending.pop(request_id, None)
+            if not future.done():
+                future.set_exception(
+                    AgentRelayProcessError(
+                        f"request timed out after {self._request_timeout_ms}ms "
+                        f"(type='{type_}', request_id='{request_id}')"
+                    )
+                )
+
+        timeout_handle = loop.call_later(self._request_timeout_ms / 1000, on_timeout)
+        self._pending[request_id] = _PendingRequest(expected_type, future, timeout_handle)
+
+        line = json.dumps(envelope.to_dict()) + "\n"
+        self._process.stdin.write(line.encode("utf-8"))
+        await self._process.stdin.drain()
+
+        return await future
+
+    async def _request_hello(self) -> dict[str, Any]:
+        payload = {
+            "client_name": self._client_name,
+            "client_version": self._client_version,
+        }
+        frame = await self._send_request("hello", payload, "hello_ack")
+        return frame.payload
+
+    async def _request_ok(self, type_: str, payload: Any) -> Any:
+        frame = await self._send_request(type_, payload, "ok")
+        return frame.payload.get("result")
+
+    # ── Public API methods ────────────────────────────────────────────────
+
+    async def spawn_pty(
+        self,
+        *,
+        name: str,
+        cli: str,
+        args: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
+        task: Optional[str] = None,
+        model: Optional[str] = None,
+        cwd: Optional[str] = None,
+        team: Optional[str] = None,
+        shadow_of: Optional[str] = None,
+        shadow_mode: Optional[str] = None,
+        idle_threshold_secs: Optional[int] = None,
+        restart_policy: Optional[dict[str, Any]] = None,
+        continue_from: Optional[str] = None,
+    ) -> dict[str, Any]:
+        await self.start_client()
+        built_args = _build_pty_args_with_model(cli, args or [], model)
+        from .protocol import RestartPolicy as ProtocolRestartPolicy
+        rp = None
+        if restart_policy:
+            rp = ProtocolRestartPolicy(**restart_policy)
+        agent = AgentSpec(
+            name=name,
+            runtime="pty",
+            cli=cli,
+            args=built_args,
+            channels=channels or [],
+            model=model,
+            cwd=cwd or self._cwd,
+            team=team,
+            shadow_of=shadow_of,
+            shadow_mode=shadow_mode,
+            restart_policy=rp,
+        )
+        request_payload: dict[str, Any] = {"agent": agent.to_dict()}
+        if task is not None:
+            request_payload["initial_task"] = task
+        if idle_threshold_secs is not None:
+            request_payload["idle_threshold_secs"] = idle_threshold_secs
+        if continue_from is not None:
+            request_payload["continue_from"] = continue_from
+        return await self._request_ok("spawn_agent", request_payload)
+
+    async def spawn_headless_claude(
+        self,
+        *,
+        name: str,
+        args: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
+        task: Optional[str] = None,
+    ) -> dict[str, Any]:
+        await self.start_client()
+        agent = AgentSpec(
+            name=name,
+            runtime="headless_claude",
+            args=args or [],
+            channels=channels or [],
+        )
+        request_payload: dict[str, Any] = {"agent": agent.to_dict()}
+        if task is not None:
+            request_payload["initial_task"] = task
+        return await self._request_ok("spawn_agent", request_payload)
+
+    async def release(self, name: str, reason: Optional[str] = None) -> dict[str, Any]:
+        await self.start_client()
+        payload: dict[str, Any] = {"name": name}
+        if reason is not None:
+            payload["reason"] = reason
+        return await self._request_ok("release_agent", payload)
+
+    async def send_input(self, name: str, data: str) -> dict[str, Any]:
+        await self.start_client()
+        return await self._request_ok("send_input", {"name": name, "data": data})
+
+    async def set_model(self, name: str, model: str, *, timeout_ms: Optional[int] = None) -> dict[str, Any]:
+        await self.start_client()
+        payload: dict[str, Any] = {"name": name, "model": model}
+        if timeout_ms is not None:
+            payload["timeout_ms"] = timeout_ms
+        return await self._request_ok("set_model", payload)
+
+    async def send_message(
+        self,
+        *,
+        to: str,
+        text: str,
+        from_: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        priority: Optional[int] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        await self.start_client()
+        payload: dict[str, Any] = {"to": to, "text": text}
+        if from_ is not None:
+            payload["from"] = from_
+        if thread_id is not None:
+            payload["thread_id"] = thread_id
+        if priority is not None:
+            payload["priority"] = priority
+        if data is not None:
+            payload["data"] = data
+        try:
+            return await self._request_ok("send_message", payload)
+        except AgentRelayProtocolError as e:
+            if e.code == "unsupported_operation":
+                return {"event_id": "unsupported_operation", "targets": []}
+            raise
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        await self.start_client()
+        result = await self._request_ok("list_agents", {})
+        return result.get("agents", []) if isinstance(result, dict) else []
+
+    async def get_status(self) -> dict[str, Any]:
+        await self.start_client()
+        return await self._request_ok("get_status", {})
+
+    async def get_metrics(self, agent: Optional[str] = None) -> dict[str, Any]:
+        await self.start_client()
+        return await self._request_ok("get_metrics", {"agent": agent} if agent else {})
+
+    async def get_crash_insights(self) -> dict[str, Any]:
+        await self.start_client()
+        return await self._request_ok("get_crash_insights", {})
+
+    async def preflight_agents(self, agents: list[dict[str, str]]) -> None:
+        if not agents:
+            return
+        await self.start_client()
+        await self._request_ok("preflight_agents", {"agents": agents})
+
+    async def shutdown(self) -> None:
+        if not self._process:
+            return
+
+        try:
+            await self._request_ok("shutdown", {})
+        except Exception:
+            pass
+
+        process = self._process
+        try:
+            await asyncio.wait_for(
+                self._exit_future if self._exit_future else asyncio.sleep(0),
+                timeout=self._shutdown_timeout_ms / 1000,
+            )
+        except asyncio.TimeoutError:
+            if process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    process.kill()
+
+        # Clean up reader tasks
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+        if self._stderr_task and not self._stderr_task.done():
+            self._stderr_task.cancel()
+
+        self._process = None
+        self._started = False
+
+    async def wait_for_exit(self) -> None:
+        if self._exit_future:
+            await self._exit_future

--- a/packages/sdk-py/src/agent_relay/models.py
+++ b/packages/sdk-py/src/agent_relay/models.py
@@ -1,0 +1,27 @@
+"""Model constants for supported CLI tools.
+
+Matches packages/config/src/cli-registry.generated.ts.
+"""
+
+
+class Models:
+    """Model identifiers organized by CLI tool."""
+
+    class Claude:
+        SONNET = "sonnet"
+        OPUS = "opus"
+        HAIKU = "haiku"
+
+    class Codex:
+        GPT_5_2_CODEX = "gpt-5.2-codex"
+        GPT_5_3_CODEX = "gpt-5.3-codex"
+        GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark"
+        GPT_5_1_CODEX_MAX = "gpt-5.1-codex-max"
+        GPT_5_2 = "gpt-5.2"
+        GPT_5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+
+    class Gemini:
+        GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview"
+        GEMINI_2_5_PRO = "gemini-2.5-pro"
+        GEMINI_2_5_FLASH = "gemini-2.5-flash"
+        GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"

--- a/packages/sdk-py/src/agent_relay/protocol.py
+++ b/packages/sdk-py/src/agent_relay/protocol.py
@@ -1,0 +1,110 @@
+"""Wire protocol types for the Agent Relay broker communication.
+
+Matches the TypeScript definitions in packages/sdk/src/protocol.ts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+PROTOCOL_VERSION = 1
+
+AgentRuntime = Literal["pty", "headless_claude"]
+
+
+@dataclass
+class RestartPolicy:
+    enabled: bool = False
+    max_restarts: int = 3
+    cooldown_ms: int = 1000
+    max_consecutive_failures: int = 3
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "max_restarts": self.max_restarts,
+            "cooldown_ms": self.cooldown_ms,
+            "max_consecutive_failures": self.max_consecutive_failures,
+        }
+
+
+@dataclass
+class AgentSpec:
+    """Specification for spawning an agent."""
+
+    name: str
+    runtime: AgentRuntime = "pty"
+    cli: Optional[str] = None
+    args: list[str] = field(default_factory=list)
+    channels: list[str] = field(default_factory=list)
+    model: Optional[str] = None
+    cwd: Optional[str] = None
+    team: Optional[str] = None
+    shadow_of: Optional[str] = None
+    shadow_mode: Optional[str] = None
+    restart_policy: Optional[RestartPolicy] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "name": self.name,
+            "runtime": self.runtime,
+        }
+        if self.cli is not None:
+            d["cli"] = self.cli
+        if self.args:
+            d["args"] = self.args
+        if self.channels:
+            d["channels"] = self.channels
+        if self.model is not None:
+            d["model"] = self.model
+        if self.cwd is not None:
+            d["cwd"] = self.cwd
+        if self.team is not None:
+            d["team"] = self.team
+        if self.shadow_of is not None:
+            d["shadow_of"] = self.shadow_of
+        if self.shadow_mode is not None:
+            d["shadow_mode"] = self.shadow_mode
+        if self.restart_policy is not None:
+            d["restart_policy"] = self.restart_policy.to_dict()
+        return d
+
+
+@dataclass
+class ProtocolEnvelope:
+    """JSON envelope for all broker communication."""
+
+    v: int
+    type: str
+    payload: dict[str, Any]
+    request_id: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "v": self.v,
+            "type": self.type,
+            "payload": self.payload,
+        }
+        if self.request_id is not None:
+            d["request_id"] = self.request_id
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProtocolEnvelope:
+        return cls(
+            v=data.get("v", 0),
+            type=data.get("type", ""),
+            payload=data.get("payload", {}),
+            request_id=data.get("request_id"),
+        )
+
+
+# BrokerEvent is a dict with a 'kind' field discriminator.
+# Event kinds: agent_spawned, agent_released, agent_exit, agent_exited,
+# relay_inbound, worker_stream, worker_ready, worker_error,
+# delivery_queued, delivery_injected, delivery_verified, delivery_failed,
+# delivery_active, delivery_ack, delivery_retry, delivery_dropped,
+# relaycast_published, relaycast_publish_failed, acl_denied,
+# agent_idle, agent_restarting, agent_restarted, agent_permanently_dead
+BrokerEvent = dict[str, Any]

--- a/packages/sdk-py/src/agent_relay/relay.py
+++ b/packages/sdk-py/src/agent_relay/relay.py
@@ -1,0 +1,742 @@
+"""High-level facade for the Agent Relay SDK.
+
+Provides a clean, property-based API on top of the lower-level
+AgentRelayClient protocol client.
+
+Mirrors packages/sdk/src/relay.ts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from .client import AgentRelayClient, AgentRelayProtocolError
+from .protocol import AgentRuntime, BrokerEvent
+
+# ── Public types ──────────────────────────────────────────────────────────────
+
+AgentStatus = str  # "spawning" | "ready" | "idle" | "exited"
+
+EventHook = Optional[Callable[..., None]]
+
+
+@dataclass
+class Message:
+    """A relay message between agents."""
+
+    event_id: str
+    from_name: str
+    to: str
+    text: str
+    thread_id: Optional[str] = None
+    data: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class SpawnOptions:
+    """Options for spawning an agent."""
+
+    args: list[str] = field(default_factory=list)
+    channels: list[str] = field(default_factory=list)
+    model: Optional[str] = None
+    cwd: Optional[str] = None
+    team: Optional[str] = None
+    shadow_of: Optional[str] = None
+    shadow_mode: Optional[str] = None
+    idle_threshold_secs: Optional[int] = None
+    restart_policy: Optional[dict[str, Any]] = None
+
+
+# ── Agent handle ──────────────────────────────────────────────────────────────
+
+
+class Agent:
+    """Handle for a spawned agent with lifecycle methods."""
+
+    def __init__(
+        self,
+        name: str,
+        runtime: AgentRuntime,
+        channels: list[str],
+        relay: AgentRelay,
+    ):
+        self._name = name
+        self._runtime = runtime
+        self._channels = channels
+        self._relay = relay
+        self.exit_code: Optional[int] = None
+        self.exit_signal: Optional[str] = None
+        self.exit_reason: Optional[str] = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def runtime(self) -> AgentRuntime:
+        return self._runtime
+
+    @property
+    def channels(self) -> list[str]:
+        return self._channels
+
+    @property
+    def status(self) -> AgentStatus:
+        if self._name in self._relay._exited_agents:
+            return "exited"
+        if self._name in self._relay._idle_agents:
+            return "idle"
+        if self._name in self._relay._ready_agents:
+            return "ready"
+        return "spawning"
+
+    async def release(self, reason: Optional[str] = None) -> None:
+        client = await self._relay._ensure_started()
+        await client.release(self._name, reason)
+
+    async def wait_for_ready(self, timeout_ms: int = 60_000) -> None:
+        await self._relay.wait_for_agent_ready(self._name, timeout_ms)
+
+    async def wait_for_exit(self, timeout_ms: Optional[int] = None) -> str:
+        """Wait for agent to exit. Returns 'exited', 'released', or 'timeout'."""
+        if self._name not in self._relay._known_agents:
+            return "exited"
+        if timeout_ms == 0:
+            return "timeout"
+
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        self._relay._exit_resolvers[self._name] = future
+
+        if timeout_ms is not None:
+            try:
+                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
+            except asyncio.TimeoutError:
+                self._relay._exit_resolvers.pop(self._name, None)
+                return "timeout"
+        else:
+            return await future
+
+    async def wait_for_idle(self, timeout_ms: Optional[int] = None) -> str:
+        """Wait for agent to go idle. Returns 'idle', 'exited', or 'timeout'."""
+        if self._name not in self._relay._known_agents:
+            return "exited"
+        if timeout_ms == 0:
+            return "timeout"
+
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        self._relay._idle_resolvers[self._name] = future
+
+        if timeout_ms is not None:
+            try:
+                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
+            except asyncio.TimeoutError:
+                self._relay._idle_resolvers.pop(self._name, None)
+                return "timeout"
+        else:
+            return await future
+
+    async def send_message(
+        self,
+        *,
+        to: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        priority: Optional[int] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> Message:
+        client = await self._relay._ensure_started()
+        try:
+            result = await client.send_message(
+                to=to,
+                text=text,
+                from_=self._name,
+                thread_id=thread_id,
+                priority=priority,
+                data=data,
+            )
+        except AgentRelayProtocolError as e:
+            if e.code == "unsupported_operation":
+                return Message(
+                    event_id="unsupported_operation",
+                    from_name=self._name,
+                    to=to,
+                    text=text,
+                    thread_id=thread_id,
+                    data=data,
+                )
+            raise
+
+        event_id = result.get("event_id", secrets.token_hex(8))
+        msg = Message(
+            event_id=event_id,
+            from_name=self._name,
+            to=to,
+            text=text,
+            thread_id=thread_id,
+            data=data,
+        )
+        if self._relay.on_message_sent:
+            self._relay.on_message_sent(msg)
+        return msg
+
+    def on_output(self, callback: Callable[[str], None]) -> Callable[[], None]:
+        listeners = self._relay._output_listeners.setdefault(self._name, [])
+        listeners.append(callback)
+
+        def unsubscribe() -> None:
+            try:
+                listeners.remove(callback)
+            except ValueError:
+                pass
+            if not listeners:
+                self._relay._output_listeners.pop(self._name, None)
+
+        return unsubscribe
+
+
+# ── Human handle ──────────────────────────────────────────────────────────────
+
+
+class HumanHandle:
+    """A messaging handle for human/system messages."""
+
+    def __init__(self, name: str, relay: AgentRelay):
+        self._name = name
+        self._relay = relay
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def send_message(
+        self,
+        *,
+        to: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        priority: Optional[int] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> Message:
+        client = await self._relay._ensure_started()
+        try:
+            result = await client.send_message(
+                to=to,
+                text=text,
+                from_=self._name,
+                thread_id=thread_id,
+                priority=priority,
+                data=data,
+            )
+        except AgentRelayProtocolError as e:
+            if e.code == "unsupported_operation":
+                return Message(
+                    event_id="unsupported_operation",
+                    from_name=self._name,
+                    to=to,
+                    text=text,
+                    thread_id=thread_id,
+                    data=data,
+                )
+            raise
+
+        event_id = result.get("event_id", secrets.token_hex(8))
+        msg = Message(
+            event_id=event_id,
+            from_name=self._name,
+            to=to,
+            text=text,
+            thread_id=thread_id,
+            data=data,
+        )
+        if self._relay.on_message_sent:
+            self._relay.on_message_sent(msg)
+        return msg
+
+
+# ── Agent spawner ─────────────────────────────────────────────────────────────
+
+
+class AgentSpawner:
+    """Shorthand spawner for a specific CLI (e.g., relay.claude.spawn(...))."""
+
+    def __init__(self, cli: str, default_name: str, relay: AgentRelay):
+        self._cli = cli
+        self._default_name = default_name
+        self._relay = relay
+
+    async def spawn(
+        self,
+        *,
+        name: Optional[str] = None,
+        args: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
+        task: Optional[str] = None,
+        model: Optional[str] = None,
+        cwd: Optional[str] = None,
+    ) -> Agent:
+        agent_name = name or self._default_name
+        agent_channels = channels or ["general"]
+        client = await self._relay._ensure_started()
+
+        result = await client.spawn_pty(
+            name=agent_name,
+            cli=self._cli,
+            args=args or [],
+            channels=agent_channels,
+            task=task,
+            model=model,
+            cwd=cwd,
+        )
+
+        agent = Agent(
+            name=result.get("name", agent_name),
+            runtime=result.get("runtime", "pty"),
+            channels=agent_channels,
+            relay=self._relay,
+        )
+        self._relay._known_agents[agent.name] = agent
+        self._relay._ready_agents.discard(agent.name)
+        self._relay._message_ready_agents.discard(agent.name)
+        self._relay._exited_agents.discard(agent.name)
+        self._relay._idle_agents.discard(agent.name)
+        return agent
+
+
+# ── AgentRelay facade ─────────────────────────────────────────────────────────
+
+
+class AgentRelay:
+    """High-level facade for the Agent Relay SDK.
+
+    Example::
+
+        relay = AgentRelay(channels=["GTM"])
+        relay.on_message_received = lambda msg: print(f"[{msg.from_name}]: {msg.text}")
+
+        await relay.claude.spawn(name="Analyst", model="opus", channels=["GTM"], task="Analyze")
+        await relay.wait_for_agent_ready("Analyst")
+        await relay.shutdown()
+    """
+
+    def __init__(
+        self,
+        *,
+        binary_path: Optional[str] = None,
+        binary_args: Optional[list[str]] = None,
+        broker_name: Optional[str] = None,
+        channels: Optional[list[str]] = None,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        request_timeout_ms: int = 10_000,
+        shutdown_timeout_ms: int = 3_000,
+    ):
+        # Event hooks — assign a callback or None to clear
+        self.on_message_received: EventHook = None
+        self.on_message_sent: EventHook = None
+        self.on_agent_spawned: EventHook = None
+        self.on_agent_released: EventHook = None
+        self.on_agent_exited: EventHook = None
+        self.on_agent_ready: EventHook = None
+        self.on_worker_output: EventHook = None
+        self.on_delivery_update: EventHook = None
+        self.on_agent_exit_requested: EventHook = None
+        self.on_agent_idle: EventHook = None
+
+        self._default_channels = channels or ["general"]
+        self._client_kwargs: dict[str, Any] = {
+            "binary_path": binary_path,
+            "binary_args": binary_args,
+            "broker_name": broker_name,
+            "channels": self._default_channels,
+            "cwd": cwd,
+            "env": env,
+            "request_timeout_ms": request_timeout_ms,
+            "shutdown_timeout_ms": shutdown_timeout_ms,
+        }
+
+        self._client: Optional[AgentRelayClient] = None
+        self._start_lock = asyncio.Lock()
+        self._unsubscribe_event: Optional[Callable[[], None]] = None
+
+        # Agent tracking
+        self._known_agents: dict[str, Agent] = {}
+        self._ready_agents: set[str] = set()
+        self._message_ready_agents: set[str] = set()
+        self._exited_agents: set[str] = set()
+        self._idle_agents: set[str] = set()
+        self._output_listeners: dict[str, list[Callable[[str], None]]] = {}
+        self._exit_resolvers: dict[str, asyncio.Future[str]] = {}
+        self._idle_resolvers: dict[str, asyncio.Future[str]] = {}
+
+        # Shorthand spawners
+        self.codex = AgentSpawner("codex", "Codex", self)
+        self.claude = AgentSpawner("claude", "Claude", self)
+        self.gemini = AgentSpawner("gemini", "Gemini", self)
+
+    @property
+    def workspace_key(self) -> Optional[str]:
+        return self._client.workspace_key if self._client else None
+
+    # ── Internal startup ──────────────────────────────────────────────────
+
+    async def _ensure_started(self) -> AgentRelayClient:
+        if self._client:
+            return self._client
+        async with self._start_lock:
+            if self._client:
+                return self._client
+
+            # Ensure env has RELAY_API_KEY if available
+            env = self._client_kwargs.get("env")
+            if env is None:
+                env_key = os.environ.get("RELAY_API_KEY")
+                if env_key:
+                    self._client_kwargs["env"] = {**os.environ, "RELAY_API_KEY": env_key}
+                else:
+                    self._client_kwargs["env"] = dict(os.environ)
+
+            # Remove None values to use defaults
+            kwargs = {k: v for k, v in self._client_kwargs.items() if v is not None}
+            client = AgentRelayClient(**kwargs)
+            await client.start_client()
+
+            self._client = client
+            if client.workspace_key:
+                pass  # workspace_key is available via property
+
+            self._wire_events(client)
+            return client
+
+    # ── Spawning ──────────────────────────────────────────────────────────
+
+    async def spawn(
+        self,
+        name: str,
+        cli: str,
+        task: Optional[str] = None,
+        options: Optional[SpawnOptions] = None,
+    ) -> Agent:
+        client = await self._ensure_started()
+        opts = options or SpawnOptions()
+        channels = opts.channels or ["general"]
+
+        result = await client.spawn_pty(
+            name=name,
+            cli=cli,
+            task=task,
+            args=opts.args,
+            channels=channels,
+            model=opts.model,
+            cwd=opts.cwd,
+            team=opts.team,
+            shadow_of=opts.shadow_of,
+            shadow_mode=opts.shadow_mode,
+            idle_threshold_secs=opts.idle_threshold_secs,
+            restart_policy=opts.restart_policy,
+        )
+
+        self._ready_agents.discard(name)
+        self._message_ready_agents.discard(name)
+        self._exited_agents.discard(name)
+        self._idle_agents.discard(name)
+        agent = Agent(
+            name=result.get("name", name),
+            runtime=result.get("runtime", "pty"),
+            channels=channels,
+            relay=self,
+        )
+        self._known_agents[agent.name] = agent
+        return agent
+
+    async def spawn_and_wait(
+        self,
+        name: str,
+        cli: str,
+        task: str,
+        options: Optional[SpawnOptions] = None,
+        timeout_ms: int = 60_000,
+        wait_for_message: bool = False,
+    ) -> Agent:
+        await self.spawn(name, cli, task, options)
+        if wait_for_message:
+            return await self.wait_for_agent_message(name, timeout_ms)
+        return await self.wait_for_agent_ready(name, timeout_ms)
+
+    # ── Human/system messaging ────────────────────────────────────────────
+
+    def human(self, name: str) -> HumanHandle:
+        return HumanHandle(name, self)
+
+    def system(self) -> HumanHandle:
+        return HumanHandle("system", self)
+
+    async def broadcast(self, text: str, *, from_name: str = "human:orchestrator") -> Message:
+        return await self.human(from_name).send_message(to="*", text=text)
+
+    # ── Listing / status ──────────────────────────────────────────────────
+
+    async def list_agents(self) -> list[Agent]:
+        client = await self._ensure_started()
+        raw_list = await client.list_agents()
+        agents = []
+        for entry in raw_list:
+            name = entry.get("name", "")
+            existing = self._known_agents.get(name)
+            if existing:
+                agents.append(existing)
+            else:
+                agent = Agent(
+                    name=name,
+                    runtime=entry.get("runtime", "pty"),
+                    channels=entry.get("channels", []),
+                    relay=self,
+                )
+                self._known_agents[name] = agent
+                agents.append(agent)
+        return agents
+
+    async def preflight_agents(self, agents: list[dict[str, str]]) -> None:
+        client = await self._ensure_started()
+        await client.preflight_agents(agents)
+
+    async def get_status(self) -> dict[str, Any]:
+        client = await self._ensure_started()
+        return await client.get_status()
+
+    # ── Wait helpers ──────────────────────────────────────────────────────
+
+    async def wait_for_agent_ready(self, name: str, timeout_ms: int = 60_000) -> Agent:
+        client = await self._ensure_started()
+        existing = self._known_agents.get(name)
+        if existing and name in self._ready_agents:
+            return existing
+
+        future: asyncio.Future[Agent] = asyncio.get_running_loop().create_future()
+
+        def on_event(event: BrokerEvent) -> None:
+            if event.get("kind") != "worker_ready" or event.get("name") != name:
+                return
+            agent = self._ensure_agent_handle(name, event.get("runtime", "pty"))
+            self._ready_agents.add(name)
+            self._exited_agents.discard(name)
+            if not future.done():
+                future.set_result(agent)
+
+        unsub = client.on_event(on_event)
+        try:
+            # Check again after subscribing (race condition guard)
+            known = self._known_agents.get(name)
+            if known and name in self._ready_agents:
+                return known
+            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"Timed out waiting for worker_ready for '{name}' after {timeout_ms}ms"
+            ) from None
+        finally:
+            unsub()
+
+    async def wait_for_agent_message(self, name: str, timeout_ms: int = 60_000) -> Agent:
+        client = await self._ensure_started()
+        existing = self._known_agents.get(name)
+        if existing and name in self._message_ready_agents:
+            return existing
+
+        future: asyncio.Future[Agent] = asyncio.get_running_loop().create_future()
+
+        def on_event(event: BrokerEvent) -> None:
+            if future.done():
+                return
+            if event.get("kind") == "relay_inbound" and event.get("from") == name:
+                self._message_ready_agents.add(name)
+                self._exited_agents.discard(name)
+                future.set_result(self._ensure_agent_handle(name))
+            elif event.get("kind") == "agent_exited" and event.get("name") == name:
+                future.set_exception(
+                    RuntimeError(f"Agent '{name}' exited before sending its first relay message")
+                )
+
+        unsub = client.on_event(on_event)
+        try:
+            known = self._known_agents.get(name)
+            if known and name in self._message_ready_agents:
+                return known
+            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"Timed out waiting for first relay message from '{name}' after {timeout_ms}ms"
+            ) from None
+        finally:
+            unsub()
+
+    @staticmethod
+    async def wait_for_any(
+        agents: list[Agent], timeout_ms: Optional[int] = None
+    ) -> tuple[Agent, str]:
+        """Wait for any agent to exit. Returns (agent, result) tuple."""
+        if not agents:
+            raise ValueError("wait_for_any requires at least one agent")
+
+        async def _wait(agent: Agent) -> tuple[Agent, str]:
+            result = await agent.wait_for_exit(timeout_ms)
+            return (agent, result)
+
+        done, pending = await asyncio.wait(
+            [asyncio.create_task(_wait(a)) for a in agents],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        return done.pop().result()
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    async def shutdown(self) -> None:
+        if self._unsubscribe_event:
+            self._unsubscribe_event()
+            self._unsubscribe_event = None
+        if self._client:
+            await self._client.shutdown()
+            self._client = None
+
+        self._known_agents.clear()
+        self._ready_agents.clear()
+        self._message_ready_agents.clear()
+        self._exited_agents.clear()
+        self._idle_agents.clear()
+        self._output_listeners.clear()
+
+        for future in self._exit_resolvers.values():
+            if not future.done():
+                future.set_result("released")
+        self._exit_resolvers.clear()
+        for future in self._idle_resolvers.values():
+            if not future.done():
+                future.set_result("exited")
+        self._idle_resolvers.clear()
+
+    # ── Private helpers ───────────────────────────────────────────────────
+
+    def _ensure_agent_handle(
+        self, name: str, runtime: AgentRuntime = "pty", channels: Optional[list[str]] = None,
+    ) -> Agent:
+        existing = self._known_agents.get(name)
+        if existing:
+            return existing
+        agent = Agent(name, runtime, channels or [], self)
+        self._known_agents[name] = agent
+        return agent
+
+    def _wire_events(self, client: AgentRelayClient) -> None:
+        def on_event(event: BrokerEvent) -> None:
+            kind = event.get("kind")
+            name = event.get("name", "")
+
+            if kind == "relay_inbound":
+                from_name = event.get("from", "")
+                if from_name in self._known_agents:
+                    self._message_ready_agents.add(from_name)
+                    self._exited_agents.discard(from_name)
+                msg = Message(
+                    event_id=event.get("event_id", ""),
+                    from_name=event.get("from", ""),
+                    to=event.get("target", ""),
+                    text=event.get("body", ""),
+                    thread_id=event.get("thread_id"),
+                )
+                if self.on_message_received:
+                    self.on_message_received(msg)
+
+            elif kind == "agent_spawned":
+                agent = self._ensure_agent_handle(name, event.get("runtime", "pty"))
+                self._ready_agents.discard(name)
+                self._message_ready_agents.discard(name)
+                self._exited_agents.discard(name)
+                self._idle_agents.discard(name)
+                if self.on_agent_spawned:
+                    self.on_agent_spawned(agent)
+
+            elif kind == "agent_released":
+                agent = self._known_agents.get(name) or self._ensure_agent_handle(name)
+                self._exited_agents.add(name)
+                self._ready_agents.discard(name)
+                self._message_ready_agents.discard(name)
+                self._idle_agents.discard(name)
+                if self.on_agent_released:
+                    self.on_agent_released(agent)
+                self._known_agents.pop(name, None)
+                self._output_listeners.pop(name, None)
+                future = self._exit_resolvers.pop(name, None)
+                if future and not future.done():
+                    future.set_result("released")
+                idle_future = self._idle_resolvers.pop(name, None)
+                if idle_future and not idle_future.done():
+                    idle_future.set_result("exited")
+
+            elif kind == "agent_exited":
+                agent = self._known_agents.get(name) or self._ensure_agent_handle(name)
+                self._exited_agents.add(name)
+                self._ready_agents.discard(name)
+                self._message_ready_agents.discard(name)
+                self._idle_agents.discard(name)
+                agent.exit_code = event.get("code")
+                agent.exit_signal = event.get("signal")
+                if self.on_agent_exited:
+                    self.on_agent_exited(agent)
+                self._known_agents.pop(name, None)
+                self._output_listeners.pop(name, None)
+                future = self._exit_resolvers.pop(name, None)
+                if future and not future.done():
+                    future.set_result("exited")
+                idle_future = self._idle_resolvers.pop(name, None)
+                if idle_future and not idle_future.done():
+                    idle_future.set_result("exited")
+
+            elif kind == "agent_exit":
+                agent = self._known_agents.get(name) or self._ensure_agent_handle(name)
+                agent.exit_reason = event.get("reason", "")
+                if self.on_agent_exit_requested:
+                    self.on_agent_exit_requested({"name": name, "reason": event.get("reason", "")})
+
+            elif kind == "worker_ready":
+                agent = self._ensure_agent_handle(name, event.get("runtime", "pty"))
+                self._ready_agents.add(name)
+                self._exited_agents.discard(name)
+                self._idle_agents.discard(name)
+                if self.on_agent_ready:
+                    self.on_agent_ready(agent)
+
+            elif kind == "worker_stream":
+                self._idle_agents.discard(name)
+                if self.on_worker_output:
+                    self.on_worker_output({
+                        "name": name,
+                        "stream": event.get("stream", ""),
+                        "chunk": event.get("chunk", ""),
+                    })
+                # Per-agent output listeners
+                listeners = self._output_listeners.get(name, [])
+                for listener in listeners:
+                    listener(event.get("chunk", ""))
+
+            elif kind == "agent_idle":
+                self._idle_agents.add(name)
+                if self.on_agent_idle:
+                    self.on_agent_idle({
+                        "name": name,
+                        "idle_secs": event.get("idle_secs", 0),
+                    })
+                idle_future = self._idle_resolvers.pop(name, None)
+                if idle_future and not idle_future.done():
+                    idle_future.set_result("idle")
+
+            # Delivery events
+            if kind and kind.startswith("delivery_"):
+                if self.on_delivery_update:
+                    self.on_delivery_update(event)
+
+        self._unsubscribe_event = client.on_event(on_event)

--- a/packages/sdk-py/src/agent_relay/relay.py
+++ b/packages/sdk-py/src/agent_relay/relay.py
@@ -439,10 +439,6 @@ class AgentRelay:
             restart_policy=opts.restart_policy,
         )
 
-        self._ready_agents.discard(name)
-        self._message_ready_agents.discard(name)
-        self._exited_agents.discard(name)
-        self._idle_agents.discard(name)
         agent = Agent(
             name=result.get("name", name),
             runtime=result.get("runtime", "pty"),
@@ -450,6 +446,10 @@ class AgentRelay:
             relay=self,
         )
         self._known_agents[agent.name] = agent
+        self._ready_agents.discard(agent.name)
+        self._message_ready_agents.discard(agent.name)
+        self._exited_agents.discard(agent.name)
+        self._idle_agents.discard(agent.name)
         return agent
 
     async def spawn_and_wait(
@@ -461,10 +461,10 @@ class AgentRelay:
         timeout_ms: int = 60_000,
         wait_for_message: bool = False,
     ) -> Agent:
-        await self.spawn(name, cli, task, options)
+        agent = await self.spawn(name, cli, task, options)
         if wait_for_message:
-            return await self.wait_for_agent_message(name, timeout_ms)
-        return await self.wait_for_agent_ready(name, timeout_ms)
+            return await self.wait_for_agent_message(agent.name, timeout_ms)
+        return await self.wait_for_agent_ready(agent.name, timeout_ms)
 
     # ── Human/system messaging ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `AgentRelay` facade, `AgentRelayClient`, `Agent` handles, and `Models` constants to the Python SDK so it can spawn agents and exchange messages directly via the broker binary — matching the TypeScript SDK's API
- New files: `protocol.py`, `client.py`, `relay.py`, `models.py` in `packages/sdk-py/src/agent_relay/`
- Backward compatible: workflow builder (`workflow()`, `fan_out()`, `pipeline()`, `dag()`) still works unchanged
- Version bumped to 0.3.0

## Target usage
```python
from agent_relay import AgentRelay, Models

async def main():
    relay = AgentRelay(channels=["GTM"])
    relay.on_message_received = lambda msg: print(f"[{msg.from_name}]: {msg.text}")

    await relay.claude.spawn(name="Analyst", model=Models.Claude.OPUS, channels=["GTM"], task="Analyze")
    await relay.codex.spawn(name="Coder", model=Models.Codex.GPT_5_3_CODEX, channels=["GTM"], task="Build")

    await asyncio.gather(
        relay.wait_for_agent_ready("Analyst"),
        relay.wait_for_agent_ready("Coder"),
    )
    await relay.shutdown()
```

## Test plan
- [x] All 32 existing workflow builder tests pass (`pytest tests/`)
- [x] All new imports verified working
- [x] Event hooks confirmed instance-level (not shared across instances)
- [ ] Integration test with live broker binary
- [ ] Create quickstart script in `relay-a2a-python/main.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
