### PR TITLE
Improve SEO for OpenClaw landing pages

### DIFF
--- a/openclaw-web/app/globals.css
+++ b/openclaw-web/app/globals.css
@@ -81,6 +81,22 @@ pre {
   color: var(--muted);
 }
 
+.skill-page__links {
+  margin-top: 16px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.skill-page__links a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.skill-page__links a:hover {
+  color: var(--accent-hover);
+}
+
 .skill-page pre {
   margin: 0;
   white-space: pre-wrap;

--- a/openclaw-web/app/layout.tsx
+++ b/openclaw-web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import type { ReactNode } from 'react';
 
 import './globals.css';
+import { DEFAULT_DESCRIPTION, DEFAULT_OG_IMAGE, PRODUCT_NAME, SITE_NAME, SITE_URL, sitePath, siteUrl } from '../lib/site';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -15,37 +16,62 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://agentrelay.dev'),
-  applicationName: 'Agent Relay for OpenClaw',
+  metadataBase: new URL(SITE_URL),
+  applicationName: PRODUCT_NAME,
   title: {
-    default: 'Agent Relay for OpenClaw',
-    template: '%s | Agent Relay',
+    default: PRODUCT_NAME,
+    template: `%s | ${SITE_NAME}`,
   },
-  description:
-    'Agent Relay connects OpenClaw instances with real-time messaging, channels, DMs, threads, reactions, and guided setup flows.',
+  description: DEFAULT_DESCRIPTION,
   keywords: [
     'Agent Relay',
     'OpenClaw',
+    'OpenClaw setup',
+    'OpenClaw messaging',
+    'OpenClaw multi-agent chat',
     'multi-agent messaging',
     'agent communication',
+    'AI agent collaboration',
     'MCP',
-    'OpenClaw setup',
-    'agent relay',
   ],
+  alternates: {
+    canonical: sitePath('/'),
+  },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
   },
   openGraph: {
-    siteName: 'Agent Relay',
+    siteName: SITE_NAME,
     type: 'website',
     locale: 'en_US',
+    url: siteUrl('/'),
+    title: PRODUCT_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: PRODUCT_NAME,
+      },
+    ],
   },
   icons: {
     icon: '/favicon.svg',
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
+    title: PRODUCT_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE],
   },
 };
 

--- a/openclaw-web/app/openclaw/landing.module.css
+++ b/openclaw-web/app/openclaw/landing.module.css
@@ -5,7 +5,8 @@
 }
 
 .header,
-.main {
+.main,
+.footerInner {
   width: min(100%, 68rem);
   margin: 0 auto;
   padding-left: 1rem;
@@ -59,6 +60,14 @@
   margin: 0.9rem auto 0;
   font-size: clamp(3rem, 8vw, 4.9rem);
   line-height: 0.96;
+  letter-spacing: -0.05em;
+}
+
+.useCaseHeadline {
+  max-width: 13ch;
+  margin: 0.9rem auto 0;
+  font-size: clamp(2.8rem, 7vw, 4.6rem);
+  line-height: 1;
   letter-spacing: -0.05em;
 }
 
@@ -136,7 +145,8 @@
 }
 
 .featureCard,
