### PR TITLE
feat: deterministic workspace key & fix MCP config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ await relay.shutdown();
 ## Supported CLI’s
 - Claude
 - Codex
+- Gemini
+- Opencode
 
 ---
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,7 +3,7 @@ title: 'Introduction'
 description: 'Programmatically spawn and coordinate AI agents from TypeScript or Python.'
 ---
 
-The Agent Relay SDK lets you spawn AI agents (Claude, Codex) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done. Available for both TypeScript and Python.
+The Agent Relay SDK lets you spawn AI agents (Claude, Codex, Gemini, OpenCode) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done. Available for both TypeScript and Python.
 
 <CodeGroup>
 ```bash TypeScript
@@ -19,7 +19,7 @@ pip install agent-relay-sdk
 
 <CardGroup cols={2}>
   <Card title="Spawn Agents" icon="users">
-    Programmatically create Claude or Codex agents with a specific model and task.
+    Programmatically create Claude, Codex, Gemini, or OpenCode agents with a specific model and task.
   </Card>
   <Card title="Send Messages" icon="messages">
     Route messages between agents — direct, broadcast, or channel-based.
@@ -28,7 +28,7 @@ pip install agent-relay-sdk
     Subscribe to incoming messages and react in real-time.
   </Card>
   <Card title="Multi-Provider" icon="shuffle">
-    Mix Claude and Codex agents in a single workflow, each using their strengths.
+    Mix Claude, Codex, Gemini, and OpenCode agents in a single workflow, each using their strengths.
   </Card>
 </CardGroup>
 

--- a/docs/markdown/introduction.md
+++ b/docs/markdown/introduction.md
@@ -2,7 +2,7 @@
 
 Programmatically spawn and coordinate AI agents from TypeScript or Python.
 
-The Agent Relay SDK lets you spawn AI agents (Claude, Codex) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done. Available for both TypeScript and Python.
+The Agent Relay SDK lets you spawn AI agents (Claude, Codex, Gemini, OpenCode) and coordinate them from code — send messages between agents, listen for responses, and shut them down when done. Available for both TypeScript and Python.
 
 ## Install
 
@@ -20,10 +20,10 @@ pip install agent-relay-sdk
 
 ## What You Can Do
 
-- **Spawn Agents** — Programmatically create Claude or Codex agents with a specific model and task.
+- **Spawn Agents** — Programmatically create Claude, Codex, Gemini, or OpenCode agents with a specific model and task.
 - **Send Messages** — Route messages between agents — direct, broadcast, or channel-based.
 - **Listen for Responses** — Subscribe to incoming messages and react in real-time.
-- **Multi-Provider** — Mix Claude and Codex agents in a single workflow, each using their strengths.
+- **Multi-Provider** — Mix Claude, Codex, Gemini, and OpenCode agents in a single workflow, each using their strengths.
 
 ## LLM / Machine-Readable Docs
 

--- a/docs/markdown/quickstart.md
+++ b/docs/markdown/quickstart.md
@@ -91,10 +91,12 @@ asyncio.run(main())
 
 ## Supported CLIs
 
-| CLI    | Constant prefix   |
-| ------ | ----------------- |
-| Claude | `Models.Claude.*` |
-| Codex  | `Models.Codex.*`  |
+| CLI      | Constant prefix     |
+| -------- | ------------------- |
+| Claude   | `Models.Claude.*`   |
+| Codex    | `Models.Codex.*`    |
+| Gemini   | `Models.Gemini.*`   |
+| OpenCode | `Models.OpenCode.*` |
 
 ## Next Steps
 

--- a/docs/markdown/quickstart.md
+++ b/docs/markdown/quickstart.md
@@ -96,7 +96,7 @@ asyncio.run(main())
 | Claude   | `Models.Claude.*`   |
 | Codex    | `Models.Codex.*`    |
 | Gemini   | `Models.Gemini.*`   |
-| OpenCode | `Models.OpenCode.*` |
+| OpenCode | `Models.Opencode.*` |
 
 ## Next Steps
 

--- a/docs/markdown/reference/sdk-py.md
+++ b/docs/markdown/reference/sdk-py.md
@@ -40,6 +40,7 @@ relay = AgentRelay(
 agent = await relay.claude.spawn(name="Analyst", model=Models.Claude.OPUS, channels=["dev"], task="...")
 agent = await relay.codex.spawn(name="Coder", model=Models.Codex.GPT_5_3_CODEX, channels=["dev"], task="...")
 agent = await relay.gemini.spawn(name="Researcher", model=Models.Gemini.GEMINI_2_5_PRO, channels=["dev"], task="...")
+agent = await relay.opencode.spawn(name="Optimizer", model=Models.Opencode.OPENAI_GPT_5_2, channels=["dev"], task="...")
 ```
 
 **Spawn keyword arguments:**
