### PR TITLE
fix: canonicalize relay workspace routing

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -133,8 +133,11 @@ jobs:
           node dist/src/cli/index.js up --port "$TEST_PORT" &
           DAEMON_PID=$!
 
-          # Wait for health endpoint
-          for i in {1..20}; do
+          # Wait for health endpoint. On cold runners the dashboard may need
+          # extra time because `agent-relay up` can fall back to `npx
+          # @agent-relay/dashboard-server@latest` when no standalone binary is
+          # preinstalled.
+          for i in {1..60}; do
             if curl -sf "http://127.0.0.1:${TEST_PORT}/health" > /dev/null; then
               break
             fi

--- a/packages/openclaw/src/__tests__/config.test.ts
+++ b/packages/openclaw/src/__tests__/config.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const files = new Map<string, string>();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/home/test'),
+  };
+});
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn(async (path: string) => {
+    if (!files.has(path)) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return files.get(path)!;
+  }),
+  writeFile: vi.fn(async (path: string, data: string) => {
+    files.set(path, data);
+  }),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn((path: string) => files.has(path)),
+  readFileSync: vi.fn((path: string) => {
+    if (!files.has(path)) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return files.get(path)!;
+  }),
+}));
+
+const registerRelaycastAgent = vi.fn();
+const syncMcporterServers = vi.fn().mockResolvedValue({
+  configured: true,
+  tokenAction: 'provided',
+});
+
+vi.mock('../mcporter-config.js', () => ({
+  registerRelaycastAgent,
+  syncMcporterServers,
+}));
+
+describe('workspace config', () => {
+  const workspacesPath = '/home/test/.openclaw/workspace/relaycast/workspaces.json';
+  const gatewayEnvPath = '/home/test/.openclaw/workspace/relaycast/.env';
+
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+    process.env.OPENCLAW_HOME = '/home/test/.openclaw';
+    registerRelaycastAgent.mockResolvedValue({ agentToken: 'tok_new' });
+    syncMcporterServers.mockResolvedValue({
+      configured: true,
+      tokenAction: 'provided',
+      agentToken: 'tok_new',
+    });
+  });
+
+  it('migrates legacy default selectors to canonical workspace ids on load', async () => {
+    files.set(
+      workspacesPath,
+      JSON.stringify({
+        workspaces: [
+          {
+            api_key: 'rk_live_a',
+            workspace_alias: 'Team-A',
+            workspace_id: 'ws_a',
+            is_default: true,
+          },
+        ],
+        default_workspace: 'Team-A',
+      })
+    );
+
+    const { loadWorkspacesConfig } = await import('../config.js');
+    const config = await loadWorkspacesConfig();
+
+    expect(config).toEqual({
+      workspaces: [
+        {
+          api_key: 'rk_live_a',
+          workspace_alias: 'Team-A',
+          workspace_id: 'ws_a',
+          is_default: true,
+        },
+      ],
+      default_workspace_id: 'ws_a',
+    });
+    expect(JSON.parse(files.get(workspacesPath)!)).toEqual({
+      workspaces: [
+        {
+          api_key: 'rk_live_a',
+          workspace_alias: 'Team-A',
+          workspace_id: 'ws_a',
+          is_default: true,
+        },
+      ],
+      default_workspace_id: 'ws_a',
+    });
+  });
+
+  it('rejects duplicate aliases case-insensitively', async () => {
+    files.set(
+      workspacesPath,
+      JSON.stringify({
+        workspaces: [
+          {
+            api_key: 'rk_live_a',
+            workspace_alias: 'Team-A',
+            workspace_id: 'ws_a',
+            is_default: true,
+          },
+        ],
+        default_workspace_id: 'ws_a',
+      })
+    );
+
+    const { addWorkspace } = await import('../config.js');
+    await expect(
+      addWorkspace({
+        api_key: 'rk_live_b',
+        workspace_alias: 'team-a',
+        workspace_id: 'ws_b',
+      })
+    ).rejects.toThrow(/Aliases must be unique/);
+  });
+
+  it('throws on ambiguous switch targets', async () => {
+    files.set(
+      workspacesPath,
+      JSON.stringify({
+        workspaces: [
+          {
+            api_key: 'rk_live_a',
+            workspace_alias: 'shared',
+            workspace_id: 'ws_a',
+            is_default: true,
+          },
+          {
+            api_key: 'rk_live_b',
+            workspace_alias: 'team-b',
+            workspace_id: 'shared',
+            is_default: false,
+          },
+        ],
+        default_workspace_id: 'ws_a',
+      })
+    );
+
+    const { switchWorkspace } = await import('../config.js');
+    await expect(switchWorkspace('shared')).rejects.toThrow(/ambiguous/);
+  });
+
+  it('switches by alias using canonical ids and preserves the claw name in .env', async () => {
+    files.set(
+      workspacesPath,
+      JSON.stringify({
+        workspaces: [
+          {
+            api_key: 'rk_live_a',
+            workspace_alias: 'team-a',
+            workspace_id: 'ws_a',
+            is_default: true,
+          },
+          {
+            api_key: 'rk_live_b',
+            workspace_alias: 'team-b',
+            workspace_id: 'ws_b',
+            is_default: false,
+          },
+        ],
+        default_workspace_id: 'ws_a',
+      })
+    );
+    files.set(
+      gatewayEnvPath,
+      [
+        'RELAY_API_KEY=rk_live_a',
+        'RELAY_CLAW_NAME=my-claw',
+        'RELAY_BASE_URL=https://api.relaycast.dev',
+        'RELAY_CHANNELS=general',
+        '',
+      ].join('\n')
+    );
+
+    const { switchWorkspace } = await import('../config.js');
+    const config = await switchWorkspace('team-b');
+
+    expect(config?.default_workspace_id).toBe('ws_b');
+    expect(files.get(gatewayEnvPath)).toContain('RELAY_API_KEY=rk_live_b');
+    expect(files.get(gatewayEnvPath)).toContain('RELAY_CLAW_NAME=my-claw');
+    expect(syncMcporterServers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gatewayConfig: expect.objectContaining({
+          apiKey: 'rk_live_b',
+          clawName: 'my-claw',
+        }),
+        workspacesConfig: expect.objectContaining({
+          default_workspace_id: 'ws_b',
+        }),
+        agentToken: 'tok_new',
+      })
+    );
+  });
+
+  it('builds RELAY_WORKSPACES_JSON with canonical default_workspace_id', async () => {
+    const { buildWorkspacesJson } = await import('../config.js');
+    const json = buildWorkspacesJson({
+      workspaces: [
+        { api_key: 'rk_live_a', workspace_alias: 'team-a', workspace_id: 'ws_a' },
+        { api_key: 'rk_live_b', workspace_alias: 'team-b', workspace_id: 'ws_b' },
+      ],
+      default_workspace_id: 'ws_b',
+    });
+
+    expect(JSON.parse(json!)).toEqual({
+      memberships: [
+        { api_key: 'rk_live_a', workspace_alias: 'team-a', workspace_id: 'ws_a' },
+        { api_key: 'rk_live_b', workspace_alias: 'team-b', workspace_id: 'ws_b' },
+      ],
+      default_workspace_id: 'ws_b',
+    });
+  });
+});

--- a/packages/openclaw/src/__tests__/mcporter-config.test.ts
+++ b/packages/openclaw/src/__tests__/mcporter-config.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const files = new Map<string, string>();
 const execFileSync = vi.fn();
 const registerOrGet = vi.fn();
+const workspaceInfo = vi.fn();
 
 vi.mock('node:child_process', () => ({
   execFileSync,
@@ -34,6 +35,9 @@ vi.mock('@relaycast/sdk', () => ({
     agents: {
       registerOrGet,
     },
+    workspace: {
+      info: workspaceInfo,
+    },
   })),
 }));
 
@@ -62,6 +66,7 @@ describe('mcporter config helpers', () => {
       token: 'tok_new',
       data: { workspace_id: 'ws_new' },
     });
+    workspaceInfo.mockResolvedValue({ id: 'ws_from_info' });
   });
 
   it('preserves the existing agent token when the active workspace key stays the same', async () => {
@@ -153,5 +158,29 @@ describe('mcporter config helpers', () => {
       agentToken: 'tok_new',
       workspaceId: 'ws_new',
     });
+  });
+
+  it('falls back to workspace.info when registration omits workspace id', async () => {
+    registerOrGet.mockResolvedValue({ token: 'tok_new' });
+    workspaceInfo.mockResolvedValue({ id: 'ws_from_info' });
+
+    const { registerRelaycastAgent, resolveRelaycastWorkspaceId } = await import('../mcporter-config.js');
+    const registration = await registerRelaycastAgent({
+      apiKey: 'rk_live_a',
+      baseUrl: 'https://api.relaycast.dev',
+      clawName: 'my-claw',
+    });
+    const resolved = await resolveRelaycastWorkspaceId({
+      apiKey: 'rk_live_a',
+      baseUrl: 'https://api.relaycast.dev',
+      clawName: 'my-claw',
+    });
+
+    expect(registration).toEqual({
+      agentToken: 'tok_new',
+      workspaceId: 'ws_from_info',
+    });
+    expect(resolved).toBe('ws_from_info');
+    expect(workspaceInfo).toHaveBeenCalled();
   });
 });

