### PR TITLE
docs(skill): improve headless orchestrator broker guidance

### DIFF
--- a/packages/sdk-swift/Package.swift
+++ b/packages/sdk-swift/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "AgentRelaySDK",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .tvOS(.v16)
+    ],
+    products: [
+        .library(name: "AgentRelaySDK", targets: ["AgentRelaySDK"])
+    ],
+    targets: [
+        .target(
+            name: "AgentRelaySDK",
+            path: "Sources/AgentRelaySDK"
+        ),
+        .testTarget(
+            name: "AgentRelaySDKTests",
+            dependencies: ["AgentRelaySDK"],
+            path: "Tests/AgentRelaySDKTests"
+        )
+    ]
+)

--- a/packages/sdk-swift/README.md
+++ b/packages/sdk-swift/README.md
@@ -7,8 +7,10 @@ Native Swift SDK for the Agent Relay broker.
 Add the package in Swift Package Manager:
 
 ```swift
-.package(url: "https://github.com/AgentWorkforce/relay.git", branch: "feature/swift-sdk")
+.package(url: "https://github.com/AgentWorkforce/relay.git", revision: "0a2c878748dc34af8b617c8da5ce70af447dfa37")
 ```
+
+> Temporary until the SDK is released under a stable tag.
 
 Then depend on `AgentRelaySDK`.
 

