### PR TITLE
fix: inject inter-agent DMs via workspace WebSocket

### DIFF
--- a/src/multi_workspace.rs
+++ b/src/multi_workspace.rs
@@ -40,7 +40,7 @@ impl MultiWorkspaceSession {
     pub fn new(
         http_base: impl Into<String>,
         ws_base: impl Into<String>,
-        auth: AuthClient,
+        _auth: AuthClient,
         sessions: AuthSessionSet,
         channels: Vec<String>,
         read_mcp_identity: bool,
@@ -94,13 +94,8 @@ impl MultiWorkspaceSession {
 
             let (workspace_tx, mut workspace_rx) = mpsc::channel(512);
             let (ws_control_tx, ws_control_rx) = mpsc::channel(8);
-            let ws_client = RelaycastWsClient::new(
-                ws_base.clone(),
-                auth.clone(),
-                self_token.clone(),
-                session.credentials,
-                channels.clone(),
-            );
+            let ws_client =
+                RelaycastWsClient::new(ws_base.clone(), http_client.clone(), channels.clone());
             let merged_tx_clone = merged_tx.clone();
             let workspace_id_clone = workspace_id.clone();
             let workspace_alias_clone = workspace_alias.clone();

--- a/src/relaycast_ws.rs
+++ b/src/relaycast_ws.rs
@@ -5,16 +5,13 @@ use parking_lot::Mutex;
 use relaycast::{
     format_registration_error, retry_agent_registration as sdk_retry_agent_registration,
     AgentClient, AgentRegistrationClient, AgentRegistrationError, AgentRegistrationRetryOutcome,
-    MessageListQuery, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
-    WsLifecycleEvent,
+    MessageListQuery, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest, WsClient,
+    WsClientOptions, WsLifecycleEvent,
 };
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
-use crate::{
-    auth::{AuthClient, CredentialCache},
-    events::EventEmitter,
-};
+use crate::events::EventEmitter;
 
 #[derive(Debug, Clone)]
 pub enum WsControl {
@@ -27,26 +24,20 @@ pub enum WsControl {
 
 #[derive(Clone)]
 pub struct RelaycastWsClient {
-    base_url: String,
-    auth: AuthClient,
-    token: Arc<Mutex<String>>,
-    creds: Arc<Mutex<CredentialCache>>,
+    ws_base_url: String,
+    workspace_http: RelaycastHttpClient,
     subscriptions: Arc<Mutex<HashSet<String>>>,
 }
 
 impl RelaycastWsClient {
     pub fn new(
-        base_url: impl Into<String>,
-        auth: AuthClient,
-        token: String,
-        creds: CredentialCache,
+        ws_base_url: impl Into<String>,
+        workspace_http: RelaycastHttpClient,
         channels: impl IntoIterator<Item = String>,
     ) -> Self {
         Self {
-            base_url: base_url.into(),
-            auth,
-            token: Arc::new(Mutex::new(token)),
-            creds: Arc::new(Mutex::new(creds)),
+            ws_base_url: ws_base_url.into(),
+            workspace_http,
             subscriptions: Arc::new(Mutex::new(channels.into_iter().collect())),
         }
     }
@@ -64,26 +55,20 @@ impl RelaycastWsClient {
         let mut has_connected = false;
 
         loop {
-            let token = self.token.lock().clone();
-            let base_url = Some(self.base_url.clone());
+            if let Err(error) = self.workspace_http.ensure_workspace_stream_enabled().await {
+                tracing::warn!(
+                    target = "relay_broker::ws",
+                    error = %error,
+                    "failed to enable workspace stream before websocket connect"
+                );
+            }
 
-            let mut agent = match AgentClient::new(&token, base_url) {
-                Ok(agent) => agent,
-                Err(error) => {
-                    tracing::warn!(
-                        target = "relay_broker::ws",
-                        error = %error,
-                        "failed to create SDK agent client"
-                    );
-                    tokio::time::sleep(Duration::from_secs(2)).await;
-                    if let Err(error) = self.refresh_token().await {
-                        tracing::warn!(target = "relay_broker::ws", error = %error, "token refresh failed");
-                    }
-                    continue;
-                }
-            };
+            let mut ws = WsClient::new(
+                WsClientOptions::new(self.workspace_http.api_key.clone())
+                    .with_base_url(self.ws_base_url.clone()),
+            );
 
-            match agent.connect().await {
+            match ws.connect().await {
                 Ok(()) => {
                     let status = if has_connected {
                         "reconnected"
@@ -93,7 +78,7 @@ impl RelaycastWsClient {
                     has_connected = true;
                     tracing::info!(
                         target = "broker::ws",
-                        base_url = %self.base_url,
+                        base_url = %self.ws_base_url,
                         status = %status,
                         "WebSocket {status}"
                     );
@@ -105,64 +90,29 @@ impl RelaycastWsClient {
                         }))
                         .await;
 
-                    // Subscribe to channels
+                    // Workspace stream receives all workspace events, including DMs.
+                    // We still track configured broker channels locally so existing
+                    // broker UI/state consumers see the same channel join events.
                     let channels = self.active_subscriptions();
                     if !channels.is_empty() {
-                        tracing::debug!(
+                        tracing::info!(
                             target = "broker::ws",
                             channels = ?channels,
-                            "subscribing to channels"
+                            "workspace stream active; tracking broker channels locally"
                         );
-                        match agent.subscribe_channels(channels.clone()).await {
-                            Ok(()) => {
-                                tracing::info!(
-                                    target = "broker::ws",
-                                    count = channels.len(),
-                                    channels = ?channels,
-                                    "subscribed to channels"
-                                );
-                                for channel in &channels {
-                                    let _ = inbound_tx
-                                        .send(json!({
-                                            "type":"broker.channel_join",
-                                            "payload":{"channel":channel}
-                                        }))
-                                        .await;
-                                }
-                            }
-                            Err(error) => {
-                                tracing::warn!(
-                                    target = "relay_broker::ws",
-                                    error = %error,
-                                    "channel subscribe failed"
-                                );
-                            }
+                        for channel in &channels {
+                            let _ = inbound_tx
+                                .send(json!({
+                                    "type":"broker.channel_join",
+                                    "payload":{"channel":channel}
+                                }))
+                                .await;
                         }
                     }
 
                     // Get event and lifecycle receivers
-                    let mut event_rx = match agent.subscribe_events() {
-                        Ok(rx) => rx,
-                        Err(error) => {
-                            tracing::warn!(
-                                target = "relay_broker::ws",
-                                error = %error,
-                                "failed to subscribe to SDK events"
-                            );
-                            continue;
-                        }
-                    };
-                    let mut lifecycle_rx = match agent.subscribe_lifecycle() {
-                        Ok(rx) => rx,
-                        Err(error) => {
-                            tracing::warn!(
-                                target = "relay_broker::ws",
-                                error = %error,
-                                "failed to subscribe to SDK lifecycle events"
-                            );
-                            continue;
-                        }
-                    };
+                    let mut event_rx = ws.subscribe_events();
+                    let mut lifecycle_rx = ws.subscribe_lifecycle();
 
                     let mut shutdown = false;
                     while !shutdown {
@@ -170,7 +120,7 @@ impl RelaycastWsClient {
                             ctrl = control_rx.recv() => {
                                 match ctrl {
                                     Some(WsControl::Shutdown) | None => {
-                                        agent.disconnect().await;
+                                        ws.disconnect().await;
                                         shutdown = true;
                                     }
                                     Some(WsControl::Publish(payload)) => {
@@ -178,22 +128,26 @@ impl RelaycastWsClient {
                                         let _ = inbound_tx.send(payload).await;
                                     }
                                     Some(WsControl::Subscribe(channels)) => {
-                                        // Re-subscribe after channels are created/joined.
+                                        let mut joined_now = Vec::new();
                                         {
                                             let mut subs = self.subscriptions.lock();
                                             for ch in &channels {
-                                                subs.insert(ch.clone());
+                                                if subs.insert(ch.clone()) {
+                                                    joined_now.push(ch.clone());
+                                                }
                                             }
                                         }
-                                        match agent.subscribe_channels(channels.clone()).await {
-                                            Ok(()) => tracing::info!(
-                                                channels = ?channels,
-                                                "re-subscribed to channels after creation"
-                                            ),
-                                            Err(error) => tracing::warn!(
-                                                error = %error,
-                                                "failed to re-subscribe to channels"
-                                            ),
+                                        tracing::info!(
+                                            channels = ?channels,
+                                            "updated local broker channel tracking for workspace stream"
+                                        );
+                                        for channel in joined_now {
+                                            let _ = inbound_tx
+                                                .send(json!({
+                                                    "type":"broker.channel_join",
+                                                    "payload":{"channel":channel}
+                                                }))
+                                                .await;
                                         }
                                     }
                                 }
@@ -268,7 +222,7 @@ impl RelaycastWsClient {
                 Err(error) => {
                     tracing::warn!(
                         target = "relay_broker::ws",
-                        base_url = %self.base_url,
+                        base_url = %self.ws_base_url,
                         error = %error,
                         "SDK ws connect failed"
                     );
@@ -282,19 +236,8 @@ impl RelaycastWsClient {
                     "payload":{"status":"disconnected"}
                 }))
                 .await;
-            if let Err(error) = self.refresh_token().await {
-                tracing::warn!(target = "relay_broker::ws", error = %error, "token refresh failed");
-            }
             tokio::time::sleep(Duration::from_secs(3)).await;
         }
-    }
-
-    async fn refresh_token(&self) -> Result<()> {
-        let creds = self.creds.lock().clone();
-        let refreshed = self.auth.rotate_token(&creds).await?;
-        *self.token.lock() = refreshed.token;
-        *self.creds.lock() = refreshed.credentials;
-        Ok(())
     }
 }
 
@@ -460,6 +403,26 @@ impl RelaycastHttpClient {
             .send(channel, text, None, None, None)
             .await
             .map_err(|e| anyhow::anyhow!("relaycast send_to_channel failed: {e}"))?;
+        Ok(())
+    }
+
+    /// Ensure workspace-wide WebSocket fanout is enabled for this workspace.
+    pub async fn ensure_workspace_stream_enabled(&self) -> Result<()> {
+        let Some(relay) = (*self.relay).as_ref() else {
+            tracing::warn!("SDK relay client not initialized; cannot enable workspace stream");
+            return Ok(());
+        };
+
+        let config = relay
+            .workspace_stream_set(true)
+            .await
+            .map_err(|error| anyhow::anyhow!("relaycast workspace_stream_set failed: {error}"))?;
+        tracing::debug!(
+            enabled = config.enabled,
+            default_enabled = config.default_enabled,
+            override = ?config.override_value,
+            "ensured workspace stream enabled"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Fix agent-to-agent DMs not being delivered in real-time
- Root cause: broker connected to Relaycast WebSocket with agent token, only subscribing to channel events — `dm.received` and `group_dm.received` events never reached the broker
- Switch to Relaycast SDK `WsClient` with workspace key so DM events flow through existing inbound routing and PTY injection path

## Changes
- `src/relaycast_ws.rs` — use `WsClient` with workspace key instead of agent-only subscription
- `src/multi_workspace.rs` — wire workspace DM stream into broker routing

## Test plan
- [x] `cargo check --quiet`
- [x] `cargo test maps_dm_received_top_level --quiet`
- [x] `cargo test maps_group_dm_top_level --quiet`
- [x] `cargo test maps_message_created_conversation_shape_as_dm_received --quiet`
- [ ] Manual: send DM between two agents and confirm real-time injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