@@ -237,8 +238,12 @@ Models.Codex.GPT_5_1_CODEX_MAX    # "gpt-5.1-codex-max"
 Models.Codex.GPT_5_1_CODEX_MINI   # "gpt-5.1-codex-mini"
 
 # Gemini
-Models.Gemini.GEMINI_2_5_PRO    # "gemini-2.5-pro"
-Models.Gemini.GEMINI_2_5_FLASH  # "gemini-2.5-flash"
+Models.Gemini.GEMINI_3_1_PRO_PREVIEW    # "gemini-3.1-pro-preview"
+Models.Gemini.GEMINI_2_5_PRO            # "gemini-2.5-pro"
+
+# OpenCode
+Models.Opencode.OPENAI_GPT_5_2          # "openai/gpt-5.2"
+Models.Opencode.OPENCODE_GPT_5_NANO     # "opencode/gpt-5-nano"
 ```
 
 ---

--- a/docs/markdown/reference/sdk.md
+++ b/docs/markdown/reference/sdk.md
@@ -43,6 +43,8 @@ const relay = new AgentRelay(options?: AgentRelayOptions);
 // Spawn by CLI type
 const agent = await relay.claude.spawn(options?)
 const agent = await relay.codex.spawn(options?)
+const agent = await relay.gemini.spawn(options?)
+const agent = await relay.opencode.spawn(options?)
 ```
 
 **Spawn options:**
@@ -265,11 +267,16 @@ Models.Claude.SONNET; // 'sonnet'
 Models.Claude.HAIKU; // 'haiku'
 
 // Codex
+Models.Codex.GPT_5_4; // 'gpt-5.4' (default)
 Models.Codex.GPT_5_3_CODEX; // 'gpt-5.3-codex'