--- a/packages/sdk-swift/README.md
+++ b/packages/sdk-swift/README.md
@@ -1,0 +1,37 @@
+# AgentRelaySDK
+
+Native Swift SDK for the Agent Relay broker.
+
+## Installation
+
+Add the package in Swift Package Manager:
+
+```swift
+.package(url: "https://github.com/AgentWorkforce/relay.git", branch: "feature/swift-sdk")
+```
+
+Then depend on `AgentRelaySDK`.
+
+## Quick start
+
+```swift
+import AgentRelaySDK
+
+let relay = RelayCast(apiKey: "rk_live_...")
+let channel = relay.channel("wf-my-workflow")
+try await channel.subscribe()
+try await channel.post("Hello from Swift")
+
+for await event in channel.events {
+    print("\(event.from): \(event.body)")
+}
+```
+
+## API
+
+- `RelayCast(apiKey:baseURL:)`
+- `channel(_:) -> Channel`
+- `registerOrRotate(name:)`
+- `AgentRegistration.asClient()`
+- `AgentClient.post(to:message:)`
+- `AgentClient.dm(to:message:)`

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public enum RelayError: Error, Sendable {
+    case invalidBaseURL(String)
+    case connectionFailed(String)
+    case handshakeFailed(String)
+    case protocolError(code: String, message: String, retryable: Bool)
+    case encodingFailed(String)
+    case decodingFailed(String)
+    case notConnected
+    case unsupported(String)
+    case timeout(String)
+}
+
+public struct RelayChannelEvent: Sendable {
+    public let from: String
+    public let body: String
+    public let threadId: String?
+    public let timestamp: Date
+
+    public init(from: String, body: String, threadId: String?, timestamp: Date = Date()) {
+        self.from = from
+        self.body = body
+        self.threadId = threadId
+        self.timestamp = timestamp
+    }
+}
+
+public struct AgentRegistration: Sendable {
+    public let agentName: String
+    public let token: String
+    private let factory: @Sendable (String, String) -> AgentClient
+
+    public init(agentName: String, token: String, factory: @escaping @Sendable (String, String) -> AgentClient) {
+        self.agentName = agentName
+        self.token = token
+        self.factory = factory
+    }
+
+    public func asClient() -> AgentClient {
+        factory(agentName, token)
+    }
+}
+
+actor RelayCore {
+    let apiKey: String
+    let transport: RelayTransport
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    private var handshakeComplete = false
+    private var routerTask: Task<Void, Never>?
+    private var channelContinuations: [String: [AsyncStream<RelayChannelEvent>.Continuation]] = [:]
+
+    init(apiKey: String, transport: RelayTransport) {
+        self.apiKey = apiKey
+        self.transport = transport
+    }
+
+    func ensureConnected() async throws {
+        if !handshakeComplete {
+            try await transport.connect()
+            try await send(.hello(HelloPayload(clientName: "AgentRelaySDK.Swift", clientVersion: "0.1.0")))
+            routerTask = Task { [weak self] in await self?.routeFrames() }
+            handshakeComplete = true
+        }
+    }
+
+    func registerChannelContinuation(_ continuation: AsyncStream<RelayChannelEvent>.Continuation, for channel: String) {
+        channelContinuations[channel, default: []].append(continuation)
+    }
+
+    func sendChannelPost(channel: String, text: String) async throws {
+        try await ensureConnected()
+        try await send(.sendMessage(SendMessagePayload(to: channel, text: text, from: nil, threadId: nil, workspaceId: nil, workspaceAlias: nil, priority: nil, data: nil)))
+    }
+
+    func sendAgentMessage(from agentName: String, to target: String, text: String) async throws {
+        try await ensureConnected()
+        try await send(.sendMessage(SendMessagePayload(to: target, text: text, from: agentName, threadId: nil, workspaceId: nil, workspaceAlias: nil, priority: nil, data: nil)))
+    }
+
+    func registerOrRotate(name: String) async throws -> AgentRegistration {
+        try await ensureConnected()
+        return AgentRegistration(agentName: name, token: name) { agentName, token in
+            AgentClient(core: self, agentName: agentName, token: token)
+        }
+    }
+
+    private func send(_ message: OutboundMessage) async throws {
+        do {
+            let data = try encoder.encode(message)
+            try await transport.send(data)
+        } catch let error as RelayTransport.TransportError {
+            switch error {
+            case .notConnected: throw RelayError.notConnected
+            case .connectionFailed(let message), .sendFailed(let message): throw RelayError.connectionFailed(message)
+            case .invalidResponse: throw RelayError.connectionFailed("Invalid response")
+            }
+        } catch {
+            throw RelayError.encodingFailed(String(describing: error))
+        }
+    }
+
+    private func routeFrames() async {
+        for await data in transport.inbound {
+            do {
+                let inbound = try decoder.decode(InboundMessage.self, from: data)
+                switch inbound {
+                case .event(let event):
+                    if case .relayInbound(let relayEvent) = event {
+                        let message = RelayChannelEvent(from: relayEvent.from, body: relayEvent.body, threadId: relayEvent.threadId)
+                        for continuation in channelContinuations[relayEvent.target] ?? [] {
+                            continuation.yield(message)
+                        }
+                    }
+                case .error(let error):
+                    _ = error
+                default:
+                    break
+                }
+            } catch {
+                continue
+            }
+        }
+    }
+}
+
+public final class RelayCast: @unchecked Sendable {
+    private let core: RelayCore
+    public let apiKey: String
+    public let baseURL: URL
+
+    public init(apiKey: String, baseURL: URL? = nil) {
+        self.apiKey = apiKey
+        let resolved = Self.resolveWebSocketURL(from: baseURL)
+        self.baseURL = resolved
+        self.core = RelayCore(apiKey: apiKey, transport: RelayTransport(url: resolved))
+    }
+
+    public func channel(_ name: String) -> Channel {
+        Channel(name: name, core: core)
+    }
+
+    public func registerOrRotate(name: String) async throws -> AgentRegistration {
+        try await core.registerOrRotate(name: name)
+    }
+
+    public func `as`(_ agentToken: String) -> AgentClient {
+        AgentClient(core: core, agentName: agentToken, token: agentToken)
+    }
+
+    private static func resolveWebSocketURL(from baseURL: URL?) -> URL {
+        if let baseURL {
+            if baseURL.scheme == "ws" || baseURL.scheme == "wss" {
+                return baseURL
+            }
+            if baseURL.scheme == "http" || baseURL.scheme == "https" {
+                var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+                components?.scheme = baseURL.scheme == "https" ? "wss" : "ws"
+                if components?.path.isEmpty ?? true {
+                    components?.path = "/ws"
+                }
+                return components?.url ?? URL(string: "ws://localhost:3889/ws")!
+            }
+        }
+        return URL(string: "ws://localhost:3889/ws")!
+    }
+}
+
+public final class Channel: @unchecked Sendable {
+    public let name: String
+    private let core: RelayCore
+    public let events: AsyncStream<RelayChannelEvent>
+
+    init(name: String, core: RelayCore) {
+        self.name = name
+        self.core = core
+        var continuationRef: AsyncStream<RelayChannelEvent>.Continuation?
+        self.events = AsyncStream<RelayChannelEvent> { continuation in
+            continuationRef = continuation
+        }
+        if let continuationRef {
+            Task { await core.registerChannelContinuation(continuationRef, for: name) }
+        }
+    }
+
+    public func subscribe() async throws {
+        try await core.ensureConnected()
+    }
+
+    public func post(_ text: String) async throws {
+        try await core.sendChannelPost(channel: name, text: text)
+    }
+}
+
+public final class AgentClient: @unchecked Sendable {
+    private let core: RelayCore
+    public let agentName: String
+    public let token: String
+
+    init(core: RelayCore, agentName: String, token: String) {
+        self.core = core
+        self.agentName = agentName
+        self.token = token
+    }
+
+    public func post(to channel: String, message: String) async throws {
+        try await core.sendAgentMessage(from: agentName, to: channel, text: message)
+    }
+
+    public func dm(to agentName: String, message: String) async throws {
+        try await core.sendAgentMessage(from: self.agentName, to: agentName, text: message)
+    }
+}

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
@@ -48,21 +48,42 @@ actor RelayCore {
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()
 
-    private var handshakeComplete = false
+    private var handshakeInFlight = false
+    private var handshakeContinuation: CheckedContinuation<Void, Error>?
     private var routerTask: Task<Void, Never>?
     private var channelContinuations: [String: [AsyncStream<RelayChannelEvent>.Continuation]] = [:]
 
     init(apiKey: String, transport: RelayTransport) {
         self.apiKey = apiKey
         self.transport = transport
+        Task { [weak self] in
+            await transport.setOnConnect {
+                await self?.transportDidConnect()
+            }
+        }
     }
 
     func ensureConnected() async throws {
-        if !handshakeComplete {
-            try await transport.connect()
-            try await send(.hello(HelloPayload(clientName: "AgentRelaySDK.Swift", clientVersion: "0.1.0")))
+        if routerTask == nil || routerTask?.isCancelled == true {
             routerTask = Task { [weak self] in await self?.routeFrames() }
-            handshakeComplete = true
+        }
+        if handshakeInFlight {
+            return try await waitForHandshake()
+        }
+        handshakeInFlight = true
+        try await transport.connect()
+        try await send(.hello(HelloPayload(clientName: "AgentRelaySDK.Swift", clientVersion: "0.1.0")))
+        try await waitForHandshake()
+    }
+
+    func transportDidConnect() async {
+        handshakeInFlight = true
+        handshakeContinuation?.resume(throwing: RelayError.connectionFailed("Transport reconnected before previous handshake completed"))
+        handshakeContinuation = nil
+        do {
+            try await send(.hello(HelloPayload(clientName: "AgentRelaySDK.Swift", clientVersion: "0.1.0")))
+        } catch {
+            finishHandshake(with: error)
         }
     }
 
@@ -102,11 +123,40 @@ actor RelayCore {
         }
     }
 
+    private func waitForHandshake() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            handshakeContinuation = continuation
+            Task {
+                try? await Task.sleep(for: .seconds(10))
+                await self.failHandshakeIfPending(with: RelayError.timeout("Timed out waiting for hello_ack"))
+            }
+        }
+    }
+
+    private func finishHandshake() {
+        handshakeInFlight = false
+        handshakeContinuation?.resume(returning: ())
+        handshakeContinuation = nil
+    }
+
+    private func finishHandshake(with error: Error) {
+        handshakeInFlight = false
+        handshakeContinuation?.resume(throwing: error)
+        handshakeContinuation = nil
+    }
+
+    private func failHandshakeIfPending(with error: Error) {
+        guard handshakeInFlight else { return }
+        finishHandshake(with: error)
+    }
+
     private func routeFrames() async {
         for await data in transport.inbound {
             do {
                 let inbound = try decoder.decode(InboundMessage.self, from: data)
                 switch inbound {
+                case .helloAck:
+                    finishHandshake()
                 case .event(let event):
                     if case .relayInbound(let relayEvent) = event {
                         let message = RelayChannelEvent(from: relayEvent.from, body: relayEvent.body, threadId: relayEvent.threadId)
@@ -114,8 +164,13 @@ actor RelayCore {
                             continuation.yield(message)
                         }
                     }
+                case .deliverRelay(let relayEvent):
+                    let message = RelayChannelEvent(from: relayEvent.from, body: relayEvent.body, threadId: relayEvent.threadId)
+                    for continuation in channelContinuations[relayEvent.target] ?? [] {
+                        continuation.yield(message)
+                    }
                 case .error(let error):
-                    _ = error
+                    finishHandshake(with: RelayError.protocolError(code: error.code, message: error.message, retryable: error.retryable))
                 default:
                     break
                 }
@@ -133,9 +188,9 @@ public final class RelayCast: @unchecked Sendable {
 
     public init(apiKey: String, baseURL: URL? = nil) {
         self.apiKey = apiKey
-        let resolved = Self.resolveWebSocketURL(from: baseURL)
+        let resolved = Self.resolveBaseURL(from: baseURL)
         self.baseURL = resolved
-        self.core = RelayCore(apiKey: apiKey, transport: RelayTransport(url: resolved))
+        self.core = RelayCore(apiKey: apiKey, transport: RelayTransport(baseURL: resolved, authToken: apiKey))
     }
 
     public func channel(_ name: String) -> Channel {
@@ -146,46 +201,38 @@ public final class RelayCast: @unchecked Sendable {
         try await core.registerOrRotate(name: name)
     }
 
-    public func `as`(_ agentToken: String) -> AgentClient {
-        AgentClient(core: core, agentName: agentToken, token: agentToken)
+    public func `as`(agentName: String, token: String) -> AgentClient {
+        AgentClient(core: core, agentName: agentName, token: token)
     }
 
-    private static func resolveWebSocketURL(from baseURL: URL?) -> URL {
+    private static func resolveBaseURL(from baseURL: URL?) -> URL {
         if let baseURL {
-            if baseURL.scheme == "ws" || baseURL.scheme == "wss" {
-                return baseURL
-            }
-            if baseURL.scheme == "http" || baseURL.scheme == "https" {
-                var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
-                components?.scheme = baseURL.scheme == "https" ? "wss" : "ws"
-                if components?.path.isEmpty ?? true {
-                    components?.path = "/ws"
-                }
-                return components?.url ?? URL(string: "ws://localhost:3889/ws")!
-            }
+            return baseURL
         }
-        return URL(string: "ws://localhost:3889/ws")!
+        return URL(string: "http://localhost:3889")!
     }
 }
 
 public final class Channel: @unchecked Sendable {
     public let name: String
     private let core: RelayCore
+    private let continuationRef: AsyncStream<RelayChannelEvent>.Continuation?
     public let events: AsyncStream<RelayChannelEvent>
 
     init(name: String, core: RelayCore) {
         self.name = name
         self.core = core
-        var continuationRef: AsyncStream<RelayChannelEvent>.Continuation?
-        self.events = AsyncStream<RelayChannelEvent> { continuation in
-            continuationRef = continuation
+        var continuation: AsyncStream<RelayChannelEvent>.Continuation?
+        self.events = AsyncStream<RelayChannelEvent> { incoming in
+            continuation = incoming
         }
-        if let continuationRef {
-            Task { await core.registerChannelContinuation(continuationRef, for: name) }
-        }
+        self.continuationRef = continuation
     }
 
     public func subscribe() async throws {
+        if let continuationRef {
+            await core.registerChannelContinuation(continuationRef, for: name)
+        }
         try await core.ensureConnected()
     }
 

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
@@ -49,17 +49,18 @@ actor RelayCore {
     let decoder = JSONDecoder()
 
     private var handshakeInFlight = false
-    private var handshakeContinuation: CheckedContinuation<Void, Error>?
+    private var handshakeContinuations: [CheckedContinuation<Void, Error>] = []
     private var routerTask: Task<Void, Never>?
     private var channelContinuations: [String: [AsyncStream<RelayChannelEvent>.Continuation]] = [:]
 
     init(apiKey: String, transport: RelayTransport) {
         self.apiKey = apiKey
         self.transport = transport
-        Task { [weak self] in
-            await transport.setOnConnect {
-                await self?.transportDidConnect()
-            }
+    }
+
+    func configureTransportCallbacks() async {
+        await transport.setOnConnect { [weak self] in
+            await self?.transportDidConnect()
         }
     }
 
@@ -77,9 +78,10 @@ actor RelayCore {
     }
 
     func transportDidConnect() async {
+        if handshakeInFlight {
+            finishHandshake(with: RelayError.connectionFailed("Transport reconnected before previous handshake completed"))
+        }
         handshakeInFlight = true
-        handshakeContinuation?.resume(throwing: RelayError.connectionFailed("Transport reconnected before previous handshake completed"))
-        handshakeContinuation = nil
         do {
             try await send(.hello(HelloPayload(clientName: "AgentRelaySDK.Swift", clientVersion: "0.1.0")))
         } catch {
@@ -125,7 +127,7 @@ actor RelayCore {
 
     private func waitForHandshake() async throws {
         try await withCheckedThrowingContinuation { continuation in
-            handshakeContinuation = continuation
+            handshakeContinuations.append(continuation)
             Task {
                 try? await Task.sleep(for: .seconds(10))
                 await self.failHandshakeIfPending(with: RelayError.timeout("Timed out waiting for hello_ack"))
@@ -135,14 +137,20 @@ actor RelayCore {
 
     private func finishHandshake() {
         handshakeInFlight = false
-        handshakeContinuation?.resume(returning: ())
-        handshakeContinuation = nil
+        let continuations = handshakeContinuations
+        handshakeContinuations.removeAll()
+        for continuation in continuations {
+            continuation.resume(returning: ())
+        }
     }
 
     private func finishHandshake(with error: Error) {
         handshakeInFlight = false
-        handshakeContinuation?.resume(throwing: error)
-        handshakeContinuation = nil
+        let continuations = handshakeContinuations
+        handshakeContinuations.removeAll()
+        for continuation in continuations {
+            continuation.resume(throwing: error)
+        }
     }
 
     private func failHandshakeIfPending(with error: Error) {
@@ -190,7 +198,11 @@ public final class RelayCast: @unchecked Sendable {
         self.apiKey = apiKey
         let resolved = Self.resolveBaseURL(from: baseURL)
         self.baseURL = resolved
-        self.core = RelayCore(apiKey: apiKey, transport: RelayTransport(baseURL: resolved, authToken: apiKey))
+        let transport = RelayTransport(baseURL: resolved, authToken: apiKey)
+        self.core = RelayCore(apiKey: apiKey, transport: transport)
+        Task {
+            await self.core.configureTransportCallbacks()
+        }
     }
 
     public func channel(_ name: String) -> Channel {

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+public actor RelayTransport {
+    public enum ConnectionState: Sendable {
+        case disconnected
+        case connecting
+        case connected
+        case reconnecting
+    }
+
+    public enum TransportError: Error, Sendable {
+        case invalidResponse
+        case notConnected
+        case sendFailed(String)
+        case connectionFailed(String)
+    }
+
+    public nonisolated let inbound: AsyncStream<Data>
+
+    private let url: URL
+    private let session: URLSession
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var pingTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+    private var inboundContinuation: AsyncStream<Data>.Continuation?
+    private var state: ConnectionState = .disconnected
+    private var manuallyDisconnected = false
+    private var reconnectAttempt = 0
+    private var lastPongAt = Date()
+
+    public init(url: URL, session: URLSession = .shared) {
+        self.url = url
+        self.session = session
+        var continuationRef: AsyncStream<Data>.Continuation?
+        self.inbound = AsyncStream<Data> { continuation in
+            continuationRef = continuation
+        }
+        self.inboundContinuation = continuationRef
+    }
+
+    public func connect() async throws {
+        switch state {
+        case .connected, .connecting:
+            return
+        case .disconnected, .reconnecting:
+            break
+        }
+
+        manuallyDisconnected = false
+        state = reconnectAttempt == 0 ? .connecting : .reconnecting
+
+        let task = session.webSocketTask(with: url)
+        webSocketTask = task
+        task.resume()
+        state = .connected
+        reconnectAttempt = 0
+        lastPongAt = Date()
+
+        startReceiveLoop()
+        startPingLoop()
+    }
+
+    public func disconnect() {
+        manuallyDisconnected = true
+        receiveTask?.cancel()
+        pingTask?.cancel()
+        reconnectTask?.cancel()
+        receiveTask = nil
+        pingTask = nil
+        reconnectTask = nil
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+        state = .disconnected
+    }
+
+    public func send(_ message: Data) async throws {
+        guard let task = webSocketTask, state == .connected else {
+            throw TransportError.notConnected
+        }
+
+        do {
+            try await task.send(.data(message))
+        } catch {
+            throw TransportError.sendFailed(String(describing: error))
+        }
+    }
+
+    private func startReceiveLoop() {
+        receiveTask?.cancel()
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { return }
+                    let message = try await task.receive()
+                    await self.handle(message)
+                } catch {
+                    await self.handleDisconnect(error: error)
+                    return
+                }
+            }
+        }
+    }
+
+    private func startPingLoop() {
+        pingTask?.cancel()
+        pingTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(20))
+                if Task.isCancelled { return }
+                do {
+                    try await self.sendPing()
+                } catch {
+                    await self.handleDisconnect(error: error)
+                    return
+                }
+            }
+        }
+    }
+
+    private func sendPing() async throws {
+        guard let task = webSocketTask else { throw TransportError.notConnected }
+        let before = Date()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            task.sendPing { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+        lastPongAt = Date()
+        if lastPongAt.timeIntervalSince(before) > 10 {
+            throw TransportError.connectionFailed("Pong exceeded watchdog")
+        }
+    }
+
+    private func handle(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .data(let data):
+            inboundContinuation?.yield(data)
+        case .string(let string):
+            if let data = string.data(using: .utf8) {
+                inboundContinuation?.yield(data)
+            }
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleDisconnect(error: Error) async {
+        receiveTask?.cancel()
+        pingTask?.cancel()
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+
+        guard !manuallyDisconnected else {
+            state = .disconnected
+            return
+        }
+
+        state = .reconnecting
+        reconnectAttempt += 1
+        let delay = reconnectDelay(for: reconnectAttempt)
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .milliseconds(delay))
+            do {
+                try await self.connect()
+            } catch {
+                await self.handleDisconnect(error: error)
+            }
+        }
+    }
+
+    private func reconnectDelay(for attempt: Int) -> Int {
+        switch attempt {
+        case 0: return 500
+        case 1: return 1_000
+        case 2: return 2_000
+        case 3: return 4_000
+        case 4: return 8_000
+        case 5: return 16_000
+        default: return 30_000
+        }
+    }
+}

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
@@ -17,8 +17,9 @@ public actor RelayTransport {
 
     public nonisolated let inbound: AsyncStream<Data>
 
-    private let url: URL
+    private let baseURL: URL
     private let session: URLSession
+    private let authToken: String
     private var webSocketTask: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
     private var pingTask: Task<Void, Never>?
@@ -28,15 +29,21 @@ public actor RelayTransport {
     private var manuallyDisconnected = false
     private var reconnectAttempt = 0
     private var lastPongAt = Date()
+    private var onConnect: (@Sendable () async -> Void)?
 
-    public init(url: URL, session: URLSession = .shared) {
-        self.url = url
+    public init(baseURL: URL, authToken: String, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.authToken = authToken
         self.session = session
         var continuationRef: AsyncStream<Data>.Continuation?
         self.inbound = AsyncStream<Data> { continuation in
             continuationRef = continuation
         }
         self.inboundContinuation = continuationRef
+    }
+
+    public func setOnConnect(_ handler: @escaping @Sendable () async -> Void) {
+        self.onConnect = handler
     }
 
     public func connect() async throws {
@@ -50,7 +57,8 @@ public actor RelayTransport {
         manuallyDisconnected = false
         state = reconnectAttempt == 0 ? .connecting : .reconnecting
 
-        let task = session.webSocketTask(with: url)
+        let request = websocketRequest()
+        let task = session.webSocketTask(with: request)
         webSocketTask = task
         task.resume()
         state = .connected
@@ -59,6 +67,9 @@ public actor RelayTransport {
 
         startReceiveLoop()
         startPingLoop()
+        if let onConnect {
+            await onConnect()
+        }
     }
 
     public func disconnect() {
@@ -84,6 +95,22 @@ public actor RelayTransport {
         } catch {
             throw TransportError.sendFailed(String(describing: error))
         }
+    }
+
+    private func websocketRequest() -> URLRequest {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        if components?.scheme == "http" { components?.scheme = "ws" }
+        if components?.scheme == "https" { components?.scheme = "wss" }
+        if components?.path.isEmpty ?? true { components?.path = "/v1/ws" }
+        if !(components?.path.hasSuffix("/v1/ws") ?? false) && !(components?.path.hasSuffix("/ws") ?? false) {
+            components?.path = "/v1/ws"
+        }
+        components?.queryItems = (components?.queryItems ?? []) + [URLQueryItem(name: "token", value: authToken)]
+
+        var request = URLRequest(url: components?.url ?? baseURL)
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(authToken, forHTTPHeaderField: "X-API-Key")
+        return request
     }
 
     private func startReceiveLoop() {
@@ -163,8 +190,8 @@ public actor RelayTransport {
         }
 
         state = .reconnecting
-        reconnectAttempt += 1
         let delay = reconnectDelay(for: reconnectAttempt)
+        reconnectAttempt += 1
         reconnectTask?.cancel()
         reconnectTask = Task { [weak self] in
             guard let self else { return }

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
@@ -57,6 +57,7 @@ public actor RelayTransport {
         manuallyDisconnected = false
         state = reconnectAttempt == 0 ? .connecting : .reconnecting
 
+        let isReconnect = reconnectAttempt > 0
         let request = websocketRequest()
         let task = session.webSocketTask(with: request)
         webSocketTask = task
@@ -67,7 +68,7 @@ public actor RelayTransport {
 
         startReceiveLoop()
         startPingLoop()
-        if let onConnect {
+        if isReconnect, let onConnect {
             await onConnect()
         }
     }

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayTypes.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayTypes.swift
@@ -1,0 +1,418 @@
+import Foundation
+
+public enum AgentRuntime: String, Codable, Sendable {
+    case pty
+    case headless
+}
+
+public enum HeadlessProvider: String, Codable, Sendable {
+    case claude
+    case opencode
+}
+
+public struct RestartPolicy: Codable, Sendable {
+    public var enabled: Bool?
+    public var maxRestarts: Int?
+    public var cooldownMs: Int?
+    public var maxConsecutiveFailures: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case maxRestarts = "max_restarts"
+        case cooldownMs = "cooldown_ms"
+        case maxConsecutiveFailures = "max_consecutive_failures"
+    }
+
+    public init(enabled: Bool? = nil, maxRestarts: Int? = nil, cooldownMs: Int? = nil, maxConsecutiveFailures: Int? = nil) {
+        self.enabled = enabled
+        self.maxRestarts = maxRestarts
+        self.cooldownMs = cooldownMs
+        self.maxConsecutiveFailures = maxConsecutiveFailures
+    }
+}
+
+public struct AgentSpec: Codable, Sendable {
+    public var name: String
+    public var runtime: AgentRuntime
+    public var provider: HeadlessProvider?
+    public var cli: String?
+    public var args: [String]?
+    public var channels: [String]?
+    public var model: String?
+    public var cwd: String?
+    public var team: String?
+    public var shadowOf: String?
+    public var shadowMode: String?
+    public var restartPolicy: RestartPolicy?
+
+    enum CodingKeys: String, CodingKey {
+        case name, runtime, provider, cli, args, channels, model, cwd, team
+        case shadowOf = "shadow_of"
+        case shadowMode = "shadow_mode"
+        case restartPolicy = "restart_policy"
+    }
+
+    public init(
+        name: String,
+        runtime: AgentRuntime,
+        provider: HeadlessProvider? = nil,
+        cli: String? = nil,
+        args: [String]? = nil,
+        channels: [String]? = nil,
+        model: String? = nil,
+        cwd: String? = nil,
+        team: String? = nil,
+        shadowOf: String? = nil,
+        shadowMode: String? = nil,
+        restartPolicy: RestartPolicy? = nil
+    ) {
+        self.name = name
+        self.runtime = runtime
+        self.provider = provider
+        self.cli = cli
+        self.args = args
+        self.channels = channels
+        self.model = model
+        self.cwd = cwd
+        self.team = team
+        self.shadowOf = shadowOf
+        self.shadowMode = shadowMode
+        self.restartPolicy = restartPolicy
+    }
+}
+
+public struct RelayDelivery: Codable, Sendable {
+    public var deliveryId: String
+    public var eventId: String
+    public var workspaceId: String?
+    public var workspaceAlias: String?
+    public var from: String
+    public var target: String
+    public var body: String
+    public var threadId: String?
+    public var priority: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case deliveryId = "delivery_id"
+        case eventId = "event_id"
+        case workspaceId = "workspace_id"
+        case workspaceAlias = "workspace_alias"
+        case from, target, body
+        case threadId = "thread_id"
+        case priority
+    }
+}
+
+public struct ProtocolErrorPayload: Codable, Sendable, Error {
+    public var code: String
+    public var message: String
+    public var retryable: Bool
+    public var data: JSONValue?
+}
+
+public struct HelloAck: Codable, Sendable {
+    public var brokerVersion: String
+    public var protocolVersion: Int
+
+    enum CodingKeys: String, CodingKey {
+        case brokerVersion = "broker_version"
+        case protocolVersion = "protocol_version"
+    }
+}
+
+public struct OkResponse: Codable, Sendable {
+    public var result: JSONValue?
+}
+
+public struct PongPayload: Codable, Sendable {
+    public var tsMs: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case tsMs = "ts_ms"
+    }
+}
+
+public struct WorkerStreamPayload: Codable, Sendable {
+    public var stream: String
+    public var chunk: String
+}
+
+public struct WorkerExitedPayload: Codable, Sendable {
+    public var code: Int?
+    public var signal: String?
+}
+
+public struct EmptyPayload: Codable, Sendable {
+    public init() {}
+}
+
+public struct HelloPayload: Codable, Sendable {
+    public var clientName: String
+    public var clientVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientName = "client_name"
+        case clientVersion = "client_version"
+    }
+
+    public init(clientName: String, clientVersion: String) {
+        self.clientName = clientName
+        self.clientVersion = clientVersion
+    }
+}
+
+public struct SendMessagePayload: Codable, Sendable {
+    public var to: String
+    public var text: String
+    public var from: String?
+    public var threadId: String?
+    public var workspaceId: String?
+    public var workspaceAlias: String?
+    public var priority: Int?
+    public var data: [String: JSONValue]?
+
+    enum CodingKeys: String, CodingKey {
+        case to, text, from, priority, data
+        case threadId = "thread_id"
+        case workspaceId = "workspace_id"
+        case workspaceAlias = "workspace_alias"
+    }
+}
+
+public struct SpawnAgentPayload: Codable, Sendable {
+    public var agent: AgentSpec
+    public var initialTask: String?
+    public var skipRelayPrompt: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case agent
+        case initialTask = "initial_task"
+        case skipRelayPrompt = "skip_relay_prompt"
+    }
+}
+
+public struct ReleaseAgentPayload: Codable, Sendable {
+    public var name: String
+    public var reason: String?
+}
+
+public struct PingPayload: Codable, Sendable {
+    public var tsMs: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case tsMs = "ts_ms"
+    }
+}
+
+public enum BrokerEvent: Sendable {
+    case agentSpawned(AgentSpawnedEvent)
+    case agentReleased(AgentReleasedEvent)
+    case agentExit(AgentExitRequestedEvent)
+    case agentExited(AgentExitedEvent)
+    case relayInbound(RelayInboundEvent)
+    case workerStream(WorkerStreamEvent)
+    case deliveryRetry(DeliveryRetryEvent)
+    case deliveryDropped(DeliveryDroppedEvent)
+    case deliveryQueued(DeliveryStateEvent)
+    case deliveryInjected(DeliveryStateEvent)
+    case deliveryVerified(DeliveryStateEvent)
+    case deliveryFailed(DeliveryFailedEvent)
+    case deliveryActive(DeliveryStateEvent)
+    case deliveryAck(DeliveryStateEvent)
+    case workerReady(WorkerReadyEvent)
+    case workerError(WorkerErrorEvent)
+    case relaycastPublished(RelaycastPublishedEvent)
+    case relaycastPublishFailed(RelaycastPublishFailedEvent)
+    case aclDenied(ACLDeniedEvent)
+    case agentIdle(AgentIdleEvent)
+    case agentRestarting(AgentRestartingEvent)
+    case agentRestarted(AgentRestartedEvent)
+    case agentPermanentlyDead(AgentPermanentlyDeadEvent)
+}
+
+extension BrokerEvent: Codable {
+    enum CodingKeys: String, CodingKey { case kind }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(String.self, forKey: .kind) {
+        case "agent_spawned": self = .agentSpawned(try AgentSpawnedEvent(from: decoder))
+        case "agent_released": self = .agentReleased(try AgentReleasedEvent(from: decoder))
+        case "agent_exit": self = .agentExit(try AgentExitRequestedEvent(from: decoder))
+        case "agent_exited": self = .agentExited(try AgentExitedEvent(from: decoder))
+        case "relay_inbound": self = .relayInbound(try RelayInboundEvent(from: decoder))
+        case "worker_stream": self = .workerStream(try WorkerStreamEvent(from: decoder))
+        case "delivery_retry": self = .deliveryRetry(try DeliveryRetryEvent(from: decoder))
+        case "delivery_dropped": self = .deliveryDropped(try DeliveryDroppedEvent(from: decoder))
+        case "delivery_queued": self = .deliveryQueued(try DeliveryStateEvent(from: decoder))
+        case "delivery_injected": self = .deliveryInjected(try DeliveryStateEvent(from: decoder))
+        case "delivery_verified": self = .deliveryVerified(try DeliveryStateEvent(from: decoder))
+        case "delivery_failed": self = .deliveryFailed(try DeliveryFailedEvent(from: decoder))
+        case "delivery_active": self = .deliveryActive(try DeliveryStateEvent(from: decoder))
+        case "delivery_ack": self = .deliveryAck(try DeliveryStateEvent(from: decoder))
+        case "worker_ready": self = .workerReady(try WorkerReadyEvent(from: decoder))
+        case "worker_error": self = .workerError(try WorkerErrorEvent(from: decoder))
+        case "relaycast_published": self = .relaycastPublished(try RelaycastPublishedEvent(from: decoder))
+        case "relaycast_publish_failed": self = .relaycastPublishFailed(try RelaycastPublishFailedEvent(from: decoder))
+        case "acl_denied": self = .aclDenied(try ACLDeniedEvent(from: decoder))
+        case "agent_idle": self = .agentIdle(try AgentIdleEvent(from: decoder))
+        case "agent_restarting": self = .agentRestarting(try AgentRestartingEvent(from: decoder))
+        case "agent_restarted": self = .agentRestarted(try AgentRestartedEvent(from: decoder))
+        case "agent_permanently_dead": self = .agentPermanentlyDead(try AgentPermanentlyDeadEvent(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unsupported broker event kind")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .agentSpawned(let value): try value.encode(to: encoder)
+        case .agentReleased(let value): try value.encode(to: encoder)
+        case .agentExit(let value): try value.encode(to: encoder)
+        case .agentExited(let value): try value.encode(to: encoder)
+        case .relayInbound(let value): try value.encode(to: encoder)
+        case .workerStream(let value): try value.encode(to: encoder)
+        case .deliveryRetry(let value): try value.encode(to: encoder)
+        case .deliveryDropped(let value): try value.encode(to: encoder)
+        case .deliveryQueued(let value): try value.encode(to: encoder)
+        case .deliveryInjected(let value): try value.encode(to: encoder)
+        case .deliveryVerified(let value): try value.encode(to: encoder)
+        case .deliveryFailed(let value): try value.encode(to: encoder)
+        case .deliveryActive(let value): try value.encode(to: encoder)
+        case .deliveryAck(let value): try value.encode(to: encoder)
+        case .workerReady(let value): try value.encode(to: encoder)
+        case .workerError(let value): try value.encode(to: encoder)
+        case .relaycastPublished(let value): try value.encode(to: encoder)
+        case .relaycastPublishFailed(let value): try value.encode(to: encoder)
+        case .aclDenied(let value): try value.encode(to: encoder)
+        case .agentIdle(let value): try value.encode(to: encoder)
+        case .agentRestarting(let value): try value.encode(to: encoder)
+        case .agentRestarted(let value): try value.encode(to: encoder)
+        case .agentPermanentlyDead(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum InboundMessage: Sendable {
+    case helloAck(HelloAck)
+    case ok(OkResponse)
+    case error(ProtocolErrorPayload)
+    case event(BrokerEvent)
+    case deliverRelay(RelayDelivery)
+    case workerStream(WorkerStreamPayload)
+    case workerExited(WorkerExitedPayload)
+    case pong(PongPayload)
+}
+
+extension InboundMessage: Codable {
+    enum CodingKeys: String, CodingKey { case type, payload }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "hello_ack": self = .helloAck(try container.decode(HelloAck.self, forKey: .payload))
+        case "ok": self = .ok(try container.decode(OkResponse.self, forKey: .payload))
+        case "error": self = .error(try container.decode(ProtocolErrorPayload.self, forKey: .payload))
+        case "event": self = .event(try container.decode(BrokerEvent.self, forKey: .payload))
+        case "deliver_relay": self = .deliverRelay(try container.decode(RelayDelivery.self, forKey: .payload))
+        case "worker_stream": self = .workerStream(try container.decode(WorkerStreamPayload.self, forKey: .payload))
+        case "worker_exited": self = .workerExited(try container.decode(WorkerExitedPayload.self, forKey: .payload))
+        case "pong", "ping": self = .pong(try container.decode(PongPayload.self, forKey: .payload))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unsupported inbound message type")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .helloAck(let payload): try container.encode("hello_ack", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .ok(let payload): try container.encode("ok", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .error(let payload): try container.encode("error", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .event(let payload): try container.encode("event", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .deliverRelay(let payload): try container.encode("deliver_relay", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .workerStream(let payload): try container.encode("worker_stream", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .workerExited(let payload): try container.encode("worker_exited", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .pong(let payload): try container.encode("pong", forKey: .type); try container.encode(payload, forKey: .payload)
+        }
+    }
+}
+
+public enum OutboundMessage: Sendable {
+    case hello(HelloPayload)
+    case sendMessage(SendMessagePayload)
+    case spawnAgent(SpawnAgentPayload)
+    case releaseAgent(ReleaseAgentPayload)
+    case ping(PingPayload)
+    case listAgents(EmptyPayload)
+}
+
+extension OutboundMessage: Encodable {
+    enum CodingKeys: String, CodingKey { case v, type, payload }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(1, forKey: .v)
+        switch self {
+        case .hello(let payload): try container.encode("hello", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .sendMessage(let payload): try container.encode("send_message", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .spawnAgent(let payload): try container.encode("spawn_agent", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .releaseAgent(let payload): try container.encode("release_agent", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .ping(let payload): try container.encode("ping", forKey: .type); try container.encode(payload, forKey: .payload)
+        case .listAgents(let payload): try container.encode("list_agents", forKey: .type); try container.encode(payload, forKey: .payload)
+        }
+    }
+}
+
+public struct AgentSpawnedEvent: Codable, Sendable { public var kind: String = "agent_spawned"; public var name: String; public var runtime: AgentRuntime; public var provider: HeadlessProvider?; public var cli: String?; public var model: String?; public var parent: String?; public var pid: Int?; public var source: String? }
+public struct AgentReleasedEvent: Codable, Sendable { public var kind: String = "agent_released"; public var name: String }
+public struct AgentExitRequestedEvent: Codable, Sendable { public var kind: String = "agent_exit"; public var name: String; public var reason: String }
+public struct AgentExitedEvent: Codable, Sendable { public var kind: String = "agent_exited"; public var name: String; public var code: Int?; public var signal: String? }
+public struct RelayInboundEvent: Codable, Sendable { public var kind: String = "relay_inbound"; public var eventId: String; public var from: String; public var target: String; public var body: String; public var threadId: String?; enum CodingKeys: String, CodingKey { case kind, from, target, body; case eventId = "event_id"; case threadId = "thread_id" } }
+public struct WorkerStreamEvent: Codable, Sendable { public var kind: String = "worker_stream"; public var name: String; public var stream: String; public var chunk: String }
+public struct DeliveryRetryEvent: Codable, Sendable { public var kind: String = "delivery_retry"; public var name: String; public var deliveryId: String; public var eventId: String; public var attempts: Int; enum CodingKeys: String, CodingKey { case kind, name, attempts; case deliveryId = "delivery_id"; case eventId = "event_id" } }
+public struct DeliveryDroppedEvent: Codable, Sendable { public var kind: String = "delivery_dropped"; public var name: String; public var count: Int; public var reason: String }
+public struct DeliveryStateEvent: Codable, Sendable { public var kind: String; public var name: String; public var deliveryId: String; public var eventId: String; enum CodingKeys: String, CodingKey { case kind, name; case deliveryId = "delivery_id"; case eventId = "event_id" } }
+public struct DeliveryFailedEvent: Codable, Sendable { public var kind: String = "delivery_failed"; public var name: String; public var deliveryId: String; public var eventId: String; public var reason: String; enum CodingKeys: String, CodingKey { case kind, name, reason; case deliveryId = "delivery_id"; case eventId = "event_id" } }
+public struct WorkerReadyEvent: Codable, Sendable { public var kind: String = "worker_ready"; public var name: String; public var runtime: AgentRuntime; public var provider: HeadlessProvider?; public var cli: String?; public var model: String? }
+public struct WorkerErrorEvent: Codable, Sendable { public var kind: String = "worker_error"; public var name: String; public var code: String; public var message: String }
+public struct RelaycastPublishedEvent: Codable, Sendable { public var kind: String = "relaycast_published"; public var eventId: String; public var to: String; public var targetType: String; enum CodingKeys: String, CodingKey { case kind, to; case eventId = "event_id"; case targetType = "target_type" } }
+public struct RelaycastPublishFailedEvent: Codable, Sendable { public var kind: String = "relaycast_publish_failed"; public var eventId: String; public var to: String; public var reason: String; enum CodingKeys: String, CodingKey { case kind, to, reason; case eventId = "event_id" } }
+public struct ACLDeniedEvent: Codable, Sendable { public var kind: String = "acl_denied"; public var name: String; public var sender: String; public var ownerChain: [String]; enum CodingKeys: String, CodingKey { case kind, name, sender; case ownerChain = "owner_chain" } }
+public struct AgentIdleEvent: Codable, Sendable { public var kind: String = "agent_idle"; public var name: String; public var idleSecs: Int; enum CodingKeys: String, CodingKey { case kind, name; case idleSecs = "idle_secs" } }
+public struct AgentRestartingEvent: Codable, Sendable { public var kind: String = "agent_restarting"; public var name: String; public var code: Int?; public var signal: String?; public var restartCount: Int; public var delayMs: Int; enum CodingKeys: String, CodingKey { case kind, name, code, signal; case restartCount = "restart_count"; case delayMs = "delay_ms" } }
+public struct AgentRestartedEvent: Codable, Sendable { public var kind: String = "agent_restarted"; public var name: String; public var restartCount: Int; enum CodingKeys: String, CodingKey { case kind, name; case restartCount = "restart_count" } }
+public struct AgentPermanentlyDeadEvent: Codable, Sendable { public var kind: String = "agent_permanently_dead"; public var name: String; public var reason: String }
+
+public enum JSONValue: Codable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([String: JSONValue].self) { self = .object(value) }
+        else if let value = try? container.decode([JSONValue].self) { self = .array(value) }
+        else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value") }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+}

--- a/packages/sdk-swift/Tests/AgentRelaySDKTests/AgentRelaySDKTests.swift
+++ b/packages/sdk-swift/Tests/AgentRelaySDKTests/AgentRelaySDKTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import AgentRelaySDK
+
+final class AgentRelaySDKTests: XCTestCase {
+    func testRelayCastInit() {
+        let relay = RelayCast(apiKey: "rk_test_key")
+        XCTAssertEqual(relay.apiKey, "rk_test_key")
+    }
+
+    func testChannelCreation() {
+        let relay = RelayCast(apiKey: "rk_test_key")
+        let channel = relay.channel("test-channel")
+        XCTAssertEqual(channel.name, "test-channel")
+    }
+}

--- a/skills/running-headless-orchestrator/SKILL.md
+++ b/skills/running-headless-orchestrator/SKILL.md
@@ -53,20 +53,37 @@ npx agent-relay --version
 
 ### Step 1: Start Infrastructure
 
-```bash
-# Start broker in background (no dashboard needed for headless)
-agent-relay up --background --no-dashboard
+Prefer a **foreground stdio broker** first. Background mode can be flaky in some environments and may report "started" while `agent-relay status` still shows `STOPPED`.
 
-# Verify it's running
+```bash
+# Preferred: run broker in foreground/stdin mode and keep the session open
+agent-relay up --no-dashboard --verbose
+```
+
+In another terminal/session, verify it is ready before spawning workers:
+
+```bash
+agent-relay status
+# Optional: confirm API/broker readiness from startup logs before spawning
+```
+
+Only use background mode if you have confirmed it stays healthy in this project:
+
+```bash
+agent-relay up --background --no-dashboard
 agent-relay status
 ```
+
+If background mode says it started but status still shows `STOPPED`, fall back to foreground mode.
 
 The broker:
 - Auto-creates a Relaycast workspace if `RELAY_API_KEY` not set
 - Removes `CLAUDECODE` env var when spawning (fixes nested session error)
 - Persists state to `.agent-relay/`
 
-### Step 2: Spawn Workers via MCP
+### Step 2: Spawn Workers via MCP or CLI
+
+Start conservatively: spawn **one worker first**, confirm it connects, then add more workers gradually. Spawning several immediately after broker startup can cause dropped internal replies or relay registration timeouts.
 
 ```
 mcp__relaycast__agent_add(
@@ -74,6 +91,12 @@ mcp__relaycast__agent_add(
   cli: "claude",
   task: "Implement the authentication module following the existing patterns"
 )
+```
+
+CLI equivalent:
+
+```bash
+agent-relay spawn Worker1 claude "Implement the authentication module following the existing patterns"
 ```
 
 ### Step 3: Monitor and Coordinate
@@ -121,8 +144,8 @@ agent-relay release Worker1
 ### Monitoring Workers (Essential)
 
 ```bash
-# List all active agents with status
-agent-relay agents
+# Show currently active agents
+agent-relay who
 
 # View real-time output from a worker (critical for debugging)
 agent-relay agents:logs Worker1
@@ -204,8 +227,10 @@ The broker emits these events (available via SDK subscriptions):
 |---------|-----|
 | `agent-relay: command not found` | Install with `npm i -g agent-relay` or use `npx agent-relay` |
 | "Nested session" error | Broker handles this automatically; if running manually, unset `CLAUDECODE` env var |
-| Broker not starting | Check `agent-relay status`; may need `agent-relay down` first |
-| Workers not connecting | Ensure broker started; check `agent-relay agents` |
+| Broker not starting | Try `agent-relay down` first, then use foreground `agent-relay up --no-dashboard --verbose` to see readiness logs |
+| Background broker says started but status is STOPPED | Prefer foreground mode for that project/session; background mode may have detached incorrectly |
+| Spawn fails with `internal reply dropped` | Broker likely is not fully ready yet; wait for readiness, then spawn one worker first |
+| Workers not connecting | Ensure broker started; check `agent-relay who` and worker logs |
 | Not monitoring workers | Use `agent-relay agents:logs <name>` frequently to track progress |
 | Workers seem stuck | Check logs with `agent-relay agents:logs <name>` for errors |
 | Messages not delivered | Check `agent-relay history` to verify message flow |

--- a/workflows/add-swift-sdk.ts
+++ b/workflows/add-swift-sdk.ts
@@ -120,11 +120,12 @@ const [result] = await Promise.all([
     .step('read-msd-reference', {
       type: 'deterministic',
       dependsOn: ['create-branch'],
-      // MSD's RelayConnection.swift is a real working WebSocket client for the
-      // same broker — invaluable reference for wire types and reconnect logic.
+      // Optional local reference path for a real Swift broker client.
+      // Set SWIFT_RELAY_REFERENCE_PATH to enable this extra context.
       command:
-        'cat "/Users/khaliqgant/Projects/My Senior Dev/app/packages/desktop/' +
-        'MSDReview/Sources/Data/RelayConnection.swift" 2>/dev/null',
+        'if [ -n "$SWIFT_RELAY_REFERENCE_PATH" ] && [ -f "$SWIFT_RELAY_REFERENCE_PATH" ]; then ' +
+        'cat "$SWIFT_RELAY_REFERENCE_PATH"; ' +
+        'else echo "No local Swift relay reference configured"; fi',
       captureOutput: true,
       failOnError: false,
     })

--- a/workflows/add-swift-sdk.ts
+++ b/workflows/add-swift-sdk.ts
@@ -1,0 +1,545 @@
+/**
+ * add-swift-sdk.ts
+ *
+ * Creates a native Swift SDK (Swift Package Manager) for the Agent Relay broker.
+ *
+ * The SDK gives Swift/macOS/iOS apps a first-class client without needing a
+ * TypeScript/Node bridge process. It mirrors the TypeScript and Python SDK
+ * surface and ships as an SPM package at packages/sdk-swift/.
+ *
+ * Public API shape (produced by this workflow):
+ *
+ *   let relay = RelayCast(apiKey: "rk_live_...")
+ *   let channel = relay.channel("wf-my-workflow")
+ *   channel.subscribe()
+ *   channel.post("Hello from Swift")
+ *   for await event in channel.events { ... }
+ *
+ *   let agent  = try await relay.registerOrRotate(name: "my-agent")
+ *   try await agent.post(to: "general", message: "Hi")
+ *   try await agent.dm(to: "other-agent", message: "...")
+ *
+ * Phases:
+ *   1. Context: read protocol, TS relay client, Python SDK, MSD reference impl
+ *   2. Plan: lead designs the full SDK API and file breakdown
+ *   3. Scaffold: create dir structure + Package.swift (deterministic)
+ *   4. Implement: 3 parallel workers — types, transport, API
+ *   5. Verify: file existence check + swift build
+ *   6. Review: lead fixes build errors and commits
+ *
+ * Run with:
+ *   agent-relay run workflows/add-swift-sdk.ts
+ */
+
+import { workflow, createWorkflowRenderer } from '@agent-relay/sdk/workflows';
+
+const renderer = createWorkflowRenderer();
+
+const cwd = process.cwd(); // run from the relay repo root
+
+const [result] = await Promise.all([
+  workflow('add-swift-sdk')
+    .description(
+      'Create a native Swift SDK (SPM) for the Agent Relay broker — ' +
+      'WebSocket transport, typed events, channel pub/sub, and agent registration. ' +
+      'Mirrors the TypeScript and Python SDK surface.',
+    )
+    .pattern('dag')
+    .channel('wf-add-swift-sdk')
+    .maxConcurrency(5)
+    .timeout(3600000)
+
+    // ── Agents ──────────────────────────────────────────────────────────────
+
+    .agent('lead', {
+      cli: 'claude',
+      role:
+        'Swift SDK architect. Reads context, produces the API design plan, ' +
+        'assigns files to workers, reviews the build output, fixes errors, and ' +
+        'commits the finished package.',
+    })
+    .agent('types-worker', {
+      cli: 'claude',
+      preset: 'worker',
+      role:
+        'Writes Sources/AgentRelaySDK/RelayTypes.swift — ' +
+        'all Codable event structs and enums matching the broker wire protocol.',
+    })
+    .agent('transport-worker', {
+      cli: 'claude',
+      preset: 'worker',
+      role:
+        'Writes Sources/AgentRelaySDK/RelayTransport.swift — ' +
+        'URLSessionWebSocketTask connection with exponential-backoff reconnect and ping/pong.',
+    })
+    .agent('api-worker', {
+      cli: 'claude',
+      preset: 'worker',
+      role:
+        'Writes Sources/AgentRelaySDK/RelayCast.swift — ' +
+        'the public RelayCast, Channel, and AgentClient types that apps consume.',
+    })
+
+    // ── Phase 1: Context gathering (parallel deterministic) ─────────────────
+
+    .step('create-branch', {
+      type: 'deterministic',
+      command:
+        'git checkout -b feature/swift-sdk 2>&1 || git checkout feature/swift-sdk 2>&1',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('read-protocol', {
+      type: 'deterministic',
+      dependsOn: ['create-branch'],
+      command: 'cat packages/sdk/src/protocol.ts',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('read-ts-relay', {
+      type: 'deterministic',
+      dependsOn: ['create-branch'],
+      // First 400 lines covers the WebSocket setup, event loop, and public API
+      command: 'head -400 packages/sdk/src/relay.ts',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('read-python-sdk', {
+      type: 'deterministic',
+      dependsOn: ['create-branch'],
+      command:
+        'find packages/sdk-py -name "*.py" -not -path "*/__pycache__/*" ' +
+        '| sort | xargs head -n 60 2>/dev/null | head -500',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('read-msd-reference', {
+      type: 'deterministic',
+      dependsOn: ['create-branch'],
+      // MSD's RelayConnection.swift is a real working WebSocket client for the
+      // same broker — invaluable reference for wire types and reconnect logic.
+      command:
+        'cat "/Users/khaliqgant/Projects/My Senior Dev/app/packages/desktop/' +
+        'MSDReview/Sources/Data/RelayConnection.swift" 2>/dev/null',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    // ── Phase 2: Architecture plan ──────────────────────────────────────────
+
+    .step('plan', {
+      agent: 'lead',
+      dependsOn: ['read-protocol', 'read-ts-relay', 'read-python-sdk', 'read-msd-reference'],
+      task: `You are designing a native Swift SDK for the Agent Relay broker.
+
+## Context
+
+Broker wire protocol (TypeScript):
+{{steps.read-protocol.output}}
+
+TypeScript relay client (first 400 lines):
+{{steps.read-ts-relay.output}}
+
+Python SDK reference:
+{{steps.read-python-sdk.output}}
+
+Existing Swift WebSocket client (MSD project — real production code for this same broker):
+{{steps.read-msd-reference.output}}
+
+## Your task
+
+Produce a detailed design document covering:
+
+1. **Package structure** — files to create under packages/sdk-swift/Sources/AgentRelaySDK/
+2. **RelayTypes.swift** — every Codable struct/enum needed to decode broker events
+   (hello_ack, event, worker_stream, worker_exited, pong, error, deliver_relay, ok)
+   and encode client messages (hello, send_message, spawn_agent, release_agent, ping)
+3. **RelayTransport.swift** — URLSessionWebSocketTask connection class:
+   - connect() / disconnect()
+   - Exponential backoff reconnect (max 30s)
+   - Ping every 20s, disconnect if pong not received in 10s
+   - Inbound message stream via AsyncStream
+4. **RelayCast.swift** — public API:
+   - RelayCast(apiKey:baseURL:) — manages a single WebSocket connection
+   - channel(_ name: String) -> Channel
+   - registerOrRotate(name:) async throws -> AgentRegistration
+   - Channel: subscribe(), post(_ text:), events: AsyncStream<InboundEvent>
+   - AgentClient (returned by as(_ token:)): post(to:message:), dm(to:message:)
+5. **Concurrency model** — Swift structured concurrency (async/await, Actor isolation)
+6. **Platform targets** — macOS 13+, iOS 16+, no third-party dependencies
+
+End your plan with the exact file list workers must create. Use the marker:
+PLAN_COMPLETE`,
+      verification: { type: 'output_contains', value: 'PLAN_COMPLETE' },
+    })
+
+    // ── Phase 3: Scaffold (deterministic) ───────────────────────────────────
+
+    .step('scaffold-dirs', {
+      type: 'deterministic',
+      dependsOn: ['plan'],
+      command:
+        'mkdir -p packages/sdk-swift/Sources/AgentRelaySDK ' +
+        'packages/sdk-swift/Tests/AgentRelaySDKTests',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-package-swift', {
+      type: 'deterministic',
+      dependsOn: ['scaffold-dirs'],
+      command: `cat > packages/sdk-swift/Package.swift << 'SWIFTEOF'
+// swift-tools-version: 5.9
+// AgentRelaySDK — Swift Package Manager manifest
+//
+// Native Swift client for the Agent Relay broker.
+// No third-party dependencies — uses URLSession WebSocket and Swift Concurrency.
+
+import PackageDescription
+
+let package = Package(
+    name: "AgentRelaySDK",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .tvOS(.v16),
+    ],
+    products: [
+        .library(
+            name: "AgentRelaySDK",
+            targets: ["AgentRelaySDK"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "AgentRelaySDK",
+            path: "Sources/AgentRelaySDK"
+        ),
+        .testTarget(
+            name: "AgentRelaySDKTests",
+            dependencies: ["AgentRelaySDK"],
+            path: "Tests/AgentRelaySDKTests"
+        ),
+    ]
+)
+SWIFTEOF`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-test-stub', {
+      type: 'deterministic',
+      dependsOn: ['scaffold-dirs'],
+      command: `cat > packages/sdk-swift/Tests/AgentRelaySDKTests/AgentRelaySDKTests.swift << 'SWIFTEOF'
+import XCTest
+@testable import AgentRelaySDK
+
+final class AgentRelaySDKTests: XCTestCase {
+
+    func testRelayCastInit() {
+        let relay = RelayCast(apiKey: "rk_test_key")
+        XCTAssertNotNil(relay)
+    }
+
+    func testChannelCreation() {
+        let relay = RelayCast(apiKey: "rk_test_key")
+        let channel = relay.channel("test-channel")
+        XCTAssertEqual(channel.name, "test-channel")
+    }
+}
+SWIFTEOF`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Phase 4: Parallel implementation ────────────────────────────────────
+
+    .step('implement-types', {
+      agent: 'types-worker',
+      dependsOn: ['scaffold-dirs', 'plan'],
+      task: `Write the file packages/sdk-swift/Sources/AgentRelaySDK/RelayTypes.swift.
+
+Architecture plan from the lead:
+{{steps.plan.output}}
+
+Broker wire protocol reference:
+{{steps.read-protocol.output}}
+
+MSD production reference (existing working types):
+{{steps.read-msd-reference.output}}
+
+## Requirements
+
+Write a complete Swift file containing:
+
+1. **Inbound message types** (broker → client, Decodable):
+   - InboundMessage enum with associated values for each event type
+   - BrokerEvent struct (wraps event kind + payload)
+   - EventKind for relay_inbound, agent_spawned, agent_released, worker_stream, worker_exited
+   - HelloAck, BrokerError structs
+
+2. **Outbound message types** (client → broker, Encodable):
+   - OutboundMessage enum: hello, send_message, release_agent, ping, list_agents
+   - SendMessagePayload, SpawnAgentPayload, HelloPayload structs
+
+3. Use Swift Codable (Encodable + Decodable), snake_case CodingKeys to match broker JSON.
+4. Add // MARK: - section headers for clarity.
+
+IMPORTANT: Write the complete file to disk at
+packages/sdk-swift/Sources/AgentRelaySDK/RelayTypes.swift
+Do NOT output to stdout — the file must exist on disk when you finish.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('implement-transport', {
+      agent: 'transport-worker',
+      dependsOn: ['scaffold-dirs', 'plan'],
+      task: `Write the file packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift.
+
+Architecture plan from the lead:
+{{steps.plan.output}}
+
+MSD production WebSocket reference (existing working transport for this same broker):
+{{steps.read-msd-reference.output}}
+
+## Requirements
+
+Write a complete Swift file containing the RelayTransport actor:
+
+\`\`\`swift
+actor RelayTransport {
+    init(url: URL)
+    func connect() async throws
+    func disconnect()
+    func send(_ message: Data) async throws
+    var inbound: AsyncStream<Data> { get }
+}
+\`\`\`
+
+Implementation details:
+1. Use URLSessionWebSocketTask — no third-party dependencies
+2. Reconnect with exponential backoff: 0.5s, 1s, 2s, 4s, 8s, 16s, 30s (cap)
+3. Send a ping frame every 20s; treat no pong within 10s as a disconnect
+4. Expose inbound messages via AsyncStream<Data> (raw frames before JSON decode)
+5. Target macOS 13+, iOS 16+ — use structured concurrency (async/await, Task, actor)
+6. Include a ConnectionState enum: disconnected, connecting, connected, reconnecting
+
+IMPORTANT: Write the complete file to disk at
+packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift
+Do NOT output to stdout — the file must exist on disk when you finish.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('implement-api', {
+      agent: 'api-worker',
+      dependsOn: ['scaffold-dirs', 'plan'],
+      task: `Write the file packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift.
+
+Architecture plan from the lead:
+{{steps.plan.output}}
+
+TypeScript SDK reference (API shape to mirror):
+{{steps.read-ts-relay.output}}
+
+## Requirements
+
+Write a complete Swift file with the public API:
+
+\`\`\`swift
+// Entry point
+public final class RelayCast {
+    public init(apiKey: String, baseURL: URL? = nil)
+    public func channel(_ name: String) -> Channel
+    public func registerOrRotate(name: String) async throws -> AgentRegistration
+    public func \`as\`(_ agentToken: String) -> AgentClient
+}
+
+// Channel pub/sub
+public final class Channel {
+    public let name: String
+    public func subscribe() async throws
+    public func post(_ text: String) async throws
+    public var events: AsyncStream<RelayChannelEvent> { get }
+}
+
+// Agent posting
+public final class AgentClient {
+    public func post(to channel: String, message: String) async throws
+    public func dm(to agentName: String, message: String) async throws
+}
+
+// Returned by registerOrRotate
+public struct AgentRegistration {
+    public let agentName: String
+    public let token: String
+    public func asClient() -> AgentClient
+}
+
+// Events surfaced to callers
+public struct RelayChannelEvent {
+    public let from: String
+    public let body: String
+    public let threadId: String?
+    public let timestamp: Date
+}
+\`\`\`
+
+Implementation notes:
+- RelayCast owns the RelayTransport, shared by all Channel and AgentClient instances
+- Use the broker's WebSocket at ws://{host}/ws (default: ws://localhost:3889/ws)
+- Authenticate with apiKey in the hello handshake (payload.client_name + apiKey header or token)
+- Channel.subscribe() sends a channel subscription message to the broker
+- AgentClient.post / dm send send_message frames with from set to the agent name
+- All async methods throw RelayError (define a public enum for connection/protocol errors)
+
+IMPORTANT: Write the complete file to disk at
+packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift
+Do NOT output to stdout — the file must exist on disk when you finish.`,
+      verification: { type: 'exit_code' },
+    })
+
+    // ── Phase 5: Verify files + build ───────────────────────────────────────
+
+    .step('verify-files', {
+      type: 'deterministic',
+      dependsOn: ['implement-types', 'implement-transport', 'implement-api', 'write-package-swift'],
+      command: `missing=0
+for f in \
+  packages/sdk-swift/Package.swift \
+  packages/sdk-swift/Sources/AgentRelaySDK/RelayTypes.swift \
+  packages/sdk-swift/Sources/AgentRelaySDK/RelayTransport.swift \
+  packages/sdk-swift/Sources/AgentRelaySDK/RelayCast.swift; do
+  if [ ! -f "$f" ]; then
+    echo "MISSING: $f"
+    missing=$((missing + 1))
+  else
+    echo "OK: $f ($(wc -l < "$f") lines)"
+  fi
+done
+if [ $missing -gt 0 ]; then
+  echo "$missing file(s) missing — workers did not write to disk"
+  exit 1
+fi
+echo "All files present"`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('swift-build', {
+      type: 'deterministic',
+      dependsOn: ['verify-files'],
+      command:
+        'cd packages/sdk-swift && swift build 2>&1 | tail -50',
+      captureOutput: true,
+      failOnError: false, // lead will diagnose and fix errors
+    })
+
+    // ── Phase 6: Review, fix, commit ────────────────────────────────────────
+
+    .step('review-and-commit', {
+      agent: 'lead',
+      dependsOn: ['swift-build'],
+      task: `Review the Swift SDK build result and leave durable repo output on this branch.
+
+Files produced:
+{{steps.verify-files.output}}
+
+Swift build output:
+{{steps.swift-build.output}}
+
+## Non-negotiable contract
+
+This workflow is only successful if the repository itself contains the finished SDK files.
+A status update to WorkflowRunner is NOT enough.
+Do not stop after sending a message. Do not remove yourself until the repo state is durable.
+
+## Your tasks
+
+1. **If the build failed:** read each source file, diagnose the errors, and fix them
+   directly using your file-editing tools. Common issues to check:
+   - Missing CodingKeys for snake_case fields
+   - Actor isolation violations (mark mutating state with nonisolated(unsafe) or move to actor)
+   - Missing 'public' access modifiers on exported types
+   - AsyncStream continuation retention
+
+2. **If the build still cannot be made green because the host Swift toolchain is broken:**
+   - keep the generated SDK files on disk
+   - write packages/sdk-swift/README.md explaining the current status
+   - commit the package anyway with a message that clearly notes validation was blocked by the local environment
+   - explicitly say in your final summary whether validation was blocked by environment vs source errors
+
+3. **Write a README** at packages/sdk-swift/README.md with:
+   - Installation (SPM dependency snippet)
+   - Quick-start example (connect, subscribe to a channel, post a message)
+   - Current validation status / known limitations
+
+4. **Commit** all files under packages/sdk-swift/.
+   Required commands:
+   \`\`\`
+   git add packages/sdk-swift/
+   git commit -m "feat(sdk-swift): add native Swift SDK for Agent Relay broker"
+   \`\`\`
+
+5. In your final response include all of the following markers on separate lines:
+   - REVIEW_COMPLETE
+   - README_WRITTEN
+   - COMMIT_STATUS: <committed|blocked>
+   - COMMIT_SHA: <sha or none>
+   - VALIDATION_STATUS: <passed|env-blocked|source-blocked>
+
+If you cannot commit, explain exactly why and output COMMIT_STATUS: blocked.`,
+      verification: { type: 'output_contains', value: 'REVIEW_COMPLETE' },
+    })
+
+    .step('verify-readme', {
+      type: 'deterministic',
+      dependsOn: ['review-and-commit'],
+      command: 'test -f packages/sdk-swift/README.md && echo README_OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('verify-commit', {
+      type: 'deterministic',
+      dependsOn: ['review-and-commit'],
+      command: `set -e
+if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "No HEAD commit"
+  exit 1
+fi
+if git diff --quiet HEAD -- packages/sdk-swift; then
+  if git diff --cached --quiet -- packages/sdk-swift; then
+    echo "SDK files are committed in HEAD"
+  else
+    echo "SDK changes are only staged, not committed"
+    exit 1
+  fi
+else
+  echo "SDK changes are still uncommitted after review-and-commit"
+  exit 1
+fi`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 2, retryDelayMs: 10000 })
+    .run({
+      onEvent: renderer.onEvent,
+      cwd,
+    }),
+
+  renderer.start(),
+]);
+
+renderer.unmount();
+
+console.log(`\nSwift SDK workflow: ${result.status}`);
+if (result.status === 'completed') {
+  console.log('Package location: packages/sdk-swift/');
+  console.log('Run: cd packages/sdk-swift && swift build');
+}


### PR DESCRIPTION
## Summary

Tighten the `running-headless-orchestrator` skill based on real-world broker startup behavior observed while using `agent-relay` to coordinate NightCTO workflow authoring.

## What changed

- prefer a foreground `agent-relay up --no-dashboard --verbose` broker first instead of assuming background mode is reliable
- explicitly verify broker readiness before spawning workers
- recommend spawning one worker first, then scaling out gradually
- document `internal reply dropped` as a likely broker-readiness symptom
- switch active-agent monitoring guidance to `agent-relay who`

## Why

In practice, `agent-relay up --background --no-dashboard` can sometimes report that it started while `agent-relay status` still shows `STOPPED`, which leads to flaky worker spawns and dropped internal replies.

This PR updates the skill to steer orchestrators toward the safer startup/monitoring path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
