### PR TITLE
fix: skip in-sandbox provisioning when cloud launcher already seeded ACLs

### DIFF
--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -1545,6 +1545,13 @@ export class WorkflowRunner {
   }
 
   private async provisionAgents(config: RelayYamlConfig): Promise<void> {
+    // Cloud launcher already compiled and seeded relayfile ACLs before the
+    // sandbox started.  Skip in-sandbox provisioning — the relayfile API has
+    // no POST /v1/workspaces route, so attempting it causes a fatal 404.
+    if (process.env.RELAY_CLOUD_PROVISIONING_DONE === '1') {
+      return;
+    }
+
     this.agentTokens.clear();
     await this.stopProvisionedMounts();
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -145,7 +145,7 @@ if [ ! -f "$PROJECT_DIR/dist/src/cli/index.js" ]; then
   log_info "Building project..."
   npm run build
 else
-  log_info "Build exists, skipping (run 'npm run build' to rebuild)"
+  log_info "Build exists, skipping initial rebuild (Phase 4 will rebuild before SDK lifecycle)"
 fi
 
 # Phase 1: Broker startup smoke test
@@ -305,6 +305,8 @@ fi
 
 # Phase 4: SDK lifecycle test (spawn/list/release)
 log_phase "Phase 4: SDK Agent Lifecycle"
+log_info "Rebuilding before SDK lifecycle test to ensure dist matches current source..."
+npm run build > /dev/null
 if ! node "$PROJECT_DIR/scripts/e2e-sdk-lifecycle.mjs" \
   --name "$AGENT_NAME" \
   --cli "claude" \


### PR DESCRIPTION
## Summary
- Add early-return guard in `WorkflowRunner.provisionAgents()` when `RELAY_CLOUD_PROVISIONING_DONE=1` is set
- The cloud bootstrap already compiles and seeds relayfile ACLs before the sandbox starts. The SDK provisioner (added in v4.0.9) calls `POST /v1/workspaces` on the relayfile API — which has no such route — causing a fatal 404 that kills standalone TS workflows

## Companion PR
- Cloud side: sets the env var in the bootstrap script before all execution paths (YAML, TS config extraction, standalone `bun run`)

## Test plan
- [ ] Run a cloud workflow with agent permissions via `agent-relay cloud run` — should no longer 404
- [ ] Run a local workflow with agent permissions — provisioner still works (env var not set locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
