### PR TITLE
fix(cli): visible launch checkpoint for cloud connect fallback path

### DIFF
--- a/src/cli/lib/ssh-interactive.test.ts
+++ b/src/cli/lib/ssh-interactive.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi } from 'vitest';
 
-import { formatShellInvocation, runInteractiveSession } from './ssh-interactive.js';
+import { formatShellInvocation, runInteractiveSession, wrapWithLaunchCheckpoint } from './ssh-interactive.js';
 
 interface FakeStream extends EventEmitter {
   stderr: EventEmitter;
@@ -159,6 +159,26 @@ describe('formatShellInvocation', () => {
   });
 });
 
+describe('wrapWithLaunchCheckpoint', () => {
+  it('prefixes the command with a visible stderr printf before it runs', () => {
+    const wrapped = wrapWithLaunchCheckpoint('exec claude');
+    expect(wrapped.startsWith("printf '")).toBe(true);
+    expect(wrapped).toContain('launching provider CLI');
+    expect(wrapped).toContain('>&2;');
+    expect(wrapped.endsWith('exec claude')).toBe(true);
+  });
+
+  it('keeps the checkpoint on stderr so it does not pollute command output piping', () => {
+    const wrapped = wrapWithLaunchCheckpoint('true');
+    expect(wrapped).toMatch(/>&2\s*;/);
+  });
+
+  it('preserves env-var prefixes in the wrapped command', () => {
+    const wrapped = wrapWithLaunchCheckpoint('PATH=/foo/bin exec claude');
+    expect(wrapped.endsWith('PATH=/foo/bin exec claude')).toBe(true);
+  });
+});
+
 describe('runInteractiveSession — handler-order and pattern gating', () => {
   it("attaches stream.on('data') before the first stream.write", async () => {
     const listenerCountsAtWrite: number[] = [];
@@ -192,6 +212,9 @@ describe('runInteractiveSession — handler-order and pattern gating', () => {
     const payload = String(getClient().stream.write.mock.calls[0][0]);
     expect(payload.startsWith("exec sh -c '")).toBe(true);
     expect(payload.includes('; exit $?')).toBe(false);
+    // The launch-checkpoint wrap is applied before formatShellInvocation,
+    // so the inner sh -c body starts with the visible printf breadcrumb.
+    expect(payload).toContain('launching provider CLI');
   });
 
   it('matches success patterns against output produced after the command is written', async () => {

--- a/src/cli/lib/ssh-interactive.ts
+++ b/src/cli/lib/ssh-interactive.ts
@@ -110,6 +110,22 @@ export function formatShellInvocation(command: string): string {
 }
 
 /**
+ * Wrap the remote command with a visible checkpoint so the user sees proof
+ * the ssh pipeline reached the sandbox before the provider CLI takes over
+ * the terminal. Without this, claude/codex enter alt-screen immediately and
+ * the user sees zero output — indistinguishable from a hang.
+ *
+ * The printf runs before the exec that launches the provider CLI, so the
+ * user gets one visible line ("launching provider CLI…") right before
+ * alt-screen engages. When the provider CLI later exits and the alt-screen
+ * tears down, this line remains in scrollback as a breadcrumb.
+ */
+export function wrapWithLaunchCheckpoint(command: string): string {
+  // Escape single quotes for inclusion in the printf argument.
+  return `printf '\\033[2m[agent-relay] launching provider CLI…\\033[0m\\n' >&2; ${command}`;
+}
+
+/**
  * Run an interactive SSH session with PTY.
  *
  * Connects via ssh2 (if available) or falls back to system ssh,
@@ -119,11 +135,23 @@ export function formatShellInvocation(command: string): string {
 export async function runInteractiveSession(
   options: InteractiveSessionOptions
 ): Promise<InteractiveSessionResult> {
-  const { ssh, remoteCommand, successPatterns, errorPatterns, timeoutMs, io, tunnelPort = 1455 } = options;
+  const { ssh, successPatterns, errorPatterns, timeoutMs, io, tunnelPort = 1455 } = options;
 
   const runtime = { ...DEFAULT_RUNTIME, ...options.runtime };
 
+  // Wrap the remote command with a visible checkpoint so the user sees proof
+  // the ssh pipeline is alive before the provider CLI enters alt-screen.
+  const remoteCommand = wrapWithLaunchCheckpoint(options.remoteCommand);
+
   const ssh2 = await runtime.loadSSH2();
+
+  io.log(color.yellow('Starting interactive authentication...'));
+  io.log(color.dim('The provider CLI may take 5-15s to render its first screen after connecting.'));
+  io.log(
+    color.dim('A welcome / theme picker may appear before the sign-in step. Follow the on-screen prompts.')
+  );
+  io.log(color.dim('Wait for the CLI to render before pressing Ctrl+C.'));
+  io.log('');
 
   let execResult: InteractiveSessionResult | null = null;
   let execError: Error | null = null;
@@ -411,14 +439,6 @@ export async function runInteractiveSession(
       });
 
     try {
-      io.log(color.yellow('Starting interactive authentication...'));
-      io.log(
-        color.dim('The provider CLI may show a first-run screen (welcome, theme picker, or similar) before')
-      );
-      io.log(
-        color.dim('the sign-in step. Follow the on-screen prompts. Press Ctrl+C to cancel at any time.')
-      );
-      io.log('');
       execResult = await execInteractive(remoteCommand, timeoutMs);
     } catch (err) {
       execError = err instanceof Error ? err : new Error(String(err));
@@ -442,10 +462,6 @@ export async function runInteractiveSession(
       sshArgs.push('-tt');
       sshArgs.push(`${ssh.user}@${ssh.host}`);
       sshArgs.push(remoteCommand);
-
-      io.log(color.yellow('Starting interactive authentication...'));
-      io.log(color.dim('Follow the prompts below.'));
-      io.log('');
 
       const child = runtime.spawnProcess('ssh', sshArgs, {
         stdio: 'inherit',


### PR DESCRIPTION
## Summary

The prior cloud-connect hang fix (#743, released as v4.0.25) improved the **ssh2** code path, but the released Bun binary marks \`ssh2\` as \`--external\` (scripts/build-bun.sh:68) and does not ship it. At runtime \`loadSSH2()\` silently returns \`null\` and every user lands on the **system-ssh fallback** branch — the one place my previous UX work did not touch. Users saw:

\`\`\`
Starting interactive authentication...
Follow the prompts below.

<long silence>
\`\`\`

…while the provider CLI took 5–15s to render its first screen and enter alt-screen. Indistinguishable from a hang.

## Fix

- **Wraps the remote command with a visible stderr \`printf\` checkpoint** (\`[agent-relay] launching provider CLI…\`) that runs right before the exec. This lives in the command string itself, so it works through both ssh2 and system-ssh paths. Users now see a concrete breadcrumb the moment ssh reaches the sandbox, before claude/codex take over the terminal.
- **Unifies the launch banner** and hoists it out of both branches so every user sees the same "may take 5–15s" expectation before anything spawns. Removes the duplicate per-branch banners.

## Follow-up (not in this PR)

Bundle \`ssh2\` into the Bun binary so the ssh2 path actually runs in releases. That's a release-critical build-script change that needs validation across all four cross-compilation targets (darwin-arm64/x64, linux-x64/arm64) and was held out of this PR to keep the risk surface small.

## Test plan

- [x] \`npx vitest run src/cli/lib/ssh-interactive.test.ts\` — 13/13 passing (adds 3 tests for \`wrapWithLaunchCheckpoint\`, asserts the ssh2 payload still starts with \`exec sh -c '\` and now contains the checkpoint string)
- [x] \`npm run build\` — clean across all 13 workspace tasks
- [ ] Manual: \`agent-relay cloud connect claude\` in a fresh terminal — confirm the dim \`[agent-relay] launching provider CLI…\` line appears between "Connecting via SSH…" and the claude welcome screen, and remains in scrollback after alt-screen tears down
- [ ] Manual: \`agent-relay cloud connect openai\` — same checkpoint visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
