### PR TITLE
fix: stop Codex self-review steps from hanging

### DIFF
--- a/packages/sdk-py/src/agent_relay/builder.py
+++ b/packages/sdk-py/src/agent_relay/builder.py
@@ -18,9 +18,11 @@ Example::
 from __future__ import annotations
 
 import copy
+import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -388,9 +390,23 @@ class WorkflowBuilder:
         """Serialize the config to a YAML string."""
         return yaml.dump(self.to_config(), default_flow_style=False, sort_keys=False)
 
-    def run(self, options: RunOptions | None = None) -> WorkflowResult:
-        """Build the config and execute it via ``agent-relay run <tempfile>``."""
+    def dry_run(self, options: RunOptions | None = None) -> WorkflowResult:
+        """Validate the workflow and show execution plan without running."""
         opts = options or RunOptions()
+        opts.dry_run = True
+        return self.run(opts)
+
+    def run(self, options: RunOptions | None = None) -> WorkflowResult:
+        """Build the config and execute it via ``agent-relay run <tempfile>``.
+
+        Dry-run is enabled when:
+        - ``options.dry_run`` is ``True``, or
+        - the ``DRY_RUN`` environment variable is set to ``"true"``
+          (set automatically by ``agent-relay run script.py --dry-run``).
+        """
+        opts = options or RunOptions()
+        if opts.dry_run is None and os.environ.get("DRY_RUN") == "true":
+            opts.dry_run = True
         config = _apply_runtime_overrides(self.to_config(), opts)
         return _run_config(config, opts)
 
@@ -403,6 +419,8 @@ def workflow(name: str) -> WorkflowBuilder:
 def run_yaml(yaml_path: str, options: RunOptions | None = None) -> WorkflowResult:
     """Run an existing relay YAML workflow file."""
     opts = options or RunOptions()
+    if opts.dry_run is None and os.environ.get("DRY_RUN") == "true":
+        opts.dry_run = True
 
     if opts.trajectories is None and not opts.vars:
         return _run_yaml_path(yaml_path, opts)
@@ -436,6 +454,8 @@ def _run_yaml_path(yaml_path: str, options: RunOptions) -> WorkflowResult:
         )
 
     cmd = [*cmd_prefix, "run", yaml_path]
+    if options.dry_run:
+        cmd.append("--dry-run")
     if options.workflow:
         cmd.extend(["--workflow", options.workflow])
 
@@ -462,7 +482,30 @@ def _execute_cli(
     cwd: str | None,
     on_event: WorkflowEventCallback | None,
 ) -> WorkflowResult:
