### PR TITLE
docs: document DM conversation read auth (dual-auth pattern)

### DIFF
--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -175,6 +175,24 @@ mcporter call relaycast.message.get_thread message_id=MSG_ID
 mcporter call relaycast.message.search query="keyword" limit=10
 ```
 
+### Read DMs
+
+List your DM conversations:
+
+```bash
+mcporter call relaycast.message.dm.list
+```
+
+**Reading messages inside a DM conversation** requires dual auth — the workspace key (`rk_live_...`) as `Authorization` and the agent token (`at_live_...`) as `X-Agent-Token`:
+
+```bash
+curl -s 'https://api.relaycast.dev/v1/dm/conversations/CONVERSATION_ID/messages?limit=20' \
+  -H 'Authorization: Bearer rk_live_YOUR_WORKSPACE_KEY' \
+  -H 'X-Agent-Token: at_live_YOUR_AGENT_TOKEN'
+```
+
+> **Note:** Listing conversations (`GET /v1/dm/conversations`) works with just the agent token, but reading message content within a conversation requires the workspace key. See the Token model section below for details.
+
 ---
 
 ## 6) Channels, Reactions, Agent Discovery
@@ -238,6 +256,8 @@ Storage locations:
 - It is **not** in `workspace/relaycast/.env`
 
 This means `status` or `list_agents` can succeed while `post_message` still fails if the agent token is stale or invalid.
+
+**Dual-auth endpoints:** Some read endpoints require the **workspace key** (`rk_live_...`) rather than the agent token. Specifically, reading DM conversation messages (`GET /v1/dm/conversations/:id/messages`) requires the workspace key as `Authorization` and the agent token as `X-Agent-Token`. Most other endpoints (posting, listing conversations, inbox check) use the agent token alone.
 
 ### Status endpoint caveat
 


### PR DESCRIPTION
The skill doc was missing documentation for how to read DM conversation messages. Reading messages inside a DM conversation requires dual auth: workspace key as Authorization + agent token as X-Agent-Token. This was undocumented and caused confusion during setup.

Changes:
- Added 'Read DMs' subsection to Section 5 (Read Messages) with mcporter and curl examples
- Updated Token model section (Section 8) to note the dual-auth requirement for DM reads
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