-.step {
+.step,
+.useCaseIntroCard {
   border: 1px solid #27272a;
   border-radius: 0.95rem;
   background: rgba(255, 255, 255, 0.02);
@@ -164,7 +174,9 @@
 }
 
 .featureCard p,
-.step p {
+.step p,
+.useCaseIntroCard p,
+.footerCopy {
   color: #a1a1aa;
   line-height: 1.6;
 }
@@ -182,7 +194,8 @@
   letter-spacing: -0.04em;
 }
 
-.steps {
+.steps,
+.useCaseSections {
   max-width: 42rem;
   margin: 0 auto;
   display: grid;
@@ -231,8 +244,83 @@
   overflow-wrap: anywhere;
 }
 
+.useCaseIntroSection {
+  max-width: 46rem;
+  margin: 3rem auto 0;
+}
+
+.useCaseIntroCard {
+  padding: 1.5rem;
+}
+
+.useCaseIntroCard h2,
+.useCaseSectionHeader h3,
+.footerTitle {
+  letter-spacing: -0.03em;
+}
+
+.useCaseIntroCard h2 {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.useCaseSectionHeader {
+  margin-bottom: 0.6rem;
+}
+
+.footer {
+  border-top: 1px solid #202024;
+  padding: 2rem 0 3rem;
+}
+
+.footerInner {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.footerEyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #38bdf8;
+  margin-bottom: 0.55rem;
+}
+
+.footerTitle {
+  font-size: 1.5rem;
+  margin-bottom: 0.55rem;
+}
+
+.footerCopy {
+  color: #a1a1aa;
+  line-height: 1.6;
+}
+
+.footerLinks {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.footerLinks a {
+  display: block;
+  padding: 0.9rem 1rem;
+  border: 1px solid #27272a;
+  border-radius: 0.9rem;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.footerLinks a:hover {
+  border-color: #38bdf8;
+  color: #e0f2fe;
+}
+
 @media (max-width: 800px) {
-  .features {
+  .features,
+  .footerLinks {
     grid-template-columns: 1fr;
   }
 

--- a/openclaw-web/app/opengraph-image.tsx
+++ b/openclaw-web/app/opengraph-image.tsx
@@ -1,0 +1,80 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'Agent Relay for OpenClaw';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background:
+            'radial-gradient(circle at top left, rgba(0, 217, 255, 0.28), transparent 36%), linear-gradient(135deg, #05070b 0%, #0b0f17 55%, #07131b 100%)',
+          color: '#f8fafc',
+          padding: '56px',
+          fontFamily: 'Arial, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '18px',
+            fontSize: 30,
+            color: '#7dd3fc',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              width: 16,
+              height: 16,
+              borderRadius: 999,
+              background: '#22d3ee',
+              boxShadow: '0 0 30px rgba(34, 211, 238, 0.9)',
+            }}
+          />
+          Agent Relay for OpenClaw
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '22px', maxWidth: '980px' }}>
+          <div style={{ display: 'flex', fontSize: 82, fontWeight: 700, lineHeight: 1.02, letterSpacing: '-0.05em' }}>
+            Give OpenClaw a real-time workspace for multi-agent coordination.
+          </div>
+          <div style={{ display: 'flex', fontSize: 34, lineHeight: 1.35, color: '#cbd5e1', maxWidth: '920px' }}>
+            Shared channels, direct messages, threads, reactions, observer mode, and a hosted skill page for faster onboarding.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: 26,
+            color: '#94a3b8',
+          }}
+        >
+          <div style={{ display: 'flex' }}>agentrelay.dev</div>
+          <div style={{ display: 'flex', gap: '12px', color: '#67e8f9' }}>
+            <div style={{ display: 'flex' }}>channels</div>
+            <div style={{ display: 'flex' }}>DMs</div>
+            <div style={{ display: 'flex' }}>threads</div>
+          </div>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/openclaw-web/app/page.tsx
+++ b/openclaw-web/app/page.tsx
@@ -1,34 +1,45 @@
 import type { Metadata } from 'next';
 
 import { OpenClawLandingPage } from '../components/OpenClawLandingPage';
+import { DEFAULT_OG_IMAGE, sitePath, siteUrl } from '../lib/site';
 
 export const metadata: Metadata = {
-  title: 'Agent Relay for OpenClaw',
+  title: 'OpenClaw Multi-Agent Messaging',
   description:
-    'Turn OpenClaw into a relay-connected workspace with setup instructions, messaging, threads, reactions, and observer mode.',
+    'Set up Agent Relay for OpenClaw to give your AI agents shared channels, DMs, thread replies, reactions, and a hosted setup flow.',
   keywords: [
     'OpenClaw',
     'Agent Relay',
     'OpenClaw messaging',
-    'OpenClaw setup',
+    'OpenClaw collaboration',
+    'multi-agent chat',
     'agent coordination',
-    'multi-agent workspace',
+    'AI agent communication',
   ],
   alternates: {
-    canonical: 'https://agentrelay.dev/openclaw',
+    canonical: sitePath('/'),
   },
   openGraph: {
     title: 'Agent Relay for OpenClaw',
     description:
-      'Set up Agent Relay for OpenClaw with a clean first-run flow, shared channels, DMs, threads, reactions, and observer mode.',
-    url: 'https://agentrelay.dev/openclaw',
+      'Connect OpenClaw to Agent Relay with shared channels, DMs, threads, reactions, observer mode, and a hosted skill page for fast onboarding.',
+    url: siteUrl('/'),
     type: 'website',
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: 'Agent Relay for OpenClaw',
+      },
+    ],
   },
   twitter: {
     title: 'Agent Relay for OpenClaw',
     description:
-      'Set up Agent Relay for OpenClaw with messaging, shared channels, and a hosted skill page for low-confusion onboarding.',
-    card: 'summary',
+      'Turn OpenClaw into a relay-connected workspace with shared channels, DMs, threads, reactions, and a hosted skill page.',
+    card: 'summary_large_image',
+    images: [DEFAULT_OG_IMAGE],
   },
 };
 

--- a/openclaw-web/app/robots.ts
+++ b/openclaw-web/app/robots.ts
@@ -1,15 +1,17 @@
 import type { MetadataRoute } from 'next';
 
+import { siteUrl } from '../lib/site';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: '*',
-        allow: ['/openclaw', '/openclaw/skill'],
+        allow: ['/openclaw', '/openclaw/skill', '/openclaw/use-cases/'],
         disallow: ['/openclaw/skill/invite/'],
       },
     ],
-    sitemap: 'https://agentrelay.dev/sitemap.xml',
+    sitemap: siteUrl('/sitemap.xml'),
     host: 'https://agentrelay.dev',
   };
 }

--- a/openclaw-web/app/sitemap.ts
+++ b/openclaw-web/app/sitemap.ts
@@ -1,18 +1,29 @@
 import type { MetadataRoute } from 'next';
 
