### PR TITLE
fix(sdk): make --resume work for script workflows

### DIFF
--- a/.trajectories/completed/traj_1776024661304_cfc829b9.json
+++ b/.trajectories/completed/traj_1776024661304_cfc829b9.json
@@ -1,0 +1,342 @@
+{
+  "id": "traj_1776024661304_cfc829b9",
+  "version": 1,
+  "task": {
+    "title": "fix-workflow-resume-elegant-workflow",
+    "source": {
+      "system": "workflow-runner",
+      "id": "48742820beafee5b824c4b38"
+    }
+  },
+  "status": "abandoned",
+  "startedAt": "2026-04-12T20:11:01.304Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-04-12T20:11:01.304Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "ch_b202ffbd",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-12T20:11:01.304Z",
+      "events": [
+        {
+          "ts": 1776024661304,
+          "type": "note",
+          "content": "Purpose: Make --resume work for script workflows: default to file-backed db, forward config into resume(), add vitest coverage, verify in built dist"
+        },
+        {
+          "ts": 1776024661304,
+          "type": "note",
+          "content": "Approach: 18-step dag workflow — Parsed 18 steps, 17 dependent steps, DAG validated, no cycles"
+        },
+        {
+          "ts": 1776024676363,
+          "type": "note",
+          "content": "\"read-builder\" skipped — Upstream dependency \"preflight\" failed"
+        },
+        {
+          "ts": 1776024676364,
+          "type": "decision",
+          "content": "Whether to skip read-builder → skip: Upstream dependency \"preflight\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip read-builder",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"preflight\" failed"
+          }
+        },
+        {
+          "ts": 1776024676365,
+          "type": "note",
+          "content": "\"read-reconstruct\" skipped — Upstream dependency \"preflight\" failed"
+        },
+        {
+          "ts": 1776024676365,
+          "type": "decision",
+          "content": "Whether to skip read-reconstruct → skip: Upstream dependency \"preflight\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip read-reconstruct",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"preflight\" failed"
+          }
+        },
+        {
+          "ts": 1776024676366,
+          "type": "note",
+          "content": "\"read-file-db\" skipped — Upstream dependency \"preflight\" failed"
+        },
+        {
+          "ts": 1776024676366,
+          "type": "decision",
+          "content": "Whether to skip read-file-db → skip: Upstream dependency \"preflight\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip read-file-db",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"preflight\" failed"
+          }
+        },
+        {
+          "ts": 1776024676367,
+          "type": "note",
+          "content": "\"edit-builder\" skipped — Upstream dependency \"read-builder\" failed"
+        },
+        {
+          "ts": 1776024676368,
+          "type": "decision",
+          "content": "Whether to skip edit-builder → skip: Upstream dependency \"read-builder\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip edit-builder",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"read-builder\" failed"
+          }
+        },
+        {
+          "ts": 1776024676368,
+          "type": "note",
+          "content": "\"verify-builder-edit\" skipped — Upstream dependency \"edit-builder\" failed"
+        },
+        {
+          "ts": 1776024676369,
+          "type": "decision",
+          "content": "Whether to skip verify-builder-edit → skip: Upstream dependency \"edit-builder\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip verify-builder-edit",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"edit-builder\" failed"
+          }
+        },
+        {
+          "ts": 1776024676369,
+          "type": "note",
+          "content": "\"write-unit-tests\" skipped — Upstream dependency \"verify-builder-edit\" failed"
+        },
+        {
+          "ts": 1776024676369,
+          "type": "decision",
+          "content": "Whether to skip write-unit-tests → skip: Upstream dependency \"verify-builder-edit\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip write-unit-tests",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"verify-builder-edit\" failed"
+          }
+        },
+        {
+          "ts": 1776024676370,
+          "type": "note",
+          "content": "\"verify-tests-written\" skipped — Upstream dependency \"write-unit-tests\" failed"
+        },
+        {
+          "ts": 1776024676370,
+          "type": "decision",
+          "content": "Whether to skip verify-tests-written → skip: Upstream dependency \"write-unit-tests\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip verify-tests-written",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"write-unit-tests\" failed"
+          }
+        },
+        {
+          "ts": 1776024676371,
+          "type": "note",
+          "content": "\"run-new-tests\" skipped — Upstream dependency \"verify-tests-written\" failed"
+        },
+        {
+          "ts": 1776024676371,
+          "type": "decision",
+          "content": "Whether to skip run-new-tests → skip: Upstream dependency \"verify-tests-written\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip run-new-tests",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"verify-tests-written\" failed"
+          }
+        },
+        {
+          "ts": 1776024676371,
+          "type": "note",
+          "content": "\"fix-new-test-failures\" skipped — Upstream dependency \"run-new-tests\" failed"
+        },
+        {
+          "ts": 1776024676372,
+          "type": "decision",
+          "content": "Whether to skip fix-new-test-failures → skip: Upstream dependency \"run-new-tests\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip fix-new-test-failures",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"run-new-tests\" failed"
+          }
+        },
+        {
+          "ts": 1776024676372,
+          "type": "note",
+          "content": "\"run-new-tests-final\" skipped — Upstream dependency \"fix-new-test-failures\" failed"
+        },
+        {
+          "ts": 1776024676372,
+          "type": "decision",
+          "content": "Whether to skip run-new-tests-final → skip: Upstream dependency \"fix-new-test-failures\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip run-new-tests-final",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"fix-new-test-failures\" failed"
+          }
+        },
+        {
+          "ts": 1776024676373,
+          "type": "note",
+          "content": "\"run-related-tests\" skipped — Upstream dependency \"run-new-tests-final\" failed"
+        },
+        {
+          "ts": 1776024676373,
+          "type": "decision",
+          "content": "Whether to skip run-related-tests → skip: Upstream dependency \"run-new-tests-final\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip run-related-tests",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"run-new-tests-final\" failed"
+          }
+        },
+        {
+          "ts": 1776024676373,
+          "type": "note",
+          "content": "\"fix-related-test-regressions\" skipped — Upstream dependency \"run-related-tests\" failed"
+        },
+        {
+          "ts": 1776024676374,
+          "type": "decision",
+          "content": "Whether to skip fix-related-test-regressions → skip: Upstream dependency \"run-related-tests\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip fix-related-test-regressions",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"run-related-tests\" failed"
+          }
+        },
+        {
+          "ts": 1776024676374,
+          "type": "note",
+          "content": "\"run-related-tests-final\" skipped — Upstream dependency \"fix-related-test-regressions\" failed"
+        },
+        {
+          "ts": 1776024676374,
+          "type": "decision",
+          "content": "Whether to skip run-related-tests-final → skip: Upstream dependency \"fix-related-test-regressions\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip run-related-tests-final",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"fix-related-test-regressions\" failed"
+          }
+        },
+        {
+          "ts": 1776024676374,
+          "type": "note",
+          "content": "\"run-full-sdk-tests\" skipped — Upstream dependency \"run-related-tests-final\" failed"
+        },
+        {
+          "ts": 1776024676375,
+          "type": "decision",
+          "content": "Whether to skip run-full-sdk-tests → skip: Upstream dependency \"run-related-tests-final\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip run-full-sdk-tests",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"run-related-tests-final\" failed"
+          }
+        },
+        {
+          "ts": 1776024676376,
+          "type": "note",
+          "content": "\"dist-verification\" skipped — Upstream dependency \"run-full-sdk-tests\" failed"
+        },
+        {
+          "ts": 1776024676378,
+          "type": "decision",
+          "content": "Whether to skip dist-verification → skip: Upstream dependency \"run-full-sdk-tests\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip dist-verification",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"run-full-sdk-tests\" failed"
+          }
+        },
+        {
+          "ts": 1776024676378,
+          "type": "note",
+          "content": "\"show-diff\" skipped — Upstream dependency \"dist-verification\" failed"
+        },
+        {
+          "ts": 1776024676380,
+          "type": "decision",
+          "content": "Whether to skip show-diff → skip: Upstream dependency \"dist-verification\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip show-diff",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"dist-verification\" failed"
+          }
+        },
+        {
+          "ts": 1776024676380,
+          "type": "note",
+          "content": "\"commit-and-push\" skipped — Upstream dependency \"show-diff\" failed"
+        },
+        {
+          "ts": 1776024676380,
+          "type": "decision",
+          "content": "Whether to skip commit-and-push → skip: Upstream dependency \"show-diff\" failed",
+          "significance": "medium",
+          "raw": {
+            "question": "Whether to skip commit-and-push",
+            "chosen": "skip",
+            "reasoning": "Upstream dependency \"show-diff\" failed"
+          }
+        }
+      ],
+      "endedAt": "2026-04-12T20:11:16.381Z"
+    },
+    {
+      "id": "ch_c570f8a2",
+      "title": "Retrospective",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-12T20:11:16.381Z",
+      "events": [
+        {
+          "ts": 1776024676381,
+          "type": "reflection",
+          "content": "Failed at \"preflight\" [exit_nonzero] after 15s. Caused 17 downstream step(s) to be skipped: read-builder, read-reconstruct, read-file-db, edit-builder, verify-builder-edit, write-unit-tests, verify-tests-written, run-new-tests, fix-new-test-failures, run-new-tests-final, run-related-tests, fix-related-test-regressions, run-related-tests-final, run-full-sdk-tests, dist-verification, show-diff, commit-and-push. 0/18 steps completed before failure. (abandoned after 15 seconds)",
+          "significance": "high"
+        },
+        {
+          "ts": 1776024676381,
+          "type": "error",
+          "content": "Workflow abandoned: Step \"preflight\" failed: Step \"preflight\" failed: Command failed with exit code 1",
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-04-12T20:11:16.381Z"
+    }
+  ],
+  "completedAt": "2026-04-12T20:11:16.381Z",
+  "retrospective": {
+    "summary": "Failed at \"preflight\" [exit_nonzero] after 15s. Caused 17 downstream step(s) to be skipped: read-builder, read-reconstruct, read-file-db, edit-builder, verify-builder-edit, write-unit-tests, verify-tests-written, run-new-tests, fix-new-test-failures, run-new-tests-final, run-related-tests, fix-related-test-regressions, run-related-tests-final, run-full-sdk-tests, dist-verification, show-diff, commit-and-push. 0/18 steps completed before failure.",
+    "approach": "dag workflow (0 agents)",
+    "confidence": 0,
+    "learnings": [],
+    "challenges": ["The agent process exited with a non-zero exit code. Check stderr for the root cause."]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "bundleDependencies": [
         "@agent-relay/cloud",
         "@agent-relay/config",
@@ -25,14 +25,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "4.0.14",
-        "@agent-relay/config": "4.0.14",
-        "@agent-relay/hooks": "4.0.14",
-        "@agent-relay/sdk": "4.0.14",
-        "@agent-relay/telemetry": "4.0.14",
-        "@agent-relay/trajectory": "4.0.14",
-        "@agent-relay/user-directory": "4.0.14",
-        "@agent-relay/utils": "4.0.14",
+        "@agent-relay/cloud": "4.0.15",
+        "@agent-relay/config": "4.0.15",
+        "@agent-relay/hooks": "4.0.15",
+        "@agent-relay/sdk": "4.0.15",
+        "@agent-relay/telemetry": "4.0.15",
+        "@agent-relay/trajectory": "4.0.15",
+        "@agent-relay/user-directory": "4.0.15",
+        "@agent-relay/utils": "4.0.15",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -15269,10 +15269,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.14",
+        "@agent-relay/sdk": "4.0.15",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15288,13 +15288,13 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "4.0.14"
+      "version": "4.0.15"
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14",
+        "@agent-relay/config": "4.0.15",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15306,7 +15306,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15318,9 +15318,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.14"
+        "@agent-relay/sdk": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15329,11 +15329,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14",
-        "@agent-relay/sdk": "4.0.14",
-        "@agent-relay/trajectory": "4.0.14"
+        "@agent-relay/config": "4.0.15",
+        "@agent-relay/sdk": "4.0.15",
+        "@agent-relay/trajectory": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15342,9 +15342,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/hooks": "4.0.14"
+        "@agent-relay/hooks": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15353,11 +15353,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.14",
+        "@agent-relay/sdk": "4.0.15",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16180,9 +16180,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14"
+        "@agent-relay/config": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16191,9 +16191,9 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14",
+        "@agent-relay/config": "4.0.15",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": "^0.1.2",
         "@sinclair/typebox": "^0.34.48",
@@ -16254,7 +16254,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
         "posthog-node": "^4.0.1"
       },
@@ -16265,9 +16265,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14"
+        "@agent-relay/config": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16276,9 +16276,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/utils": "4.0.14"
+        "@agent-relay/utils": "4.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16287,9 +16287,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "4.0.14",
+      "version": "4.0.15",
       "dependencies": {
-        "@agent-relay/config": "4.0.14",
+        "@agent-relay/config": "4.0.15",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/sdk/src/__tests__/builder-resume-persistence.test.ts
+++ b/packages/sdk/src/__tests__/builder-resume-persistence.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for WorkflowBuilder.run() local persistence and resume behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// ── Mock fetch ───────────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve({ data: { api_key: 'rk_live_test', workspace_id: 'ws-test' } }),
+  text: () => Promise.resolve(''),
+});
+vi.stubGlobal('fetch', mockFetch);
+
+// ── Mock RelayCast SDK ───────────────────────────────────────────────────────
+
+const mockRelaycastAgent = {
+  send: vi.fn().mockResolvedValue(undefined),
+  heartbeat: vi.fn().mockResolvedValue(undefined),
+  channels: {
+    create: vi.fn().mockResolvedValue(undefined),
+    join: vi.fn().mockResolvedValue(undefined),
+    invite: vi.fn().mockResolvedValue(undefined),
+  },
+};
+
+const mockRelaycast = {
+  agents: {
+    register: vi.fn().mockResolvedValue({ token: 'token-1' }),
+  },
+  as: vi.fn().mockReturnValue(mockRelaycastAgent),
+};
+
+class MockRelayError extends Error {
+  code: string;
+  constructor(code: string, message: string, status = 400) {
+    super(message);
+    this.code = code;
+    this.name = 'RelayError';
+    (this as any).status = status;
+  }
+}
+
+vi.mock('@relaycast/sdk', () => ({
+  RelayCast: vi.fn().mockImplementation(() => mockRelaycast),
+  RelayError: MockRelayError,
+}));
+
+// ── Mock AgentRelay ──────────────────────────────────────────────────────────
+
+const mockRelayInstance = {
+  shutdown: vi.fn().mockResolvedValue(undefined),
+  onBrokerStderr: vi.fn().mockReturnValue(() => {}),
+  onMessageReceived: null as any,
+  onAgentSpawned: null as any,
+  onAgentReleased: null as any,
+  onAgentExited: null as any,
+  onAgentIdle: null as any,
+  onWorkerOutput: null as any,
+  onDeliveryUpdate: null as any,
+};
+
+vi.mock('../relay.js', () => ({
+  AgentRelay: vi.fn().mockImplementation(() => mockRelayInstance),
+}));
+
+// Import after mocking
+const { workflow } = await import('../workflows/builder.js');
+
+type JsonlEntry =
+  | { kind: 'run'; row: { id: string; workflowName: string; status: string } }
+  | { kind: 'step'; row: { runId: string; stepName: string; status: string; output?: string } };
+
+function readJsonl(filePath: string): JsonlEntry[] {
+  return readFileSync(filePath, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as JsonlEntry);
+}
+
+describe('WorkflowBuilder.run() resume persistence', () => {
+  let tmpDir: string;
+  let originalResumeRunId: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'builder-resume-persistence-'));
+    originalResumeRunId = process.env.RESUME_RUN_ID;
+    delete process.env.RESUME_RUN_ID;
+  });
+
+  afterEach(() => {
+    if (originalResumeRunId === undefined) {
+      delete process.env.RESUME_RUN_ID;
+    } else {
+      process.env.RESUME_RUN_ID = originalResumeRunId;
+    }
+
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // tmpDir may already be gone; nothing to clean up.
+    }
+  });
+
+  it('WorkflowBuilder.run() persists run state to JsonFileWorkflowDb by default', async () => {
+    const run = await workflow('t')
+      .trajectories(false)
+      .step('s1', { type: 'deterministic', command: 'echo ok' })
+      .run({ cwd: tmpDir, logLevel: false });
+
+    const dbPath = path.join(tmpDir, '.agent-relay', 'workflow-runs.jsonl');
+    const dbContents = readFileSync(dbPath, 'utf8');
+    const entries = readJsonl(dbPath);
+
+    expect(run.status).toBe('completed');
+    expect(existsSync(dbPath)).toBe(true);
+    expect(dbContents).toContain('"kind":"run"');
+    expect(dbContents).toContain('"workflowName":"t-workflow"');
+    expect(entries.some((entry) => entry.kind === 'run' && entry.row.workflowName === 't-workflow')).toBe(
+      true
+    );
+  });
+
+  it('WorkflowBuilder.run() with RESUME_RUN_ID reconstructs from cached step outputs', async () => {
+    const runId = 'test-run-cached';
+    const stepOutputDir = path.join(tmpDir, '.agent-relay', 'step-outputs', runId);
+    const s1OutputPath = path.join(stepOutputDir, 's1.md');
+    mkdirSync(stepOutputDir, { recursive: true });
+    writeFileSync(s1OutputPath, 'cached-step-1');
+
+    process.env.RESUME_RUN_ID = runId;
+
+    const run = await workflow('t')
+      .trajectories(false)
+      .step('s1', { type: 'deterministic', command: 'echo ok' })
+      .step('s2', { type: 'deterministic', command: 'echo ok', dependsOn: ['s1'] })
+      .run({ cwd: tmpDir, logLevel: false });
+
+    const dbPath = path.join(tmpDir, '.agent-relay', 'workflow-runs.jsonl');
+    const entries = readJsonl(dbPath);
+
+    expect(run.id).toBe(runId);
+    expect(run.status).toBe('completed');
+    expect(readFileSync(s1OutputPath, 'utf8')).toBe('cached-step-1');
+    expect(entries.some((entry) => entry.kind === 'run' && entry.row.id === runId)).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.kind === 'step' &&
+          entry.row.runId === runId &&
+          entry.row.stepName === 's1' &&
+          entry.row.output === 'cached-step-1'
+      )
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.kind === 'step' &&
+          entry.row.runId === runId &&
+          entry.row.stepName === 's2' &&
+          entry.row.status === 'completed'
+      )
+    ).toBe(true);
+  });
+
+  it.skip('WorkflowBuilder.run() with cloud option does NOT create local JSONL db', () => {
+    // Add this as a dedicated cloud-path test once packages/sdk/src/workflows/cloud-runner.ts
+    // is mocked at the builder boundary without invoking the remote API contract.
+  });
+});

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { stringify as stringifyYaml } from 'yaml';
 
 import type { AgentRelayOptions } from '../relay.js';