--- a/packages/openclaw/src/__tests__/mcporter-config.test.ts
+++ b/packages/openclaw/src/__tests__/mcporter-config.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const files = new Map<string, string>();
+const execFileSync = vi.fn();
+const registerOrGet = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync,
+}));
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/home/test'),
+  };
+});
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn((path: string) => files.has(path)),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(async (path: string) => {
+    if (!files.has(path)) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return files.get(path)!;
+  }),
+}));
+
+vi.mock('@relaycast/sdk', () => ({
+  RelayCast: vi.fn().mockImplementation(() => ({
+    agents: {
+      registerOrGet,
+    },
+  })),
+}));
+
+vi.mock('../config.js', () => ({
+  buildWorkspacesJson: vi.fn((config: { default_workspace_id?: string }) =>
+    JSON.stringify({
+      memberships: [{ api_key: 'rk_live_a', workspace_id: 'ws_a', workspace_alias: 'team-a' }],
+      ...(config.default_workspace_id
+        ? { default_workspace_id: config.default_workspace_id }
+        : {}),
+    })
+  ),
+}));
+
+describe('mcporter config helpers', () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+    execFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes('--version')) {
+        return '1.0.0';
+      }
+      return '';
+    });
+    registerOrGet.mockResolvedValue({
+      token: 'tok_new',
+      data: { workspace_id: 'ws_new' },
+    });
+  });
+
+  it('preserves the existing agent token when the active workspace key stays the same', async () => {
+    files.set(
+      '/home/test/.mcporter/mcporter.json',
+      JSON.stringify({
+        mcpServers: {
+          relaycast: {
+            env: {
+              RELAY_API_KEY: 'rk_live_a',
+              RELAY_AGENT_TOKEN: 'tok_existing',
+            },
+          },
+        },
+      })
+    );
+
+    const { syncMcporterServers } = await import('../mcporter-config.js');
+    const result = await syncMcporterServers({
+      gatewayConfig: {
+        apiKey: 'rk_live_a',
+        clawName: 'my-claw',
+        baseUrl: 'https://api.relaycast.dev',
+        channels: ['general'],
+      },
+      workspacesConfig: {
+        workspaces: [{ api_key: 'rk_live_a', workspace_id: 'ws_a', workspace_alias: 'team-a' }],
+        default_workspace_id: 'ws_a',
+      },
+    });
+
+    expect(result.tokenAction).toBe('preserved');
+    const relaycastAddCall = execFileSync.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args.includes('add') && args.includes('relaycast')
+    );
+    expect(relaycastAddCall?.[1]).toContain('RELAY_AGENT_TOKEN=tok_existing');
+  });
+
+  it('clears stale agent tokens when the active workspace key changes', async () => {
+    files.set(
+      '/home/test/.mcporter/mcporter.json',
+      JSON.stringify({
+        mcpServers: {
+          relaycast: {
+            env: {
+              RELAY_API_KEY: 'rk_live_old',
+              RELAY_AGENT_TOKEN: 'tok_old',
+            },
+          },
+        },
+      })
+    );
+
+    const { syncMcporterServers } = await import('../mcporter-config.js');
+    const result = await syncMcporterServers({
+      gatewayConfig: {
+        apiKey: 'rk_live_new',
+        clawName: 'my-claw',
+        baseUrl: 'https://api.relaycast.dev',
+        channels: ['general'],
+      },
+      workspacesConfig: {
+        workspaces: [
+          { api_key: 'rk_live_old', workspace_id: 'ws_old', workspace_alias: 'old' },
+          { api_key: 'rk_live_new', workspace_id: 'ws_new', workspace_alias: 'new' },
+        ],
+        default_workspace_id: 'ws_new',
+      },
+    });
+
+    expect(result.tokenAction).toBe('cleared');
+    const relaycastAddCall = execFileSync.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args.includes('add') && args.includes('relaycast')
+    );
+    expect(
+      (relaycastAddCall?.[1] as string[]).some((arg) => arg.includes('RELAY_AGENT_TOKEN='))
+    ).toBe(false);
+  });
+
+  it('extracts agent tokens and workspace ids from Relaycast registration responses', async () => {
+    const { registerRelaycastAgent } = await import('../mcporter-config.js');
+    const registration = await registerRelaycastAgent({
+      apiKey: 'rk_live_a',
+      baseUrl: 'https://api.relaycast.dev',
+      clawName: 'my-claw',
+    });
+
+    expect(registration).toEqual({
+      agentToken: 'tok_new',
+      workspaceId: 'ws_new',
+    });
+  });
+});

--- a/packages/openclaw/src/__tests__/setup.test.ts
+++ b/packages/openclaw/src/__tests__/setup.test.ts
@@ -6,6 +6,7 @@ const addWorkspace = vi.fn();
 const detectOpenClaw = vi.fn();
 const saveGatewayConfig = vi.fn();
 const registerRelaycastAgent = vi.fn();
+const resolveRelaycastWorkspaceId = vi.fn();
 const syncMcporterServers = vi.fn();
 
 vi.mock('node:fs/promises', () => ({
@@ -52,6 +53,7 @@ vi.mock('./../config.js', () => ({
 
 vi.mock('./../mcporter-config.js', () => ({
   registerRelaycastAgent,
+  resolveRelaycastWorkspaceId,
   syncMcporterServers,
 }));
 
@@ -88,6 +90,7 @@ describe('setup', () => {
       agentToken: 'tok_new',
       workspaceId: 'ws_new',
     });
+    resolveRelaycastWorkspaceId.mockResolvedValue('ws_new');
     addWorkspace.mockResolvedValue({
       workspaces: [
         {
@@ -141,6 +144,47 @@ describe('setup', () => {
         }),
         agentToken: 'tok_new',
       })
+    );
+  });
+
+  it('falls back to workspace.info when agent registration omits workspaceId', async () => {
+    registerRelaycastAgent.mockResolvedValue({
+      agentToken: 'tok_new',
+    });
+    resolveRelaycastWorkspaceId.mockResolvedValue('ws_fallback');
+    addWorkspace.mockResolvedValue({
+      workspaces: [
+        {
+          api_key: 'rk_live_new',
+          workspace_alias: 'test-claw',
+          workspace_id: 'ws_fallback',
+          is_default: true,
+        },
+      ],
+      default_workspace_id: 'ws_fallback',
+    });
+
+    const { setup } = await import('../setup.js');
+    const result = await setup({
+      apiKey: 'rk_live_existing',
+      clawName: 'test-claw',
+      channels: ['general'],
+      baseUrl: 'https://api.relaycast.dev',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(resolveRelaycastWorkspaceId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'rk_live_existing',
+        clawName: 'test-claw',
+      })
+    );
+    expect(addWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        api_key: 'rk_live_existing',
+        workspace_id: 'ws_fallback',
+      }),
+      { syncRuntime: false }
     );
   });
 });

--- a/packages/openclaw/src/__tests__/setup.test.ts
+++ b/packages/openclaw/src/__tests__/setup.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from 'node:events';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addWorkspace = vi.fn();
+const detectOpenClaw = vi.fn();
+const saveGatewayConfig = vi.fn();
+const registerRelaycastAgent = vi.fn();
+const syncMcporterServers = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue('{}'),
+  copyFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('node:net', () => ({
+  createConnection: vi.fn(() => {
+    const socket = new EventEmitter() as EventEmitter & {
+      setTimeout: (ms: number) => void;
+      destroy: () => void;
+    };
+    socket.setTimeout = () => undefined;
+    socket.destroy = () => undefined;
+    queueMicrotask(() => socket.emit('error', new Error('offline')));
+    return socket;
+  }),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+  })),
+}));
+
+vi.mock('./../gateway.js', () => ({
+  InboundGateway: {
+    DEFAULT_CONTROL_PORT: 18790,
+  },
+}));
+
+vi.mock('./../config.js', () => ({
+  detectOpenClaw,
+  saveGatewayConfig,
+  addWorkspace,
+}));
+
+vi.mock('./../mcporter-config.js', () => ({
+  registerRelaycastAgent,
+  syncMcporterServers,
+}));
+
+describe('setup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            data: {
+              api_key: 'rk_live_new',
+              workspace_id: 'ws_new',
+            },
+          }),
+        text: () => Promise.resolve(''),
+      })
+    );
+
+    detectOpenClaw.mockResolvedValue({
+      installed: true,
+      homeDir: '/home/test/.openclaw',
+      workspaceDir: '/home/test/.openclaw/workspace',
+      configFile: '/home/test/.openclaw/openclaw.json',
+      config: {},
+      variant: 'openclaw',
+      configFilename: 'openclaw.json',
+    });
+    saveGatewayConfig.mockResolvedValue(undefined);
+    registerRelaycastAgent.mockResolvedValue({
+      agentToken: 'tok_new',
+      workspaceId: 'ws_new',
+    });
+    addWorkspace.mockResolvedValue({
+      workspaces: [
+        {
+          api_key: 'rk_live_new',
+          workspace_alias: 'test-claw',
+          workspace_id: 'ws_new',
+          is_default: true,
+        },
+      ],
+      default_workspace_id: 'ws_new',
+    });
+    syncMcporterServers.mockResolvedValue({
+      configured: true,
+      tokenAction: 'provided',
+      agentToken: 'tok_new',
+    });
+  });
+
+  it('records canonical workspace ids during setup and syncs mcporter with the registered token', async () => {
+    const { setup } = await import('../setup.js');
+    const result = await setup({
+      clawName: 'test-claw',
+      channels: ['general'],
+      baseUrl: 'https://api.relaycast.dev',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(saveGatewayConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'rk_live_new',
+        clawName: 'test-claw',
+      })
+    );
+    expect(addWorkspace).toHaveBeenCalledWith(
+      {
+        api_key: 'rk_live_new',
+        workspace_alias: 'test-claw',
+        workspace_id: 'ws_new',
+        is_default: true,
+      },
+      { syncRuntime: false }
+    );
+    expect(syncMcporterServers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gatewayConfig: expect.objectContaining({
+          apiKey: 'rk_live_new',
+          clawName: 'test-claw',
+        }),
+        workspacesConfig: expect.objectContaining({
+          default_workspace_id: 'ws_new',
+        }),
+        agentToken: 'tok_new',
+      })
+    );
+  });
+});

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -4,6 +4,7 @@ import { loadGatewayConfig, addWorkspace, listWorkspaces, switchWorkspace } from
 import { InboundGateway } from './gateway.js';
 import { listOpenClaws, releaseOpenClaw, spawnOpenClaw } from './control.js';
 import { startMcpServer } from './mcp/server.js';
