### PR TITLE
fix: pass failure context to workflow step retry attempts

### DIFF
--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -223,6 +223,8 @@ export class WorkflowRunner {
 
   // PTY-based output capture: accumulate terminal output per-agent
   private readonly ptyOutputBuffers = new Map<string, string[]>();
+  /** Snapshot of PTY output from the most recent failed attempt, keyed by step name. */
+  private readonly lastFailedStepOutput = new Map<string, string>();
   private readonly ptyListeners = new Map<string, (chunk: string) => void>();
   private readonly ptyLogStreams = new Map<string, WriteStream>();
   /** Path to workers.json so `agents:kill` can find workflow-spawned agents */
@@ -1540,6 +1542,7 @@ export class WorkflowRunner {
       for (const stream of this.ptyLogStreams.values()) stream.end();
       this.ptyLogStreams.clear();
       this.ptyOutputBuffers.clear();
+      this.lastFailedStepOutput.clear();
       this.ptyListeners.clear();
 
       this.unsubBrokerStderr?.();
@@ -2335,6 +2338,16 @@ export class WorkflowRunner {
         // Resolve step-output variables (e.g. {{steps.plan.output}}) at execution time
         const stepOutputContext = this.buildStepOutputContext(stepStates, runId);
         let resolvedTask = this.interpolateStepTask(step.task ?? '', stepOutputContext);
+
+        // On retry attempts, prepend failure context so the agent knows what went wrong
+        if (attempt > 0 && lastError) {
+          const priorOutput = (this.lastFailedStepOutput.get(step.name) ?? '').slice(-2000);
+          resolvedTask =
+            `[RETRY — Attempt ${attempt + 1}/${maxRetries + 1}]\n` +
+            `Previous attempt failed: ${lastError}\n` +
+            (priorOutput ? `Previous output (last 2000 chars):\n${priorOutput}\n` : '') +
+            `---\n${resolvedTask}`;
+        }
 
         // If this is an interactive agent, append awareness of non-interactive workers
         // so the lead knows not to message them and to use step output chaining instead
@@ -3260,6 +3273,11 @@ export class WorkflowRunner {
 
       return output;
     } finally {
+      // Snapshot output so retry attempts can include failure context
+      const combinedOutput = stdoutChunks.join('') + stderrChunks.join('');
+      if (combinedOutput) {
+        this.lastFailedStepOutput.set(step.name, combinedOutput);
+      }
       stopHeartbeat?.();
       logStream.end();
       this.unregisterWorker(agentName);
@@ -3459,6 +3477,11 @@ export class WorkflowRunner {
     } finally {
       // Snapshot PTY chunks before cleanup — we need them for output reading below
       ptyChunks = this.ptyOutputBuffers.get(agentName) ?? [];
+
+      // Snapshot failed output so retry attempts can include failure context
+      if (ptyChunks.length > 0) {
+        this.lastFailedStepOutput.set(step.name, ptyChunks.join(''));
+      }
 
       // Always clean up PTY resources — prevents fd leaks if spawnPty or waitForExit throws
       stopHeartbeat?.();


### PR DESCRIPTION
## Summary

Closes #497

- When a workflow step fails and retries, the retried agent now receives failure context prepended to its task string
- Context includes: retry attempt number, the previous error message, and the last 2000 characters of PTY/stdout output from the failed attempt
- Output is captured from both interactive (PTY-based) and non-interactive (subprocess) execution paths

## Test plan

- [ ] Run a workflow with a step configured with `retries: 1+` that is expected to fail on the first attempt
- [ ] Verify the retried agent receives the `[RETRY]` header with the failure message and prior output
- [ ] Verify that successful first attempts are unaffected (no retry header prepended)
- [ ] Verify non-interactive agent retries also include stdout/stderr from the failed attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