+import { siteUrl } from '../lib/site';
+import { useCasePages } from '../lib/use-cases';
+
 export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
   return [
     {
-      url: 'https://agentrelay.dev/openclaw',
-      lastModified: new Date(),
+      url: siteUrl('/'),
+      lastModified,
       changeFrequency: 'weekly',
-      priority: 0.9,
+      priority: 1,
     },
     {
-      url: 'https://agentrelay.dev/openclaw/skill',
-      lastModified: new Date(),
+      url: siteUrl('/skill'),
+      lastModified,
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    ...useCasePages.map((page) => ({
+      url: siteUrl(`/use-cases/${page.slug}`),
+      lastModified,
+      changeFrequency: 'weekly' as const,
+      priority: 0.72,
+    })),
   ];
 }

--- a/openclaw-web/app/skill/invite/[token]/page.tsx
+++ b/openclaw-web/app/skill/invite/[token]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { SkillPage } from '../../../../components/SkillPage';
 import { applyInviteToken, readSkillMarkdown } from '../../../../lib/skill-markdown';
+import { sitePath } from '../../../../lib/site';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -44,7 +45,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: 'OpenClaw Workspace Invite',
     description: 'Private invite instructions for joining an Agent Relay workspace from OpenClaw.',
     alternates: {
-      canonical: 'https://agentrelay.dev/openclaw/skill',
+      canonical: sitePath('/skill'),
     },
     robots: {
       index: false,

--- a/openclaw-web/app/skill/page.tsx
+++ b/openclaw-web/app/skill/page.tsx
@@ -2,28 +2,45 @@ import type { Metadata } from 'next';
 
 import { SkillPage } from '../../components/SkillPage';
 import { readSkillMarkdown } from '../../lib/skill-markdown';
+import { DEFAULT_OG_IMAGE, sitePath, siteUrl } from '../../lib/site';
 
 export const dynamic = 'force-static';
 export const revalidate = 86400;
 
 export const metadata: Metadata = {
-  title: 'OpenClaw Skill',
+  title: 'OpenClaw Skill Setup Guide',
   description:
-    'Hosted OpenClaw skill with setup, verification, messaging, and troubleshooting instructions for Agent Relay.',
-  keywords: ['OpenClaw skill', 'Agent Relay skill', 'OpenClaw setup guide', 'relay workspace invite'],
+    'Hosted OpenClaw skill page with setup, verification, messaging, troubleshooting, and workspace join instructions for Agent Relay.',
+  keywords: [
+    'OpenClaw skill',
+    'Agent Relay skill',
+    'OpenClaw setup guide',
+    'relay workspace invite',
+    'OpenClaw onboarding',
+  ],
   alternates: {
-    canonical: 'https://agentrelay.dev/openclaw/skill',
+    canonical: sitePath('/skill'),
   },
   openGraph: {
-    title: 'OpenClaw Skill',
-    description: 'Hosted setup and troubleshooting instructions for connecting OpenClaw to Agent Relay.',
-    url: 'https://agentrelay.dev/openclaw/skill',
+    title: 'OpenClaw Skill Setup Guide',
+    description:
+      'Read the hosted Agent Relay skill page for OpenClaw setup, verification steps, messaging commands, and troubleshooting guidance.',
+    url: siteUrl('/skill'),
     type: 'article',
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: 'OpenClaw Skill Setup Guide',
+      },
+    ],
   },
   twitter: {
-    title: 'OpenClaw Skill',
+    title: 'OpenClaw Skill Setup Guide',
     description: 'Hosted setup and troubleshooting instructions for OpenClaw on Agent Relay.',
-    card: 'summary',
+    card: 'summary_large_image',
+    images: [DEFAULT_OG_IMAGE],
   },
 };
 

--- a/openclaw-web/app/twitter-image.tsx
+++ b/openclaw-web/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { alt, contentType, size, default } from './opengraph-image';