@@ -20,6 +21,7 @@ import type {
   WorkflowRunRow,
   WorkflowStep,
 } from './types.js';
+import { JsonFileWorkflowDb } from './file-db.js';
 import { WorkflowRunner, type WorkflowEventListener, type RunnerStepExecutor } from './runner.js';
 import { formatDryRunReport } from './dry-run-format.js';
 import { createDefaultEventLogger, type LogLevel } from './default-logger.js';
@@ -384,12 +386,16 @@ export class WorkflowBuilder {
   async run(options?: WorkflowRunOptions): Promise<WorkflowRunRow>;
   async run(options: WorkflowRunOptions = {}): Promise<WorkflowRunRow | DryRunReport> {
     const config = this.toConfig();
+    const runnerCwd = options.cwd ?? process.cwd();
+    const dbPath = path.join(runnerCwd, '.agent-relay', 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
 
     const runner = new WorkflowRunner({
       cwd: options.cwd,
       relay: options.relay,
       executor: options.executor,
       envSecrets: options.envSecrets,
+      db,
     });
 
     // Auto-detect DRY_RUN env var so existing scripts get dry-run for free
@@ -448,7 +454,7 @@ export class WorkflowBuilder {
       runner.on(renderer.onEvent);
 
       const runPromise = resumeRunId
-        ? runner.resume(resumeRunId, options.vars)
+        ? runner.resume(resumeRunId, options.vars, config)
         : runner.execute(config, options.workflow, options.vars, executeOptions);
 
       try {
@@ -460,7 +466,7 @@ export class WorkflowBuilder {
     }
 
     if (resumeRunId) {
-      return runner.resume(resumeRunId, options.vars);
+      return runner.resume(resumeRunId, options.vars, config);
     }
 
     return runner.execute(config, options.workflow, options.vars, executeOptions);


### PR DESCRIPTION
## Summary

Script workflows (TS files that call `workflow(...).run()`) could not be resumed. Three linked bugs in `packages/sdk/src/workflows/builder.ts`:

1. `WorkflowBuilder.run()` constructed a `WorkflowRunner` without a `db` option, so it silently defaulted to `InMemoryWorkflowDb` and `.agent-relay/workflow-runs.jsonl` was never written for script workflows. `--resume` then found no db entry.
2. The cache-reconstruction fallback (`reconstructRunFromCache`) bails out for script workflows because it looks for `relay.yaml` on disk when no config is passed — and script workflows do not have a `relay.yaml`.
3. Both `runner.resume()` call sites in `builder.ts` only pass `(resumeRunId, options.vars)` — never forwarding the config the script just built. Even if (2) were fixed, the config still would not reach the fallback.

**Net effect:** a script workflow that fails mid-DAG with cached step outputs on disk still threw `Run "<id>" not found (no database entry or cached step outputs)` on resume.

## Fix

- Default `WorkflowBuilder.run()` to `JsonFileWorkflowDb` pointed at `<cwd>/.agent-relay/workflow-runs.jsonl` — matching the YAML CLI code path in `cli.ts:338`.
- Forward the built `config` as the third arg into both `runner.resume()` call sites so `reconstructRunFromCache` can use it without needing `relay.yaml`.

## Test plan

- [x] New vitest coverage: `builder-resume-persistence.test.ts` with two tests — "run state persisted to JSONL by default" and "resume reconstructs from cached step outputs when jsonl is missing"
- [x] Full `packages/sdk` test suite green (regression sweep covers `resume-fallback`, `builder-deterministic`, `start-from`)
- [x] Dist-level verification: rebuilt `packages/sdk` and grepped the compiled `dist/workflows/builder.js` for `JsonFileWorkflowDb` and the 3-arg `runner.resume(...)` call

## Repro before this fix

1. Run any script workflow: `agent-relay run workflows/my.ts`
2. Workflow fails at some step; note the printed run id
3. `agent-relay run workflows/my.ts --resume <run-id>` → throws `Run "<id>" not found (no database entry or cached step outputs)` even though `.agent-relay/step-outputs/<run-id>/` has cached `.md` files on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
