### PR TITLE
feat: add cloud cancel CLI + fix opencode headless spawn

### DIFF
--- a/src/cli/bootstrap.test.ts
+++ b/src/cli/bootstrap.test.ts
@@ -45,6 +45,7 @@ const expectedLeafCommands = [
   'cloud status',
   'cloud logs',
   'cloud sync',
+  'cloud cancel',
 ];
 
 function collectLeafCommandPaths(program: Command): string[] {
@@ -119,7 +120,7 @@ describe('bootstrap CLI', () => {
     const program = createProgram();
     const leafCommandPaths = collectLeafCommandPaths(program);
 
-    expect(leafCommandPaths).toHaveLength(41);
+    expect(leafCommandPaths).toHaveLength(expectedLeafCommands.length);
     expect(leafCommandPaths).toEqual(expect.arrayContaining(expectedLeafCommands));
     expect(leafCommandPaths).not.toContain('create-agent');
   });

--- a/src/cli/commands/cloud.test.ts
+++ b/src/cli/commands/cloud.test.ts
@@ -36,6 +36,7 @@ describe('registerCloudCommands', () => {
       'status',
       'logs',
       'sync',
+      'cancel',
     ]);
   });
 
@@ -91,5 +92,15 @@ describe('registerCloudCommands', () => {
     expect(sync).toBeDefined();
     const optionNames = sync?.options.map((option) => option.long);
     expect(optionNames).toContain('--dry-run');
+  });
+
+  it('registers cloud cancel subcommand', () => {
+    const { program } = createHarness();
+    const cloud = program.commands.find((command) => command.name() === 'cloud');
+    const cancel = cloud?.commands.find((command) => command.name() === 'cancel');
+
+    expect(cancel).toBeDefined();
+    expect(cancel?.registeredArguments[0]?.required).toBe(true);
+    expect(cancel?.registeredArguments[0]?.name()).toBe('runId');
   });
 });

