### PR TITLE
Fix SDK trajectory publish build

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -194,6 +194,40 @@ jobs:
           node dist/src/cli/index.js down --force --timeout 5000 || true
           kill $DAEMON_PID 2>/dev/null || true
 
+  publish-fresh-install-build:
+    name: Publish Fresh Install Build
+    needs: changes
+    if: needs.changes.outputs.web_only != 'true'
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_FUND: false
+      TURBO_TELEMETRY_DISABLED: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+
+      # The publish workflow bumps versions, removes package-lock.json, then
+      # runs npm install. This catches range-resolved dependency breaks before merge.
+      - name: Install dependencies with publish resolution
+        run: |
+          rm -rf node_modules packages/*/node_modules package-lock.json
+          npm install
+
+      - name: Show resolved trajectory dependency
+        run: npm ls agent-trajectories --all
+
+      - name: Ensure rollup optional dependencies are installed
+        run: npm install --no-save rollup || true
+
+      - name: Build packages
+        run: npm run build:packages
+
   standalone-macos-smoke:
     name: Standalone macOS Smoke
     needs: changes

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -225,8 +225,8 @@ jobs:
       - name: Ensure rollup optional dependencies are installed
         run: npm install --no-save rollup || true
 
-      - name: Build packages
-        run: npm run build:packages
+      - name: Build full workspace
+        run: npm run build
 
   standalone-macos-smoke:
     name: Standalone macOS Smoke

--- a/.trajectories/active/traj_1776113772922_bc92f121.json
+++ b/.trajectories/active/traj_1776113772922_bc92f121.json
@@ -33,6 +33,7 @@
       "title": "Planning",
       "agentName": "orchestrator",
       "startedAt": "2026-04-13T20:56:12.922Z",
+      "endedAt": "2026-04-13T20:56:16.452Z",
       "events": [
         {
           "ts": 1776113772922,
@@ -44,44 +45,41 @@
           "type": "note",
           "content": "Approach: 8-step dag workflow — Parsed 8 steps, 2 parallel tracks, 6 dependent steps, DAG validated, no cycles"
         }
-      ],
-      "endedAt": "2026-04-13T20:56:16.452Z"
+      ]
     },
     {
       "id": "ch_e9e14d47",
       "title": "Execution: init-msd-dir, read-context",
       "agentName": "orchestrator",
       "startedAt": "2026-04-13T20:56:16.452Z",
-      "events": [],
-      "endedAt": "2026-04-13T20:56:16.561Z"
+      "endedAt": "2026-04-13T20:56:16.561Z",
+      "events": []
     },
     {
       "id": "ch_0a7adc44",
       "title": "Convergence: init-msd-dir + read-context",
       "agentName": "orchestrator",
       "startedAt": "2026-04-13T20:56:16.561Z",
+      "endedAt": "2026-04-13T20:56:16.583Z",
       "events": [
         {
           "ts": 1776113776563,
           "type": "reflection",
           "content": "init-msd-dir + read-context resolved. 2/2 steps completed. All steps completed on first attempt. Unblocking: fast-plan.",
-          "significance": "high",
           "raw": {
             "confidence": 0.75,
-            "focalPoints": [
-              "init-msd-dir: completed",
-              "read-context: completed"
-            ]
-          }
+            "focalPoints": ["init-msd-dir: completed", "read-context: completed"]
+          },
+          "significance": "high"
         }
-      ],
-      "endedAt": "2026-04-13T20:56:16.583Z"
+      ]
     },
     {
       "id": "ch_b774dc47",
       "title": "Execution: fix-worker-1-step",
       "agentName": "fix-worker-1",
       "startedAt": "2026-04-13T20:56:16.583Z",
+      "endedAt": "2026-04-13T20:58:30.128Z",
       "events": [
         {
           "ts": 1776113776583,
@@ -95,7 +93,6 @@
           "ts": 1776113909226,
           "type": "completion-evidence",
           "content": "\"fix-worker-1-step\" verification-based completion — Verification passed (4 signal(s), 1 relevant channel post(s), 4 file change(s), exit=0; signals=0, Both fixes look correct. Here's the summary:, Verification passed, **[fix-worker-1-step] Output:**; channel=**[fix-worker-1-step] Output:**\n```\nBoth fixes look correct. Here's the summary:\n## Fix Summary\n### Finding 1: Duplicate `bundledDependencies`/`bundleDependenci; files=modified:.claude/settings.json, created:.claude/settings.local.json, modified:package.json, modified:src/cli/commands/messaging.ts; exit=0)",
-          "significance": "medium",
           "raw": {
             "stepName": "fix-worker-1-step",
             "completionMode": "verification",
@@ -119,7 +116,8 @@
               ],
               "exitCode": 0
             }
-          }
+          },
+          "significance": "medium"
         },
         {
           "ts": 1776113909226,
@@ -127,8 +125,7 @@
           "content": "\"fix-worker-1-step\" completed → Both fixes look correct. Here's the summary:\n\n---\n\n## Fix Summary\n\n### Finding 1: Duplicate `bundledDependencies`/`bundl",
           "significance": "medium"
         }
-      ],
-      "endedAt": "2026-04-13T20:58:30.128Z"
+      ]
     },
     {
       "id": "ch_826d971e",
@@ -143,8 +140,34 @@
           "raw": {
             "agent": "verifier"
           }
+        },
+        {
+          "ts": 1776268360472,
+          "type": "decision",
+          "content": "Localized workflow trajectory compatibility casts: Localized workflow trajectory compatibility casts",
+          "raw": {
+            "question": "Localized workflow trajectory compatibility casts",
+            "chosen": "Localized workflow trajectory compatibility casts",
+            "alternatives": [],
+            "reasoning": "Publish removes package-lock and resolves agent-trajectories@0.5.5, whose exported type aliases are narrower than its runtime schema. Keeping workflow metadata and casting only at the agent-trajectories adapter boundary preserves persisted trajectory shape while compiling against both 0.5.4 and 0.5.5."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1776268399439,
+          "type": "reflection",
+          "content": "SDK trajectory build failure fixed and package-validation now includes a publish-style fresh npm install build. Verified sdk build with lifecycle scripts, sdk build against agent-trajectories@0.5.5 declarations, and full package build.",
+          "raw": {
+            "focalPoints": ["publish", "ci", "typescript"],
+            "confidence": 0.88
+          },
+          "significance": "high",
+          "tags": ["focal:publish", "focal:ci", "focal:typescript", "confidence:0.88"]
         }
       ]
     }
-  ]
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "tags": []
 }

--- a/.trajectories/active/traj_1776113772922_bc92f121.json
+++ b/.trajectories/active/traj_1776113772922_bc92f121.json
@@ -163,6 +163,18 @@
           },
           "significance": "high",
           "tags": ["focal:publish", "focal:ci", "focal:typescript", "confidence:0.88"]
+        },
+        {
+          "ts": 1776269504512,
+          "type": "decision",
+          "content": "Aligned publish-resolution CI check with publish build command: Aligned publish-resolution CI check with publish build command",
+          "raw": {
+            "question": "Aligned publish-resolution CI check with publish build command",
+            "chosen": "Aligned publish-resolution CI check with publish build command",
+            "alternatives": [],
+            "reasoning": "Codex review noted the new job used build:packages while publish runs npm run build. The CI guard now runs the full root build so root CLI/TypeScript failures are caught before merge."
+          },
+          "significance": "high"
         }
       ]
     }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-15T15:53:19.442Z",
+  "lastUpdated": "2026-04-15T16:11:44.516Z",
   "trajectories": {
     "traj_qb54w47qwod6": {
       "title": "fix-history-from-workflow",

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-13T21:52:53.833Z",
+  "lastUpdated": "2026-04-15T15:53:19.442Z",
   "trajectories": {
     "traj_qb54w47qwod6": {
       "title": "fix-history-from-workflow",
@@ -3637,7 +3637,7 @@
       "title": "autofix-swarm-Agentworkforce-relay-workflow",
       "status": "active",
       "startedAt": "2026-04-13T20:56:12.922Z",
-      "path": "/home/runner/work/relay/relay/.trajectories/active/traj_1776113772922_bc92f121.json"
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/active/traj_1776113772922_bc92f121.json"
     }
   }
 }

--- a/packages/sdk/src/workflows/trajectory.ts
+++ b/packages/sdk/src/workflows/trajectory.ts
@@ -13,6 +13,26 @@ import {
 } from 'agent-trajectories';
 import type { StepCompletionDecision, TrajectoryConfig, WorkflowStep } from './types.js';
 
+type WorkflowTrajectoryEventType =
+  | TrajectoryEventType
+  | 'review-completed'
+  | 'completion-marker'
+  | 'completion-evidence';
+
+type WorkflowTrajectoryAgent = {
+  name: string;
+  role: string;
+  joinedAt: string;
+  leftAt?: string;
+};
+
+// agent-trajectories runtime accepts workflow metadata and open-ended roles,
+// while some published declaration aliases are narrower.
+type WorkflowTrajectoryData = Omit<Trajectory, 'agents'> & {
+  agents: WorkflowTrajectoryAgent[];
+  workflowId?: string;
+};
+
 interface StepParticipants {
   role?: string;
   owner?: string;
@@ -151,7 +171,7 @@ const extractChallenges = (outcomes: StepOutcome[]): string[] =>
     .map((step) => diagnosisFor(classifyFailure(step.error ?? ''), step));
 
 export class WorkflowTrajectory {
-  private trajectory: Trajectory | null = null;
+  private trajectory: WorkflowTrajectoryData | null = null;
   private storage?: FileStorage;
   private storageInit?: Promise<void>;
   private readonly enabled: boolean;
@@ -184,13 +204,14 @@ export class WorkflowTrajectory {
     if (!this.enabled) return;
     this.startTime = Date.now();
     this.swarmPattern = pattern ?? 'dag';
-    this.trajectory = createTrajectory({
+    const trajectory = createTrajectory({
       title: workflowName,
       description,
       source: { system: 'workflow-runner', id: this.runId },
-    });
+    }) as WorkflowTrajectoryData;
     const workflowId = process.env.TRAJECTORIES_WORKFLOW_ID?.trim();
-    if (workflowId) this.trajectory = { ...this.trajectory, workflowId };
+    if (workflowId) trajectory.workflowId = workflowId;
+    this.trajectory = trajectory;
     this.trajectory.agents.push({
       name: 'orchestrator',
       role: 'workflow-runner',
@@ -420,13 +441,13 @@ export class WorkflowTrajectory {
       `${summary} (completed in ${formatElapsed(Date.now() - this.startTime, true)})`,
       'high'
     );
-    this.trajectory = completeTrajectory(this.trajectory, {
+    this.trajectory = completeTrajectory(this.trajectory as Trajectory, {
       summary,
       approach: this.buildApproach(),
       confidence,
       learnings: meta?.learnings,
       challenges: meta?.challenges,
-    });
+    }) as WorkflowTrajectoryData;
     await this.flush();
   }
 
@@ -444,7 +465,7 @@ export class WorkflowTrajectory {
     );
     this.addEvent('error', `Workflow abandoned: ${reason}`, 'high');
     this.trajectory = {
-      ...abandonTrajectory(this.trajectory),
+      ...abandonTrajectory(this.trajectory as Trajectory),
       retrospective: {
         summary,
         approach: this.buildApproach(),
@@ -452,7 +473,7 @@ export class WorkflowTrajectory {
         learnings: meta?.learnings,
         challenges: meta?.challenges,
       },
-    };
+    } as WorkflowTrajectoryData;
     await this.flush();
   }
 
@@ -486,17 +507,25 @@ export class WorkflowTrajectory {
 
   private openChapter(title: string, agentName: string): void {
     if (!this.trajectory) return;
-    this.trajectory = appendChapter(this.trajectory, { title, agentName });
+    this.trajectory = appendChapter(this.trajectory as Trajectory, {
+      title,
+      agentName,
+    }) as WorkflowTrajectoryData;
   }
 
   private addEvent(
-    type: TrajectoryEventType,
+    type: WorkflowTrajectoryEventType,
     content: string,
     significance?: EventSignificance,
     raw?: Record<string, unknown>
   ): void {
     if (!this.trajectory) return;
-    this.trajectory = appendEvent(this.trajectory, { type, content, significance, raw });
+    this.trajectory = appendEvent(this.trajectory as Trajectory, {
+      type: type as TrajectoryEventType,
+      content,
+      significance,
+      raw,
+    }) as WorkflowTrajectoryData;
   }
 
   private buildApproach(): string {
@@ -526,7 +555,7 @@ export class WorkflowTrajectory {
     if (!this.trajectory) return;
     try {
       await this.ensureStorage();
-      await this.storage?.save(this.trajectory);
+      await this.storage?.save(this.trajectory as Trajectory);
     } catch {
       // non-blocking: flush failures must never break the workflow
     }


### PR DESCRIPTION
## Summary
- make the SDK workflow trajectory adapter compile against the publish-resolved `agent-trajectories` declarations while preserving workflow metadata, open-ended roles, and custom workflow event types
- add a package-validation job that mimics publish dependency resolution by removing `package-lock.json`, running `npm install`, and building packages
- record the work in the tracked trajectory files

## Verification
- `NPM_CONFIG_IGNORE_SCRIPTS=false npm --prefix packages/sdk run build`
- temporary `agent-trajectories@0.5.5` override + `NPM_CONFIG_USERCONFIG=/dev/null npm --prefix packages/sdk run build`
- `NPM_CONFIG_USERCONFIG=/dev/null npm run build:packages -- --force`
- `npx prettier --check packages/sdk/src/workflows/trajectory.ts .github/workflows/package-validation.yml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