-Models.Codex.GPT_5_2_CODEX; // 'gpt-5.2-codex' (default)
-Models.Codex.GPT_5_3_CODEX_SPARK; // 'gpt-5.3-codex-spark'
-Models.Codex.GPT_5_1_CODEX_MAX; // 'gpt-5.1-codex-max'
-Models.Codex.GPT_5_1_CODEX_MINI; // 'gpt-5.1-codex-mini'
+
+// Gemini
+Models.Gemini.GEMINI_3_1_PRO_PREVIEW; // 'gemini-3.1-pro-preview' (default)
+Models.Gemini.GEMINI_2_5_PRO; // 'gemini-2.5-pro'
+
+// OpenCode
+Models.Opencode.OPENAI_GPT_5_2; // 'openai/gpt-5.2' (default)
+Models.Opencode.OPENCODE_GPT_5_NANO; // 'opencode/gpt-5-nano'
 ```
 
 ---

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -88,10 +88,12 @@ asyncio.run(main())
 
 ## Supported CLIs
 
-| CLI    | Constant prefix        |
-| ------ | ---------------------- |
-| Claude | `Models.Claude.*`      |
-| Codex  | `Models.Codex.*`       |
+| CLI      | Constant prefix          |
+| -------- | ------------------------ |
+| Claude   | `Models.Claude.*`        |
+| Codex    | `Models.Codex.*`         |
+| Gemini   | `Models.Gemini.*`        |
+| OpenCode | `Models.OpenCode.*`      |
 
 ## Next Steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -93,7 +93,7 @@ asyncio.run(main())
 | Claude   | `Models.Claude.*`        |
 | Codex    | `Models.Codex.*`         |
 | Gemini   | `Models.Gemini.*`        |
-| OpenCode | `Models.OpenCode.*`      |
+| OpenCode | `Models.Opencode.*`      |
 
 ## Next Steps
 

--- a/docs/reference/sdk-py.mdx
+++ b/docs/reference/sdk-py.mdx
@@ -43,6 +43,7 @@ relay = AgentRelay(
 agent = await relay.claude.spawn(name="Analyst", model=Models.Claude.OPUS, channels=["dev"], task="...")
 agent = await relay.codex.spawn(name="Coder", model=Models.Codex.GPT_5_3_CODEX, channels=["dev"], task="...")
 agent = await relay.gemini.spawn(name="Researcher", model=Models.Gemini.GEMINI_2_5_PRO, channels=["dev"], task="...")
+agent = await relay.opencode.spawn(name="Optimizer", model=Models.Opencode.OPENAI_GPT_5_2, channels=["dev"], task="...")
 ```
 
 **Spawn keyword arguments:**
@@ -240,8 +241,12 @@ Models.Codex.GPT_5_1_CODEX_MAX    # "gpt-5.1-codex-max"
 Models.Codex.GPT_5_1_CODEX_MINI   # "gpt-5.1-codex-mini"
 
 # Gemini
-Models.Gemini.GEMINI_2_5_PRO    # "gemini-2.5-pro"
-Models.Gemini.GEMINI_2_5_FLASH  # "gemini-2.5-flash"
+Models.Gemini.GEMINI_3_1_PRO_PREVIEW    # "gemini-3.1-pro-preview"
+Models.Gemini.GEMINI_2_5_PRO            # "gemini-2.5-pro"
+
+# OpenCode
+Models.Opencode.OPENAI_GPT_5_2          # "openai/gpt-5.2"
+Models.Opencode.OPENCODE_GPT_5_NANO     # "opencode/gpt-5-nano"
 ```
 
 ---

--- a/docs/reference/sdk.mdx
+++ b/docs/reference/sdk.mdx
@@ -46,6 +46,8 @@ const relay = new AgentRelay(options?: AgentRelayOptions);
 // Spawn by CLI type
 const agent = await relay.claude.spawn(options?)
 const agent = await relay.codex.spawn(options?)
+const agent = await relay.gemini.spawn(options?)
+const agent = await relay.opencode.spawn(options?)
 ```
 
 **Spawn options:**
@@ -268,11 +270,16 @@ Models.Claude.SONNET; // 'sonnet'
 Models.Claude.HAIKU; // 'haiku'
 
 // Codex
+Models.Codex.GPT_5_4; // 'gpt-5.4' (default)
 Models.Codex.GPT_5_3_CODEX; // 'gpt-5.3-codex'