+import { registerRelaycastAgent } from './mcporter-config.js';
 import { runtimeSetup } from './runtime/setup.js';
 
 const require = createRequire(import.meta.url);
@@ -258,12 +259,48 @@ async function runAddWorkspace(
     process.exit(1);
   }
 
-  const config = await addWorkspace({
-    api_key: apiKey,
-    ...(flags['alias'] ? { workspace_alias: flags['alias'] } : {}),
-    ...(flags['workspace-id'] ? { workspace_id: flags['workspace-id'] } : {}),
-    ...(flags['default'] !== undefined ? { is_default: flags['default'] === 'true' } : {}),
-  });
+  const wantsDefault = flags['default'] === 'true';
+  let workspaceId = flags['workspace-id'];
+
+  if (wantsDefault && !workspaceId) {
+    const gateway = await loadGatewayConfig();
+    if (!gateway) {
+      console.error('add-workspace --default requires --workspace-id before setup has been run.');
+      process.exit(1);
+    }
+
+    try {
+      const registration = await registerRelaycastAgent({
+        apiKey,
+        baseUrl: gateway.baseUrl,
+        clawName: gateway.clawName,
+      });
+      workspaceId = registration.workspaceId;
+    } catch (err) {
+      console.error(
+        `Failed to resolve workspace_id automatically: ${err instanceof Error ? err.message : String(err)}`
+      );
+      process.exit(1);
+    }
+
+    if (!workspaceId) {
+      console.error('add-workspace --default could not resolve workspace_id automatically. Pass --workspace-id.');
+      process.exit(1);
+    }
+  }
+
+  let config;
+  try {
+    config = await addWorkspace({
+      api_key: apiKey,
+      ...(flags['alias'] ? { workspace_alias: flags['alias'] } : {}),
+      ...(workspaceId ? { workspace_id: workspaceId } : {}),
+      ...(flags['default'] !== undefined ? { is_default: flags['default'] === 'true' } : {}),
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
 
   const entry = config.workspaces.find((w) => w.api_key === apiKey);
   const label = entry?.workspace_alias
@@ -271,8 +308,8 @@ async function runAddWorkspace(
     ?? apiKey.slice(0, 12) + '...';
   console.log(`Workspace "${label}" added.`);
   console.log(`Total workspaces: ${config.workspaces.length}`);
-  if (config.default_workspace) {
-    console.log(`Default workspace: ${config.default_workspace}`);
+  if (config.default_workspace_id) {
+    console.log(`Default workspace: ${config.default_workspace_id}`);
   }
 }
 
@@ -302,15 +339,21 @@ async function runSwitchWorkspace(positional: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const result = await switchWorkspace(identifier);
+  let result;
+  try {
+    result = await switchWorkspace(identifier);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
   if (!result) {
     console.error(`Workspace "${identifier}" not found.`);
     console.error('Run "relay-openclaw list-workspaces" to see available workspaces.');
     process.exit(1);
   }
 
-  console.log(`Switched default workspace to "${identifier}".`);
-  console.log('The .env config has been updated. Restart the gateway to apply.');
+  console.log(`Switched default workspace to "${result.default_workspace_id ?? identifier}".`);
+  console.log('Gateway and MCP configuration were updated for the selected workspace.');
 }
 
 async function main(): Promise<void> {

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -5,6 +5,7 @@ import { InboundGateway } from './gateway.js';
 import { listOpenClaws, releaseOpenClaw, spawnOpenClaw } from './control.js';
 import { startMcpServer } from './mcp/server.js';
 import { registerRelaycastAgent } from './mcporter-config.js';
+import { redactErrorMessage, redactRelaySecrets } from './redaction.js';
 import { runtimeSetup } from './runtime/setup.js';
 
 const require = createRequire(import.meta.url);
@@ -117,7 +118,7 @@ async function runSetup(
     console.log(`\nWorkspace key: ${maskedApiKey}`);
     console.log('Share this key with other claws to join the same workspace.');
   } else {
-    console.error(`Setup failed: ${result.message}`);
+    console.error(`Setup failed: ${redactRelaySecrets(result.message)}`);
     process.exit(1);
   }
 }
@@ -278,7 +279,7 @@ async function runAddWorkspace(
       workspaceId = registration.workspaceId;
     } catch (err) {
       console.error(
-        `Failed to resolve workspace_id automatically: ${err instanceof Error ? err.message : String(err)}`
+        `Failed to resolve workspace_id automatically: ${redactErrorMessage(err)}`
       );
       process.exit(1);
     }
@@ -298,7 +299,7 @@ async function runAddWorkspace(
       ...(flags['default'] !== undefined ? { is_default: flags['default'] === 'true' } : {}),
     });
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    console.error(redactErrorMessage(err));
     process.exit(1);
   }
 
@@ -343,11 +344,11 @@ async function runSwitchWorkspace(positional: string[]): Promise<void> {
   try {
     result = await switchWorkspace(identifier);
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    console.error(redactErrorMessage(err));
     process.exit(1);
   }
   if (!result) {
-    console.error(`Workspace "${identifier}" not found.`);
+    console.error(`Workspace "${redactRelaySecrets(identifier)}" not found.`);
     console.error('Run "relay-openclaw list-workspaces" to see available workspaces.');
     process.exit(1);
   }
@@ -411,6 +412,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error(redactErrorMessage(err));
   process.exit(1);
 });

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -260,7 +260,7 @@ async function runAddWorkspace(
   }
 
   const wantsDefault = flags['default'] === 'true';
-  let workspaceId = flags['workspace-id'];
+  let workspaceId: string | undefined = flags['workspace-id'];
 
   if (wantsDefault && !workspaceId) {
     const gateway = await loadGatewayConfig();

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from 'node:fs';
 
 import type { GatewayConfig, WorkspaceEntry, WorkspacesConfig } from './types.js';
 import { registerRelaycastAgent, syncMcporterServers } from './mcporter-config.js';
+import { maskWorkspaceKey, redactErrorMessage, redactRelaySecrets } from './redaction.js';
 
 function envValue(vars: Record<string, string>, key: string): string | undefined {
   const processValue = process.env[key]?.trim();
@@ -455,7 +456,7 @@ export async function addWorkspace(
     } catch (err) {
       console.warn(
         `[config] Failed to refresh Relaycast agent token for "${gateway.clawName}": ${
-          err instanceof Error ? err.message : String(err)
+          redactErrorMessage(err)
         }`
       );
     }
@@ -524,7 +525,7 @@ export async function switchWorkspace(identifier: string): Promise<WorkspacesCon
     } catch (err) {
       console.warn(
         `[config] Failed to refresh Relaycast agent token for "${gateway.clawName}": ${
-          err instanceof Error ? err.message : String(err)
+          redactErrorMessage(err)
         }`
       );
     }
@@ -580,7 +581,7 @@ function normalizeAlias(alias?: string): string | null {
 }
 
 function workspaceDisplayLabel(workspace: WorkspaceEntry): string {
-  return workspace.workspace_alias ?? workspace.workspace_id ?? workspace.api_key;
+  return workspace.workspace_alias ?? workspace.workspace_id ?? maskWorkspaceKey(workspace.api_key);
 }
 
 function applyDefaultWorkspaceId(config: WorkspacesConfig, workspaceId: string): void {
@@ -622,7 +623,7 @@ function resolveWorkspaceTarget(workspaces: WorkspaceEntry[], identifier: string
 
   if (uniqueMatches.length > 1) {
     throw new Error(
-      `Workspace selector "${identifier}" is ambiguous. Matches: ${uniqueMatches
+      `Workspace selector "${redactRelaySecrets(identifier)}" is ambiguous. Matches: ${uniqueMatches
         .map((workspace) => workspaceDisplayLabel(workspace))
         .join(', ')}.`
     );

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { existsSync, readFileSync } from 'node:fs';
 
 import type { GatewayConfig, WorkspaceEntry, WorkspacesConfig } from './types.js';
+import { registerRelaycastAgent, syncMcporterServers } from './mcporter-config.js';
 
 function envValue(vars: Record<string, string>, key: string): string | undefined {
   const processValue = process.env[key]?.trim();
@@ -352,12 +353,22 @@ export async function loadWorkspacesConfig(): Promise<WorkspacesConfig | null> {
 
   try {
     const raw = await readFile(configPath, 'utf-8');
-    return JSON.parse(raw) as WorkspacesConfig;
+    const parsed = JSON.parse(raw) as WorkspacesConfig;
+    const normalized = normalizeWorkspacesConfig(parsed);
+
+    for (const warning of normalized.warnings) {
+      console.warn(`Warning: ${warning}`);
+    }
+    if (normalized.changed) {
+      await saveWorkspacesConfig(normalized.config);
+    }
+
+    return normalized.config;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn(`Warning: failed to parse ${configPath}: ${message}`);
     console.warn('The file may be corrupted. Existing workspace config will not be modified.');
-    return { workspaces: [], default_workspace: undefined };
+    return { workspaces: [] };
   }
 }
 
@@ -367,69 +378,107 @@ export async function loadWorkspacesConfig(): Promise<WorkspacesConfig | null> {
 export async function saveWorkspacesConfig(config: WorkspacesConfig): Promise<void> {
   const configPath = await workspacesConfigPath();
   await mkdir(dirname(configPath), { recursive: true });
-  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  const normalized: WorkspacesConfig = {
+    workspaces: config.workspaces,
+    ...(config.default_workspace_id ? { default_workspace_id: config.default_workspace_id } : {}),
+  };
+  await writeFile(configPath, JSON.stringify(normalized, null, 2) + '\n', 'utf-8');
 }
 
 /**
  * Add a workspace entry. If an entry with the same api_key already exists,
  * it is updated in place. The first workspace added becomes the default.
  */
-export async function addWorkspace(entry: WorkspaceEntry): Promise<WorkspacesConfig> {
-  let config = await loadWorkspacesConfig();
+export interface WorkspaceMutationOptions {
+  syncRuntime?: boolean;
+}
 
-  if (!config) {
-    // Bootstrap from existing single-workspace .env if available
-    const gateway = await loadGatewayConfig();
-    if (gateway) {
-      config = {
-        workspaces: [{
-          api_key: gateway.apiKey,
-          workspace_alias: gateway.clawName,
-          is_default: true,
-        }],
-        default_workspace: gateway.clawName,
-      };
-    } else {
-      config = { workspaces: [], default_workspace: undefined };
-    }
-  }
-
-  const normalizeWorkspaceLabel = (workspace: WorkspaceEntry): string => {
-    return workspace.workspace_alias ?? workspace.workspace_id ?? workspace.api_key;
+export async function addWorkspace(
+  entry: WorkspaceEntry,
+  options: WorkspaceMutationOptions = {}
+): Promise<WorkspacesConfig> {
+  const config = await loadOrBootstrapWorkspacesConfig();
+  const normalizedEntry = normalizeWorkspaceEntry(entry);
+  const existingIdx = config.workspaces.findIndex((w) => w.api_key === normalizedEntry.api_key);
+  const existingEntry = existingIdx >= 0 ? config.workspaces[existingIdx] : undefined;
+  const mergedEntry = {
+    ...existingEntry,
+    ...normalizedEntry,
+    ...(normalizedEntry.is_default === undefined && existingEntry
+      ? { is_default: existingEntry.is_default }
+      : {}),
   };
 
-  // Check for existing entry with same api_key
-  const hasExplicitDefault = entry.is_default !== undefined;
-  const existingIdx = config.workspaces.findIndex((w) => w.api_key === entry.api_key);
+  if (mergedEntry.is_default && !mergedEntry.workspace_id) {
+    throw new Error(
+      `Workspace "${workspaceDisplayLabel(mergedEntry)}" is missing workspace_id. Pass --workspace-id before setting it as default.`
+    );
+  }
+
+  assertUniqueWorkspaceAlias(
+    config.workspaces.filter((workspace) => workspace.api_key !== normalizedEntry.api_key),
+    mergedEntry
+  );
+
   if (existingIdx >= 0) {
-    const existingEntry = config.workspaces[existingIdx];
-    config.workspaces[existingIdx] = { ...existingEntry, ...entry };
-    if (!hasExplicitDefault) {
-      config.workspaces[existingIdx].is_default = existingEntry.is_default;
-    }
-    const updatedEntry = config.workspaces[existingIdx];
-    if (updatedEntry.is_default) {
-      config.default_workspace = normalizeWorkspaceLabel(updatedEntry);
-    }
+    config.workspaces[existingIdx] = mergedEntry;
   } else {
-    config.workspaces.push(entry);
+    config.workspaces.push(mergedEntry);
   }
 
-  const targetWorkspace = config.workspaces.find((w) => w.api_key === entry.api_key);
-  if (!targetWorkspace) {
-    throw new Error(`Failed to locate workspace entry for ${entry.api_key}`);
-  }
+  const shouldPromoteToDefault =
+    mergedEntry.is_default === true ||
+    (!config.default_workspace_id &&
+      config.workspaces.length === 1 &&
+      Boolean(mergedEntry.workspace_id));
 
-  // If this is explicitly default, or this is the first workspace without an existing default,
-  // set it as default.
-  if (
-    entry.is_default === true ||
-    (config.default_workspace === undefined && config.workspaces.length === 1)
+  if (shouldPromoteToDefault && mergedEntry.workspace_id) {
+    applyDefaultWorkspaceId(config, mergedEntry.workspace_id);
+  } else if (
+    existingEntry?.is_default &&
+    mergedEntry.workspace_id &&
+    (!config.default_workspace_id || config.default_workspace_id === existingEntry.workspace_id)
   ) {
-    config.default_workspace = normalizeWorkspaceLabel(targetWorkspace);
-    for (const w of config.workspaces) {
-      w.is_default = w.api_key === targetWorkspace.api_key;
+    applyDefaultWorkspaceId(config, mergedEntry.workspace_id);
+  }
+
+  const shouldSyncRuntime = options.syncRuntime !== false;
+  const gateway = await loadGatewayConfig();
+  if (shouldSyncRuntime && gateway && config.default_workspace_id && mergedEntry.workspace_id === config.default_workspace_id) {
+    gateway.apiKey = mergedEntry.api_key;
+    await saveGatewayConfig(gateway);
+
+    let agentToken: string | undefined;
+    try {
+      const registration = await registerRelaycastAgent(gateway);
+      agentToken = registration.agentToken;
+    } catch (err) {
+      console.warn(
+        `[config] Failed to refresh Relaycast agent token for "${gateway.clawName}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
+
+    const sync = await syncMcporterServers({
+      gatewayConfig: gateway,
+      workspacesConfig: config,
+      agentToken,
+    });
+    if (!sync.configured) {
+      console.warn('mcporter not found (tried global binary and npx). MCP tools were not updated.');
+    }
+  } else if (shouldSyncRuntime && gateway) {
+    const sync = await syncMcporterServers({
+      gatewayConfig: gateway,
+      workspacesConfig: config,
+    });
+    if (!sync.configured) {
+      console.warn('mcporter not found (tried global binary and npx). MCP tools were not updated.');
+    }
+  } else if (!shouldSyncRuntime && gateway && config.default_workspace_id && mergedEntry.workspace_id === config.default_workspace_id) {
+    gateway.apiKey = mergedEntry.api_key;
+    await saveGatewayConfig(gateway);
   }
 
   await saveWorkspacesConfig(config);
@@ -452,22 +501,42 @@ export async function switchWorkspace(identifier: string): Promise<WorkspacesCon
   const config = await loadWorkspacesConfig();
   if (!config) return null;
 
-  const target = config.workspaces.find(
-    (w) => w.workspace_alias === identifier || w.workspace_id === identifier
-  );
+  const target = resolveWorkspaceTarget(config.workspaces, identifier);
   if (!target) return null;
-
-  config.default_workspace = target.workspace_alias ?? target.workspace_id ?? target.api_key;
-  for (const w of config.workspaces) {
-    w.is_default = w.api_key === target.api_key;
+  if (!target.workspace_id) {
+    throw new Error(
+      `Workspace "${workspaceDisplayLabel(target)}" is missing workspace_id and cannot be selected as the default workspace.`
+    );
   }
+
+  applyDefaultWorkspaceId(config, target.workspace_id);
 
   // Also update the single-workspace .env to match the new default
   const gateway = await loadGatewayConfig();
   if (gateway) {
     gateway.apiKey = target.api_key;
-    gateway.clawName = target.workspace_alias ?? target.workspace_id ?? target.api_key;
     await saveGatewayConfig(gateway);
+
+    let agentToken: string | undefined;
+    try {
+      const registration = await registerRelaycastAgent(gateway);
+      agentToken = registration.agentToken;
+    } catch (err) {
+      console.warn(
+        `[config] Failed to refresh Relaycast agent token for "${gateway.clawName}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    const sync = await syncMcporterServers({
+      gatewayConfig: gateway,
+      workspacesConfig: config,
+      agentToken,
+    });
+    if (!sync.configured) {
+      console.warn('mcporter not found (tried global binary and npx). MCP tools were not updated.');
+    }
   }
 
   await saveWorkspacesConfig(config);
@@ -488,9 +557,152 @@ export function buildWorkspacesJson(config: WorkspacesConfig): string | null {
   }));
 
   const payload: Record<string, unknown> = { memberships };
-  if (config.default_workspace) {
-    payload.default_workspace_id = config.default_workspace;
+  if (config.default_workspace_id) {
+    payload.default_workspace_id = config.default_workspace_id;
   }
 
   return JSON.stringify(payload);
+}
+
+function normalizeWorkspaceEntry(entry: WorkspaceEntry): WorkspaceEntry {
+  const workspaceAlias = entry.workspace_alias?.trim();
+  const workspaceId = entry.workspace_id?.trim();
+  return {
+    ...entry,
+    ...(workspaceAlias ? { workspace_alias: workspaceAlias } : {}),
+    ...(workspaceId ? { workspace_id: workspaceId } : {}),
+  };
+}
+
+function normalizeAlias(alias?: string): string | null {
+  const trimmed = alias?.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function workspaceDisplayLabel(workspace: WorkspaceEntry): string {
+  return workspace.workspace_alias ?? workspace.workspace_id ?? workspace.api_key;
+}
+
+function applyDefaultWorkspaceId(config: WorkspacesConfig, workspaceId: string): void {
+  config.default_workspace_id = workspaceId;
+  delete config.default_workspace;
+  for (const workspace of config.workspaces) {
+    workspace.is_default = workspace.workspace_id === workspaceId;
+  }
+}
+
+function assertUniqueWorkspaceAlias(existing: WorkspaceEntry[], candidate: WorkspaceEntry): void {
+  const normalizedAlias = normalizeAlias(candidate.workspace_alias);
+  if (!normalizedAlias) return;
+
+  const conflict = existing.find((workspace) => normalizeAlias(workspace.workspace_alias) === normalizedAlias);
+  if (!conflict) return;
+
+  throw new Error(
+    `Workspace alias "${candidate.workspace_alias}" is already used by "${workspaceDisplayLabel(conflict)}". Aliases must be unique.`
+  );
+}
+
+function resolveWorkspaceTarget(workspaces: WorkspaceEntry[], identifier: string): WorkspaceEntry | null {
+  const trimmed = identifier.trim();
+  if (!trimmed) return null;
+
+  const normalizedIdentifier = trimmed.toLowerCase();
+  const matches = workspaces.filter(
+    (workspace) =>
+      workspace.workspace_id === trimmed ||
+      workspace.api_key === trimmed ||
+      normalizeAlias(workspace.workspace_alias) === normalizedIdentifier
+  );
+
+  const uniqueMatches = matches.filter(
+    (workspace, index) =>
+      matches.findIndex((candidate) => candidate.api_key === workspace.api_key) === index
+  );
+
+  if (uniqueMatches.length > 1) {
+    throw new Error(
+      `Workspace selector "${identifier}" is ambiguous. Matches: ${uniqueMatches
+        .map((workspace) => workspaceDisplayLabel(workspace))
+        .join(', ')}.`
+    );
+  }
+
+  return uniqueMatches[0] ?? null;
+}
+
+async function loadOrBootstrapWorkspacesConfig(): Promise<WorkspacesConfig> {
+  const existing = await loadWorkspacesConfig();
+  if (existing) return existing;
+
+  const gateway = await loadGatewayConfig();
+  if (!gateway) {
+    return { workspaces: [] };
+  }
+
+  return {
+    workspaces: [
+      {
+        api_key: gateway.apiKey,
+        workspace_alias: gateway.clawName,
+        is_default: true,
+      },
+    ],
+  };
+}
+
+function normalizeWorkspacesConfig(config: WorkspacesConfig): {
+  config: WorkspacesConfig;
+  changed: boolean;
+  warnings: string[];
+} {
+  const normalized: WorkspacesConfig = {
+    workspaces: config.workspaces.map((workspace) => normalizeWorkspaceEntry(workspace)),
+  };
+  const warnings: string[] = [];
+  let changed = false;
+
+  const selector = config.default_workspace_id ?? config.default_workspace;
+  let resolvedDefaultWorkspaceId: string | undefined;
+  if (selector) {
+    try {
+      resolvedDefaultWorkspaceId = resolveWorkspaceTarget(normalized.workspaces, selector)?.workspace_id;
+    } catch (err) {
+      warnings.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  if (!resolvedDefaultWorkspaceId) {
+    const explicitDefaults = normalized.workspaces.filter((workspace) => workspace.is_default);
+    if (explicitDefaults.length === 1 && explicitDefaults[0].workspace_id) {
+      resolvedDefaultWorkspaceId = explicitDefaults[0].workspace_id;
+    } else if (!selector && normalized.workspaces.length === 1 && normalized.workspaces[0].workspace_id) {
+      resolvedDefaultWorkspaceId = normalized.workspaces[0].workspace_id;
+    }
+  }
+
+  if (selector && !resolvedDefaultWorkspaceId) {
+    warnings.push(
+      `Could not migrate default workspace selector "${selector}" to a canonical workspace_id.`
+    );
+  }
+
+  if (resolvedDefaultWorkspaceId) {
+    normalized.default_workspace_id = resolvedDefaultWorkspaceId;
+    for (const workspace of normalized.workspaces) {
+      workspace.is_default = workspace.workspace_id === resolvedDefaultWorkspaceId;
+    }
+  }
+
+  if (config.default_workspace !== undefined) {
+    changed = true;
+  }
+  if (config.default_workspace_id !== normalized.default_workspace_id) {
+    changed = true;
+  }
+  if (JSON.stringify(config.workspaces) !== JSON.stringify(normalized.workspaces)) {
+    changed = true;
+  }
+
+  return { config: normalized, changed, warnings };
 }

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -566,12 +566,12 @@ export function buildWorkspacesJson(config: WorkspacesConfig): string | null {
 }
 
 function normalizeWorkspaceEntry(entry: WorkspaceEntry): WorkspaceEntry {
-  const workspaceAlias = entry.workspace_alias?.trim();
-  const workspaceId = entry.workspace_id?.trim();
+  const workspaceAlias = entry.workspace_alias?.trim() || undefined;
+  const workspaceId = entry.workspace_id?.trim() || undefined;
   return {
     ...entry,
-    ...(workspaceAlias ? { workspace_alias: workspaceAlias } : {}),
-    ...(workspaceId ? { workspace_id: workspaceId } : {}),
+    workspace_alias: workspaceAlias,
+    workspace_id: workspaceId,
   };
 }
 

--- a/packages/openclaw/src/mcporter-config.ts
+++ b/packages/openclaw/src/mcporter-config.ts
@@ -232,25 +232,32 @@ export async function syncMcporterServers(
   const relaycastEnv = buildRelaycastEnv(options.gatewayConfig, options.workspacesConfig, agentToken);
   const spawnerEnv = buildRelaycastEnv(options.gatewayConfig, options.workspacesConfig);
 
-  removeServer(mcp, 'relaycast');
-  addServer(
-    mcp,
-    'relaycast',
-    'npx',
-    ['@relaycast/mcp'],
-    relaycastEnv,
-    'Relaycast messaging MCP server'
-  );
+  try {
+    removeServer(mcp, 'relaycast');
+    addServer(
+      mcp,
+      'relaycast',
+      'npx',
+      ['@relaycast/mcp'],
+      relaycastEnv,
+      'Relaycast messaging MCP server'
+    );
 
-  removeServer(mcp, 'openclaw-spawner');
-  addServer(
-    mcp,
-    'openclaw-spawner',
-    'npx',
-    ['@agent-relay/openclaw', 'mcp-server'],
-    spawnerEnv,
-    'OpenClaw spawner MCP server'
-  );
+    removeServer(mcp, 'openclaw-spawner');
+    addServer(
+      mcp,
+      'openclaw-spawner',
+      'npx',
+      ['@agent-relay/openclaw', 'mcp-server'],
+      spawnerEnv,
+      'OpenClaw spawner MCP server'
+    );
+  } catch (err) {
+    console.warn(
+      `mcporter configuration failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { configured: false, tokenAction, agentToken };
+  }
 
   return { configured: true, tokenAction, agentToken };
 }

--- a/packages/openclaw/src/mcporter-config.ts
+++ b/packages/openclaw/src/mcporter-config.ts
@@ -35,6 +35,15 @@ function mcporterConfigPath(): string {
   return join(homedir(), '.mcporter', 'mcporter.json');
 }
 
+function createRelaycastClient(
+  gatewayConfig: Pick<GatewayConfig, 'apiKey' | 'baseUrl'>
+): RelayCast {
+  return new RelayCast({
+    apiKey: gatewayConfig.apiKey,
+    baseUrl: gatewayConfig.baseUrl,
+  });
+}
+
 function extractNestedString(value: unknown, path: string[]): string | undefined {
   let current = value;
   for (const key of path) {
@@ -42,6 +51,15 @@ function extractNestedString(value: unknown, path: string[]): string | undefined
     current = (current as Record<string, unknown>)[key];
   }
   return typeof current === 'string' && current.trim() ? current : undefined;
+}
+
+async function resolveWorkspaceIdFromClient(relaycast: RelayCast): Promise<string | undefined> {
+  const workspace = (await relaycast.workspace.info()) as Record<string, unknown>;
+  return (
+    extractNestedString(workspace, ['id']) ??
+    extractNestedString(workspace, ['workspaceId']) ??
+    extractNestedString(workspace, ['workspace_id'])
+  );
 }
 
 async function loadMcporterServerEnv(serverName: string): Promise<Record<string, string>> {
@@ -156,27 +174,33 @@ export function resolveMcporter(): McporterCommand {
 export async function registerRelaycastAgent(
   gatewayConfig: Pick<GatewayConfig, 'apiKey' | 'baseUrl' | 'clawName'>
 ): Promise<AgentRegistration> {
-  const relaycast = new RelayCast({
-    apiKey: gatewayConfig.apiKey,
-    baseUrl: gatewayConfig.baseUrl,
-  });
+  const relaycast = createRelaycastClient(gatewayConfig);
   const registered = (await relaycast.agents.registerOrGet({
     name: gatewayConfig.clawName,
     type: 'agent',
   })) as Record<string, unknown>;
+  const workspaceId =
+    extractNestedString(registered, ['workspaceId']) ??
+    extractNestedString(registered, ['workspace_id']) ??
+    extractNestedString(registered, ['workspace', 'id']) ??
+    extractNestedString(registered, ['data', 'workspaceId']) ??
+    extractNestedString(registered, ['data', 'workspace_id']) ??
+    extractNestedString(registered, ['data', 'workspace', 'id']) ??
+    await resolveWorkspaceIdFromClient(relaycast);
 
   return {
     agentToken:
       extractNestedString(registered, ['token']) ??
       extractNestedString(registered, ['data', 'token']),
-    workspaceId:
-      extractNestedString(registered, ['workspaceId']) ??
-      extractNestedString(registered, ['workspace_id']) ??
-      extractNestedString(registered, ['workspace', 'id']) ??
-      extractNestedString(registered, ['data', 'workspaceId']) ??
-      extractNestedString(registered, ['data', 'workspace_id']) ??
-      extractNestedString(registered, ['data', 'workspace', 'id']),
+    workspaceId,
   };
+}
+
+export async function resolveRelaycastWorkspaceId(
+  gatewayConfig: Pick<GatewayConfig, 'apiKey' | 'baseUrl' | 'clawName'>
+): Promise<string | undefined> {
+  const relaycast = createRelaycastClient(gatewayConfig);
+  return resolveWorkspaceIdFromClient(relaycast);
 }
 
 export async function syncMcporterServers(

--- a/packages/openclaw/src/mcporter-config.ts
+++ b/packages/openclaw/src/mcporter-config.ts
@@ -1,0 +1,232 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { RelayCast } from '@relaycast/sdk';
+
+import type { GatewayConfig, WorkspacesConfig } from './types.js';
+import { buildWorkspacesJson } from './config.js';
+
+export interface McporterCommand {
+  cmd: string;
+  prefix: string[];
+}
+
+export interface AgentRegistration {
+  agentToken?: string;
+  workspaceId?: string;
+}
+
+export interface SyncMcporterServersOptions {
+  gatewayConfig: GatewayConfig;
+  workspacesConfig: WorkspacesConfig | null;
+  agentToken?: string;
+}
+
+export interface SyncMcporterServersResult {
+  configured: boolean;
+  agentToken?: string;
+  tokenAction: 'provided' | 'preserved' | 'cleared' | 'none';
+}
+
+function mcporterConfigPath(): string {
+  return join(homedir(), '.mcporter', 'mcporter.json');
+}
+
+function extractNestedString(value: unknown, path: string[]): string | undefined {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === 'string' && current.trim() ? current : undefined;
+}
+
+async function loadMcporterServerEnv(serverName: string): Promise<Record<string, string>> {
+  const configPath = mcporterConfigPath();
+  if (!existsSync(configPath)) return {};
+
+  try {
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const env = ((parsed.mcpServers as Record<string, unknown> | undefined)?.[serverName] as
+      | { env?: Record<string, unknown> }
+      | undefined)?.env;
+    if (!env || typeof env !== 'object') return {};
+
+    return Object.fromEntries(
+      Object.entries(env).filter(([, value]) => typeof value === 'string')
+    ) as Record<string, string>;
+  } catch (err) {
+    console.warn(
+      `[mcporter] Failed to read ${serverName} env from ${configPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return {};
+  }
+}
+
+function buildRelaycastEnv(
+  gatewayConfig: GatewayConfig,
+  workspacesConfig: WorkspacesConfig | null,
+  agentToken?: string
+): Record<string, string> {
+  const env: Record<string, string> = {
+    RELAY_API_KEY: gatewayConfig.apiKey,
+  };
+
+  if (gatewayConfig.baseUrl !== 'https://api.relaycast.dev') {
+    env.RELAY_BASE_URL = gatewayConfig.baseUrl;
+  }
+
+  const workspacesJson = workspacesConfig ? buildWorkspacesJson(workspacesConfig) : null;
+  if (workspacesJson) {
+    env.RELAY_WORKSPACES_JSON = workspacesJson;
+  }
+  if (workspacesConfig?.default_workspace_id) {
+    env.RELAY_DEFAULT_WORKSPACE = workspacesConfig.default_workspace_id;
+  }
+  if (agentToken) {
+    env.RELAY_AGENT_TOKEN = agentToken;
+  }
+
+  return env;
+}
+
+function envArgs(env: Record<string, string>): string[] {
+  return Object.entries(env).flatMap(([key, value]) => ['--env', `${key}=${value}`]);
+}
+
+function removeServer(mcp: McporterCommand, name: string): void {
+  try {
+    execFileSync(mcp.cmd, [...mcp.prefix, 'config', 'remove', name], { stdio: 'pipe' });
+  } catch {
+    // Missing entries are expected on first run.
+  }
+}
+
+function addServer(
+  mcp: McporterCommand,
+  name: string,
+  command: string,
+  args: string[],
+  env: Record<string, string>,
+  description: string
+): void {
+  execFileSync(
+    mcp.cmd,
+    [
+      ...mcp.prefix,
+      'config',
+      'add',
+      name,
+      '--command',
+      command,
+      ...args.flatMap((arg) => ['--arg', arg]),
+      ...envArgs(env),
+      '--scope',
+      'home',
+      '--description',
+      description,
+    ],
+    { stdio: 'pipe' }
+  );
+}
+
+/**
+ * Resolve how to invoke mcporter. Prefers a global binary, falls back to npx.
+ */
+export function resolveMcporter(): McporterCommand {
+  try {
+    execFileSync('mcporter', ['--version'], { stdio: 'pipe' });
+    return { cmd: 'mcporter', prefix: [] };
+  } catch {
+    try {
+      execFileSync('npx', ['-y', 'mcporter', '--version'], { stdio: 'pipe' });
+      return { cmd: 'npx', prefix: ['-y', 'mcporter'] };
+    } catch {
+      throw new Error('mcporter not found (tried global binary and npx)');
+    }
+  }
+}
+
+export async function registerRelaycastAgent(
+  gatewayConfig: Pick<GatewayConfig, 'apiKey' | 'baseUrl' | 'clawName'>
+): Promise<AgentRegistration> {
+  const relaycast = new RelayCast({
+    apiKey: gatewayConfig.apiKey,
+    baseUrl: gatewayConfig.baseUrl,
+  });
+  const registered = (await relaycast.agents.registerOrGet({
+    name: gatewayConfig.clawName,
+    type: 'agent',
+  })) as Record<string, unknown>;
+
+  return {
+    agentToken:
+      extractNestedString(registered, ['token']) ??
+      extractNestedString(registered, ['data', 'token']),
+    workspaceId:
+      extractNestedString(registered, ['workspaceId']) ??
+      extractNestedString(registered, ['workspace_id']) ??
+      extractNestedString(registered, ['workspace', 'id']) ??
+      extractNestedString(registered, ['data', 'workspaceId']) ??
+      extractNestedString(registered, ['data', 'workspace_id']) ??
+      extractNestedString(registered, ['data', 'workspace', 'id']),
+  };
+}
+
+export async function syncMcporterServers(
+  options: SyncMcporterServersOptions
+): Promise<SyncMcporterServersResult> {
+  const existingRelaycastEnv = await loadMcporterServerEnv('relaycast');
+  const existingApiKey = existingRelaycastEnv.RELAY_API_KEY?.trim();
+  const existingAgentToken = existingRelaycastEnv.RELAY_AGENT_TOKEN?.trim();
+
+  let agentToken = options.agentToken?.trim() || undefined;
+  let tokenAction: SyncMcporterServersResult['tokenAction'] = 'none';
+
+  if (agentToken) {
+    tokenAction = 'provided';
+  } else if (existingAgentToken && existingApiKey === options.gatewayConfig.apiKey) {
+    agentToken = existingAgentToken;
+    tokenAction = 'preserved';
+  } else if (existingAgentToken) {
+    tokenAction = 'cleared';
+  }
+
+  let mcp: McporterCommand;
+  try {
+    mcp = resolveMcporter();
+  } catch {
+    return { configured: false, tokenAction, agentToken };
+  }
+
+  const relaycastEnv = buildRelaycastEnv(options.gatewayConfig, options.workspacesConfig, agentToken);
+  const spawnerEnv = buildRelaycastEnv(options.gatewayConfig, options.workspacesConfig);
+
+  removeServer(mcp, 'relaycast');
+  addServer(
+    mcp,
+    'relaycast',
+    'npx',
+    ['@relaycast/mcp'],
+    relaycastEnv,
+    'Relaycast messaging MCP server'
+  );
+
+  removeServer(mcp, 'openclaw-spawner');
+  addServer(
+    mcp,
+    'openclaw-spawner',
+    'npx',
+    ['@agent-relay/openclaw', 'mcp-server'],
+    spawnerEnv,
+    'OpenClaw spawner MCP server'
+  );
+
+  return { configured: true, tokenAction, agentToken };
+}

--- a/packages/openclaw/src/redaction.ts
+++ b/packages/openclaw/src/redaction.ts
@@ -1,0 +1,31 @@
+function maskSecret(value: string, visiblePrefix: number): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '***';
+  if (trimmed.length <= visiblePrefix) return '***';
+  return `${trimmed.slice(0, visiblePrefix)}...`;
+}
+
+const RELAY_SECRET_PATTERNS = [
+  /\brk_[A-Za-z0-9._-]{8,}\b/g,
+  /\bat_[A-Za-z0-9._-]{8,}\b/g,
+];
+
+export function maskWorkspaceKey(value: string): string {
+  return maskSecret(value, 12);
+}
+
+export function redactRelaySecrets(value: string): string {
+  let redacted = value;
+  for (const pattern of RELAY_SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, (match) => maskWorkspaceKey(match));
+  }
+
+  return redacted.replace(
+    /\b(Bearer\s+)([A-Za-z0-9._~-]{8,})\b/gi,
+    (_, prefix: string, secret: string) => `${prefix}${maskSecret(secret, 8)}`
+  );
+}
+
+export function redactErrorMessage(error: unknown): string {
+  return redactRelaySecrets(error instanceof Error ? error.message : String(error));
+}

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -4,13 +4,12 @@ import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { spawn as spawnProcess, execFileSync } from 'node:child_process';
+import { spawn as spawnProcess } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 
-import { RelayCast } from '@relaycast/sdk';
-
-import { detectOpenClaw, saveGatewayConfig, addWorkspace, loadWorkspacesConfig, buildWorkspacesJson } from './config.js';
+import { detectOpenClaw, saveGatewayConfig, addWorkspace } from './config.js';
 import { InboundGateway } from './gateway.js';
+import { registerRelaycastAgent, syncMcporterServers } from './mcporter-config.js';
 import { DEFAULT_OPENCLAW_GATEWAY_PORT, type GatewayConfig } from './types.js';
 
 /**
@@ -48,24 +47,6 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: unkno
     current = current[key] as Record<string, unknown>;
   }
   current[keys[keys.length - 1]] = value;
-}
-
-/**
- * Resolve how to invoke mcporter. Prefers a global binary, falls back to npx.
- */
-function resolveMcporter(): { cmd: string; prefix: string[] } {
-  try {
-    execFileSync('mcporter', ['--version'], { stdio: 'pipe' });
-    return { cmd: 'mcporter', prefix: [] };
-  } catch {
-    // Global binary not found — try npx (no timeout; cold-cache downloads can be slow)
-    try {
-      execFileSync('npx', ['-y', 'mcporter', '--version'], { stdio: 'pipe' });
-      return { cmd: 'npx', prefix: ['-y', 'mcporter'] };
-    } catch {
-      throw new Error('mcporter not found (tried global binary and npx)');
-    }
-  }
 }
 
 /** Check if a port is already in use by attempting a TCP connection. */
@@ -201,6 +182,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
 
   // Resolve API key: use provided key or create a new workspace
   let apiKey = options.apiKey;
+  let workspaceId: string | undefined;
 
   if (!apiKey) {
     try {
@@ -219,6 +201,11 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const lookupBody = (await lookupRes.json()) as any;
           apiKey = lookupBody.apiKey ?? lookupBody.api_key ?? lookupBody.data?.apiKey ?? lookupBody.data?.api_key;
+          workspaceId =
+            lookupBody.workspaceId ??
+            lookupBody.workspace_id ??
+            lookupBody.data?.workspaceId ??
+            lookupBody.data?.workspace_id;
         }
         if (!apiKey) {
           return {
@@ -242,6 +229,11 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const successBody = (await res.json()) as any;
         apiKey = successBody.apiKey ?? successBody.api_key ?? successBody.data?.apiKey ?? successBody.data?.api_key;
+        workspaceId =
+          successBody.workspaceId ??
+          successBody.workspace_id ??
+          successBody.data?.workspaceId ??
+          successBody.data?.workspace_id;
       }
 
       if (!apiKey) {
@@ -353,115 +345,54 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
   };
   await saveGatewayConfig(gatewayConfig);
 
-  // Register this workspace in the multi-workspace config
-  await addWorkspace({
+  let mcpConfigured = false;
+  let agentToken: string | undefined;
+  try {
+    const registration = await registerRelaycastAgent(gatewayConfig);
+    agentToken = registration.agentToken;
+    workspaceId = workspaceId ?? registration.workspaceId;
+    if (agentToken) {
+      console.log(`Agent "${clawName}" registered with token.`);
+    } else {
+      console.warn('Agent registered but no token found in response.');
+    }
+  } catch (regErr) {
+    console.warn(
+      `Agent registration failed (non-fatal): ${
+        regErr instanceof Error ? regErr.message : String(regErr)
+      }`
+    );
+  }
+
+  if (!workspaceId) {
+    return {
+      ok: false,
+      apiKey: '',
+      clawName,
+      skillDir: '',
+      message:
+        'Workspace registration succeeded but no workspace_id was available. Re-run setup with a workspace that exposes workspace_id metadata.',
+    };
+  }
+
+  const wsConfig = await addWorkspace({
     api_key: apiKey,
     workspace_alias: clawName,
+    workspace_id: workspaceId,
     is_default: true,
+  }, { syncRuntime: false });
+
+  const sync = await syncMcporterServers({
+    gatewayConfig,
+    workspacesConfig: wsConfig,
+    agentToken,
   });
-
-  // Register MCP servers via mcporter (global binary or npx fallback)
-  let mcpConfigured = false;
-  {
-    // Build env args for mcporter, including multi-workspace JSON if available
-    const wsConfig = await loadWorkspacesConfig();
-    const workspacesJson = wsConfig ? buildWorkspacesJson(wsConfig) : null;
-
-    const envArgs = [
-      '--env', `RELAY_API_KEY=${apiKey}`,
-      ...(baseUrl !== 'https://api.relaycast.dev'
-        ? ['--env', `RELAY_BASE_URL=${baseUrl}`]
-        : []),
-      ...(workspacesJson
-        ? ['--env', `RELAY_WORKSPACES_JSON=${workspacesJson}`]
-        : []),
-      ...(wsConfig?.default_workspace
-        ? ['--env', `RELAY_DEFAULT_WORKSPACE=${wsConfig.default_workspace}`]
-        : []),
-    ];
-
-    let mcp: { cmd: string; prefix: string[] } | null = null;
-    try {
-      mcp = resolveMcporter();
-    } catch {
-      console.warn('mcporter not found (tried global binary and npx). MCP tools will not be available.');
-      console.warn('Install mcporter and re-run setup to enable MCP tools:');
-      console.warn('  npm install -g mcporter');
-      console.warn(`  npx -y @agent-relay/openclaw@latest setup ${apiKey} --name ${clawName}`);
-    }
-
-    if (mcp) {
-      try {
-        // Register relaycast messaging MCP server
-        execFileSync(mcp.cmd, [
-          ...mcp.prefix,
-          'config', 'add', 'relaycast',
-          '--command', 'npx',
-          '--arg', '@relaycast/mcp',
-          ...envArgs,
-          '--scope', 'home',
-          '--description', 'Relaycast messaging MCP server',
-        ], { stdio: 'pipe' });
-
-        // Register openclaw-spawner MCP server
-        execFileSync(mcp.cmd, [
-          ...mcp.prefix,
-          'config', 'add', 'openclaw-spawner',
-          '--command', 'npx',
-          '--arg', '@agent-relay/openclaw',
-          '--arg', 'mcp-server',
-          ...envArgs,
-          '--scope', 'home',
-          '--description', 'OpenClaw spawner MCP server',
-        ], { stdio: 'pipe' });
-
-        mcpConfigured = true;
-
-        // Register this claw via the Relaycast SDK and fetch the current
-        // usable agent token for the named claw.
-        //
-        // IMPORTANT: use registerOrGet here, not registerOrRotate.
-        // Re-running setup is a common, user-facing recovery step. Rotating the
-        // token during setup can invalidate an already-running MCP server or any
-        // other local process that still has the previous token, producing the
-        // confusing partial-failure mode where list/read works (workspace key)
-        // but post/send fails with "Invalid agent token".
-        try {
-          const relaycast = new RelayCast({ apiKey, baseUrl });
-          const registered = await relaycast.agents.registerOrGet({
-            name: clawName,
-            type: 'agent',
-          });
-          const agentToken = registered.token;
-
-          if (agentToken) {
-            // Reconfigure mcporter with the agent token so subsequent calls are authenticated
-            try {
-              execFileSync(mcp.cmd, [...mcp.prefix, 'config', 'remove', 'relaycast'], { stdio: 'pipe' });
-            } catch { /* may not exist */ }
-
-            execFileSync(mcp.cmd, [
-              ...mcp.prefix,
-              'config', 'add', 'relaycast',
-              '--command', 'npx',
-              '--arg', '@relaycast/mcp',
-              ...envArgs,
-              '--env', `RELAY_AGENT_TOKEN=${agentToken}`,
-              '--scope', 'home',
-              '--description', 'Relaycast messaging MCP server',
-            ], { stdio: 'pipe' });
-
-            console.log(`Agent "${clawName}" registered with token.`);
-          } else {
-            console.warn('Agent registered but no token found in response.');
-          }
-        } catch (regErr) {
-          console.warn(`Agent registration failed (non-fatal): ${regErr instanceof Error ? regErr.message : String(regErr)}`);
-        }
-      } catch (err) {
-        console.warn(`mcporter configuration failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
+  mcpConfigured = sync.configured;
+  if (!sync.configured) {
+    console.warn('mcporter not found (tried global binary and npx). MCP tools will not be available.');
+    console.warn('Install mcporter and re-run setup to enable MCP tools:');
+    console.warn('  npm install -g mcporter');
+    console.warn(`  npx -y @agent-relay/openclaw@latest setup ${apiKey} --name ${clawName}`);
   }
 
   // Auto-start the inbound gateway in the background, but only if one isn't

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -9,7 +9,12 @@ import { randomBytes } from 'node:crypto';
 
 import { detectOpenClaw, saveGatewayConfig, addWorkspace } from './config.js';
 import { InboundGateway } from './gateway.js';
-import { registerRelaycastAgent, syncMcporterServers } from './mcporter-config.js';
+import {
+  registerRelaycastAgent,
+  resolveRelaycastWorkspaceId,
+  syncMcporterServers,
+} from './mcporter-config.js';
+import { redactErrorMessage, redactRelaySecrets } from './redaction.js';
 import { DEFAULT_OPENCLAW_GATEWAY_PORT, type GatewayConfig } from './types.js';
 
 /**
@@ -217,13 +222,15 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
           };
         }
       } else if (!res.ok) {
-        const body = await res.text();
+        const body = redactRelaySecrets((await res.text()).trim());
         return {
           ok: false,
           apiKey: '',
           clawName,
           skillDir: '',
-          message: `Failed to create workspace: ${res.status} ${body}`,
+          message: body
+            ? `Failed to create workspace: ${res.status} ${body}`
+            : `Failed to create workspace: ${res.status}`,
         };
       } else {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -251,7 +258,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
         apiKey: '',
         clawName,
         skillDir: '',
-        message: `Failed to create workspace: ${err instanceof Error ? err.message : String(err)}`,
+        message: `Failed to create workspace: ${redactErrorMessage(err)}`,
       };
     }
   }
@@ -300,11 +307,12 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
         detection.config = cfg;
         configMutated = true;
       } catch (writeErr) {
-        console.warn(`[setup] Could not write generated token to config file: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`);
+        console.warn(`[setup] Could not write generated token to config file: ${redactErrorMessage(writeErr)}`);
       }
     } else {
-      console.warn('[setup] No config file available to persist generated token. Set manually:');
-      console.warn(`[setup]   export OPENCLAW_GATEWAY_TOKEN=${generated}`);
+      console.warn(
+        '[setup] No config file available to persist generated token. Set OPENCLAW_GATEWAY_TOKEN manually in your environment or config.'
+      );
     }
   }
 
@@ -358,10 +366,18 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     }
   } catch (regErr) {
     console.warn(
-      `Agent registration failed (non-fatal): ${
-        regErr instanceof Error ? regErr.message : String(regErr)
-      }`
+      `Agent registration failed (non-fatal): ${redactErrorMessage(regErr)}`
     );
+  }
+
+  if (!workspaceId) {
+    try {
+      workspaceId = await resolveRelaycastWorkspaceId(gatewayConfig);
+    } catch (workspaceErr) {
+      console.warn(
+        `Workspace ID lookup failed (non-fatal): ${redactErrorMessage(workspaceErr)}`
+      );
+    }
   }
 
   if (!workspaceId) {
@@ -371,7 +387,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
       clawName,
       skillDir: '',
       message:
-        'Workspace registration succeeded but no workspace_id was available. Re-run setup with a workspace that exposes workspace_id metadata.',
+        'Workspace setup succeeded but canonical workspace_id could not be resolved. Re-run setup with --workspace-id or verify the workspace key.',
     };
   }
 
@@ -392,7 +408,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     console.warn('mcporter not found (tried global binary and npx). MCP tools will not be available.');
     console.warn('Install mcporter and re-run setup to enable MCP tools:');
     console.warn('  npm install -g mcporter');
-    console.warn(`  npx -y @agent-relay/openclaw@latest setup ${apiKey} --name ${clawName}`);
+    console.warn(`  npx -y @agent-relay/openclaw@latest setup <workspace-key> --name ${clawName}`);
   }
 
   // Auto-start the inbound gateway in the background, but only if one isn't

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { spawn as spawnProcess } from 'node:child_process';
+import { spawn as spawnProcess, execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 
 import { detectOpenClaw, saveGatewayConfig, addWorkspace } from './config.js';

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -87,7 +87,9 @@ export interface WorkspaceEntry {
 export interface WorkspacesConfig {
   /** All configured workspace entries. */
   workspaces: WorkspaceEntry[];
-  /** Alias or workspace_id of the default workspace. */
+  /** Canonical workspace_id of the default workspace. */
+  default_workspace_id?: string;
+  /** Legacy alias-preferred selector retained only for migration on load. */
   default_workspace?: string;
 }
 


### PR DESCRIPTION
## Summary
- persist canonical `default_workspace_id` values instead of alias-first selectors
- reject duplicate/ambiguous workspace aliases and require real workspace IDs for default selection
- extract shared mcporter sync helpers so setup/add/switch keep relaycast and openclaw-spawner MCP configs aligned with multi-workspace state
- add tests covering config migration, ambiguity handling, mcporter sync, and setup behavior

## Testing
- npm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
