### PR TITLE
feat(sdk): add workflow defaults abstraction

### DIFF
--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -22,6 +22,7 @@ import type {
 } from './types.js';
 import { WorkflowRunner, type WorkflowEventListener, type VariableContext, type StepExecutor } from './runner.js';
 import { formatDryRunReport } from './dry-run-format.js';
+import { createDefaultEventLogger, type LogLevel } from './default-logger.js';
 
 // ── Option types for the builder API ────────────────────────────────────────
 
@@ -106,6 +107,10 @@ export interface WorkflowRunOptions {
   startFrom?: string;
   /** Previous run ID whose cached outputs are used with startFrom. */
   previousRunId?: string;
+  /** Console log verbosity: "verbose" | "normal" (default) | "quiet" | false (silent). */
+  logLevel?: LogLevel;
+  /** Renderer: "listr" for listr2 UI, "default" for console logger, false to disable. */
+  renderer?: 'listr' | 'default' | false;
 }
 
 // ── WorkflowBuilder ─────────────────────────────────────────────────────────
@@ -333,7 +338,11 @@ export class WorkflowBuilder {
     if (this._timeoutMs !== undefined) config.swarm.timeoutMs = this._timeoutMs;
     if (this._channel !== undefined) config.swarm.channel = this._channel;
     if (this._idleNudge !== undefined) config.swarm.idleNudge = this._idleNudge;
-    if (this._errorHandling !== undefined) config.errorHandling = this._errorHandling;
+    config.errorHandling = this._errorHandling ?? {
+      strategy: 'retry',
+      maxRetries: 2,
+      retryDelayMs: 10_000,
+    };
     if (this._coordination !== undefined) config.coordination = this._coordination;
     if (this._state !== undefined) config.state = this._state;
     if (this._trajectories !== undefined) config.trajectories = this._trajectories;
@@ -367,6 +376,17 @@ export class WorkflowBuilder {
       return report;
     }
 
+    // Wire up default console logger unless explicitly disabled
+    // renderer: "listr" owns the terminal — skip console logger to avoid garbled output
+    // renderer: false implies no output at all
+    const logLevel = options.renderer === 'listr' || options.renderer === false
+      ? false
+      : (options.logLevel ?? 'normal');
+    if (logLevel !== false) {
+      runner.on(createDefaultEventLogger(logLevel));
+    }
+
+    // Wire up user-provided event handler (additive — does not replace the default logger)
     if (options.onEvent) {
       runner.on(options.onEvent);
     }
@@ -382,6 +402,19 @@ export class WorkflowBuilder {
     const executeOptions: WorkflowExecuteOptions | undefined = startFrom
       ? { startFrom, previousRunId }
       : undefined;
+
+    // If listr renderer requested, wire it up and run concurrently
+    if (options.renderer === 'listr') {
+      const { createWorkflowRenderer } = await import('./listr-renderer.js');
+      const renderer = createWorkflowRenderer();
+      runner.on(renderer.onEvent);
+      const [result] = await Promise.all([
+        runner.execute(config, options.workflow, options.vars, executeOptions),
+        renderer.start(),
+      ]);
+      renderer.unmount();
+      return result;
+    }
 
     return runner.execute(config, options.workflow, options.vars, executeOptions);
   }

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -411,9 +411,12 @@ export class WorkflowBuilder {
         ? runner.resume(resumeRunId, options.vars)
         : runner.execute(config, options.workflow, options.vars, executeOptions);
 
-      const [result] = await Promise.all([runPromise, renderer.start()]);
-      renderer.unmount();
-      return result;
+      try {
+        const [result] = await Promise.all([runPromise, renderer.start()]);
+        return result;
+      } finally {
+        renderer.unmount();
+      }
     }
 
     if (resumeRunId) {

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -393,9 +393,6 @@ export class WorkflowBuilder {
 
     // Auto-detect RESUME_RUN_ID env var for resuming failed runs
     const resumeRunId = process.env.RESUME_RUN_ID;
-    if (resumeRunId) {
-      return runner.resume(resumeRunId, options.vars);
-    }
 
     const startFrom = this._startFrom ?? options.startFrom ?? process.env.START_FROM;
     const previousRunId = this._previousRunId ?? options.previousRunId ?? process.env.PREVIOUS_RUN_ID;
@@ -404,16 +401,23 @@ export class WorkflowBuilder {
       : undefined;
 
     // If listr renderer requested, wire it up and run concurrently
+    // Must be set up BEFORE the resume check so resume runs also get event output
     if (options.renderer === 'listr') {
       const { createWorkflowRenderer } = await import('./listr-renderer.js');
       const renderer = createWorkflowRenderer();
       runner.on(renderer.onEvent);
-      const [result] = await Promise.all([
-        runner.execute(config, options.workflow, options.vars, executeOptions),
-        renderer.start(),
-      ]);
+
+      const runPromise = resumeRunId
+        ? runner.resume(resumeRunId, options.vars)
+        : runner.execute(config, options.workflow, options.vars, executeOptions);
+
+      const [result] = await Promise.all([runPromise, renderer.start()]);
       renderer.unmount();
       return result;
+    }
+
+    if (resumeRunId) {
+      return runner.resume(resumeRunId, options.vars);
     }
 
     return runner.execute(config, options.workflow, options.vars, executeOptions);

--- a/packages/sdk/src/workflows/collectors/opencode.ts
+++ b/packages/sdk/src/workflows/collectors/opencode.ts
@@ -74,6 +74,32 @@ function loadDatabaseConstructor(): DatabaseConstructor | null {
   try {
     return require('better-sqlite3') as DatabaseConstructor;
   } catch {
+    // fall through
+  }
+
+  // Fall back to Node 22+ native node:sqlite (experimental)
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { DatabaseSync } = require('node:sqlite');
+    return function NativeSqliteWrapper(filename: string, options?: { readonly?: boolean; fileMustExist?: boolean }) {
+      const db = new DatabaseSync(filename, { open: true, readOnly: options?.readonly ?? false });
+      return {
+        prepare(sql: string) {
+          const stmt = db.prepare(sql);
+          return {
+            get<T>(params?: unknown): T | undefined {
+              return params != null ? stmt.get(params) as T | undefined : stmt.get() as T | undefined;
+            },
+            all<T>(params?: unknown): T[] {
+              return (params != null ? stmt.all(params) : stmt.all()) as T[];
+            },
+          };
+        },
+        pragma(source: string) { db.exec(`PRAGMA ${source}`); return undefined; },
+        close() { db.close(); },
+      };
+    } as unknown as DatabaseConstructor;
+  } catch {
     return null;
   }
 }

--- a/packages/sdk/src/workflows/default-logger.ts
+++ b/packages/sdk/src/workflows/default-logger.ts
@@ -1,0 +1,120 @@
+import chalk from 'chalk';
+import type { WorkflowEvent, WorkflowEventListener } from './runner.js';
+
+export type LogLevel = 'verbose' | 'normal' | 'quiet' | false;
+
+const noop: WorkflowEventListener = () => {};
+
+/**
+ * Create a default event logger that writes workflow progress to the console.
+ *
+ * @param level - Log verbosity: "verbose" | "normal" (default) | "quiet" | false (no-op)
+ */
+export function createDefaultEventLogger(level: LogLevel = 'normal'): WorkflowEventListener {
+  if (level === false) return noop;
+
+  return (event: WorkflowEvent) => {
+    switch (event.type) {
+      // ── Run lifecycle ──
+      case 'run:started':
+        if (level !== 'quiet') {
+          console.log(chalk.cyan(`[workflow] run ${event.runId.slice(0, 8)}...`));
+        }
+        break;
+
+      case 'run:completed':
+        console.log(chalk.green(`[workflow] completed`));
+        break;
+
+      case 'run:failed':
+        console.log(chalk.red(`[workflow] FAILED: ${event.error}`));
+        break;
+
+      case 'run:cancelled':
+        if (level !== 'quiet') {
+          console.log(chalk.yellow(`[workflow] cancelled`));
+        }
+        break;
+
+      // ── Step lifecycle ──
+      case 'step:started':
+        if (level !== 'quiet') {
+          console.log(chalk.blue(`  ● ${event.stepName} — started`));
+        }
+        break;
+
+      case 'step:completed':
+        if (level !== 'quiet') {
+          console.log(chalk.green(`  ✓ ${event.stepName} — completed`));
+        }
+        break;
+
+      case 'step:failed':
+        console.log(chalk.red(`  ✗ ${event.stepName} — FAILED: ${event.error}`));
+        break;
+
+      case 'step:skipped':
+        if (level !== 'quiet') {
+          console.log(chalk.gray(`  ○ ${event.stepName} — skipped`));
+        }
+        break;
+
+      case 'step:retrying':
+        if (level !== 'quiet') {
+          console.log(chalk.yellow(`  ↻ ${event.stepName} — retrying (attempt ${event.attempt})`));
+        }
+        break;
+
+      case 'step:nudged':
+        if (level !== 'quiet') {
+          console.log(chalk.yellow(`  ⚡ ${event.stepName} — nudged (${event.nudgeCount})`));
+        }
+        break;
+
+      case 'step:agent-report': {
+        if (level !== 'quiet') {
+          const r = event.report;
+          const parts: string[] = [];
+          if (r.model) parts.push(r.model);
+          if (r.cost != null) parts.push(`$${r.cost.toFixed(2)}`);
+          if (r.tokens) parts.push(`${r.tokens.input}+${r.tokens.output} tokens`);
+          parts.push(`${r.errors.length} errors`);
+          console.log(chalk.dim(`  📊 ${event.stepName} — ${parts.join(' · ')}`));
+        }
+        break;
+      }
+
+      // ── Broker-level events (verbose only) ──
+      case 'broker:event':
+        if (level === 'verbose') {
+          console.log(chalk.dim(`  [broker] ${JSON.stringify(event.event)}`));
+        }
+        break;
+
+      // ── Other events (verbose only) ──
+      case 'step:owner-assigned':
+        if (level === 'verbose') {
+          console.log(chalk.dim(`  ${event.stepName} — owner: ${event.ownerName}, specialist: ${event.specialistName}`));
+        }
+        break;
+
+      case 'step:review-completed':
+        if (level === 'verbose') {
+          console.log(chalk.dim(`  ${event.stepName} — review: ${event.decision} by ${event.reviewerName}`));
+        }
+        break;
+
+      case 'step:owner-timeout':
+        if (level !== 'quiet') {
+          console.log(chalk.yellow(`  ⏱ ${event.stepName} — owner timeout (${event.ownerName})`));
+        }
+        break;
+
+      case 'step:force-released':
+        if (level === 'verbose') {
+          console.log(chalk.dim(`  ${event.stepName} — force-released`));
+        }
+        break;
+    }
+  };
+}

--- a/packages/sdk/src/workflows/index.ts
+++ b/packages/sdk/src/workflows/index.ts
@@ -25,3 +25,4 @@ export * from './templates.js';
 export { WorkflowTrajectory, type StepOutcome } from './trajectory.js';
 export { formatDryRunReport } from './dry-run-format.js';
 export { createWorkflowRenderer, type WorkflowRenderer } from './listr-renderer.js';
+export { createDefaultEventLogger, type LogLevel } from './default-logger.js';

--- a/packages/sdk/src/workflows/index.ts
+++ b/packages/sdk/src/workflows/index.ts
@@ -25,4 +25,4 @@ export * from './templates.js';
 export { WorkflowTrajectory, type StepOutcome } from './trajectory.js';
 export { formatDryRunReport } from './dry-run-format.js';
 export { createWorkflowRenderer, type WorkflowRenderer } from './listr-renderer.js';
-export { createDefaultEventLogger, type LogLevel } from './default-logger.js';
+export { createDefaultEventLogger } from './default-logger.js';


### PR DESCRIPTION
## Summary
- New `default-logger.ts` with `createDefaultEventLogger(level)` supporting verbose/normal/quiet/false log levels with chalk-colored console output
- `WorkflowRunOptions` gains `logLevel` and `renderer` fields
- `run()` auto-registers the default logger (additive with user `onEvent`), supports `renderer: "listr"` with dynamic import + Promise.all + unmount
- `toConfig()` defaults `errorHandling` to `{ strategy: 'retry', maxRetries: 2, retryDelayMs: 10_000 }` when unset

## Test plan
- [ ] Run a workflow with no options — should see colored step lifecycle output at "normal" level
- [ ] Run with `logLevel: "verbose"` — should see broker-level events
- [ ] Run with `logLevel: "quiet"` — should only see errors and final status
- [ ] Run with `logLevel: false` — should see no console output
- [ ] Run with `renderer: "listr"` — should see listr2 UI without garbled console.log lines
- [ ] Run with `onEvent` callback — should fire alongside default logger (additive)
- [ ] Verify `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
