### PR TITLE
fix(cli): make preParseWorkflowFile async to avoid Bun-compiled CLI hang

### DIFF
--- a/src/cli/commands/setup.test.ts
+++ b/src/cli/commands/setup.test.ts
@@ -202,7 +202,7 @@ describe('preParseWorkflowFile', () => {
     return full;
   }
 
-  it('returns silently for a valid TypeScript workflow file', () => {
+  it('returns silently for a valid TypeScript workflow file', async () => {
     const file = writeTempWorkflow(
       'valid.ts',
       `
@@ -215,10 +215,10 @@ workflow('w')
   });
 `.trim()
     );
-    expect(() => preParseWorkflowFile(file)).not.toThrow();
+    await expect(preParseWorkflowFile(file)).resolves.toBeUndefined();
   });
 
-  it('wraps a raw backtick inside a template literal with an actionable hint', () => {
+  it('wraps a raw backtick inside a template literal with an actionable hint', async () => {
     // A raw backtick inside a command: template literal terminates
     // the outer JS template literal early and produces an esbuild
     // parse error. We want the error message to tell the user how
@@ -227,9 +227,9 @@ workflow('w')
       'bad-backtick.ts',
       ['const step = {', '  command: `git commit -m "use `npm install` here"`,', '};'].join('\n')
     );
-    expect(() => preParseWorkflowFile(file)).toThrow(/Workflow file failed to parse/);
+    await expect(preParseWorkflowFile(file)).rejects.toThrow(/Workflow file failed to parse/);
     try {
-      preParseWorkflowFile(file);
+      await preParseWorkflowFile(file);
     } catch (err) {
       const msg = (err as Error).message;
       expect(msg).toMatch(/Hint:/);
@@ -237,7 +237,7 @@ workflow('w')
     }
   });
 
-  it('wraps an unescaped ${} interpolation with an actionable hint', () => {
+  it('wraps an unescaped ${} interpolation with an actionable hint', async () => {
     // Not strictly a parse error in isolation, but combined with a
     // bad identifier makes esbuild fail. We mostly want to verify the
     // hint path fires for the common error text.
@@ -245,12 +245,48 @@ workflow('w')
       'bad-dollar.ts',
       ['const step = {', '  command: `echo ${NOT a valid JS expression}`,', '};'].join('\n')
     );
-    expect(() => preParseWorkflowFile(file)).toThrow(/Workflow file failed to parse/);
+    await expect(preParseWorkflowFile(file)).rejects.toThrow(/Workflow file failed to parse/);
   });
 
-  it('propagates non-parse errors unchanged', () => {
+  it('times out after PREPARSE_TIMEOUT_MS and resolves without throwing when the transform hangs', async () => {
+    const file = writeTempWorkflow(
+      'hang.ts',
+      `
+import { workflow } from '@agent-relay/sdk/workflows';
+workflow('w');
+`.trim()
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    vi.resetModules();
+    vi.doMock('esbuild', async () => {
+      const actual = await vi.importActual<typeof import('esbuild')>('esbuild');
+      return {
+        ...actual,
+        transform: vi.fn(() => new Promise(() => {})),
+      };
+    });
+
+    vi.useFakeTimers();
+
+    try {
+      const { preParseWorkflowFile: preParseWorkflowFileWithHungTransform } = await import('./setup.js');
+      const parsePromise = preParseWorkflowFileWithHungTransform(file);
+
+      await vi.advanceTimersByTimeAsync(5001);
+      await expect(parsePromise).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('pre-parse timed out after 5000ms'));
+    } finally {
+      vi.useRealTimers();
+      vi.doUnmock('esbuild');
+      vi.resetModules();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('propagates non-parse errors unchanged', async () => {
     // Non-existent file should throw the fs-level error, not a fake parse wrapper.
-    expect(() => preParseWorkflowFile('/tmp/does-not-exist-' + Date.now() + '.ts')).toThrow(
+    await expect(preParseWorkflowFile('/tmp/does-not-exist-' + Date.now() + '.ts')).rejects.toThrow(
       /Cannot read workflow file/
     );
   });

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { execFileSync, spawn as spawnProcess, spawnSync } from 'node:child_process';
 import { Command } from 'commander';
-import { transformSync } from 'esbuild';
+import { transform } from 'esbuild';
 import { getProjectPaths } from '@agent-relay/config';
 import { readBrokerConnection } from '../lib/broker-lifecycle.js';
 import { enableTelemetry, disableTelemetry, getStatus, isDisabledByEnv } from '@agent-relay/telemetry';
@@ -64,7 +64,7 @@ export interface SetupDependencies {
   runScriptWorkflow: (
     filePath: string,
     options?: { dryRun?: boolean; resume?: string; startFrom?: string; previousRunId?: string }
-  ) => void;
+  ) => void | Promise<void>;
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
   exit: ExitFn;
@@ -181,7 +181,9 @@ export function ensureLocalSdkWorkflowRuntime(
  * `Unterminated template literal`) that don't hint at the actual cause when
  * you're writing workflow files.
  */
-export function preParseWorkflowFile(filePath: string): void {
+const PREPARSE_TIMEOUT_MS = 5000;
+
+export async function preParseWorkflowFile(filePath: string): Promise<void> {
   let source: string;
   try {
     source = fs.readFileSync(filePath, 'utf8');
@@ -189,19 +191,37 @@ export function preParseWorkflowFile(filePath: string): void {
     throw new Error(`Cannot read workflow file ${filePath}: ${(err as Error).message}`);
   }
 
+  let timedOut = false;
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      reject(new Error('PREPARSE_TIMEOUT'));
+    }, PREPARSE_TIMEOUT_MS);
+  });
+
   try {
-    transformSync(source, {
-      loader: 'ts',
-      sourcemap: false,
-      logLevel: 'silent',
-    });
+    await Promise.race([
+      transform(source, { loader: 'ts', sourcemap: false, logLevel: 'silent' }),
+      timeoutPromise,
+    ]);
     return;
   } catch (err) {
+    if (timedOut || (err as Error).message === 'PREPARSE_TIMEOUT') {
+      console.warn(
+        '[agent-relay] pre-parse timed out after ' +
+          PREPARSE_TIMEOUT_MS +
+          'ms — skipping (tsx will still catch real syntax errors)'
+      );
+      return;
+    }
     const errors = (err as { errors?: EsbuildError[] }).errors;
     if (!Array.isArray(errors) || errors.length === 0) {
       throw err;
     }
     throw formatWorkflowParseError(filePath, errors[0]!);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -270,10 +290,10 @@ function formatWorkflowParseError(filePath: string, e: EsbuildError): Error {
   return wrapped;
 }
 
-function runScriptFile(
+async function runScriptFile(
   filePath: string,
   options: { dryRun?: boolean; resume?: string; startFrom?: string; previousRunId?: string } = {}
-): void {
+): Promise<void> {
   diag(`runScriptFile: resolving ${filePath}`);
   const resolved = path.resolve(filePath);
   if (!fs.existsSync(resolved)) {
@@ -335,7 +355,7 @@ Run ID: ${runId}`;
     // TransformError dumped mid-run.
     try {
       diag('runScriptFile: preParseWorkflowFile start');
-      preParseWorkflowFile(resolved);
+      await preParseWorkflowFile(resolved);
       diag('runScriptFile: preParseWorkflowFile done');
     } catch (err) {
       cleanupRunIdFile();
@@ -637,7 +657,7 @@ export function registerSetupCommands(program: Command, overrides: Partial<Setup
         }
         if (ext === '.ts' || ext === '.tsx' || ext === '.py') {
           deps.log(`Running workflow script ${filePath}...`);
-          deps.runScriptWorkflow(filePath, {
+          await deps.runScriptWorkflow(filePath, {
             dryRun: options.dryRun,
             resume: options.resume,
             startFrom: options.startFrom,


### PR DESCRIPTION
## Problem

PR #727 added preParseWorkflowFile using esbuild.transformSync for actionable template-literal error hints. Unfortunately, esbuild.transformSync uses a blocking read loop to IPC with esbuild internal Go subprocess — and Bun spawnSync is subtly incompatible with that loop in compiled standalone binaries.

User-visible symptom: running agent-relay run workflow.ts silently hangs after printing

    [agent-relay] runScriptFile: preParseWorkflowFile start

with no further output and no way to recover except ctrl-c.

Empirical proof that the same file parses fine in regular Node: running node -e to call esbuild.transformSync on the same file completes in 254ms. The hang is specific to Bun-compiled standalone binaries.

## Fix

Convert preParseWorkflowFile to async and use esbuild.transform (async IPC via pipe streams) instead of transformSync. Wrap the call in Promise.race with a 5 second hard timeout as a safety net.

On timeout: log a warning and skip the pre-parse. tsx will still catch actual syntax errors downstream, so the worst case is losing the actionable hint — same behavior as pre-#727.

runScriptFile is converted to async to await preParseWorkflowFile. The SetupDependencies.runScriptWorkflow type is widened to accept void or Promise of void. Commander action handlers already support async natively; no other changes.

## Test plan

- [x] Unit tests in setup.test.ts updated to await the async API
- [x] Full typecheck clean
- [x] Full vitest run for packages/sdk/src/__tests__/
- [x] Integration test A: build CLI from source, spawn it against a synthetic TS workflow file, measure duration (< 15 seconds), assert expected diag checkpoints fire in order (resolving → preParseWorkflowFile start → preParseWorkflowFile done → trying runner). Proves the happy path.
- [x] Integration test B: build CLI from source, spawn it against the actual workflow file that was hanging in production (workflows/wire-up-slack-integration.ts from the cloud repo) with DRY_RUN=true, measure duration (< 20 seconds), assert preParseWorkflowFile start AND done diag lines fire. This is the real-world 80-to-100 gate that proves the user-visible hang is fixed on the exact input that triggered it.
- [ ] Post-merge: re-run the workflows that were silently hanging (wire-up-slack-integration.ts, and similar) to confirm.

## Why not revert PR #727?

Reverting would lose the actionable template-literal error hints that made debugging common workflow authoring mistakes much easier. The async fix preserves that feature while eliminating the hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