-Models.Codex.GPT_5_2_CODEX; // 'gpt-5.2-codex' (default)
-Models.Codex.GPT_5_3_CODEX_SPARK; // 'gpt-5.3-codex-spark'
-Models.Codex.GPT_5_1_CODEX_MAX; // 'gpt-5.1-codex-max'
-Models.Codex.GPT_5_1_CODEX_MINI; // 'gpt-5.1-codex-mini'
+
+// Gemini
+Models.Gemini.GEMINI_3_1_PRO_PREVIEW; // 'gemini-3.1-pro-preview' (default)
+Models.Gemini.GEMINI_2_5_PRO; // 'gemini-2.5-pro'
+
+// OpenCode
+Models.Opencode.OPENAI_GPT_5_2; // 'openai/gpt-5.2' (default)
+Models.Opencode.OPENCODE_GPT_5_NANO; // 'opencode/gpt-5-nano'
 ```
 
 ---

--- a/packages/sdk-py/src/agent_relay/relay.py
+++ b/packages/sdk-py/src/agent_relay/relay.py
@@ -291,10 +291,11 @@ class HumanHandle:
 class AgentSpawner:
     """Shorthand spawner for a specific CLI (e.g., relay.claude.spawn(...))."""
 
-    def __init__(self, cli: str, default_name: str, relay: AgentRelay):
+    def __init__(self, cli: str, default_name: str, relay: AgentRelay, transport: str = "pty"):
         self._cli = cli
         self._default_name = default_name
         self._relay = relay
+        self._transport = transport
 
     async def spawn(
         self,
@@ -326,9 +327,10 @@ class AgentSpawner:
         )
 
         try:
-            result = await client.spawn_pty(
+            result = await client.spawn_provider(
                 name=agent_name,
-                cli=self._cli,
+                provider=self._cli,
+                transport=self._transport,
                 args=args or [],
                 channels=agent_channels,
                 task=task,
@@ -434,9 +436,10 @@ class AgentRelay:
         self._idle_resolvers: dict[str, list[asyncio.Future[str]]] = {}
 
         # Shorthand spawners
-        self.codex = AgentSpawner("codex", "Codex", self)
-        self.claude = AgentSpawner("claude", "Claude", self)
-        self.gemini = AgentSpawner("gemini", "Gemini", self)
+        self.codex = AgentSpawner("codex", "Codex", self, transport="pty")
+        self.claude = AgentSpawner("claude", "Claude", self, transport="pty")
+        self.gemini = AgentSpawner("gemini", "Gemini", self, transport="pty")
+        self.opencode = AgentSpawner("opencode", "OpenCode", self, transport="headless")
 
     @property
     def workspace_key(self) -> Optional[str]:

--- a/packages/sdk-py/tests/test_relay_lifecycle_hooks.py
+++ b/packages/sdk-py/tests/test_relay_lifecycle_hooks.py
@@ -17,11 +17,17 @@ class _FakeRelayClient:
         self.spawn_calls: list[dict] = []
         self.release_calls: list[tuple[str, str | None]] = []
 
-    async def spawn_provider(self, **kwargs):
+    async def spawn_pty(self, **kwargs):
         self.spawn_calls.append(kwargs)
         if self.spawn_error:
             raise self.spawn_error
         return {"name": kwargs["name"], "runtime": "pty"}
+
+    async def spawn_provider(self, **kwargs):
+        self.spawn_calls.append(kwargs)
+        if self.spawn_error:
+            raise self.spawn_error
+        return {"name": kwargs["name"], "runtime": kwargs.get("transport", "pty")}
 
     async def release(self, name: str, reason: str | None = None):
         self.release_calls.append((name, reason))

--- a/packages/sdk-py/tests/test_relay_lifecycle_hooks.py
+++ b/packages/sdk-py/tests/test_relay_lifecycle_hooks.py
@@ -17,7 +17,7 @@ class _FakeRelayClient:
         self.spawn_calls: list[dict] = []
         self.release_calls: list[tuple[str, str | None]] = []
 
-    async def spawn_pty(self, **kwargs):
+    async def spawn_provider(self, **kwargs):
         self.spawn_calls.append(kwargs)
         if self.spawn_error:
             raise self.spawn_error
@@ -142,6 +142,23 @@ async def test_shorthand_spawn_lifecycle_hooks_success():
 
     assert agent.name == "ShorthandWorker"
     assert events == ["start", "success"]
+    assert client.spawn_calls[-1]["transport"] == "pty"
+
+
+@pytest.mark.asyncio
+async def test_opencode_shorthand_spawn_success():
+    relay = AgentRelay()
+    client = _FakeRelayClient()
+    relay._ensure_started = AsyncMock(return_value=client)
+
+    agent = await relay.opencode.spawn(
+        name="OpencodeWorker",
+        channels=["general"],
+    )
+
+    assert agent.name == "OpencodeWorker"
+    assert client.spawn_calls[-1]["provider"] == "opencode"
+    assert client.spawn_calls[-1]["transport"] == "headless"
 
 
 @pytest.mark.asyncio

--- a/packages/sdk/src/__tests__/unit.test.ts
+++ b/packages/sdk/src/__tests__/unit.test.ts
@@ -358,6 +358,16 @@ test('waitForIdle: idle resolves before timeout', async () => {
   const result = await promise;
   assert.equal(result, 'idle');
 });
+// ── shorthand spawners ───────────────────────────────────────────────────────
+
+test('AgentRelay: has shorthand spawners for major CLIs', () => {
+  const relay = new AgentRelay({ channels: ['general'] });
+  assert.ok(relay.claude, 'relay.claude should be defined');
+  assert.ok(relay.codex, 'relay.codex should be defined');
+  assert.ok(relay.gemini, 'relay.gemini should be defined');
+  assert.ok(relay.opencode, 'relay.opencode should be defined');
+});
+
 // ── agent.status ────────────────────────────────────────────────────────────
 
 test('agent.status: mock agent has ready status', () => {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -271,6 +271,7 @@ export class AgentRelay {
   readonly codex: AgentSpawner;
   readonly claude: AgentSpawner;
   readonly gemini: AgentSpawner;
+  readonly opencode: AgentSpawner;
 
   private readonly clientOptions: AgentRelayClientOptions;
   private readonly defaultChannels: string[];
@@ -316,6 +317,7 @@ export class AgentRelay {
     this.codex = this.createSpawner('codex', 'Codex', 'pty');
     this.claude = this.createSpawner('claude', 'Claude', 'pty');
     this.gemini = this.createSpawner('gemini', 'Gemini', 'pty');
+    this.opencode = this.createSpawner('opencode', 'OpenCode', 'headless');
   }
 
   /**

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,6 +4,7 @@ use relaycast::{CreateAgentRequest, RelayCast, RelayCastOptions, RelayError};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -191,6 +192,23 @@ impl AuthSessionSet {
 struct AuthHttpError {
     status: StatusCode,
     message: String,
+}
+
+/// Generate a deterministic workspace name based on the current user and working
+/// directory so that the same user in the same project gets the same workspace
+/// across sessions (enabling message continuity and resume).
+fn deterministic_workspace_name() -> String {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let mut hasher = Sha256::new();
+    hasher.update(format!("{user}:{cwd}"));
+    let hash = format!("{:x}", hasher.finalize());
+    format!("relay-{}", &hash[..8])
 }
 
 #[derive(Clone)]
@@ -387,7 +405,7 @@ impl AuthClient {
 
         let mut attempted_fresh_workspace = false;
         if candidates.is_empty() {
-            let ws_name = format!("relay-{}", &Uuid::new_v4().to_string()[..8]);
+            let ws_name = deterministic_workspace_name();
             let (workspace_id, api_key) = self.create_workspace(&ws_name).await?;
             workspace_id_hint = Some(workspace_id);
             candidates.push(("fresh", api_key));
@@ -439,7 +457,7 @@ impl AuthClient {
         }
 
         if !attempted_fresh_workspace {
-            let ws_name = format!("relay-{}", &Uuid::new_v4().to_string()[..8]);
+            let ws_name = deterministic_workspace_name();
             let (workspace_id, api_key) = self.create_workspace(&ws_name).await?;
             workspace_id_hint = Some(workspace_id);
             match self
@@ -1046,6 +1064,15 @@ mod tests {
             .unwrap();
         assert!(!live);
         channels.assert_hits(1);
+    }
+
+    #[test]
+    fn deterministic_workspace_name_is_stable() {
+        let a = super::deterministic_workspace_name();
+        let b = super::deterministic_workspace_name();
+        assert_eq!(a, b);
+        assert!(a.starts_with("relay-"));
+        assert_eq!(a.len(), "relay-".len() + 8);
     }
 
     #[test]

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -680,10 +680,7 @@ pub async fn configure_relaycast_mcp_with_token(
         args.push(mcp_json);
         // Use strict mode so only the merged config is used (no double-loading
         // of .mcp.json which would re-introduce stale relaycast entries).
-        if !existing_args
-            .iter()
-            .any(|a| a == "--strict-mcp-config")
-        {
+        if !existing_args.iter().any(|a| a == "--strict-mcp-config") {
             args.push("--strict-mcp-config".to_string());
         }
     }

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -665,7 +665,11 @@ pub async fn configure_relaycast_mcp_with_token(
 
     let mut args: Vec<String> = Vec::new();
 
-    if is_claude && !existing_args.iter().any(|a| a.contains("mcp-config")) {
+    if is_claude
+        && !existing_args
+            .iter()
+            .any(|a| a == "--mcp-config" || a.starts_with("--mcp-config="))
+    {
         // Build relaycast MCP config, then merge with the user's project-level
         // .mcp.json so other MCP servers (filesystem, database, etc.) are preserved.
         // Relaycast entry takes priority to prevent stale configs from overriding
@@ -678,7 +682,7 @@ pub async fn configure_relaycast_mcp_with_token(
         // of .mcp.json which would re-introduce stale relaycast entries).
         if !existing_args
             .iter()
-            .any(|a| a.contains("strict-mcp-config"))
+            .any(|a| a == "--strict-mcp-config")
         {
             args.push("--strict-mcp-config".to_string());
         }
@@ -1520,6 +1524,35 @@ Use AGENT_RELAY_OUTBOX and ->relay-file:spawn.
         assert!(
             args.is_empty(),
             "should return no args when user already provided --mcp-config"
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_still_injects_mcp_config_when_strict_flag_in_existing_args() {
+        let temp = tempdir().expect("tempdir");
+        // Regression: --strict-mcp-config in existing_args must NOT prevent
+        // broker from injecting --mcp-config (the old substring check matched
+        // "mcp-config" inside "--strict-mcp-config").
+        let existing = vec!["--strict-mcp-config".to_string()];
+        let args = super::configure_relaycast_mcp(
+            "claude",
+            "Worker",
+            Some("rk_live_abc"),
+            Some("https://api.relaycast.dev"),
+            &existing,
+            temp.path(),
+        )
+        .await
+        .expect("configure claude mcp with strict in existing");
+
+        assert!(
+            args.iter().any(|a| a == "--mcp-config"),
+            "broker must still inject --mcp-config even when --strict-mcp-config is in existing_args"
+        );
+        // Should not duplicate --strict-mcp-config since it's already present
+        assert!(
+            !args.iter().any(|a| a == "--strict-mcp-config"),
+            "should not duplicate --strict-mcp-config"
         );
     }
 


### PR DESCRIPTION
## Summary
- **Deterministic workspace key**: Use SHA-256 hash of `USER:CWD` instead of random UUID for workspace names, so the same user in the same directory gets the same workspace across sessions — enabling message continuity and session resume
- **Fix MCP config override**: The substring check `contains("mcp-config")` in `snippets.rs` falsely matched `--strict-mcp-config`, causing the broker to skip injecting `--mcp-config`. Claude would fall back to local `.mcp.json` instead of using the broker's dynamic config. Fixed with exact flag matching.

## Test plan
- [x] `cargo check` compiles cleanly
- [x] New unit test `deterministic_workspace_name_is_stable` passes
- [x] New regression test `claude_still_injects_mcp_config_when_strict_flag_in_existing_args` passes
- [x] All 9 existing claude MCP snippet tests pass
- [ ] Manual: verify workspace persists across `relay` restart in same directory
- [ ] Manual: verify spawned Claude agents pick up dynamic MCP config over local `.mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
