### PR TITLE
fix: harden macOS binary smoke checks

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -179,11 +179,34 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build packages
         run: npm run build
+
+      - name: Build broker binary
+        run: cargo build --release --bin agent-relay-broker
+
+      - name: Verify broker binary
+        run: |
+          STANDALONE_BROKER="$PWD/target/release/agent-relay-broker"
+          if [ ! -f "$STANDALONE_BROKER" ]; then
+            echo "ERROR: Broker binary not found after build: $STANDALONE_BROKER" >&2
+            echo "Contents of target/release:" >&2
+            ls -la "$PWD/target/release" >&2 || true
+            exit 1
+          fi
+          if [ ! -x "$STANDALONE_BROKER" ]; then
+            echo "ERROR: Broker binary is not executable: $STANDALONE_BROKER" >&2
+            ls -la "$STANDALONE_BROKER" >&2
+            exit 1
+          fi
+          echo "STANDALONE_BROKER=$STANDALONE_BROKER" >> "$GITHUB_ENV"
+          echo "Verified broker binary: $STANDALONE_BROKER"
 
       - name: Build standalone binary
         run: |
@@ -216,4 +239,6 @@ jobs:
           echo "STANDALONE_CLI=$PWD/release-binaries/${OUTPUT}" >> "$GITHUB_ENV"
 
       - name: Smoke standalone lifecycle
-        run: bash scripts/ci-standalone-smoke.sh "$STANDALONE_CLI" "$PWD/target/release/agent-relay-broker"
+        env:
+          AGENT_RELAY_STARTUP_DEBUG: 1
+        run: bash scripts/ci-standalone-smoke.sh "$STANDALONE_CLI" "$STANDALONE_BROKER"