--- a/src/cli/commands/cloud.ts
+++ b/src/cli/commands/cloud.ts
@@ -16,6 +16,7 @@ import {
   getRunStatus,
   getRunLogs,
   syncWorkflowPatch,
+  cancelWorkflow,
   type WhoAmIResponse,
   type AuthSessionResponse,
   type WorkflowFileType,
@@ -120,10 +121,7 @@ async function getErrorDetails(response: Response): Promise<string> {
 
 // ── Command registration ─────────────────────────────────────────────────────
 
-export function registerCloudCommands(
-  program: Command,
-  overrides: Partial<CloudDependencies> = {}
-): void {
+export function registerCloudCommands(program: Command, overrides: Partial<CloudDependencies> = {}): void {
   const deps = withDefaults(overrides);
 
   const cloudCommand = program
@@ -208,7 +206,9 @@ export function registerCloudCommands(
       deps.log(`API URL: ${auth.apiUrl}`);
       deps.log(`Auth source: ${payload.source}`);
       deps.log(`Subject type: ${payload.subjectType ?? 'session'}`);
-      deps.log(`User: ${payload.user.name || '(no name)'}${payload.user.email ? ` <${payload.user.email}>` : ''}`);
+      deps.log(
+        `User: ${payload.user.name || '(no name)'}${payload.user.email ? ` <${payload.user.email}>` : ''}`
+      );
       deps.log(`Organization: ${payload.currentOrganization.name}`);
       deps.log(`Workspace: ${payload.currentWorkspace.name}`);
       deps.log(`Scopes: ${payload.scopes.length > 0 ? payload.scopes.join(', ') : '(none)'}`);
@@ -273,13 +273,15 @@ export function registerCloudCommands(
         | null;
 
       if (!createResponse.ok || !start?.sessionId) {
-        const detail = start?.error || start?.message || `${createResponse.status} ${createResponse.statusText}`;
+        const detail =
+          start?.error || start?.message || `${createResponse.status} ${createResponse.statusText}`;
         throw new Error(detail);
       }
 
-      const sshPort = typeof start.ssh?.port === 'string'
-        ? Number.parseInt(start.ssh.port as unknown as string, 10)
-        : start.ssh?.port;
+      const sshPort =
+        typeof start.ssh?.port === 'string'
+          ? Number.parseInt(start.ssh.port as unknown as string, 10)
+          : start.ssh?.port;
       if (!start.ssh?.host || !sshPort || !start.ssh.user || !start.ssh.password) {
         throw new Error('Cloud returned invalid SSH session details.');
       }
@@ -307,21 +309,19 @@ export function registerCloudCommands(
           io,
         });
       } catch (error) {
-        throw new Error(`Failed to connect via SSH: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(
+          `Failed to connect via SSH: ${error instanceof Error ? error.message : String(error)}`
+        );
       }
 
       io.log('');
       const success = sessionResult.authDetected;
 
       io.log('Finalizing authentication with cloud...');
-      const { response: completeResponse } = await authorizedApiFetch(
-        auth,
-        '/api/v1/cli/auth/complete',
-        {
-          method: 'POST',
-          body: JSON.stringify({ sessionId: start.sessionId, success }),
-        }
-      );
+      const { response: completeResponse } = await authorizedApiFetch(auth, '/api/v1/cli/auth/complete', {
+        method: 'POST',
+        body: JSON.stringify({ sessionId: start.sessionId, success }),
+      });
 
       if (!completeResponse.ok) {
         throw new Error(await getErrorDetails(completeResponse));
@@ -333,7 +333,11 @@ export function registerCloudCommands(
           io.error(color.red(`Remote auth command exited with code ${exitCode}.`));
         }
         if (sessionResult.exitCode === 127) {
-          io.log(color.yellow(`The ${providerConfig.displayName} CLI ("${providerConfig.command}") is not installed on the sandbox.`));
+          io.log(
+            color.yellow(
+              `The ${providerConfig.displayName} CLI ("${providerConfig.command}") is not installed on the sandbox.`
+            )
+          );
           io.log(color.dim('Check the sandbox snapshot includes the required CLI tools.'));
         }
         throw new Error(`Provider auth for ${provider} did not complete successfully`);
@@ -360,24 +364,26 @@ export function registerCloudCommands(
     .option('--sync-code', 'Upload the current working directory before running')
     .option('--no-sync-code', 'Skip uploading the current working directory')
     .option('--json', 'Print raw JSON response', false)
-    .action(async (
-      workflow: string,
-      options: { apiUrl?: string; fileType?: WorkflowFileType; syncCode?: boolean; json?: boolean },
-    ) => {
-      const result = await runWorkflow(workflow, options);
-      if (options.json) {
-        deps.log(JSON.stringify(result, null, 2));
-        return;
-      }
+    .action(
+      async (
+        workflow: string,
+        options: { apiUrl?: string; fileType?: WorkflowFileType; syncCode?: boolean; json?: boolean }
+      ) => {
+        const result = await runWorkflow(workflow, options);
+        if (options.json) {
+          deps.log(JSON.stringify(result, null, 2));
+          return;
+        }
 
-      deps.log(`Run created: ${result.runId}`);
-      if (typeof result.sandboxId === 'string') {
-        deps.log(`Sandbox: ${result.sandboxId}`);
+        deps.log(`Run created: ${result.runId}`);
+        if (typeof result.sandboxId === 'string') {
+          deps.log(`Sandbox: ${result.sandboxId}`);
+        }
+        deps.log(`Status: ${result.status}`);
+        deps.log(`\nView logs:  agent-relay cloud logs ${result.runId} --follow`);
+        deps.log(`Sync code:  agent-relay cloud sync ${result.runId}`);
       }
-      deps.log(`Status: ${result.status}`);
-      deps.log(`\nView logs:  agent-relay cloud logs ${result.runId} --follow`);
-      deps.log(`Sync code:  agent-relay cloud sync ${result.runId}`);
-    });
+    );
 
   // ── status ─────────────────────────────────────────────────────────────────
 
@@ -417,42 +423,44 @@ export function registerCloudCommands(
     .option('--agent <name>', 'Read logs for a specific agent')
     .option('--sandbox-id <sandboxId>', 'Read logs for a specific step sandbox')
     .option('--json', 'Print raw JSON responses', false)
-    .action(async (
-      runId: string,
-      options: {
-        apiUrl?: string;
-        follow?: boolean;
-        pollInterval?: number;
-        offset?: number;
-        agent?: string;
-        sandboxId?: string;
-        json?: boolean;
-      },
-    ) => {
-      let offset = options.offset ?? 0;
-      const sandboxId = options.agent ?? options.sandboxId;
-
-      while (true) {
-        const result = await getRunLogs(runId, {
-          apiUrl: options.apiUrl,
-          offset,
-          sandboxId,
-        });
-
-        if (options.json) {
-          deps.log(JSON.stringify(result, null, 2));
-        } else if (result.content) {
-          process.stdout.write(result.content);
+    .action(
+      async (
+        runId: string,
+        options: {
+          apiUrl?: string;
+          follow?: boolean;
+          pollInterval?: number;
+          offset?: number;
+          agent?: string;
+          sandboxId?: string;
+          json?: boolean;
         }
+      ) => {
+        let offset = options.offset ?? 0;
+        const sandboxId = options.agent ?? options.sandboxId;
 
-        offset = result.offset;
-        if (!options.follow || result.done) {
-          break;
+        while (true) {
+          const result = await getRunLogs(runId, {
+            apiUrl: options.apiUrl,
+            offset,
+            sandboxId,
+          });
+
+          if (options.json) {
+            deps.log(JSON.stringify(result, null, 2));
+          } else if (result.content) {
+            process.stdout.write(result.content);
+          }
+
+          offset = result.offset;
+          if (!options.follow || result.done) {
+            break;
+          }
+
+          await sleep((options.pollInterval ?? 2) * 1000);
         }
-
-        await sleep((options.pollInterval ?? 2) * 1000);
       }
-    });
+    );
 
   // ── sync ───────────────────────────────────────────────────────────────────
 
@@ -463,10 +471,7 @@ export function registerCloudCommands(
     .option('--api-url <url>', 'Cloud API base URL')
     .option('--dir <path>', 'Local directory to apply the patch to', '.')
     .option('--dry-run', 'Download and display the patch without applying', false)
-    .action(async (
-      runId: string,
-      options: { apiUrl?: string; dir?: string; dryRun?: boolean },
-    ) => {
+    .action(async (runId: string, options: { apiUrl?: string; dir?: string; dryRun?: boolean }) => {
       const targetDir = path.resolve(options.dir ?? '.');
       deps.log(`Fetching patch for run ${runId}...`);
 
@@ -512,5 +517,24 @@ export function registerCloudCommands(
         deps.error(`Patch saved to: ${tmpPatch}`);
         deps.exit(1);
       }
+    });
+
+  // ── cancel ─────────────────────────────────────────────────────────────────
+
+  cloudCommand
+    .command('cancel')
+    .description('Cancel a running workflow')
+    .argument('<runId>', 'Workflow run id')
+    .option('--api-url <url>', 'Cloud API base URL')
+    .option('--json', 'Print raw JSON response', false)
+    .action(async (runId: string, options: { apiUrl?: string; json?: boolean }) => {
+      const result = await cancelWorkflow(runId, options);
+      if (options.json) {
+        deps.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      deps.log(`Run: ${result.runId ?? runId}`);
+      deps.log(`Status: ${result.status ?? 'unknown'}`);
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3876,13 +3876,22 @@ async fn run_headless_worker(cmd: HeadlessCommand) -> Result<()> {
                 let (binary, args) =
                     headless_provider_command(&provider, &task_text, &provider_args);
 
-                let mut child = match tokio::process::Command::new(&binary)
+                let mut child_cmd = tokio::process::Command::new(&binary);
+                child_cmd
                     .args(&args)
                     .stdin(Stdio::null())
                     .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .spawn()
-                {
+                    .stderr(Stdio::piped());
+
+                // Auto-approve tool permissions for opencode in headless mode.
+                if matches!(provider, ProtocolHeadlessProvider::Opencode) {
+                    child_cmd.env(
+                        "OPENCODE_PERMISSION",
+                        r#"{"*":"allow","external_directory":{"*":"allow"}}"#,
+                    );
+                }
+
+                let mut child = match child_cmd.spawn() {
                     Ok(child) => child,
                     Err(error) => {
                         let _ = send_frame(


### PR DESCRIPTION
## Summary
- Adds `agent-relay cloud cancel <runId>` CLI command (wires existing `cancelWorkflow()` to CLI)
- Fixes opencode headless spawning: sets `OPENCODE_PERMISSION` env var so opencode auto-approves tool use instead of prompting on a null stdin and exiting immediately

## Changes
- `src/cli/commands/cloud.ts` — new cancel subcommand (follows status pattern)
- `src/cli/commands/cloud.test.ts` — test for cancel subcommand
- `src/main.rs` — set OPENCODE_PERMISSION env when spawning opencode in headless mode

## Test plan
- [ ] `agent-relay cloud cancel <runId>` cancels a running workflow
- [ ] `--json` flag prints raw JSON response
- [ ] opencode agents in cloud workflows no longer exit in 2 seconds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
