### PR TITLE
feat: show workspace key and observer URL in agent-relay status

### DIFF
--- a/src/cli/commands/core.test.ts
+++ b/src/cli/commands/core.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 const sdkStatusClient = {
   getStatus: vi.fn(async () => ({ agent_count: 0, pending_delivery_count: 0 })),
+  getSession: vi.fn(async () => ({ workspace_key: '' }) as { workspace_key?: string }),
   disconnect: vi.fn(() => undefined),
 };
 
@@ -545,6 +546,7 @@ describe('registerCoreCommands', () => {
     const connectionPath = '/tmp/project/.agent-relay/connection.json';
     const fs = createFsMock({ [connectionPath]: connectionFile(4242) });
     sdkStatusClient.getStatus.mockResolvedValueOnce({ agent_count: 4, pending_delivery_count: 2 });
+    sdkStatusClient.getSession.mockResolvedValueOnce({ workspace_key: 'rk_live_test123' });
 
     const { program, deps } = createHarness({ fs });
 
@@ -554,6 +556,25 @@ describe('registerCoreCommands', () => {
     expect(deps.log).toHaveBeenCalledWith('Status: RUNNING');
     expect(deps.log).toHaveBeenCalledWith('Agents: 4');
     expect(deps.log).toHaveBeenCalledWith('Pending deliveries: 2');
+    expect(deps.log).toHaveBeenCalledWith('Workspace Key: rk_live_test123');
+    expect(deps.log).toHaveBeenCalledWith('Observer: https://agentrelay.com/observer?key=rk_live_test123');
+    expect(sdkStatusClient.disconnect).toHaveBeenCalled();
+  });
+
+  it('status omits workspace key and observer when broker has no workspace_key', async () => {
+    const connectionPath = '/tmp/project/.agent-relay/connection.json';
+    const fs = createFsMock({ [connectionPath]: connectionFile(4242) });
+    sdkStatusClient.getStatus.mockResolvedValueOnce({ agent_count: 0, pending_delivery_count: 0 });
+    sdkStatusClient.getSession.mockResolvedValueOnce({});
+
+    const { program, deps } = createHarness({ fs });
+
+    const exitCode = await runCommand(program, ['status']);
+
+    expect(exitCode).toBeUndefined();
+    const logCalls = (deps.log as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(logCalls.some((call) => String(call[0]).startsWith('Workspace Key:'))).toBe(false);
+    expect(logCalls.some((call) => String(call[0]).startsWith('Observer:'))).toBe(false);
     expect(sdkStatusClient.disconnect).toHaveBeenCalled();
   });
 

--- a/src/cli/lib/broker-lifecycle.ts
+++ b/src/cli/lib/broker-lifecycle.ts
@@ -1299,6 +1299,11 @@ export async function runStatusCommand(
       if (typeof status.pending_delivery_count === 'number' && status.pending_delivery_count > 0) {
         deps.log(`Pending deliveries: ${status.pending_delivery_count}`);
       }
+      const session = await client.getSession();
+      if (session.workspace_key) {
+        deps.log(`Workspace Key: ${session.workspace_key}`);
+        deps.log(`Observer: https://agentrelay.com/observer?key=${session.workspace_key}`);
+      }
       client.disconnect();
     } catch {
       // PID-based status is enough when broker query fails.


### PR DESCRIPTION
## Summary
Focused replacement for #739 (which accumulated unrelated commits through merges). Rebased on latest main with only the status-command change.

- Adds `Workspace Key:` and `Observer:` lines to `agent-relay status` output
- Observer URL format: `https://agentrelay.com/observer?key=<workspace_key>`
- Calls `client.getSession()` to fetch `workspace_key` from the broker

## Example output
```
Status: RUNNING
Mode: broker (stdio)
PID: 52432
Project: /Users/khaliqgant/Projects/AgentWorkforce/relay
Agents: 0
Workspace Key: rk_live_0b4133c4853b0d266042401691f3dbf8
Observer: https://agentrelay.com/observer?key=rk_live_0b4133c4853b0d266042401691f3dbf8
```

## Diff
Single file, +5 lines in `src/cli/lib/broker-lifecycle.ts`.

## Test plan
- [ ] `agent-relay status` against a running broker shows the two new lines
- [ ] `agent-relay status` when `getSession()` has no `workspace_key` omits them gracefully

Replaces #739.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