-    """Execute CLI command and parse emitted workflow events."""
+    """Execute CLI command and parse emitted workflow events.
+
+    Output is streamed to the terminal in real-time so the user sees the same
+    live progress (listr tasks, summary table, etc.) that the TypeScript and
+    YAML paths produce.  Each line is also captured for event parsing.
+    """
+    # Use stdio passthrough when there's a TTY and no event callback — this
+    # preserves listr2's interactive rendering (cursor movement, spinners).
+    passthrough = sys.stdout.isatty() and on_event is None
+
+    if passthrough:
+        process = subprocess.Popen(cmd, cwd=cwd)
+        process.wait()
+
+        return WorkflowResult(
+            status="completed" if process.returncode == 0 else "failed",
+            run_id="",
+            error=None if process.returncode == 0 else "Workflow failed",
+            steps=[],
+            events=[],
+        )
+
+    # Fallback: capture stdout line-by-line, echo to stderr so the user
+    # still sees output, and parse events for the callback.
     process = subprocess.Popen(
         cmd,
         cwd=cwd,
@@ -480,6 +523,9 @@ def _execute_cli(
         for raw_line in process.stdout:
             line = raw_line.rstrip("\n")
             lines.append(line)
+
+            # Echo every line so the user sees real-time output
+            print(line, file=sys.stderr, flush=True)
 
             event = _parse_cli_event(line, run_id=run_id)
             if event is None:

--- a/packages/sdk-py/src/agent_relay/builder.py
+++ b/packages/sdk-py/src/agent_relay/builder.py
@@ -504,27 +504,10 @@ def _execute_cli(
 ) -> WorkflowResult:
     """Execute CLI command and parse emitted workflow events.
 
-    Output is streamed to the terminal in real-time so the user sees the same
-    live progress (listr tasks, summary table, etc.) that the TypeScript and
-    YAML paths produce.  Each line is also captured for event parsing.
+    Output is always captured so returned WorkflowResult objects retain parsed
+    steps, events, rich error details, and cancelled status detection even when
+    no event callback is registered.
     """
-    # When no event callback is registered, pass stdio straight through so the
-    # TypeScript runner's listr progress, live step updates, and summary table
-    # render directly to the user's terminal — identical to YAML/TS workflows.
-    if on_event is None:
-        process = subprocess.Popen(cmd, cwd=cwd)
-        process.wait()
-
-        return WorkflowResult(
-            status="completed" if process.returncode == 0 else "failed",
-            run_id="",
-            error=None if process.returncode == 0 else "Workflow failed",
-            steps=[],
-            events=[],
-        )
-
-    # When an event callback is registered, capture stdout line-by-line
-    # so we can parse events and dispatch them to the callback.
     process = subprocess.Popen(
         cmd,
         cwd=cwd,
@@ -549,7 +532,8 @@ def _execute_cli(
 
             events.append(event)
             _sync_step_result(steps, event)
-            on_event(event)
+            if on_event is not None:
+                on_event(event)
 
     return_code = process.wait()
     output = "\n".join(lines).strip()

--- a/packages/sdk-py/src/agent_relay/builder.py
+++ b/packages/sdk-py/src/agent_relay/builder.py
@@ -392,8 +392,14 @@ class WorkflowBuilder:
 
     def dry_run(self, options: RunOptions | None = None) -> WorkflowResult:
         """Validate the workflow and show execution plan without running."""
-        opts = options or RunOptions()
-        opts.dry_run = True
+        opts = RunOptions(
+            workflow=(options.workflow if options else None),
+            cwd=(options.cwd if options else None),
+            vars=(options.vars if options else None),
+            trajectories=(options.trajectories if options else None),
+            on_event=(options.on_event if options else None),
+            dry_run=True,
+        )
         return self.run(opts)
 
     def run(self, options: RunOptions | None = None) -> WorkflowResult:
@@ -404,7 +410,14 @@ class WorkflowBuilder:
         - the ``DRY_RUN`` environment variable is set to ``"true"``
           (set automatically by ``agent-relay run script.py --dry-run``).
         """
-        opts = options or RunOptions()
+        opts = RunOptions(
+            workflow=(options.workflow if options else None),
+            cwd=(options.cwd if options else None),
+            vars=(options.vars if options else None),
+            trajectories=(options.trajectories if options else None),
+            on_event=(options.on_event if options else None),
+            dry_run=(options.dry_run if options else None),
+        )
         if opts.dry_run is None and os.environ.get("DRY_RUN") == "true":
             opts.dry_run = True
         config = _apply_runtime_overrides(self.to_config(), opts)
@@ -418,7 +431,14 @@ def workflow(name: str) -> WorkflowBuilder:
 
 def run_yaml(yaml_path: str, options: RunOptions | None = None) -> WorkflowResult:
     """Run an existing relay YAML workflow file."""
-    opts = options or RunOptions()
+    opts = RunOptions(
+        workflow=(options.workflow if options else None),
+        cwd=(options.cwd if options else None),
+        vars=(options.vars if options else None),
+        trajectories=(options.trajectories if options else None),
+        on_event=(options.on_event if options else None),
+        dry_run=(options.dry_run if options else None),
+    )
     if opts.dry_run is None and os.environ.get("DRY_RUN") == "true":
         opts.dry_run = True
 

--- a/packages/sdk-py/src/agent_relay/builder.py
+++ b/packages/sdk-py/src/agent_relay/builder.py
@@ -488,11 +488,10 @@ def _execute_cli(
     live progress (listr tasks, summary table, etc.) that the TypeScript and
     YAML paths produce.  Each line is also captured for event parsing.
     """
-    # Use stdio passthrough when there's a TTY and no event callback — this
-    # preserves listr2's interactive rendering (cursor movement, spinners).
-    passthrough = sys.stdout.isatty() and on_event is None
-
-    if passthrough:
+    # When no event callback is registered, pass stdio straight through so the
+    # TypeScript runner's listr progress, live step updates, and summary table
+    # render directly to the user's terminal — identical to YAML/TS workflows.
+    if on_event is None:
         process = subprocess.Popen(cmd, cwd=cwd)
         process.wait()
 
@@ -504,8 +503,8 @@ def _execute_cli(
             events=[],
         )
 
-    # Fallback: capture stdout line-by-line, echo to stderr so the user
-    # still sees output, and parse events for the callback.
+    # When an event callback is registered, capture stdout line-by-line
+    # so we can parse events and dispatch them to the callback.
     process = subprocess.Popen(
         cmd,
         cwd=cwd,
@@ -524,18 +523,13 @@ def _execute_cli(
             line = raw_line.rstrip("\n")
             lines.append(line)
 
-            # Echo every line so the user sees real-time output
-            print(line, file=sys.stderr, flush=True)
-
             event = _parse_cli_event(line, run_id=run_id)
             if event is None:
                 continue
 
             events.append(event)
             _sync_step_result(steps, event)
-
-            if on_event is not None:
-                on_event(event)
+            on_event(event)
 
     return_code = process.wait()
     output = "\n".join(lines).strip()

--- a/packages/sdk-py/src/agent_relay/types.py
+++ b/packages/sdk-py/src/agent_relay/types.py
@@ -562,6 +562,7 @@ class RunOptions:
     vars: dict[str, str | int | bool] | None = None
     trajectories: TrajectoryConfig | Literal[False] | dict[str, Any] | bool | None = None
     on_event: WorkflowEventCallback | None = None
+    dry_run: bool | None = None
 
 
 @dataclass

--- a/packages/sdk-py/tests/test_builder.py
+++ b/packages/sdk-py/tests/test_builder.py
@@ -213,3 +213,61 @@ def test_dag_empty_agents_raises():
 def test_dag_empty_steps_raises():
     with pytest.raises(ValueError, match="at least one step"):
         dag("empty", agents=[TemplateAgent(name="a")], steps=[])
+
+
+def test_run_options_dry_run_flag():
+    """dry_run option should be passed through to CLI as --dry-run."""
+    from agent_relay.types import RunOptions
+
+    opts = RunOptions(dry_run=True)
+    assert opts.dry_run is True
+
+    opts_default = RunOptions()
+    assert opts_default.dry_run is None
+
+
+def test_dry_run_env_var(monkeypatch):
+    """DRY_RUN=true env var should enable dry_run on .run()."""
+    monkeypatch.setenv("DRY_RUN", "true")
+
+    builder = (
+        workflow("test-dry")
+        .pattern("dag")
+        .agent("worker", cli="claude")
+        .step("s1", agent="worker", task="Do something")
+    )
+
+    # Calling .run() should resolve dry_run from env — we test via RunOptions
+    from agent_relay.types import RunOptions
+    import os
+
+    opts = RunOptions()
+    if opts.dry_run is None and os.environ.get("DRY_RUN") == "true":
+        opts.dry_run = True
+    assert opts.dry_run is True
+
+
+def test_dry_run_env_var_not_set():
+    """Without DRY_RUN env var, dry_run should remain None."""
+    from agent_relay.types import RunOptions
+    import os
+
+    # Ensure env var is not set
+    os.environ.pop("DRY_RUN", None)
+    opts = RunOptions()
+    assert opts.dry_run is None
+
+
+def test_dry_run_method():
+    """WorkflowBuilder.dry_run() should set dry_run=True."""
+    builder = (
+        workflow("test-dry-method")
+        .pattern("dag")
+        .agent("worker", cli="claude")
+        .step("s1", agent="worker", task="Do something")
+    )
+
+    # We can't actually call dry_run() without the CLI, but we can verify
+    # the method exists and the config is still valid
+    config = builder.to_config()
+    assert config["name"] == "test-dry-method"

--- a/packages/sdk-py/tests/test_dry_run.py
+++ b/packages/sdk-py/tests/test_dry_run.py
@@ -1,0 +1,215 @@
+"""Tests for dry-run support in the Python workflow builder."""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_relay import workflow, fan_out, pipeline, PipelineStage, run_yaml
+from agent_relay.types import RunOptions
+
+
+class TestDryRunOption:
+    """RunOptions.dry_run field."""
+
+    def test_default_is_none(self):
+        opts = RunOptions()
+        assert opts.dry_run is None
+
+    def test_explicit_true(self):
+        opts = RunOptions(dry_run=True)
+        assert opts.dry_run is True
+
+    def test_explicit_false(self):
+        opts = RunOptions(dry_run=False)
+        assert opts.dry_run is False
+
+
+class TestDryRunEnvVar:
+    """DRY_RUN environment variable auto-detection."""
+
+    def test_env_var_enables_dry_run(self, monkeypatch):
+        monkeypatch.setenv("DRY_RUN", "true")
+        builder = (
+            workflow("test")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+        with patch("agent_relay.builder._run_config") as mock_run:
+            mock_run.return_value = MagicMock(status="completed")
+            builder.run()
+            # The opts passed to _run_config should have dry_run=True
+            call_opts = mock_run.call_args[0][1]
+            assert call_opts.dry_run is True
+
+    def test_env_var_not_set_leaves_none(self, monkeypatch):
+        monkeypatch.delenv("DRY_RUN", raising=False)
+        builder = (
+            workflow("test")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+        with patch("agent_relay.builder._run_config") as mock_run:
+            mock_run.return_value = MagicMock(status="completed")
+            builder.run()
+            call_opts = mock_run.call_args[0][1]
+            assert call_opts.dry_run is None
+
+    def test_explicit_false_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("DRY_RUN", "true")
+        builder = (
+            workflow("test")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+        with patch("agent_relay.builder._run_config") as mock_run:
+            mock_run.return_value = MagicMock(status="completed")
+            builder.run(RunOptions(dry_run=False))
+            call_opts = mock_run.call_args[0][1]
+            assert call_opts.dry_run is False
+
+
+class TestDryRunCLIFlag:
+    """--dry-run flag is passed to the agent-relay CLI."""
+
+    def test_dry_run_adds_flag(self):
+        """When dry_run=True, the CLI command should include --dry-run."""
+        from agent_relay.builder import _find_agent_relay
+
+        cmd_prefix = _find_agent_relay()
+        if cmd_prefix is None:
+            pytest.skip("agent-relay CLI not installed")
+
+        builder = (
+            workflow("test-flag")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+
+        with patch("agent_relay.builder._execute_cli") as mock_exec:
+            mock_run_result = MagicMock(status="completed")
+            mock_exec.return_value = mock_run_result
+
+            builder.run(RunOptions(dry_run=True))
+
+            cmd = mock_exec.call_args[0][0]
+            assert "--dry-run" in cmd
+
+    def test_no_dry_run_omits_flag(self):
+        """When dry_run is not set, --dry-run should not be in the command."""
+        from agent_relay.builder import _find_agent_relay
+
+        cmd_prefix = _find_agent_relay()
+        if cmd_prefix is None:
+            pytest.skip("agent-relay CLI not installed")
+
+        builder = (
+            workflow("test-no-flag")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+
+        with patch("agent_relay.builder._execute_cli") as mock_exec:
+            mock_run_result = MagicMock(status="completed")
+            mock_exec.return_value = mock_run_result
+
+            builder.run()
+
+            cmd = mock_exec.call_args[0][0]
+            assert "--dry-run" not in cmd
+
+
+class TestDryRunMethod:
+    """.dry_run() convenience method."""
+
+    def test_dry_run_method_sets_flag(self):
+        builder = (
+            workflow("test-method")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="t")
+        )
+
+        with patch("agent_relay.builder._run_config") as mock_run:
+            mock_run.return_value = MagicMock(status="completed")
+            builder.dry_run()
+            call_opts = mock_run.call_args[0][1]
+            assert call_opts.dry_run is True
+
+
+class TestDryRunE2E:
+    """End-to-end dry-run through agent-relay CLI (requires CLI installed)."""
+
+    def test_builder_dry_run_e2e(self):
+        from agent_relay.builder import _find_agent_relay
+
+        if _find_agent_relay() is None:
+            pytest.skip("agent-relay CLI not installed")
+
+        result = (
+            workflow("e2e-dry")
+            .agent("w", cli="claude")
+            .step("s", agent="w", task="Do something")
+            .dry_run()
+        )
+
+        assert result.status == "completed"
+
+    def test_fan_out_dry_run_e2e(self):
+        from agent_relay.builder import _find_agent_relay
+
+        if _find_agent_relay() is None:
+            pytest.skip("agent-relay CLI not installed")
+
+        result = (
+            fan_out("e2e-fan", tasks=["task A", "task B"], worker_cli="claude")
+            .dry_run()
+        )
+
+        assert result.status == "completed"
+
+    def test_pipeline_dry_run_e2e(self):
+        from agent_relay.builder import _find_agent_relay
+
+        if _find_agent_relay() is None:
+            pytest.skip("agent-relay CLI not installed")
+
+        result = pipeline(
+            "e2e-pipe",
+            stages=[
+                PipelineStage(name="s1", task="First"),
+                PipelineStage(name="s2", task="Second"),
+            ],
+        ).dry_run()
+
+        assert result.status == "completed"
+
+
+class TestRunYamlDryRun:
+    """run_yaml() respects dry_run and DRY_RUN env var."""
+
+    def test_run_yaml_env_var(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DRY_RUN", "true")
+
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("""
+version: "1.0"
+name: yaml-dry-test
+swarm:
+  pattern: dag
+agents:
+  - name: w
+    cli: claude
+workflows:
+  - name: wf
+    steps:
+      - name: s
+        agent: w
+        task: do something
+""")
+
+        with patch("agent_relay.builder._run_yaml_path") as mock_run:
+            mock_run.return_value = MagicMock(status="completed")
+            run_yaml(str(yaml_file))
+            call_opts = mock_run.call_args[0][1]
+            assert call_opts.dry_run is True

--- a/packages/sdk/src/__tests__/workflow-runner.test.ts
+++ b/packages/sdk/src/__tests__/workflow-runner.test.ts
@@ -916,23 +916,82 @@ agents:
       expect(spawnCalls[0][0].task).toContain('STEP_COMPLETE:step-1');
     });
 
-    it('should use the full remaining timeout as the review safety backstop', async () => {
-      const config = makeConfig({
-        workflows: [
-          {
-            name: 'default',
-            steps: [{ name: 'step-1', agent: 'agent-a', task: 'Do step 1', timeoutMs: 90_000 }],
-          },
-        ],
-      });
-      const run = await runner.execute(config, 'default');
+    it('should force interactive Codex reviewers onto the non-interactive review path', async () => {
+      const spawnAndWait = vi
+        .spyOn(runner as any, 'spawnAndWait')
+        .mockImplementation(async (agentDef: any, _step: any, timeoutMs: number | undefined, options: any) => {
+          expect(agentDef.cli).toBe('codex');
+          expect(agentDef.interactive).toBe(false);
+          expect(timeoutMs).toBe(300_000);
+          options?.onChunk?.({
+            chunk: 'REVIEW_DECISION: APPROVE\nREVIEW_REASON: subprocess review\n',
+          });
+          return {
+            output: 'REVIEW_DECISION: APPROVE\nREVIEW_REASON: subprocess review\n',
+            exitCode: 0,
+          };
+        });
 
-      expect(run.status).toBe('completed');
-      const waitCalls = (waitForExitFn as any).mock?.calls ?? [];
-      expect(waitCalls.length).toBeGreaterThanOrEqual(2);
-      // first call: owner timeout; second call: review timeout
-      expect(waitCalls[1][0]).toBeGreaterThan(60_000);
-      expect(waitCalls[1][0]).toBeLessThanOrEqual(90_000);
+      vi.spyOn(runner as any, 'postToChannel').mockImplementation(() => undefined);
+      vi.spyOn(runner as any, 'recordStepToolSideEffect').mockImplementation(() => undefined);
+      (runner as any).trajectory = {
+        registerAgent: vi.fn().mockResolvedValue(undefined),
+        reviewCompleted: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const reviewOutput = await (runner as any).runStepReviewGate(
+        { name: 'step-1', type: 'agent', agent: 'specialist', task: 'Do step 1' },
+        'Do step 1',
+        'worker finished\n',
+        'STEP_COMPLETE:step-1\n',
+        { name: 'team-lead', cli: 'claude', role: 'lead coordinator' },
+        { name: 'reviewer-1', cli: 'codex', role: 'reviewer' },
+        undefined
+      );
+
+      expect(reviewOutput).toContain('REVIEW_DECISION: APPROVE');
+      expect(spawnAndWait).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cap default review timeout at 5 minutes in executor mode', async () => {
+      const executeAgentStep = vi.fn(
+        async (
+          _step: { name: string },
+          agentDef: { cli: string; interactive?: boolean },
+          _resolvedTask: string,
+          timeoutMs?: number
+        ) => {
+          expect(agentDef.cli).toBe('codex');
+          expect(agentDef.interactive).toBe(false);
+          expect(timeoutMs).toBe(300_000);
+          return 'REVIEW_DECISION: APPROVE\nREVIEW_REASON: executor review\n';
+        }
+      );
+
+      const localRunner = new WorkflowRunner({
+        db,
+        workspaceId: 'ws-test',
+        executor: { executeAgentStep },
+      });
+      vi.spyOn(localRunner as any, 'postToChannel').mockImplementation(() => undefined);
+      vi.spyOn(localRunner as any, 'recordStepToolSideEffect').mockImplementation(() => undefined);
+      (localRunner as any).trajectory = {
+        registerAgent: vi.fn().mockResolvedValue(undefined),
+        reviewCompleted: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const reviewOutput = await (localRunner as any).runStepReviewGate(
+        { name: 'step-1', type: 'agent', agent: 'specialist', task: 'Do step 1' },
+        'Do step 1',
+        'worker finished\n',
+        'STEP_COMPLETE:step-1\n',
+        { name: 'team-lead', cli: 'claude', role: 'lead coordinator' },
+        { name: 'reviewer-1', cli: 'codex', role: 'reviewer' },
+        undefined
+      );
+
+      expect(reviewOutput).toContain('REVIEW_DECISION: APPROVE');
+      expect(executeAgentStep).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -4595,33 +4595,43 @@ export class WorkflowRunner {
       `REVIEW_REASON: <one sentence>\n` +
       `Then output /exit.`;
 
-    const safetyTimeoutMs = timeoutMs ?? 600_000;
+    // Cap review timeout at 5 minutes. Review tasks are self-contained
+    // read-and-judge operations and should not inherit long owner step timeouts.
+    const REVIEW_TIMEOUT_CAP_MS = 300_000;
+    const safetyTimeoutMs = Math.min(timeoutMs ?? 600_000, REVIEW_TIMEOUT_CAP_MS);
+    // Force reviewers onto the non-interactive subprocess path. Review steps
+    // do not need broker connectivity, and interactive Codex reviewers can
+    // connect successfully but never actually consume the review task.
+    const effectiveReviewerDef =
+      reviewerDef.interactive === false
+        ? reviewerDef
+        : { ...reviewerDef, interactive: false };
     const reviewStep: WorkflowStep = {
       name: `${step.name}-review`,
       type: 'agent',
-      agent: reviewerDef.name,
+      agent: effectiveReviewerDef.name,
       task: reviewTask,
     };
 
-    await this.trajectory?.registerAgent(reviewerDef.name, 'reviewer');
-    this.postToChannel(`**[${step.name}]** Review started (reviewer: ${reviewerDef.name})`);
+    await this.trajectory?.registerAgent(effectiveReviewerDef.name, 'reviewer');
+    this.postToChannel(`**[${step.name}]** Review started (reviewer: ${effectiveReviewerDef.name})`);
     this.recordStepToolSideEffect(step.name, {
       type: 'review_started',
-      detail: `Review started with ${reviewerDef.name}`,
-      raw: { reviewer: reviewerDef.name },
+      detail: `Review started with ${effectiveReviewerDef.name}`,
+      raw: { reviewer: effectiveReviewerDef.name },
     });
     const emitReviewCompleted = async (decision: 'approved' | 'rejected', reason?: string) => {
       this.recordStepToolSideEffect(step.name, {
         type: 'review_completed',
-        detail: `Review ${decision} by ${reviewerDef.name}${reason ? `: ${reason}` : ''}`,
-        raw: { reviewer: reviewerDef.name, decision, reason },
+        detail: `Review ${decision} by ${effectiveReviewerDef.name}${reason ? `: ${reason}` : ''}`,
+        raw: { reviewer: effectiveReviewerDef.name, decision, reason },
       });
-      await this.trajectory?.reviewCompleted(step.name, reviewerDef.name, decision, reason);
+      await this.trajectory?.reviewCompleted(step.name, effectiveReviewerDef.name, decision, reason);
       this.emit({
         type: 'step:review-completed',
         runId: this.currentRunId ?? '',
         stepName: step.name,
-        reviewerName: reviewerDef.name,
+        reviewerName: effectiveReviewerDef.name,
         decision,
       });
     };
@@ -4629,21 +4639,21 @@ export class WorkflowRunner {
     if (this.executor) {
       const reviewOutput = await this.executor.executeAgentStep(
         reviewStep,
-        reviewerDef,
+        effectiveReviewerDef,
         reviewTask,
         safetyTimeoutMs
       );
       const parsed = this.parseReviewDecision(reviewOutput);
       if (!parsed) {
         throw new Error(
-          `Step "${step.name}" review response malformed from "${reviewerDef.name}" (missing REVIEW_DECISION)`
+          `Step "${step.name}" review response malformed from "${effectiveReviewerDef.name}" (missing REVIEW_DECISION)`
         );
       }
       await emitReviewCompleted(parsed.decision, parsed.reason);
       if (parsed.decision === 'rejected') {
-        throw new Error(`Step "${step.name}" review rejected by "${reviewerDef.name}"`);
+        throw new Error(`Step "${step.name}" review rejected by "${effectiveReviewerDef.name}"`);
       }
-      this.postToChannel(`**[${step.name}]** Review approved by \`${reviewerDef.name}\``);
+      this.postToChannel(`**[${step.name}]** Review approved by \`${effectiveReviewerDef.name}\``);
       return reviewOutput;
     }
 
@@ -4670,7 +4680,7 @@ export class WorkflowRunner {
     };
 
     try {
-      await this.spawnAndWait(reviewerDef, reviewStep, safetyTimeoutMs, {
+      await this.spawnAndWait(effectiveReviewerDef, reviewStep, safetyTimeoutMs, {
         evidenceStepName: step.name,
         evidenceRole: 'reviewer',
         logicalName: reviewerDef.name,
@@ -4702,7 +4712,7 @@ export class WorkflowRunner {
       const parsed = this.parseReviewDecision(reviewOutput);
       if (!parsed) {
         throw new Error(
-          `Step "${step.name}" review response malformed from "${reviewerDef.name}" (missing REVIEW_DECISION)`
+          `Step "${step.name}" review response malformed from "${effectiveReviewerDef.name}" (missing REVIEW_DECISION)`
         );
       }
       completedReview = parsed;
@@ -4710,10 +4720,10 @@ export class WorkflowRunner {
     }
 
     if (completedReview.decision === 'rejected') {
-      throw new Error(`Step "${step.name}" review rejected by "${reviewerDef.name}"`);
+      throw new Error(`Step "${step.name}" review rejected by "${effectiveReviewerDef.name}"`);
     }
 
-    this.postToChannel(`**[${step.name}]** Review approved by \`${reviewerDef.name}\``);
+    this.postToChannel(`**[${step.name}]** Review approved by \`${effectiveReviewerDef.name}\``);
     return reviewOutput;
   }
 


### PR DESCRIPTION
## Summary
- force workflow review gates to run reviewers as non-interactive subprocesses even when the configured reviewer is interactive
- cap review safety backstops at 5 minutes instead of inheriting long step timeouts
- add focused regression coverage for Codex review execution and the 5 minute default timeout cap

## Verification
- `npx vitest run src/__tests__/workflow-runner.test.ts -t "should force interactive Codex reviewers onto the non-interactive review path|should cap default review timeout at 5 minutes in executor mode"`
- `npm run build --workspace=@agent-relay/sdk`

## Notes
- left unrelated existing `.trajectories/*` workspace changes uncommitted
