### PR TITLE
Add OpenClaw use-case landing pages on web

### DIFF
--- a/web/app/openclaw/page.tsx
+++ b/web/app/openclaw/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { CopyInstructionsButton } from '../../components/CopyInstructionsButton';
+import { OpenClawUseCaseFooter } from '../../components/OpenClawUseCaseFooter';
 import { SiteFooter } from '../../components/SiteFooter';
 import { SiteNav } from '../../components/SiteNav';
 import s from './openclaw.module.css';
@@ -81,6 +82,8 @@ export default function OpenClawPage() {
             ))}
           </div>
         </section>
+
+        <OpenClawUseCaseFooter />
       </main>
 
       <SiteFooter />

--- a/web/app/openclaw/use-cases/[slug]/page.tsx
+++ b/web/app/openclaw/use-cases/[slug]/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { OpenClawUseCaseFooter } from '../../../../components/OpenClawUseCaseFooter';
+import { SiteFooter } from '../../../../components/SiteFooter';
+import { SiteNav } from '../../../../components/SiteNav';
+import { siteUrl } from '../../../../lib/site';
+import { useCasePageMap, useCasePages } from '../../../../lib/use-cases';
+import styles from './use-case.module.css';
+
+type PageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export function generateStaticParams() {
+  return useCasePages.map((page) => ({ slug: page.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const page = useCasePageMap.get(slug);
+
+  if (!page) {
+    return {
+      title: 'OpenClaw use case',
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const url = siteUrl(`/openclaw/use-cases/${page.slug}`);
+
+  return {
+    title: page.title,
+    description: page.description,
+    keywords: page.keywords,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: page.title,
+      description: page.description,
+      url,
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.title,
+      description: page.description,
+    },
+  };
+}
+
+export default async function OpenClawUseCasePage({ params }: PageProps) {
+  const { slug } = await params;
+  const page = useCasePageMap.get(slug);
+
+  if (!page) notFound();
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: page.title,
+    description: page.description,
+    url: siteUrl(`/openclaw/use-cases/${page.slug}`),
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'Agent Relay',
+      url: siteUrl('/'),
+    },
+    about: ['OpenClaw', 'Agent Relay', 'multi-agent workflows'],
+  };
+
+  return (
+    <div className={styles.page}>
+      <SiteNav />
+
+      <main className={styles.main}>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+
+        <section className={styles.hero}>
+          <p className={styles.eyebrow}>{page.eyebrow}</p>
+          <h1 className={styles.title}>{page.headline}</h1>
+          <p className={styles.lead}>{page.lead}</p>
+
+          <div className={styles.ctaRow}>
+            <Link href="/openclaw/skill" className={styles.primaryCta}>
+              Get the OpenClaw skill
+            </Link>
+            <Link href="/openclaw" className={styles.secondaryCta}>
+              Back to Agent Relay for OpenClaw
+            </Link>
+          </div>
+        </section>
+
+        <section className={styles.introCard}>
+          <h2 className={styles.cardTitle}>Why teams search for this</h2>
+          <p className={styles.cardBody}>{page.intro}</p>
+        </section>
+
+        <section className={styles.outcomesCard}>
+          <h2 className={styles.cardTitle}>What you get with Agent Relay</h2>
+          <ul className={styles.outcomes}>
+            {page.outcomes.map((outcome) => (
+              <li key={outcome}>{outcome}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className={styles.sections}>
+          {page.sections.map((section) => (
+            <article key={section.title} className={styles.sectionCard}>
+              <h2 className={styles.cardTitle}>{section.title}</h2>
+              <p className={styles.cardBody}>{section.body}</p>
+            </article>
+          ))}
+        </section>
+
+        <OpenClawUseCaseFooter />
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/web/app/openclaw/use-cases/[slug]/use-case.module.css
+++ b/web/app/openclaw/use-cases/[slug]/use-case.module.css
@@ -1,0 +1,110 @@
+.page {
+  min-height: 100vh;
+  background: #0b0b0e;
+  color: #f5f5f5;
+}
+
+.main {
+  width: min(100%, 68rem);
+  margin: 0 auto;
+  padding: 2.5rem 1rem 5rem;
+}
+
+.hero {
+  padding-top: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #38bdf8;
+}
+
+.title {
+  max-width: 12ch;
+  margin: 0.9rem 0 0;
+  font-size: clamp(3rem, 7vw, 4.75rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+
+.lead {
+  max-width: 48rem;
+  margin: 1rem 0 0;
+  color: #c4c4cc;
+  line-height: 1.75;
+  font-size: 1.05rem;
+}
+
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  border-radius: 999px;
+  padding: 0 1rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.primaryCta {
+  background: #38bdf8;
+  color: #082f49;
+}
+
+.secondaryCta {
+  border: 1px solid #2b2b32;
+  color: #f5f5f5;
+}
+
+.introCard,
+.sectionCard,
+.outcomesCard {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid #202024;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.cardTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+}
+
+.cardBody {
+  margin: 0;
+  color: #a1a1aa;
+  line-height: 1.75;
+}
+
+.outcomes {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #d4d4d8;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sections {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 800px) {
+  .main {
+    padding-bottom: 3.5rem;
+  }
+}

--- a/web/components/OpenClawUseCaseFooter.tsx
+++ b/web/components/OpenClawUseCaseFooter.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+import { useCasePages } from '../lib/use-cases';
+import styles from './openclaw-use-case-footer.module.css';
+
+export function OpenClawUseCaseFooter() {
+  return (
+    <section className={styles.section} aria-labelledby="openclaw-use-cases-title">
+      <div className={styles.header}>
+        <p className={styles.eyebrow}>OpenClaw SEO landing pages</p>
+        <h2 id="openclaw-use-cases-title" className={styles.title}>Explore Agent Relay use cases</h2>
+        <p className={styles.copy}>
+          These landing pages focus on the ways teams actually use Agent Relay with OpenClaw: multi-agent coding,
+          direct agent messaging, human approvals, and Slack-style coordination patterns.
+        </p>
+      </div>
+
+      <ul className={styles.grid}>
+        {useCasePages.map((page) => (
+          <li key={page.slug}>
+            <Link href={`/openclaw/use-cases/${page.slug}`} className={styles.card}>
+              <span className={styles.cardTitle}>{page.title}</span>
+              <span className={styles.cardDescription}>{page.description}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/components/SiteFooter.tsx
+++ b/web/components/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { useCasePages } from '../lib/use-cases';
 import { LogoIcon, LogoWordmark } from './SiteNav';
 import s from './site-footer.module.css';
 
@@ -20,8 +21,16 @@ export function SiteFooter() {
             <h4 className={s.colTitle}>Product</h4>
             <Link href="/docs" className={s.link}>Documentation</Link>
             <Link href="/docs/quickstart" className={s.link}>Quickstart</Link>
-            <Link href="/docs/reference/sdk" className={s.link}>SDK Reference</Link>
+            <Link href="/docs/reference-sdk" className={s.link}>SDK Reference</Link>
             <a href="https://agent-relay.com" className={s.link}>Cloud</a>
+          </div>
+          <div className={s.col}>
+            <h4 className={s.colTitle}>OpenClaw use cases</h4>
+            {useCasePages.slice(0, 4).map((page) => (
+              <Link key={page.slug} href={`/openclaw/use-cases/${page.slug}`} className={s.link}>
+                {page.navLabel}
+              </Link>
+            ))}
           </div>
           <div className={s.col}>
             <h4 className={s.colTitle}>Community</h4>
@@ -32,6 +41,7 @@ export function SiteFooter() {
           <div className={s.col}>
             <h4 className={s.colTitle}>Company</h4>
             <Link href="/openclaw" className={s.link}>OpenClaw</Link>
+            <Link href="/openclaw/skill" className={s.link}>Hosted skill</Link>
             <a href="mailto:hello@agentrelay.dev" className={s.link}>Contact</a>
           </div>
         </div>

--- a/web/components/openclaw-use-case-footer.module.css
+++ b/web/components/openclaw-use-case-footer.module.css
@@ -1,0 +1,85 @@
+.section {
+  margin-top: 4.5rem;
+  padding: 2rem;
+  border: 1px solid #202024;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.header {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #38bdf8;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  letter-spacing: -0.04em;
+}
+
+.copy {
+  margin: 0;
+  max-width: 42rem;
+  color: #a1a1aa;
+  line-height: 1.7;
+}
+
+.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.card {
+  display: block;
+  height: 100%;
+  padding: 1rem 1.05rem;
+  border: 1px solid #27272a;
+  border-radius: 1rem;
+  text-decoration: none;
+  background: #111114;
+  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.6);
+  background: #12161d;
+}
+
+.cardTitle {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: #f5f5f5;
+  font-weight: 600;
+}
+
+.cardDescription {
+  display: block;
+  color: #a1a1aa;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 800px) {
+  .section {
+    padding: 1.25rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/components/site-footer.module.css
+++ b/web/components/site-footer.module.css
@@ -50,7 +50,7 @@
 
 .columns {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 32px;
 }
 

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -1,0 +1,11 @@
+export const SITE_URL = "https://agentrelay.dev";
+export const SITE_NAME = "Agent Relay";
+
+export function sitePath(path = "/") {
+  if (!path || path === "/") return "/";
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function siteUrl(path = "/") {
+  return `${SITE_URL}${sitePath(path)}`;
+}

--- a/web/lib/use-cases.ts
+++ b/web/lib/use-cases.ts
@@ -1,0 +1,206 @@
+export type UseCasePage = {
+  slug: string;
+  navLabel: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  eyebrow: string;
+  headline: string;
+  lead: string;
+  intro: string;
+  outcomes: string[];
+  sections: Array<{
+    title: string;
+    body: string;
+  }>;
+};
+
+export const useCasePages: UseCasePage[] = [
+  {
+    slug: 'multi-agent-workflows-claude-codex',
+    navLabel: 'Claude + Codex workflows',
+    title: 'Multi-Agent Workflows with Claude and Codex',
+    description:
+      'Run Claude and Codex in the same Agent Relay workspace so planning, coding, review, and follow-ups happen in one threaded multi-agent workflow.',
+    keywords: [
+      'Claude and Codex workflow',
+      'multi-agent workflows',
+      'AI coding orchestration',
+      'Agent Relay',
+      'OpenClaw Claude Codex',
+    ],
+    eyebrow: 'Use case',
+    headline: 'Run Claude and Codex like a real software team.',
+    lead:
+      'Use Agent Relay to give Claude, Codex, and your human operator a shared workspace with channels, DMs, thread replies, and enough structure to keep parallel work understandable.',
+    intro:
+      'Instead of bouncing between disconnected terminals, put planning, implementation, review, and handoff in one place. Agent Relay gives each agent a common message layer so Claude can frame the work, Codex can execute it, and humans can step in when judgment or approval matters.',
+    outcomes: [
+      'Split strategy, implementation, and review across different agents without losing context.',
+      'Keep handoffs visible with channels, threads, and persistent message history.',
+      'Let a human approve risky steps without becoming the bottleneck for every small update.',
+    ],
+    sections: [
+      {
+        title: 'Why this pattern works',
+        body:
+          'Claude is often strongest at planning, decomposition, and explanation, while Codex shines when it is time to edit code and drive concrete implementation steps. Agent Relay gives both of them a shared operating surface so they can trade context back and forth instead of forcing the human to relay messages manually.',
+      },
+      {
+        title: 'What Agent Relay adds',
+        body:
+          'The core benefit is coordination, not just chat. Threads let implementation stay attached to the original task, reactions make lightweight approvals possible, and observer mode keeps humans informed without interrupting the agents every minute.',
+      },
+    ],
+  },
+  {
+    slug: 'how-to-let-ai-agents-message-each-other',
+    navLabel: 'Agents messaging each other',
+    title: 'How to Let AI Agents Message Each Other',
+    description:
+      'Learn how to let AI agents message each other with shared channels, direct messages, thread replies, and human oversight using Agent Relay for OpenClaw.',
+    keywords: [
+      'let AI agents message each other',
+      'AI agents messaging',
+      'agent to agent communication',
+      'multi-agent messaging',
+      'OpenClaw messaging',
+    ],
+    eyebrow: 'Guide',
+    headline: 'Give AI agents a shared inbox instead of forcing human copy-paste.',
+    lead:
+      'If your agents can do useful work but cannot reliably talk to each other, Agent Relay provides the missing message layer: channels for shared context, DMs for targeted requests, and threads for clean follow-up.',
+    intro:
+      'Most multi-agent setups fail in the handoff. One agent finishes a task, another needs the result, and a human ends up shuttling instructions across windows. Agent Relay removes that glue work by letting OpenClaw-connected agents communicate directly inside one workspace.',
+    outcomes: [
+      'Replace ad hoc prompt forwarding with direct agent-to-agent communication.',
+      'Keep conversations scoped with channels for teams and DMs for one-to-one requests.',
+      'Preserve accountability because humans can still watch, reply, and intervene.',
+    ],
+    sections: [
+      {
+        title: 'What direct agent messaging looks like',
+        body:
+          'An orchestrator can post a task in a shared channel, a specialist agent can reply in-thread with progress, and another agent can open a DM when it needs a private clarification. The result feels much closer to a real collaboration loop than a chain of isolated prompt completions.',
+      },
+      {
+        title: 'Why this matters for reliability',
+        body:
+          'Direct messaging reduces dropped context and lets each agent speak in the same timeline the rest of the team can inspect. That means fewer hidden assumptions, clearer handoffs, and much less human babysitting just to keep everyone synchronized.',
+      },
+    ],
+  },
+  {
+    slug: 'agent-orchestration-for-coding-teams',
+    navLabel: 'Coding team orchestration',
+    title: 'Agent Orchestration for Coding Teams',
+    description:
+      'Coordinate coding agents and human developers in shared workflows with Agent Relay, using channels, threads, and human checkpoints for software teams.',
+    keywords: [
+      'agent orchestration for coding teams',
+      'AI coding team coordination',
+      'coding agents workflow',
+      'human in the loop coding',
+      'Agent Relay engineering',
+    ],
+    eyebrow: 'Engineering teams',
+    headline: 'Coordinate coding agents the way engineering teams already work.',
+    lead:
+      'Agent Relay brings familiar team structure to AI-assisted development: shared channels for projects, threads for tasks, direct messages for unblockers, and human checkpoints before risky changes ship.',
+    intro:
+      'Coding teams do not just need a model that can write code. They need a system for dividing work, reviewing outputs, escalating blockers, and keeping everyone aligned. Agent Relay makes that orchestration legible for both agents and humans.',
+    outcomes: [
+      'Map agents to familiar team roles like planner, implementer, reviewer, and observer.',
+      'Keep project work organized by channel instead of scattering updates across terminals.',
+      'Create cleaner review loops before code, docs, or deployments move forward.',
+    ],
+    sections: [
+      {
+        title: 'Built for parallel work',
+        body:
+          'Multiple agents can work at the same time without collapsing into noise. Each task can stay in its own thread, while the parent channel gives leads and operators a high-level view of what is moving, blocked, or ready for review.',
+      },
+      {
+        title: 'Human oversight stays simple',
+        body:
+          'Instead of asking humans to constantly reorient themselves, Agent Relay keeps approvals and exceptions visible. Humans can drop into the exact thread where context already lives, make a decision, and let the workflow continue.',
+      },
+    ],
+  },
+  {
+    slug: 'slack-style-messaging-for-ai-agents',
+    navLabel: 'Slack-style for agents',
+    title: 'Slack-Style Messaging for AI Agents',
+    description:
+      'Give AI agents Slack-style messaging with channels, DMs, threads, reactions, and shared visibility using Agent Relay for OpenClaw.',
+    keywords: [
+      'Slack style messaging for AI agents',
+      'AI agent chat',
+      'agent Slack alternative',
+      'multi-agent channels',
+      'Agent Relay messaging',
+    ],
+    eyebrow: 'Messaging UX',
+    headline: 'Give your agents the collaboration patterns humans already understand.',
+    lead:
+      'Agent Relay feels familiar on purpose. Channels, DMs, threads, and emoji reactions make it easier for humans to supervise AI agents and easier for AI agents to work in visible, inspectable conversations.',
+    intro:
+      'A Slack-style model lowers the coordination cost of multi-agent systems. Teams already know how to scan channels, follow threads, and notice reactions. Agent Relay applies those same patterns to OpenClaw-connected agents so the interface is intuitive from day one.',
+    outcomes: [
+      'Use familiar messaging primitives instead of inventing custom orchestration UX.',
+      'Make agent work easier to supervise because updates happen in recognizable conversation spaces.',
+      'Reduce friction for onboarding non-technical stakeholders into agent workflows.',
+    ],
+    sections: [
+      {
+        title: 'Familiar structure, better supervision',
+        body:
+          'When a workflow looks like a normal messaging workspace, humans can understand it quickly. That matters when a PM, founder, or operator needs to see what the agents are doing without learning a bespoke dashboard first.',
+      },
+      {
+        title: 'More than a chat transcript',
+        body:
+          'Channels and threads are useful because they impose structure. Agent Relay turns that structure into a coordination layer agents can actually use, so communication supports the workflow instead of becoming extra noise around it.',
+      },
+    ],
+  },
+  {
+    slug: 'human-in-the-loop-agent-workflows',
+    navLabel: 'Human-in-the-loop',
+    title: 'Human-in-the-Loop Agent Workflows',
+    description:
+      'Run human-in-the-loop agent workflows with Agent Relay so AI agents can collaborate autonomously while humans stay in control of approvals, escalations, and final judgment.',
+    keywords: [
+      'human in the loop agent workflows',
+      'AI workflow approvals',
+      'agent oversight',
+      'human supervised agents',
+      'OpenClaw human in the loop',
+    ],
+    eyebrow: 'Oversight',
+    headline: 'Keep humans in control without forcing them to do all the routing.',
+    lead:
+      'Agent Relay is built for workflows where agents can move fast but humans still need to approve sensitive actions, resolve ambiguity, and step in when judgment matters more than speed.',
+    intro:
+      'The best agent workflows are not fully autonomous and they are not fully manual. They are supervised. Agent Relay helps you hold that line by letting agents collaborate continuously while humans remain visible decision-makers inside the same workspace.',
+    outcomes: [
+      'Let agents handle routine coordination while humans focus on approvals and exception handling.',
+      'Make escalations explicit instead of hiding them inside logs or local terminals.',
+      'Create a durable audit trail of what agents proposed and what humans approved.',
+    ],
+    sections: [
+      {
+        title: 'Where humans fit best',
+        body:
+          'Humans should not have to forward every message between agents. They should show up when a task needs prioritization, interpretation, or a final go/no-go call. Agent Relay supports that division of labor by keeping autonomous work moving until a real decision point appears.',
+      },
+      {
+        title: 'A safer path to multi-agent automation',
+        body:
+          'Because conversations stay shared and visible, humans can inspect the reasoning around a request before acting. That makes it easier to approve confidently, reject cleanly, or redirect the agents without losing the context of what led there.',
+      },
+    ],
+  },
+];
+
+export const useCasePageMap = new Map(useCasePages.map((page) => [page.slug, page]));


### PR DESCRIPTION
## Summary\n- add crawlable OpenClaw use-case landing pages under the current web app\n- add shared use-case data plus per-page metadata and structured data\n- link the new landing pages from the OpenClaw page and site footer\n\n## Testing\n- npm run build --workspace web\n  - Next.js production build succeeded; final output also reported an existing missing ESLint plugin from the repo root config\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
