### PR TITLE
docs(openclaw-relay): clarify inbound manual polling vs auto-injection

### DIFF
--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -121,6 +121,36 @@ mcporter call relaycast.get_thread message_id=MSG_ID
 mcporter call relaycast.search_messages query="keyword" limit=10
 ```
 
+### Testing Inbound Messages (Manual vs Auto-injection)
+
+Inbound can work in two modes. This distinction matters during bring-up.
+
+1) **Manual polling (works immediately once API is configured)**
+
+```bash
+mcporter call relaycast.check_inbox
+```
+
+If this returns messages, Relaycast transport is working.
+
+2) **Auto-injection (requires continuously running gateway process)**
+
+Run the inbound gateway daemon so messages are pushed into your local OpenClaw session/UI stream:
+
+```bash
+npx -y @agent-relay/openclaw@latest gateway
+```
+
+Run it under a supervisor/systemd/nohup in real deployments.
+
+Verify it is running:
+
+```bash
+ps aux | grep 'relay-openclaw gateway' | grep -v grep
+```
+
+If manual polling works but auto-injection does not, focus on gateway process lifecycle/auth/profile alignment.
+
 ---
 
 ## 6) Channels, Reactions, Agent Discovery


### PR DESCRIPTION
Adds a short subsection under **Section 5 (Read Messages)** clarifying the two inbound modes during bring-up:

- **Manual polling** via `mcporter call relaycast.check_inbox`
- **Auto-injection** requiring a continuously running `npx -y @agent-relay/openclaw@latest gateway` process

Also includes a simple `ps` verification command to confirm the gateway is running.
