### PR TITLE
fix: npm tarball propagation race in verify-publish and install.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -913,6 +913,11 @@ jobs:
       - name: Update npm for OIDC support
         run: npm install -g npm@latest
 
+      # bundledDependencies requires workspace packages to exist in
+      # node_modules/ at pack time so npm can include them in the tarball.
+      - name: Install workspace dependencies for bundling
+        run: npm install
+
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         run: |

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -84,14 +84,17 @@ jobs:
           echo "Testing: $SPEC"
 
       # Wait for npm to propagate the package
+      # Note: npm view checks registry metadata which propagates before the
+      # tarball is available on the CDN. We use npm cache add to verify the
+      # actual tarball is downloadable before proceeding.
       - name: Wait for npm propagation
         if: inputs.version != 'latest'
         run: |
           echo "Waiting for npm to propagate version ${{ inputs.version }}..."
           FOUND=0
           for i in {1..30}; do
-            if npm view agent-relay@${{ inputs.version }} version 2>/dev/null; then
-              echo "Package found on npm registry"
+            if npm cache add agent-relay@${{ inputs.version }} 2>/dev/null; then
+              echo "Package tarball available on npm registry"
               FOUND=1
               break
             fi
@@ -486,8 +489,8 @@ jobs:
           echo "Waiting for npm to propagate version ${{ inputs.version }}..."
           FOUND=0
           for i in {1..30}; do
-            if npm view agent-relay@${{ inputs.version }} version 2>/dev/null; then
-              echo "Package found on npm registry"
+            if npm cache add agent-relay@${{ inputs.version }} 2>/dev/null; then
+              echo "Package tarball available on npm registry"
               FOUND=1
               break
             fi
@@ -697,8 +700,8 @@ jobs:
           echo "Waiting for npm to propagate version ${{ inputs.version }}..."
           FOUND=0
           for i in {1..30}; do
-            if npm view agent-relay@${{ inputs.version }} version 2>/dev/null; then
-              echo "Package found on npm registry"
+            if npm cache add agent-relay@${{ inputs.version }} 2>/dev/null; then
+              echo "Package tarball available on npm registry"
               FOUND=1
               break
             fi

--- a/install.sh
+++ b/install.sh
@@ -566,10 +566,28 @@ Or use nvm: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/instal
     local npm_log="/tmp/npm-install-$$.log"
     local npm_exit=0
 
-    npm install -g agent-relay@"$VERSION" > "$npm_log" 2>&1 || npm_exit=$?
+    # npm registry metadata propagates before the tarball CDN does, so a
+    # freshly-published version may 404 for a short window.  Retry a few
+    # times with backoff before falling through to the unversioned install.
+    local max_attempts=6
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        npm_exit=0
+        npm install -g agent-relay@"$VERSION" > "$npm_log" 2>&1 || npm_exit=$?
+        if [ $npm_exit -eq 0 ]; then
+            break
+        fi
+        if grep -q "E404" "$npm_log" 2>/dev/null && [ $attempt -lt $max_attempts ]; then
+            info "Package not yet available on npm CDN, retrying in 10s... (attempt $attempt/$max_attempts)"
+            sleep 10
+            attempt=$((attempt + 1))
+        else
+            break
+        fi
+    done
 
     if [ $npm_exit -ne 0 ]; then
-        # First attempt failed, try without version
+        # Versioned install failed, try without version (latest)
         npm install -g agent-relay >> "$npm_log" 2>&1 || npm_exit=$?
     fi
 


### PR DESCRIPTION
## Summary

Two related publish/install issues:

### 1. npm CDN propagation race in verify-publish
- **verify-publish.yml**: Replace `npm view` with `npm cache add` in all 3 propagation wait loops. `npm view` only checks registry metadata which propagates before the tarball is available on the CDN — this caused the [verify jobs to 404](https://github.com/AgentWorkforce/relay/actions/runs/24230915460/job/70743559960) despite the package existing on npm.
- **install.sh**: Add retry loop (6 attempts, 10s backoff) for the `npm install` fallback when a specific version 404s, so users running install.sh during the CDN propagation window get retries instead of a hard failure.

### 2. bundledDependencies never actually bundled (publish.yml)
- The `publish-main` job never ran `npm install` before `npm publish`, so `node_modules/@agent-relay/*` workspace packages didn't exist at pack time
- Since these are in `bundledDependencies`, npm assumed they're in the tarball and skipped installing them as regular deps — causing `ERR_MODULE_NOT_FOUND` for `@agent-relay/utils` and all other workspace packages
- This has been broken since at least 3.2.14 but was masked because `install.sh` downloads the standalone binary directly
- Fix: add `npm install` step before publish

## Root cause

1. npm registry metadata propagates before CDN tarball availability
2. `bundledDependencies` requires packages in `node_modules/` at pack time — without `npm install`, the tarball ships without them, and npm skips installing them as regular deps

## Test plan

- [ ] Re-run the publish workflow — verify jobs should wait for actual tarball availability
- [ ] After merging, next publish should bundle workspace deps correctly
- [ ] Test `npm install -g agent-relay@<new-version>` → `agent-relay --version` should work
- [ ] Test `install.sh` during a fresh publish to confirm retry logic works

🤖 Generated with [Claude Code](https://claude.com/claude-code)