### PR TITLE
fix(cli): prefer native Node TS stripping over tsx fallback

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -444,12 +444,12 @@ Run ID: ${runId}`;
         return augmentErrorWithRunId(result.error);
       }
       if (result.status !== 0) {
-        // Node rejects `--experimental-strip-types` on <22.6 with exit 9
-        // and no TransformError fingerprint. If the stderr doesn't look
-        // like a real parse error, assume this runner is unsupported and
-        // fall through to the next one.
-        if (bin === 'node' && !parseTsxStderr(result.stderr)) {
-          diag(`runScriptFile: runner ${label} unsupported on this Node — trying next`);
+        // Node exits with code 9 ("Invalid Argument") when it doesn't
+        // recognise --experimental-strip-types (Node <22.6). Only skip
+        // to the next runner for that specific exit code; any other
+        // non-zero status is a real script failure.
+        if (bin === 'node' && result.status === 9) {
+          diag(`runScriptFile: runner ${label} unsupported on this Node (exit 9) — trying next`);
           continue;
         }
         return augmentErrorWithRunId(wrapRunnerError(label, result));

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -419,21 +419,42 @@ Run ID: ${runId}`;
       return new Error(`${runner} exited with code ${result.status}`);
     };
 
-    const runners = ['tsx', 'ts-node'];
-    for (const runner of runners) {
-      diag(`runScriptFile: trying runner ${runner}`);
-      const result = await spawnRunnerWithStderrCapture(runner, [resolved], childEnv);
+    // Prefer Node's built-in type stripping (Node 22.6+) — no extra deps,
+    // no tsx CJS resolver quirks walking node_modules. Falls through to
+    // tsx/ts-node on older Nodes (they exit non-zero with an unknown-flag
+    // error, not ENOENT, so we treat any non-zero from this runner as a
+    // "try the next runner" signal rather than a real user error).
+    const runners: Array<{ label: string; bin: string; preArgs: string[] }> = [
+      {
+        label: 'node --experimental-strip-types',
+        bin: 'node',
+        preArgs: ['--experimental-strip-types', '--no-warnings=ExperimentalWarning'],
+      },
+      { label: 'tsx', bin: 'tsx', preArgs: [] },
+      { label: 'ts-node', bin: 'ts-node', preArgs: [] },
+    ];
+    for (const { label, bin, preArgs } of runners) {
+      diag(`runScriptFile: trying runner ${label}`);
+      const result = await spawnRunnerWithStderrCapture(bin, [...preArgs, resolved], childEnv);
       if (result.error) {
         if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
-          diag(`runScriptFile: runner ${runner} returned ENOENT — trying next`);
+          diag(`runScriptFile: runner ${label} returned ENOENT — trying next`);
           continue;
         }
         return augmentErrorWithRunId(result.error);
       }
       if (result.status !== 0) {
-        return augmentErrorWithRunId(wrapRunnerError(runner, result));
+        // Node rejects `--experimental-strip-types` on <22.6 with exit 9
+        // and no TransformError fingerprint. If the stderr doesn't look
+        // like a real parse error, assume this runner is unsupported and
+        // fall through to the next one.
+        if (bin === 'node' && !parseTsxStderr(result.stderr)) {
+          diag(`runScriptFile: runner ${label} unsupported on this Node — trying next`);
+          continue;
+        }
+        return augmentErrorWithRunId(wrapRunnerError(label, result));
       }
-      diag(`runScriptFile: runner ${runner} completed exit=0`);
+      diag(`runScriptFile: runner ${label} completed exit=0`);
       cleanupRunIdFile();
       return;
     }

--- a/src/cli/lib/broker-lifecycle.ts
+++ b/src/cli/lib/broker-lifecycle.ts
@@ -1290,8 +1290,8 @@ export async function runStatusCommand(
   // Query the running broker for additional status info
   const connInfo = readBrokerConnectionFromFs(deps.fs, paths.dataDir);
   if (connInfo) {
+    const client = new AgentRelayClient({ baseUrl: connInfo.url, apiKey: connInfo.api_key });
     try {
-      const client = new AgentRelayClient({ baseUrl: connInfo.url, apiKey: connInfo.api_key });
       const status = await client.getStatus();
       if (typeof status.agent_count === 'number') {
         deps.log(`Agents: ${status.agent_count}`);
@@ -1304,9 +1304,10 @@ export async function runStatusCommand(
         deps.log(`Workspace Key: ${session.workspace_key}`);
         deps.log(`Observer: https://agentrelay.com/observer?key=${session.workspace_key}`);
       }
-      client.disconnect();
     } catch {
       // PID-based status is enough when broker query fails.
+    } finally {
+      client.disconnect();
     }
   }
 }


### PR DESCRIPTION
## Summary
- `runScriptFile` now tries `node --experimental-strip-types` before `tsx`/`ts-node`, so a plain `@agent-relay/sdk`-only install works out of the box on Node 22.6+ with no extra runtime deps.
- On older Node, `--experimental-strip-types` exits non-zero with no parse-error fingerprint; we treat that as "runner unsupported" and fall through to tsx, preserving existing behavior.

## Why
A user running `agent-relay run workflows/build-activity-monitor.ts` with only `@agent-relay/sdk` installed hit:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../agent-trajectories/package.json
  at resolveTsPaths (.../tsx/dist/register-*.cjs)
```
Root cause: no `tsx`/`ts-node` was locally installed → fell through to `npx tsx` → tsx's path resolver walked `node_modules/agent-trajectories` as CJS and the package only declares `import`/`types` conditions, so Node's CJS resolver failed before any workflow code ran.

Node 22.6+ ships built-in TS type stripping (`--experimental-strip-types`), which does not go through tsx at all, completely sidesteps the transitive CJS/ESM resolver issue, and requires no local install. I verified `node --experimental-strip-types workflows/build-activity-monitor.ts` runs the workflow's dry-run path cleanly (`Validation: PASS`).

See the companion PR on `AgentWorkforce/trajectories` that also adds a `default` condition to that package's exports as belt-and-suspenders.

## Test plan
- [x] `vitest run src/cli/commands/setup.test.ts` — 20/20 pass
- [x] `tsc --noEmit` — clean
- [ ] Build a fresh `agent-relay` binary and dry-run a `.ts` workflow in a project with only `@agent-relay/sdk` installed
- [ ] Verify on a Node <22.6 box that it falls through to tsx/ts-node as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