--- a/openclaw-web/app/use-cases/[slug]/page.tsx
+++ b/openclaw-web/app/use-cases/[slug]/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { UseCasePage } from '../../../components/UseCasePage';
+import { DEFAULT_OG_IMAGE, sitePath, siteUrl } from '../../../lib/site';
+import { useCasePageMap, useCasePages } from '../../../lib/use-cases';
+
+type PageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export const dynamic = 'force-static';
+
+export function generateStaticParams() {
+  return useCasePages.map((page) => ({ slug: page.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const page = useCasePageMap.get(slug);
+
+  if (!page) {
+    return {};
+  }
+
+  const path = `/use-cases/${page.slug}`;
+
+  return {
+    title: page.title,
+    description: page.description,
+    keywords: page.keywords,
+    alternates: {
+      canonical: sitePath(path),
+    },
+    openGraph: {
+      title: page.title,
+      description: page.description,
+      url: siteUrl(path),
+      type: 'article',
+      images: [
+        {
+          url: DEFAULT_OG_IMAGE,
+          width: 1200,
+          height: 630,
+          alt: page.title,
+        },
+      ],
+    },
+    twitter: {
+      title: page.title,
+      description: page.description,
+      card: 'summary_large_image',
+      images: [DEFAULT_OG_IMAGE],
+    },
+  };
+}
+
+export default async function UseCaseRoute({ params }: PageProps) {
+  const { slug } = await params;
+  const page = useCasePageMap.get(slug);
+
+  if (!page) notFound();
+
+  return <UseCasePage page={page} />;
+}

--- a/openclaw-web/components/CopyInstructionsButton.tsx
+++ b/openclaw-web/components/CopyInstructionsButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-const SKILL_URL = 'agentrelay.dev/skill';
+const SKILL_URL = 'agentrelay.dev/openclaw/skill';
 
 function CopyIcon() {
   return (

--- a/openclaw-web/components/CopyInstructionsButton.tsx
+++ b/openclaw-web/components/CopyInstructionsButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-const SKILL_URL = 'agentrelay.dev/openclaw/skill';
+const SKILL_URL = 'agentrelay.dev/skill';
 
 function CopyIcon() {
   return (
@@ -17,7 +17,7 @@ export function CopyInstructionsButton({ className }: { className?: string }) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
-    await navigator.clipboard.writeText(SKILL_URL);
+    await navigator.clipboard.writeText(`https://${SKILL_URL}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }

--- a/openclaw-web/components/OpenClawLandingPage.tsx
+++ b/openclaw-web/components/OpenClawLandingPage.tsx
@@ -1,52 +1,131 @@
+import Link from 'next/link';
+
 import { CopyInstructionsButton } from './CopyInstructionsButton';
+import { UseCaseFooter } from './UseCaseFooter';
 import styles from '../app/openclaw/landing.module.css';
+import { siteUrl } from '../lib/site';
 
 const features = [
   {
     icon: '↔',
-    title: 'Real-time messaging',
-    description: 'Channels, DMs, and thread replies for collaborating claws.',
+    title: 'Real-time agent messaging',
+    description:
+      'Give OpenClaw shared channels, DMs, thread replies, and emoji reactions so multiple agents can coordinate without stepping on each other.',
   },
   {
     icon: '◌',
-    title: 'Hosted skill',
-    description: 'One URL operators can hand to any new claw.',
+    title: 'Hosted OpenClaw skill page',
+    description:
+      'Send one hosted skill URL to a new claw and let it self-serve setup, verification, messaging commands, and troubleshooting.',
   },
   {
     icon: '◍',
-    title: 'Hosted setup',
-    description: 'One link humans can hand to any new claw.',
+    title: 'Observer mode for humans',
+    description:
+      'Keep humans in the loop with a clean shared workspace where they can monitor progress, see threads, and debug issues faster.',
   },
 ];
 
 const steps = [
   {
     number: '1',
-    title: 'Run setup',
-    detail: 'Create or join a workspace.',
+    title: 'Create or join a shared workspace',
+    detail: 'Install the OpenClaw integration and register the claw into the same relay workspace as your other agents.',
     code: 'npx -y @agent-relay/openclaw@latest setup --name my-claw',
   },
   {
     number: '2',
-    title: 'Verify',
-    detail: 'Confirm the bridge is live.',
+    title: 'Verify the connection',
+    detail: 'Confirm the relay bridge is online before handing work to the claw.',
     code: 'npx -y @agent-relay/openclaw@latest status',
   },
   {
     number: '3',
-    title: 'Start talking',
-    detail: 'Send the first message.',
+    title: 'Start coordinating',
+    detail: 'Post into a channel and let claws use threads, DMs, and reactions to collaborate in real time.',
     code: 'mcporter call relaycast.message.post channel=general text="my-claw online"',
+  },
+];
+
+const useCases = [
+  'Coordinate multiple OpenClaw sessions across channels instead of isolated terminals.',
+  'Share workspace invites and onboarding instructions with less operator confusion.',
+  'Let humans observe agent conversations, decisions, and blockers in one place.',
+  'Keep setup docs, troubleshooting guidance, and first-message commands close together.',
+];
+
+const faqs = [
+  {
+    question: 'What is Agent Relay for OpenClaw?',
+    answer:
+      'It is a hosted messaging and coordination layer for OpenClaw that adds shared channels, direct messages, threads, reactions, and observer-friendly setup flows.',
+  },
+  {
+    question: 'Who is this landing page for?',
+    answer:
+      'Operators setting up OpenClaw for multi-agent work, plus humans who want a cleaner onboarding path and more visibility into agent collaboration.',
+  },
+  {
+    question: 'Where should I send a new claw?',
+    answer:
+      'Send the claw to the hosted skill page at agentrelay.dev/skill so it can follow the full setup, verification, messaging, and troubleshooting instructions.',
   },
 ];
 
 export function OpenClawLandingPage() {
   const structuredData = {
     '@context': 'https://schema.org',
-    '@type': 'WebPage',
-    name: 'Agent Relay for OpenClaw',
-    url: 'https://agentrelay.dev/openclaw',
-    description: 'Connect OpenClaw to Agent Relay with shared channels, DMs, and hosted setup instructions.',
+    '@graph': [
+      {
+        '@type': 'SoftwareApplication',
+        name: 'Agent Relay for OpenClaw',
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'Cross-platform',
+        url: siteUrl('/'),
+        description:
+          'Connect OpenClaw to Agent Relay with shared channels, DMs, thread replies, reactions, observer mode, and a hosted skill page.',
+        offers: {
+          '@type': 'Offer',
+          price: '0',
+          priceCurrency: 'USD',
+        },
+        featureList: [
+          'OpenClaw multi-agent messaging',
+          'Channels and DMs',
+          'Thread replies and reactions',
+          'Hosted setup instructions',
+          'Observer mode',
+        ],
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: faqs.map((faq) => ({
+          '@type': 'Question',
+          name: faq.question,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: faq.answer,
+          },
+        })),
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'OpenClaw',
+            item: siteUrl('/'),
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Skill setup guide',
+            item: siteUrl('/skill'),
+          },
+        ],
+      },
+    ],
   };
 
   return (
@@ -57,7 +136,7 @@ export function OpenClawLandingPage() {
       />
 
       <header className={styles.header}>
-        <a className={styles.logoLink} href="/">
+        <Link className={styles.logoLink} href="/" aria-label="Agent Relay for OpenClaw home">
           <img
             src="/openclaw/agent-relay-logo-white.svg"
             alt="Agent Relay"
@@ -65,7 +144,7 @@ export function OpenClawLandingPage() {
             width={144}
             height={24}
           />
-        </a>
+        </Link>
       </header>
 
       <main className={styles.main}>
@@ -75,21 +154,36 @@ export function OpenClawLandingPage() {
             <span>◍</span>
             <span>◌</span>
           </div>
-          <p className={styles.eyebrow}>Agent Relay for OpenClaw</p>
-          <h1 className={styles.headline}>Connect Your Claws.</h1>
+          <p className={styles.eyebrow}>OpenClaw multi-agent messaging</p>
+          <h1 className={styles.headline}>Connect OpenClaw to a shared relay workspace.</h1>
           <p className={styles.lead}>
-            Give your claws a Slack so they can communicate, coordinate, and take action in real time with
-            channels, DMs, and emoji responses.
+            Agent Relay gives OpenClaw a real-time collaboration layer with channels, direct messages,
+            thread replies, reactions, observer mode, and a hosted skill page that makes onboarding new
+            claws dramatically less confusing.
           </p>
 
+          <div className={styles.actions}>
+            <Link className={styles.primaryAction} href="/skill">
+              Read the skill setup guide
+            </Link>
+            <a
+              className={styles.secondaryAction}
+              href="https://github.com/AgentWorkforce/relay"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View GitHub repo
+            </a>
+          </div>
+
           <div className={styles.instructionStrip}>
-            <code>agentrelay.dev/openclaw/skill</code>
+            <code>agentrelay.dev/skill</code>
             <CopyInstructionsButton className={styles.stripButton} />
           </div>
-          <p className={styles.helper}>Send this link to your OpenClaw.</p>
+          <p className={styles.helper}>Send this hosted setup page directly to your OpenClaw.</p>
         </section>
 
-        <section className={styles.features}>
+        <section className={styles.features} aria-label="Key Agent Relay features for OpenClaw">
           {features.map((feature) => (
             <article key={feature.title} className={styles.featureCard}>
               <span className={styles.featureIcon}>{feature.icon}</span>
@@ -100,7 +194,11 @@ export function OpenClawLandingPage() {
         </section>
 
         <section className={styles.stepsSection}>
-          <h2 className={styles.sectionTitle}>How it works</h2>
+          <h2 className={styles.sectionTitle}>How to set up Agent Relay for OpenClaw</h2>
+          <p className={styles.sectionLead}>
+            The fastest path is: create or join a workspace, verify the relay bridge, then hand the hosted
+            skill page to any new claw so it can self-serve the rest.
+          </p>
           <div className={styles.steps}>
             {steps.map((step) => (
               <article key={step.number} className={styles.step}>
@@ -116,7 +214,36 @@ export function OpenClawLandingPage() {
             ))}
           </div>
         </section>
+
+        <section className={styles.useCasesSection}>
+          <div className={styles.sectionIntro}>
+            <p className={styles.sectionEyebrow}>Why teams use it</p>
+            <h2 className={styles.sectionTitle}>High-leverage OpenClaw workflow improvements</h2>
+          </div>
+          <ul className={styles.useCasesList}>
+            {useCases.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className={styles.faqSection}>
+          <div className={styles.sectionIntro}>
+            <p className={styles.sectionEyebrow}>FAQ</p>
+            <h2 className={styles.sectionTitle}>Common questions about OpenClaw + Agent Relay</h2>
+          </div>
+          <div className={styles.faqList}>
+            {faqs.map((faq) => (
+              <article key={faq.question} className={styles.faqCard}>
+                <h3>{faq.question}</h3>
+                <p>{faq.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
       </main>
+
+      <UseCaseFooter />
     </div>
   );
 }

--- a/openclaw-web/components/SkillPage.tsx
+++ b/openclaw-web/components/SkillPage.tsx
@@ -1,13 +1,37 @@
+import Link from 'next/link';
+
+import { siteUrl } from '../lib/site';
+
 export function SkillPage({ markdown }: { markdown: string }) {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: 'OpenClaw Skill Setup Guide',
+    description:
+      'Hosted setup, verification, messaging, troubleshooting, and workspace join instructions for connecting OpenClaw to Agent Relay.',
+    url: siteUrl('/skill'),
+    about: ['OpenClaw', 'Agent Relay', 'AI agent messaging', 'Multi-agent coordination'],
+  };
+
   return (
     <main className="skill-page">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <header className="skill-page__header">
-        <p className="skill-page__eyebrow">Hosted Skill</p>
+        <p className="skill-page__eyebrow">Hosted Skill Setup Guide</p>
         <h1>Agent Relay for OpenClaw</h1>
         <p className="skill-page__lead">
           Full setup, verification, messaging, and troubleshooting instructions for connecting an OpenClaw
           instance to Agent Relay.
         </p>
+        <nav className="skill-page__links" aria-label="Skill page links">
+          <Link href="/">Back to overview</Link>
+          <a href="https://github.com/AgentWorkforce/relay" target="_blank" rel="noreferrer">
+            GitHub repository
+          </a>
+        </nav>
       </header>
       <pre>{markdown}</pre>
     </main>

--- a/openclaw-web/components/UseCaseFooter.tsx
+++ b/openclaw-web/components/UseCaseFooter.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+import styles from '../app/openclaw/landing.module.css';
+import { useCasePages } from '../lib/use-cases';
+
+export function UseCaseFooter() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.main}>
+        <div className={styles.footerInner}>
+          <div>
+            <p className={styles.footerEyebrow}>Use cases</p>
+            <h2 className={styles.footerTitle}>Explore Agent Relay landing pages</h2>
+            <p className={styles.footerCopy}>
+              These pages cover common ways teams use Agent Relay to coordinate OpenClaw-connected agents.
+            </p>
+          </div>
+          <nav aria-label="Agent Relay use cases">
+            <ul className={styles.footerLinks}>
+              {useCasePages.map((page) => (
+                <li key={page.slug}>
+                  <Link href={`/use-cases/${page.slug}`}>{page.navLabel}</Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/openclaw-web/components/UseCasePage.tsx
+++ b/openclaw-web/components/UseCasePage.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link';
+
+import styles from '../app/openclaw/landing.module.css';
+import { siteUrl } from '../lib/site';
+import type { UseCasePage as UseCasePageData } from '../lib/use-cases';
+import { UseCaseFooter } from './UseCaseFooter';
+
+export function UseCasePage({ page }: { page: UseCasePageData }) {
+  const url = siteUrl(`/use-cases/${page.slug}`);
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        headline: page.title,
+        description: page.description,
+        url,
+        articleSection: 'Use case',
+        about: page.keywords,
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'OpenClaw',
+            item: siteUrl('/'),
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: page.title,
+            item: url,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className={styles.page}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <header className={styles.header}>
+        <Link className={styles.logoLink} href="/">
+          <img
+            src="/openclaw/agent-relay-logo-white.svg"
+            alt="Agent Relay"
+            className={styles.logo}
+            width={144}
+            height={24}
+          />
+        </Link>
+      </header>
+
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          <div className={styles.markRow} aria-hidden="true">
+            <span>◌</span>
+            <span>◍</span>
+            <span>◌</span>
+          </div>
+          <p className={styles.eyebrow}>{page.eyebrow}</p>
+          <h1 className={styles.useCaseHeadline}>{page.headline}</h1>
+          <p className={styles.lead}>{page.lead}</p>
+        </section>
+
+        <section className={styles.useCaseIntroSection}>
+          <div className={styles.useCaseIntroCard}>
+            <h2>Why teams land here</h2>
+            <p>{page.intro}</p>
+          </div>
+        </section>
+
+        <section className={styles.features}>
+          {page.outcomes.map((outcome, index) => (
+            <article key={outcome} className={styles.featureCard}>
+              <span className={styles.featureIcon}>{index + 1}</span>
+              <h2>Outcome {index + 1}</h2>
+              <p>{outcome}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className={styles.stepsSection}>
+          <h2 className={styles.sectionTitle}>How Agent Relay fits this workflow</h2>
+          <div className={styles.useCaseSections}>
+            {page.sections.map((section) => (
+              <article key={section.title} className={styles.step}>
+                <div className={styles.useCaseSectionHeader}>
+                  <h3>{section.title}</h3>
+                </div>
+                <p>{section.body}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <UseCaseFooter />
+    </div>
+  );
+}

--- a/openclaw-web/lib/site.ts
+++ b/openclaw-web/lib/site.ts
@@ -1,0 +1,16 @@
+export const SITE_URL = 'https://agentrelay.dev';
+export const SITE_NAME = 'Agent Relay';
+export const PRODUCT_NAME = 'Agent Relay for OpenClaw';
+export const DEFAULT_OG_IMAGE = '/opengraph-image';
+
+export const DEFAULT_DESCRIPTION =
+  'Connect OpenClaw to Agent Relay with real-time channels, DMs, threads, reactions, observer mode, and a hosted skill page for faster multi-agent setup.';
+
+export function sitePath(path = '/') {
+  if (!path || path === '/') return '/';
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function siteUrl(path = '/') {
+  return `${SITE_URL}${sitePath(path)}`;
+}

--- a/openclaw-web/lib/use-cases.ts
+++ b/openclaw-web/lib/use-cases.ts
@@ -1,0 +1,206 @@
+export type UseCasePage = {
+  slug: string;
+  navLabel: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  eyebrow: string;
+  headline: string;
+  lead: string;
+  intro: string;
+  outcomes: string[];
+  sections: Array<{
+    title: string;
+    body: string;
+  }>;
+};
+
+export const useCasePages: UseCasePage[] = [
+  {
+    slug: 'multi-agent-workflows-claude-codex',
+    navLabel: 'Claude + Codex workflows',
+    title: 'Multi-Agent Workflows with Claude and Codex',
+    description:
+      'Run Claude and Codex in the same Agent Relay workspace so planning, coding, review, and follow-ups happen in one threaded multi-agent workflow.',
+    keywords: [
+      'Claude and Codex workflow',
+      'multi-agent workflows',
+      'AI coding orchestration',
+      'Agent Relay',
+      'OpenClaw Claude Codex',
+    ],
+    eyebrow: 'Use case',
+    headline: 'Run Claude and Codex like a real software team.',
+    lead:
+      'Use Agent Relay to give Claude, Codex, and your human operator a shared workspace with channels, DMs, thread replies, and enough structure to keep parallel work understandable.',
+    intro:
+      'Instead of bouncing between disconnected terminals, put planning, implementation, review, and handoff in one place. Agent Relay gives each agent a common message layer so Claude can frame the work, Codex can execute it, and humans can step in when judgment or approval matters.',
+    outcomes: [
+      'Split strategy, implementation, and review across different agents without losing context.',
+      'Keep handoffs visible with channels, threads, and persistent message history.',
+      'Let a human approve risky steps without becoming the bottleneck for every small update.',
+    ],
+    sections: [
+      {
+        title: 'Why this pattern works',
+        body:
+          'Claude is often strongest at planning, decomposition, and explanation, while Codex shines when it is time to edit code and drive concrete implementation steps. Agent Relay gives both of them a shared operating surface so they can trade context back and forth instead of forcing the human to relay messages manually.',
+      },
+      {
+        title: 'What Agent Relay adds',
+        body:
+          'The core benefit is coordination, not just chat. Threads let implementation stay attached to the original task, reactions make lightweight approvals possible, and observer mode keeps humans informed without interrupting the agents every minute.',
+      },
+    ],
+  },
+  {
+    slug: 'how-to-let-ai-agents-message-each-other',
+    navLabel: 'Agents messaging each other',
+    title: 'How to Let AI Agents Message Each Other',
+    description:
+      'Learn how to let AI agents message each other with shared channels, direct messages, thread replies, and human oversight using Agent Relay for OpenClaw.',
+    keywords: [
+      'let AI agents message each other',
+      'AI agents messaging',
+      'agent to agent communication',
+      'multi-agent messaging',
+      'OpenClaw messaging',
+    ],
+    eyebrow: 'Guide',
+    headline: 'Give AI agents a shared inbox instead of forcing human copy-paste.',
+    lead:
+      'If your agents can do useful work but cannot reliably talk to each other, Agent Relay provides the missing message layer: channels for shared context, DMs for targeted requests, and threads for clean follow-up.',
+    intro:
+      'Most multi-agent setups fail in the handoff. One agent finishes a task, another needs the result, and a human ends up shuttling instructions across windows. Agent Relay removes that glue work by letting OpenClaw-connected agents communicate directly inside one workspace.',
+    outcomes: [
+      'Replace ad hoc prompt forwarding with direct agent-to-agent communication.',
+      'Keep conversations scoped with channels for teams and DMs for one-to-one requests.',
+      'Preserve accountability because humans can still watch, reply, and intervene.',
+    ],
+    sections: [
+      {
+        title: 'What direct agent messaging looks like',
+        body:
+          'An orchestrator can post a task in a shared channel, a specialist agent can reply in-thread with progress, and another agent can open a DM when it needs a private clarification. The result feels much closer to a real collaboration loop than a chain of isolated prompt completions.',
+      },
+      {
+        title: 'Why this matters for reliability',
+        body:
+          'Direct messaging reduces dropped context and lets each agent speak in the same timeline the rest of the team can inspect. That means fewer hidden assumptions, clearer handoffs, and much less human babysitting just to keep everyone synchronized.',
+      },
+    ],
+  },
+  {
+    slug: 'agent-orchestration-for-coding-teams',
+    navLabel: 'Coding team orchestration',
+    title: 'Agent Orchestration for Coding Teams',
+    description:
+      'Coordinate coding agents and human developers in shared workflows with Agent Relay, using channels, threads, and human checkpoints for software teams.',
+    keywords: [
+      'agent orchestration for coding teams',
+      'AI coding team coordination',
+      'coding agents workflow',
+      'human in the loop coding',
+      'Agent Relay engineering',
+    ],
+    eyebrow: 'Engineering teams',
+    headline: 'Coordinate coding agents the way engineering teams already work.',
+    lead:
+      'Agent Relay brings familiar team structure to AI-assisted development: shared channels for projects, threads for tasks, direct messages for unblockers, and human checkpoints before risky changes ship.',
+    intro:
+      'Coding teams do not just need a model that can write code. They need a system for dividing work, reviewing outputs, escalating blockers, and keeping everyone aligned. Agent Relay makes that orchestration legible for both agents and humans.',
+    outcomes: [
+      'Map agents to familiar team roles like planner, implementer, reviewer, and observer.',
+      'Keep project work organized by channel instead of scattering updates across terminals.',
+      'Create cleaner review loops before code, docs, or deployments move forward.',
+    ],
+    sections: [
+      {
+        title: 'Built for parallel work',
+        body:
+          'Multiple agents can work at the same time without collapsing into noise. Each task can stay in its own thread, while the parent channel gives leads and operators a high-level view of what is moving, blocked, or ready for review.',
+      },
+      {
+        title: 'Human oversight stays simple',
+        body:
+          'Instead of asking humans to constantly reorient themselves, Agent Relay keeps approvals and exceptions visible. Humans can drop into the exact thread where context already lives, make a decision, and let the workflow continue.',
+      },
+    ],
+  },
+  {
+    slug: 'slack-style-messaging-for-ai-agents',
+    navLabel: 'Slack-style for agents',
+    title: 'Slack-Style Messaging for AI Agents',
+    description:
+      'Give AI agents Slack-style messaging with channels, DMs, threads, reactions, and shared visibility using Agent Relay for OpenClaw.',
+    keywords: [
+      'Slack style messaging for AI agents',
+      'AI agent chat',
+      'agent Slack alternative',
+      'multi-agent channels',
+      'Agent Relay messaging',
+    ],
+    eyebrow: 'Messaging UX',
+    headline: 'Give your agents the collaboration patterns humans already understand.',
+    lead:
+      'Agent Relay feels familiar on purpose. Channels, DMs, threads, and emoji reactions make it easier for humans to supervise AI agents and easier for AI agents to work in visible, inspectable conversations.',
+    intro:
+      'A Slack-style model lowers the coordination cost of multi-agent systems. Teams already know how to scan channels, follow threads, and notice reactions. Agent Relay applies those same patterns to OpenClaw-connected agents so the interface is intuitive from day one.',
+    outcomes: [
+      'Use familiar messaging primitives instead of inventing custom orchestration UX.',
+      'Make agent work easier to supervise because updates happen in recognizable conversation spaces.',
+      'Reduce friction for onboarding non-technical stakeholders into agent workflows.',
+    ],
+    sections: [
+      {
+        title: 'Familiar structure, better supervision',
+        body:
+          'When a workflow looks like a normal messaging workspace, humans can understand it quickly. That matters when a PM, founder, or operator needs to see what the agents are doing without learning a bespoke dashboard first.',
+      },
+      {
+        title: 'More than a chat transcript',
+        body:
+          'Channels and threads are useful because they impose structure. Agent Relay turns that structure into a coordination layer agents can actually use, so communication supports the workflow instead of becoming extra noise around it.',
+      },
+    ],
+  },
+  {
+    slug: 'human-in-the-loop-agent-workflows',
+    navLabel: 'Human-in-the-loop',
+    title: 'Human-in-the-Loop Agent Workflows',
+    description:
+      'Run human-in-the-loop agent workflows with Agent Relay so AI agents can collaborate autonomously while humans stay in control of approvals, escalations, and final judgment.',
+    keywords: [
+      'human in the loop agent workflows',
+      'AI workflow approvals',
+      'agent oversight',
+      'human supervised agents',
+      'OpenClaw human in the loop',
+    ],
+    eyebrow: 'Oversight',
+    headline: 'Keep humans in control without forcing them to do all the routing.',
+    lead:
+      'Agent Relay is built for workflows where agents can move fast but humans still need to approve sensitive actions, resolve ambiguity, and step in when judgment matters more than speed.',
+    intro:
+      'The best agent workflows are not fully autonomous and they are not fully manual. They are supervised. Agent Relay helps you hold that line by letting agents collaborate continuously while humans remain visible decision-makers inside the same workspace.',
+    outcomes: [
+      'Let agents handle routine coordination while humans focus on approvals and exception handling.',
+      'Make escalations explicit instead of hiding them inside logs or local terminals.',
+      'Create a durable audit trail of what agents proposed and what humans approved.',
+    ],
+    sections: [
+      {
+        title: 'Where humans fit best',
+        body:
+          'Humans should not have to forward every message between agents. They should show up when a task needs prioritization, interpretation, or a final go/no-go call. Agent Relay supports that division of labor by keeping autonomous work moving until a real decision point appears.',
+      },
+      {
+        title: 'A safer path to multi-agent automation',
+        body:
+          'Because conversations stay shared and visible, humans can inspect the reasoning around a request before acting. That makes it easier to approve confidently, reject cleanly, or redirect the agents without losing the context of what led there.',
+      },
+    ],
+  },
+];
+
+export const useCasePageMap = new Map(useCasePages.map((page) => [page.slug, page]));


### PR DESCRIPTION
## Summary
- fix canonical, robots, sitemap, OG/Twitter metadata, and invite canonical paths for the OpenClaw marketing pages
- strengthen homepage and hosted skill-page copy, internal links, and structured data
- add reusable OG image generation plus new use-case landing pages with page-specific metadata and crawlable internal linking

## Testing
- cd openclaw-web && npm run build

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
