### PR TITLE
fix(cloud-connect): bundle ssh2 in release pipeline (real fix for #745)

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -302,10 +302,14 @@ jobs:
             --minify \
             --target="$TARGET" \
             --external=better-sqlite3 \
-            --external=ssh2 \
             --define="process.env.AGENT_RELAY_VERSION=\"${VERSION}\"" \
             ./dist/src/cli/index.js \
             --outfile "release-binaries/${OUTPUT}"
+          if ! strings "release-binaries/${OUTPUT}" | grep -q 'ssh-userauth'; then
+            echo "FATAL: ssh2 protocol symbols missing from release-binaries/${OUTPUT}"
+            echo "cloud connect would hang; aborting validation."
+            exit 1
+          fi
           scripts/sign-macos-binary.sh "release-binaries/${OUTPUT}"
           scripts/verify-macos-binary.sh "release-binaries/${OUTPUT}" "$EXPECTED_ARCH" -- --version
           echo "STANDALONE_CLI=$PWD/release-binaries/${OUTPUT}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,10 +190,20 @@ jobs:
             --minify \
             --target=${{ matrix.target }} \
             --external=better-sqlite3 \
-            --external=ssh2 \
             --define="process.env.AGENT_RELAY_VERSION=\"${{ needs.build.outputs.new_version }}\"" \
             ./dist/src/cli/index.js \
             --outfile release-binaries/${{ matrix.binary_name }}
+
+      - name: Verify ssh2 is bundled into binary
+        run: |
+          BIN="release-binaries/${{ matrix.binary_name }}"
+          if ! strings "$BIN" | grep -q 'ssh-userauth'; then
+            echo "FATAL: ssh2 protocol symbols missing from $BIN"
+            echo "The cloud connect command will hang in the fallback path."
+            echo "Check that --external=ssh2 is NOT passed to bun build."
+            exit 1
+          fi
+          echo "OK: ssh2 is bundled (ssh-userauth symbol present)"
 
       - name: Sign macOS binary
         if: startsWith(matrix.target, 'bun-darwin-')

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -49,7 +49,6 @@ npx esbuild "$DIST_DIR/src/cli/index.js" \
     --external:better-sqlite3 \
     --external:cpu-features \
     --external:node-pty \
-    --external:ssh2 \
     --define:process.env.AGENT_RELAY_VERSION="\"$VERSION\"" \
     --minify \
     2>&1

--- a/src/cli/lib/ssh-interactive.ts
+++ b/src/cli/lib/ssh-interactive.ts
@@ -146,6 +146,7 @@ export async function runInteractiveSession(
   const ssh2 = await runtime.loadSSH2();
 
   io.log(color.yellow('Starting interactive authentication...'));
+  io.log(color.dim(`Transport: ${ssh2 ? 'ssh2 (bundled)' : 'system ssh (fallback)'}`));
   io.log(color.dim('The provider CLI may take 5-15s to render its first screen after connecting.'));
   io.log(
     color.dim('A welcome / theme picker may appear before the sign-in step. Follow the on-screen prompts.')


### PR DESCRIPTION
## Summary

- v4.0.27 shipped with ssh2 **still stripped** from the binary. PR #745 fixed `scripts/build-bun.sh`, but the release pipeline has its **own** inline bun build (`.github/workflows/publish.yml`) that was never touched. That inline build kept passing `--external=ssh2`, so `agent-relay cloud connect <provider>` silently fell through to the system-ssh path and hung.
- Proof: \`strings /tmp/agent-relay-v4.0.27 | grep -c ssh-userauth\` → **0**.
- This PR removes `--external=ssh2` from the three remaining places, adds a hard \`strings | grep ssh-userauth\` guard at release time, and adds a visible \`Transport:\` breadcrumb so future regressions are diagnosable in one command.

## What changed

| File | Change |
|---|---|
| \`.github/workflows/publish.yml\` | Drop \`--external=ssh2\` from the inline \`bun build --compile\`. Add post-build \`strings\` guard that fails the release job if \`ssh-userauth\` symbols are missing. |
| \`.github/workflows/package-validation.yml\` | Same drop + same guard for the mac validation path. |
| \`scripts/build-standalone.sh\` | Drop \`--external:ssh2\` from the esbuild bundling stage. |
| \`src/cli/lib/ssh-interactive.ts\` | Print \`Transport: ssh2 (bundled)\` vs \`Transport: system ssh (fallback)\` so a user's output tells us which code path was taken. |

## Why \`scripts/build-bun.sh\` wasn't enough

The release job at \`.github/workflows/publish.yml:184-196\` inlines its own \`bun build --compile\` and does **not** call \`scripts/build-bun.sh\`. That's why #745's edit had zero effect on the released binary — it was dead on arrival.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run src/cli/lib/ssh-interactive.test.ts\` — 13/13 pass
- [ ] On merge + release: confirm the new \`Verify ssh2 is bundled\` step passes on every matrix target in publish.yml
- [ ] After v4.0.28 ships: \`curl ... && strings agent-relay | grep -c ssh-userauth\` must return \`>0\`
- [ ] User runs \`agent-relay cloud connect claude\` and sees \`Transport: ssh2 (bundled)\` followed by the launch checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
