### PR TITLE
fix: log full deterministic step output on failure for cloud visibility

### DIFF
--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -3348,6 +3348,9 @@ export class WorkflowRunner {
 
         const stepCwd = this.resolveEffectiveCwd(step);
         this.beginStepEvidence(step.name, [stepCwd], state.row.startedAt);
+        this.log(
+          `[${step.name}] Running: ${resolvedCommand.slice(0, 200)}${resolvedCommand.length > 200 ? '...' : ''}`
+        );
 
         if (this.executor?.executeDeterministicStep) {
           const executorResult = await this.executor.executeDeterministicStep(step, resolvedCommand, stepCwd);
@@ -3355,6 +3358,10 @@ export class WorkflowRunner {
           lastExitSignal = undefined;
           const failOnError = step.failOnError !== false;
           if (failOnError && executorResult.exitCode !== 0) {
+            this.log(`[${step.name}] Command failed (exit code ${executorResult.exitCode})`);
+            if (executorResult.output) {
+              this.log(`[${step.name}] Output:\n${executorResult.output}`);
+            }
             throw new Error(
               `Command failed with exit code ${executorResult.exitCode}: ${executorResult.output.slice(0, 500)}`
             );
@@ -3443,6 +3450,13 @@ export class WorkflowRunner {
 
             const failOnError = step.failOnError !== false;
             if (failOnError && code !== 0 && code !== null) {
+              this.log(`[${step.name}] Command failed (exit code ${code})`);
+              if (stdout) {
+                this.log(`[${step.name}] stdout:\n${stdout}`);
+              }
+              if (stderr) {
+                this.log(`[${step.name}] stderr:\n${stderr}`);
+              }
               reject(
                 new Error(`Command failed with exit code ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ''}`)
               );


### PR DESCRIPTION
## Summary
- Log the command being run for every deterministic step
- On failure, log full stdout/stderr via `this.log()` before throwing — lands in `runner.log` and is visible in `agent-relay cloud logs`
- Covers both code paths: executor (cloud/Daytona) and local spawn

## Problem
When a deterministic step fails in cloud, the user sees only:
```
Step "compile" failed: Command failed with exit code 1
```
The actual error output is truncated to 500 chars in the exception message and never written to `runner.log`, making cloud failures opaque.

## After this fix
```
[workflow 00:01] [compile] Running: npm run build
[workflow 00:02] [compile] Command failed (exit code 1)
[workflow 00:02] [compile] stderr:
src/index.ts(42,5): error TS2322: Type 'string' is not assignable to type 'number'.
```

## Test plan
- [ ] Run a cloud workflow with a deterministic step that fails — full output now visible in `agent-relay cloud logs`
- [ ] Run locally with a failing deterministic step — same improvement in terminal output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
