### PR TITLE
feat(cloud): env-var auth fallback for headless consumers

### DIFF
--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  rm: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  default: fsMocks,
+  ...fsMocks,
+}));
+
+import { readStoredAuth, refreshStoredAuth } from './auth.js';
+import type { StoredAuth } from './types.js';
+
+const FILE_AUTH: StoredAuth = {
+  apiUrl: 'https://file.example/cloud',
+  accessToken: 'file-access-token',
+  refreshToken: 'file-refresh-token',
+  accessTokenExpiresAt: '2026-04-13T12:00:00.000Z',
+};
+
+const ENV_AUTH: StoredAuth = {
+  apiUrl: 'https://env.example/cloud',
+  accessToken: 'env-access-token',
+  refreshToken: 'env-refresh-token',
+  accessTokenExpiresAt: '2026-04-13T12:00:00.000Z',
+};
+
+function createEnvAuth(overrides: Partial<StoredAuth> = {}): NodeJS.ProcessEnv {
+  const next = { ...ENV_AUTH, ...overrides };
+
+  return {
+    CLOUD_API_URL: next.apiUrl,
+    CLOUD_API_ACCESS_TOKEN: next.accessToken,
+    CLOUD_API_REFRESH_TOKEN: next.refreshToken,
+    CLOUD_API_ACCESS_TOKEN_EXPIRES_AT: next.accessTokenExpiresAt,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+
+  fsMocks.readFile.mockReset();
+  fsMocks.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+  fsMocks.writeFile.mockReset();
+  fsMocks.writeFile.mockResolvedValue(undefined);
+  fsMocks.mkdir.mockReset();
+  fsMocks.mkdir.mockResolvedValue(undefined);
+  fsMocks.rm.mockReset();
+  fsMocks.rm.mockResolvedValue(undefined);
+});
+
+describe('readStoredAuth', () => {
+  it('returns env-backed auth when all CLOUD_API_* vars are present and valid', async () => {
+    const env = createEnvAuth();
+
+    await expect(readStoredAuth(env)).resolves.toEqual(ENV_AUTH);
+    expect(fsMocks.readFile).not.toHaveBeenCalled();
+  });
+
+  it('falls through to file auth when one env var is missing', async () => {
+    const env = {
+      CLOUD_API_URL: ENV_AUTH.apiUrl,
+      CLOUD_API_ACCESS_TOKEN: ENV_AUTH.accessToken,
+      CLOUD_API_ACCESS_TOKEN_EXPIRES_AT: ENV_AUTH.accessTokenExpiresAt,
+    };
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(FILE_AUTH));
+
+    await expect(readStoredAuth(env)).resolves.toEqual(FILE_AUTH);
+    expect(fsMocks.readFile).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['apiUrl', { apiUrl: 'not-a-url' }],
+    ['expiresAt', { accessTokenExpiresAt: 'not-a-date' }],
+  ])('falls through to file auth when env %s is malformed', async (_label, override) => {
+    const env = createEnvAuth(override);
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(FILE_AUTH));
+
+    await expect(readStoredAuth(env)).resolves.toEqual(FILE_AUTH);
+    expect(fsMocks.readFile).toHaveBeenCalledOnce();
+  });
+
+  it('returns file auth when env is absent', async () => {
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(FILE_AUTH));
+
+    await expect(readStoredAuth({})).resolves.toEqual(FILE_AUTH);
+    expect(fsMocks.readFile).toHaveBeenCalledOnce();
+  });
+
+  it('prefers env auth over file auth when both are available', async () => {
+    const env = createEnvAuth();
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(FILE_AUTH));
+
+    await expect(readStoredAuth(env)).resolves.toEqual(ENV_AUTH);
+    expect(fsMocks.readFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('refreshStoredAuth', () => {
+  it('refreshes env-backed auth in memory only without touching the auth file', async () => {
+    const env = createEnvAuth();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              accessToken: 'env-access-token-next',
+              refreshToken: 'env-refresh-token-next',
+              accessTokenExpiresAt: '2026-04-13T13:00:00.000Z',
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }
+          )
+      )
+    );
+
+    const auth = await readStoredAuth(env);
+    expect(auth).not.toBeNull();
+
+    const refreshed = await refreshStoredAuth(auth as StoredAuth);
+
+    expect(refreshed).toEqual({
+      apiUrl: ENV_AUTH.apiUrl,
+      accessToken: 'env-access-token-next',
+      refreshToken: 'env-refresh-token-next',
+      accessTokenExpiresAt: '2026-04-13T13:00:00.000Z',
+    });
+    expect(fsMocks.writeFile).not.toHaveBeenCalled();
+    expect(fsMocks.mkdir).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -1,29 +1,82 @@
-import fs from "node:fs/promises";
-import http from "node:http";
-import os from "node:os";
-import path from "node:path";
-import { spawn } from "node:child_process";
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
 
-import { buildApiUrl } from "./api-client.js";
-import { AUTH_FILE_PATH, REFRESH_WINDOW_MS, type StoredAuth } from "./types.js";
+import { buildApiUrl } from './api-client.js';
+import { AUTH_FILE_PATH, REFRESH_WINDOW_MS, type StoredAuth } from './types.js';
+
+const envBackedAuth = new WeakSet<StoredAuth>();
+
+function markEnvBackedAuth(auth: StoredAuth): StoredAuth {
+  envBackedAuth.add(auth);
+  return auth;
+}
+
+function isEnvBackedAuth(auth: StoredAuth): boolean {
+  return envBackedAuth.has(auth);
+}
+
+function readEnvAuth(env: NodeJS.ProcessEnv = process.env): StoredAuth | null {
+  const apiUrl = env.CLOUD_API_URL?.trim();
+  const accessToken = env.CLOUD_API_ACCESS_TOKEN?.trim();
+  const refreshToken = env.CLOUD_API_REFRESH_TOKEN?.trim();
+  const accessTokenExpiresAt = env.CLOUD_API_ACCESS_TOKEN_EXPIRES_AT?.trim();
+
+  if (!apiUrl || !accessToken || !refreshToken || !accessTokenExpiresAt) {
+    return null;
+  }
+
+  try {
+    new URL(apiUrl);
+  } catch {
+    return null;
+  }
+
+  if (Number.isNaN(Date.parse(accessTokenExpiresAt))) {
+    return null;
+  }
+
+  return markEnvBackedAuth({
+    apiUrl,
+    accessToken,
+    refreshToken,
+    accessTokenExpiresAt,
+  });
+}
+
+function toEnvAuthRefreshError(error: unknown): Error {
+  const message = error instanceof Error && error.message ? `${error.message}. ` : '';
+
+  return new Error(
+    `${message}Env-backed cloud auth could not be refreshed interactively; re-provision CLOUD_API_URL, CLOUD_API_ACCESS_TOKEN, CLOUD_API_REFRESH_TOKEN, and CLOUD_API_ACCESS_TOKEN_EXPIRES_AT.`,
+    error instanceof Error ? { cause: error } : undefined
+  );
+}
 
 function isValidStoredAuth(value: unknown): value is StoredAuth {
-  if (!value || typeof value !== "object") {
+  if (!value || typeof value !== 'object') {
     return false;
   }
 
   const auth = value as Partial<StoredAuth>;
   return (
-    typeof auth.accessToken === "string" &&
-    typeof auth.refreshToken === "string" &&
-    typeof auth.accessTokenExpiresAt === "string" &&
-    typeof auth.apiUrl === "string"
+    typeof auth.accessToken === 'string' &&
+    typeof auth.refreshToken === 'string' &&
+    typeof auth.accessTokenExpiresAt === 'string' &&
+    typeof auth.apiUrl === 'string'
   );
 }
 
-export async function readStoredAuth(): Promise<StoredAuth | null> {
+export async function readStoredAuth(env: NodeJS.ProcessEnv = process.env): Promise<StoredAuth | null> {
+  const envAuth = readEnvAuth(env);
+  if (envAuth) {
+    return envAuth;
+  }
+
   try {
-    const file = await fs.readFile(AUTH_FILE_PATH, "utf8");
+    const file = await fs.readFile(AUTH_FILE_PATH, 'utf8');
     const parsed = JSON.parse(file) as unknown;
     return isValidStoredAuth(parsed) ? parsed : null;
   } catch {
@@ -37,7 +90,7 @@ export async function writeStoredAuth(auth: StoredAuth): Promise<void> {
     mode: 0o700,
   });
   await fs.writeFile(AUTH_FILE_PATH, `${JSON.stringify(auth, null, 2)}\n`, {
-    encoding: "utf8",
+    encoding: 'utf8',
     mode: 0o600,
   });
 }
@@ -58,33 +111,33 @@ function shouldRefresh(accessTokenExpiresAt: string): boolean {
 function openBrowser(url: string) {
   const platform = os.platform();
 
-  if (platform === "darwin") {
-    return spawn("open", [url], { stdio: "ignore", detached: true });
+  if (platform === 'darwin') {
+    return spawn('open', [url], { stdio: 'ignore', detached: true });
   }
 
-  if (platform === "win32") {
-    return spawn("cmd", ["/c", "start", "", url], { stdio: "ignore", detached: true });
+  if (platform === 'win32') {
+    return spawn('cmd', ['/c', 'start', '', url], { stdio: 'ignore', detached: true });
   }
 
-  return spawn("xdg-open", [url], { stdio: "ignore", detached: true });
+  return spawn('xdg-open', [url], { stdio: 'ignore', detached: true });
 }
 
 function redirectToHostedCliAuthPage(
   response: http.ServerResponse<http.IncomingMessage>,
   apiUrl: string,
   options: {
-    status: "success" | "error";
+    status: 'success' | 'error';
     detail?: string;
-  },
+  }
 ): void {
-  const resultUrl = buildApiUrl(apiUrl, "/cli/auth-result");
-  resultUrl.searchParams.set("status", options.status);
+  const resultUrl = buildApiUrl(apiUrl, '/cli/auth-result');
+  resultUrl.searchParams.set('status', options.status);
   if (options.detail) {
-    resultUrl.searchParams.set("detail", options.detail);
+    resultUrl.searchParams.set('detail', options.detail);
   }
 
   response.statusCode = 302;
-  response.setHeader("location", resultUrl.toString());
+  response.setHeader('location', resultUrl.toString());
   response.end();
 }
 
@@ -95,35 +148,35 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
     let settled = false;
 
     const server = http.createServer((request, response) => {
-      const requestUrl = new URL(request.url || "/", "http://127.0.0.1");
+      const requestUrl = new URL(request.url || '/', 'http://127.0.0.1');
 
-      if (requestUrl.pathname !== "/callback") {
+      if (requestUrl.pathname !== '/callback') {
         response.statusCode = 404;
-        response.end("Not found");
+        response.end('Not found');
         return;
       }
 
-      const returnedState = requestUrl.searchParams.get("state");
+      const returnedState = requestUrl.searchParams.get('state');
 
       // Validate state parameter first (CSRF protection) — this check
       // must run unconditionally, before any user-controlled values.
       if (returnedState !== state) {
         redirectToHostedCliAuthPage(response, apiUrl, {
-          status: "error",
-          detail: "Invalid state parameter",
+          status: 'error',
+          detail: 'Invalid state parameter',
         });
         if (!settled) {
           settled = true;
           server.close();
-          reject(new Error("Invalid state parameter in CLI login callback"));
+          reject(new Error('Invalid state parameter in CLI login callback'));
         }
         return;
       }
 
-      const error = requestUrl.searchParams.get("error");
+      const error = requestUrl.searchParams.get('error');
       if (error) {
         redirectToHostedCliAuthPage(response, apiUrl, {
-          status: "error",
+          status: 'error',
           detail: error,
         });
         if (!settled) {
@@ -134,31 +187,26 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
         return;
       }
 
-      const accessToken = requestUrl.searchParams.get("access_token");
-      const refreshToken = requestUrl.searchParams.get("refresh_token");
-      const accessTokenExpiresAt = requestUrl.searchParams.get("access_token_expires_at");
-      const returnedApiUrl = requestUrl.searchParams.get("api_url");
+      const accessToken = requestUrl.searchParams.get('access_token');
+      const refreshToken = requestUrl.searchParams.get('refresh_token');
+      const accessTokenExpiresAt = requestUrl.searchParams.get('access_token_expires_at');
+      const returnedApiUrl = requestUrl.searchParams.get('api_url');
 
-      if (
-        !accessToken ||
-        !refreshToken ||
-        !accessTokenExpiresAt ||
-        !returnedApiUrl
-      ) {
+      if (!accessToken || !refreshToken || !accessTokenExpiresAt || !returnedApiUrl) {
         redirectToHostedCliAuthPage(response, apiUrl, {
-          status: "error",
-          detail: "Expected access token, refresh token, API URL, and expiration timestamp.",
+          status: 'error',
+          detail: 'Expected access token, refresh token, API URL, and expiration timestamp.',
         });
         if (!settled) {
           settled = true;
           server.close();
-          reject(new Error("CLI login callback was missing required fields"));
+          reject(new Error('CLI login callback was missing required fields'));
         }
         return;
       }
 
       redirectToHostedCliAuthPage(response, returnedApiUrl, {
-        status: "success",
+        status: 'success',
         detail: `API endpoint: ${returnedApiUrl}`,
       });
 
@@ -174,24 +222,24 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
       }
     });
 
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
-      if (!address || typeof address === "string") {
+      if (!address || typeof address === 'string') {
         if (!settled) {
           settled = true;
           server.close();
-          reject(new Error("Failed to start local callback server"));
+          reject(new Error('Failed to start local callback server'));
         }
         return;
       }
 
-      const callbackUrl = new URL("/callback", `http://127.0.0.1:${address.port}`);
-      const loginUrl = buildApiUrl(apiUrl, "/api/v1/cli/login");
-      loginUrl.searchParams.set("redirect_uri", callbackUrl.toString());
-      loginUrl.searchParams.set("state", state);
+      const callbackUrl = new URL('/callback', `http://127.0.0.1:${address.port}`);
+      const loginUrl = buildApiUrl(apiUrl, '/api/v1/cli/login');
+      loginUrl.searchParams.set('redirect_uri', callbackUrl.toString());
+      loginUrl.searchParams.set('state', state);
 
       console.log(`Opening browser for cloud login: ${loginUrl.toString()}`);
-      console.log("If the browser does not open, paste this URL into your browser.");
+      console.log('If the browser does not open, paste this URL into your browser.');
 
       try {
         const child = openBrowser(loginUrl.toString());
@@ -201,7 +249,7 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
       }
     });
 
-    server.on("error", (error) => {
+    server.on('error', (error) => {
       if (!settled) {
         settled = true;
         reject(error);
@@ -212,31 +260,29 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
       if (!settled) {
         settled = true;
         server.close();
-        reject(new Error("Timed out waiting for browser login"));
+        reject(new Error('Timed out waiting for browser login'));
       }
     }, 5 * 60_000).unref();
   });
 }
 
 export async function refreshStoredAuth(auth: StoredAuth): Promise<StoredAuth> {
-  const response = await fetch(buildApiUrl(auth.apiUrl, "/api/v1/auth/token/refresh"), {
-    method: "POST",
+  const response = await fetch(buildApiUrl(auth.apiUrl, '/api/v1/auth/token/refresh'), {
+    method: 'POST',
     headers: {
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify({ refreshToken: auth.refreshToken }),
   });
 
-  const payload = (await response.json().catch(() => null)) as
-    | {
-        accessToken?: string;
-        refreshToken?: string;
-        accessTokenExpiresAt?: string;
-      }
-    | null;
+  const payload = (await response.json().catch(() => null)) as {
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: string;
+  } | null;
 
   if (!response.ok || !payload?.accessToken || !payload?.refreshToken || !payload?.accessTokenExpiresAt) {
-    throw new Error("Stored cloud login has expired");
+    throw new Error('Stored cloud login has expired');
   }
 
   const nextAuth: StoredAuth = {
@@ -245,6 +291,11 @@ export async function refreshStoredAuth(auth: StoredAuth): Promise<StoredAuth> {
     refreshToken: payload.refreshToken,
     accessTokenExpiresAt: payload.accessTokenExpiresAt,
   };
+
+  if (isEnvBackedAuth(auth)) {
+    return markEnvBackedAuth(nextAuth);
+  }
+
   await writeStoredAuth(nextAuth);
   return nextAuth;
 }
@@ -256,7 +307,10 @@ async function loginWithBrowser(apiUrl: string): Promise<StoredAuth> {
   return auth;
 }
 
-export async function ensureAuthenticated(apiUrl: string, options?: { force?: boolean }): Promise<StoredAuth> {
+export async function ensureAuthenticated(
+  apiUrl: string,
+  options?: { force?: boolean }
+): Promise<StoredAuth> {
   const force = options?.force === true;
   const stored = !force ? await readStoredAuth() : null;
 
@@ -270,7 +324,11 @@ export async function ensureAuthenticated(apiUrl: string, options?: { force?: bo
 
   try {
     return await refreshStoredAuth(stored);
-  } catch {
+  } catch (error) {
+    if (isEnvBackedAuth(stored)) {
+      throw toEnvAuthRefreshError(error);
+    }
+
     return loginWithBrowser(apiUrl);
   }
 }
@@ -279,12 +337,12 @@ function apiFetch(
   apiUrl: string,
   accessToken: string,
   requestPath: string,
-  init: RequestInit,
+  init: RequestInit
 ): Promise<Response> {
   return fetch(buildApiUrl(apiUrl, requestPath), {
     ...init,
     headers: {
-      "content-type": "application/json",
+      'content-type': 'application/json',
       authorization: `Bearer ${accessToken}`,
       ...(init.headers ?? {}),
     },
@@ -294,7 +352,7 @@ function apiFetch(
 export async function authorizedApiFetch(
   auth: StoredAuth,
   requestPath: string,
-  init: RequestInit,
+  init: RequestInit
 ): Promise<{ response: Response; auth: StoredAuth }> {
   let activeAuth = auth;
   let response = await apiFetch(activeAuth.apiUrl, activeAuth.accessToken, requestPath, init);
@@ -305,7 +363,11 @@ export async function authorizedApiFetch(
 
   try {
     activeAuth = await refreshStoredAuth(activeAuth);
-  } catch {
+  } catch (error) {
+    if (isEnvBackedAuth(activeAuth)) {
+      throw toEnvAuthRefreshError(error);
+    }
+
     activeAuth = await loginWithBrowser(activeAuth.apiUrl);
   }
 


### PR DESCRIPTION
## Problem

`@agent-relay/cloud` currently reads auth state from `~/.agent-relay/cloud-auth.json` only. No env-var fallback. Every headless consumer (Daytona per-agent sandboxes, CI runners, ephemeral VMs, anything without an interactive home dir) eventually enters `ensureAuthenticated()` and hits `openBrowser()` at `packages/cloud/src/auth.ts:193`, hangs 2-3 minutes per attempt, retries, and dies with "Timed out waiting for browser login".

This was papered over in cloud PR #147 by mounting a pre-built `cloud-auth.json` into every per-agent Daytona sandbox. That workaround is a band-aid — the real fix is to teach `@agent-relay/cloud` to read env-provided credentials directly so any headless consumer works without the mount dance.

## Evidence

- Baseline run (shared-sandbox): `a154e8fe-a48c-40ff-9412-7b83b706f01a` — PASS
- Per-agent run (config-export): `0f1400c5-224b-4f40-baa9-0ee3afa335c1` — FAIL with auth loop
- Full confirmed trigger chain: `agent-relay on` → `requestWorkspaceSession` → 401 → `ensureAuthenticated` → `readStoredAuth` → file missing → `openBrowser` (see cloud PR #147 for details)

## Fix

Add a `readEnvAuth(env)` helper that builds a `StoredAuth` from:

- `CLOUD_API_URL`                         → `apiUrl`
- `CLOUD_API_ACCESS_TOKEN`                → `accessToken`
- `CLOUD_API_REFRESH_TOKEN`               → `refreshToken`
- `CLOUD_API_ACCESS_TOKEN_EXPIRES_AT`     → `accessTokenExpiresAt`

`readStoredAuth()` now tries env first, then falls back to the existing file read. Public API is unchanged.

Naming matches what `cloud/packages/core` already passes via `credentialsToEnv` in `packages/core/src/auth/credentials.ts` — so this PR + the existing cloud executor code line up without further plumbing.

### Precedence

`env → file → browser login`

Interactive local users are unaffected (they have no env vars set; file path still works). Headless users set the env and never touch the file.

### Refresh behavior

When an env-backed access token expires, the refresh POST succeeds and the new token is kept **in memory for the current process only**. It is NOT written to disk — that would clobber a local interactive user who may have their own stored auth alongside a dev loop that happens to export `CLOUD_API_*`.

### What does NOT change

- `AUTH_FILE_PATH` is unchanged (`~/.agent-relay/cloud-auth.json`)
- File read/write/clear behavior is unchanged
- Public exports are unchanged
- No new dependencies

## After this lands

Cloud PR #147 can be reverted. Filing a follow-up PR to do so.

## Test plan

- [x] New unit tests in `packages/cloud/src/auth.test.ts` covering:
  - env-only path returns valid `StoredAuth`
  - env partial (missing one var) → falls through to file
  - env malformed (bad URL / bad expiresAt) → falls through to file
  - file-only path unchanged when env is absent
  - env precedence: both present → env wins
  - env-backed refresh does not clobber the file
- [x] Typecheck clean
- [x] Full SDK + CLI test sweep passes (`packages/sdk/src/__tests__`, `src/cli/commands/setup.test.ts`)
- [x] Build clean (`npm run build:packages`)
- [ ] Post-merge + release: cloud/packages/core picks up the new @agent-relay/cloud; re-run `bash /tmp/verify-per-agent-sandbox-cloud.sh` and confirm per-agent run reaches `EXCHANGE_VERIFIED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
