### PR TITLE
fix(openclaw): address race condition in relay WS handler binding

### DIFF
--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -1407,8 +1407,12 @@ export class InboundGateway {
     }
     this.relayAgentToken = agentToken;
     this.relayAgentClient = this.relaycast.as(agentToken);
+    // SDK's onEvent() throws if the WS object doesn't exist yet.
+    // connect() synchronously creates the WS and initiates the connection,
+    // so we call it before binding handlers. The SDK guards against
+    // double-connect (no-op if ws already exists).
+    this.relayAgentClient.connect();
     this.bindRelayAgentHandlers();
-    await this.connectRelayAgentClient();
   }
 
   private async refreshRelayAgentRegistration(): Promise<void> {


### PR DESCRIPTION
## Follow-up to #513

Devin's review on #513 correctly identified a race condition: binding handlers *after* `connect()` could miss the initial `connected` event if it fires synchronously.

## Improved Fix

Instead of swapping bind/connect order, we now call `relayAgentClient.connect()` directly (which is **synchronous** — it creates the WS object and initiates connection) before binding handlers. This ensures:

1. The WS object exists when `onEvent()` is called (no throw)
2. Handlers are bound before the connection fully opens (no missed events)
3. The SDK's double-connect guard (`if (this.ws) return`) makes repeated calls safe

## Before (original bug)
```
bindRelayAgentHandlers()  // throws: WS not connected
connectRelayAgentClient() // never reached
```

## After (this fix)
```
relayAgentClient.connect()  // sync: creates WS object
bindRelayAgentHandlers()    // safe: WS exists, connection still opening
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