--- a/.trajectories/completed/2026-04/traj_7gmhsfy34hbc.json
+++ b/.trajectories/completed/2026-04/traj_7gmhsfy34hbc.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_7gmhsfy34hbc",
+  "version": 1,
+  "task": {
+    "title": "Improve standalone smoke script binary validation"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-10T13:41:57.930Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-10T13:44:41.915Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_6xkazltg8wby",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-10T13:44:41.915Z",
+      "events": [
+        {
+          "ts": 1775828681916,
+          "type": "decision",
+          "content": "Preflight binary validation before smoke temp setup: Preflight binary validation before smoke temp setup",
+          "raw": {
+            "question": "Preflight binary validation before smoke temp setup",
+            "chosen": "Preflight binary validation before smoke temp setup",
+            "alternatives": [],
+            "reasoning": "The script must fail before any CLI invocation when the CLI or broker path is missing or not executable, and installing the cleanup trap only after validation avoids cleanup calling an invalid CLI."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1775828740619,
+          "type": "decision",
+          "content": "Preserve broker startup failure signal: Preserve broker startup failure signal",
+          "raw": {
+            "question": "Preserve broker startup failure signal",
+            "chosen": "Preserve broker startup failure signal",
+            "alternatives": [],
+            "reasoning": "The up smoke now records an early nonzero up command exit and fails with the captured diagnostic excerpt instead of discarding the wait status."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-04-10T13:47:06.957Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.worktrees/macos-binary-ci-regressions",
+  "tags": [],
+  "_trace": {
+    "startRef": "172804f187019a35d388f130ef5d4485354894bc",
+    "endRef": "172804f187019a35d388f130ef5d4485354894bc"
+  },
+  "completedAt": "2026-04-10T13:47:06.957Z",
+  "retrospective": {
+    "summary": "Updated ci-standalone smoke script to validate CLI and broker binaries before invocation, enable startup debug for smoke/cleanup CLI calls, preserve early broker startup failures, and shorten broker readiness diagnostics.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-04/traj_7gmhsfy34hbc.md
+++ b/.trajectories/completed/2026-04/traj_7gmhsfy34hbc.md
@@ -1,0 +1,39 @@
+# Trajectory: Improve standalone smoke script binary validation
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** April 10, 2026 at 03:41 PM
+> **Completed:** April 10, 2026 at 03:47 PM
+
+---
+
+## Summary
+
+Updated ci-standalone smoke script to validate CLI and broker binaries before invocation, enable startup debug for smoke/cleanup CLI calls, preserve early broker startup failures, and shorten broker readiness diagnostics.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Preflight binary validation before smoke temp setup
+
+- **Chose:** Preflight binary validation before smoke temp setup
+- **Reasoning:** The script must fail before any CLI invocation when the CLI or broker path is missing or not executable, and installing the cleanup trap only after validation avoids cleanup calling an invalid CLI.
+
+### Preserve broker startup failure signal
+
+- **Chose:** Preserve broker startup failure signal
+- **Reasoning:** The up smoke now records an early nonzero up command exit and fails with the captured diagnostic excerpt instead of discarding the wait status.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Preflight binary validation before smoke temp setup: Preflight binary validation before smoke temp setup
+- Preserve broker startup failure signal: Preserve broker startup failure signal

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-10T11:29:16.283Z",
+  "lastUpdated": "2026-04-10T13:47:07.057Z",
   "trajectories": {
     "traj_1b1dj40sl6jl": {
       "title": "Revert aggressive retry logic in relay-pty-orchestrator",
@@ -1131,6 +1131,13 @@
       "startedAt": "2026-04-10T11:22:15.709Z",
       "completedAt": "2026-04-10T11:29:16.155Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/completed/2026-04/traj_28hhnf4xoa6i.json"
+    },
+    "traj_7gmhsfy34hbc": {
+      "title": "Improve standalone smoke script binary validation",
+      "status": "completed",
+      "startedAt": "2026-04-10T13:41:57.930Z",
+      "completedAt": "2026-04-10T13:47:06.957Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.worktrees/macos-binary-ci-regressions/.trajectories/completed/2026-04/traj_7gmhsfy34hbc.json"
     }
   }
 }

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -8,6 +8,37 @@ fi
 
 CLI_BIN="$1"
 BROKER_BIN="$2"
+
+validate_binary() {
+  local label="$1"
+  local path="$2"
+  local dir
+
+  if [ ! -e "$path" ]; then
+    dir="$(dirname "$path")"
+    echo "ERROR: $label binary not found: $path" >&2
+    echo "Directory listing for $dir:" >&2
+    ls -la "$dir/" 2>/dev/null >&2 || echo "  (directory does not exist)" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$path" ]; then
+    echo "ERROR: $label binary is not a regular file: $path" >&2
+    ls -ld "$path" >&2 || true
+    exit 1
+  fi
+
+  if [ ! -x "$path" ]; then
+    echo "ERROR: $label binary is not executable: $path" >&2
+    ls -l "$path" >&2 || true
+    echo "Hint: run chmod +x \"$path\" or rebuild the binary with executable permissions." >&2
+    exit 1
+  fi
+}
+
+validate_binary "CLI" "$CLI_BIN"
+validate_binary "BROKER" "$BROKER_BIN"
+
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agent-relay-standalone-smoke.XXXXXX")"
 HOME_DIR="$TMP_ROOT/home"
 PROJECT_DIR="$TMP_ROOT/project"
@@ -20,6 +51,7 @@ cleanup() {
     HOME="$HOME_DIR" \
       AGENT_RELAY_BIN="$BROKER_BIN" \
       AGENT_RELAY_SKIP_UPDATE_CHECK=1 \
+      AGENT_RELAY_STARTUP_DEBUG=1 \
       AGENT_RELAY_TELEMETRY_DISABLED=1 \
       "$CLI_BIN" down --force --timeout 5000 >/dev/null 2>&1 || true
   )
@@ -34,9 +66,27 @@ run_cli() {
     HOME="$HOME_DIR" \
       AGENT_RELAY_BIN="$BROKER_BIN" \
       AGENT_RELAY_SKIP_UPDATE_CHECK=1 \
+      AGENT_RELAY_STARTUP_DEBUG=1 \
       AGENT_RELAY_TELEMETRY_DISABLED=1 \
       "$CLI_BIN" "$@"
   )
+}
+
+print_output_excerpt() {
+  local output="$1"
+  local total_lines
+
+  total_lines="$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
+  if [ "$total_lines" -le 80 ]; then
+    echo "--- output ---" >&2
+    printf '%s\n' "$output" >&2
+    return
+  fi
+
+  echo "--- output (first 40 lines) ---" >&2
+  printf '%s\n' "$output" | sed -n '1,40p' >&2
+  echo "--- output (last 40 lines; $total_lines total) ---" >&2
+  printf '%s\n' "$output" | tail -n 40 >&2
 }
 
 assert_exact_count() {
@@ -48,9 +98,14 @@ assert_exact_count() {
 
   count="$(printf '%s\n' "$output" | grep -E -c "$pattern" || true)"
   if [ "$count" -ne "$expected" ]; then
-    echo "Unexpected $label count: expected $expected, got $count" >&2
-    echo "--- output ---" >&2
-    printf '%s\n' "$output" >&2
+    if [ "$label" = "broker start line" ]; then
+      echo "Broker startup readiness line missing or duplicated: expected $expected, got $count" >&2
+      echo "Expected pattern: $pattern" >&2
+      echo "AGENT_RELAY_STARTUP_DEBUG=1 was enabled for startup diagnostics." >&2
+    else
+      echo "Unexpected $label count: expected $expected, got $count" >&2
+    fi
+    print_output_excerpt "$output"
     exit 1
   fi
 }
@@ -65,20 +120,30 @@ assert_exact_count "$DOWN_OUTPUT" '^Cleaned up \(was not running\)$' 1 'down cle
 
 echo "=== Smoke: standalone up --no-dashboard ==="
 UP_LOG="$TMP_ROOT/up.log"
-set +e
 run_cli up --no-dashboard >"$UP_LOG" 2>&1 &
 UP_PID=$!
-set -e
 
 sleep 8
+UP_EXIT=""
 if kill -0 "$UP_PID" 2>/dev/null; then
   run_cli down --force --timeout 5000 >/dev/null 2>&1 || true
   wait "$UP_PID" || true
 else
-  wait "$UP_PID" || true
+  if wait "$UP_PID"; then
+    UP_EXIT=0
+  else
+    UP_EXIT=$?
+  fi
 fi
 
 UP_OUTPUT="$(cat "$UP_LOG")"
+if [ -n "$UP_EXIT" ] && [ "$UP_EXIT" -ne 0 ]; then
+  echo "Standalone broker startup command exited early with status $UP_EXIT" >&2
+  echo "AGENT_RELAY_STARTUP_DEBUG=1 was enabled for startup diagnostics." >&2
+  print_output_excerpt "$UP_OUTPUT"
+  exit "$UP_EXIT"
+fi
+
 assert_exact_count "$UP_OUTPUT" 'Broker started\.' 1 'broker start line'
 
 if printf '%s\n' "$UP_OUTPUT" | grep -q 'Broker already running for this project'; then

--- a/scripts/verify-macos-binary.sh
+++ b/scripts/verify-macos-binary.sh
@@ -17,6 +17,12 @@ EXPECTED_ARCH="$2"
 shift 3
 SMOKE_ARGS=("$@")
 
+EXEC_BINARY="$BINARY"
+case "$EXEC_BINARY" in
+  */*) ;;
+  *) EXEC_BINARY="./$EXEC_BINARY" ;;
+esac
+
 if [ ! -s "$BINARY" ]; then
   echo "Binary missing or empty: $BINARY" >&2
   exit 1
@@ -57,9 +63,9 @@ HOST_ARCH="$(uname -m)"
 RUNNER=()
 
 if [ "$EXPECTED_ARCH" = "$HOST_ARCH" ]; then
-  RUNNER=("$BINARY")
+  RUNNER=("$EXEC_BINARY")
 elif [ "$EXPECTED_ARCH" = "x86_64" ] && [ "$HOST_ARCH" = "arm64" ] && arch -x86_64 /usr/bin/true 2>/dev/null; then
-  RUNNER=(arch -x86_64 "$BINARY")
+  RUNNER=(arch -x86_64 "$EXEC_BINARY")
 fi
 
 if [ "${#RUNNER[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- fix macOS binary verification when the binary argument is a bare filename by executing it through a normalized `./name` path
- harden standalone smoke diagnostics with binary preflight checks, startup debug, and preserved early `up` failures
- make package-validation build and verify the broker binary before the macOS standalone lifecycle smoke

## Context
This follows PR #709. The OpenClaw binary verification passed file/codesign checks, then failed at smoke execution because `relay-openclaw-darwin-arm64` was executed without `./`. The standalone macOS smoke also lacked enough broker-path and startup diagnostics when `up --no-dashboard` failed before printing `Broker started.`

## Verification
- `bash -n scripts/ci-standalone-smoke.sh`
- `bash -n scripts/verify-macos-binary.sh`
- `bash -n scripts/sign-macos-binary.sh`
- `git diff --check HEAD~1..HEAD`
- Agent Relay workflow `fix-macos-binary-ci-regressions`: 14 passed, 0 failed, 0 skipped

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
