### PR TITLE
feat(sdk): add ProcessBackend workflow for cloud sandbox execution

### DIFF
--- a/.trajectories/active/traj_1776113772922_bc92f121.json
+++ b/.trajectories/active/traj_1776113772922_bc92f121.json
@@ -175,6 +175,29 @@
             "reasoning": "Codex review noted the new job used build:packages while publish runs npm run build. The CI guard now runs the full root build so root CLI/TypeScript failures are caught before merge."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1776455373340,
+          "type": "decision",
+          "content": "Handled PR 747 feedback in tracked parent worktree: Handled PR 747 feedback in tracked parent worktree",
+          "raw": {
+            "question": "Handled PR 747 feedback in tracked parent worktree",
+            "chosen": "Handled PR 747 feedback in tracked parent worktree",
+            "alternatives": [],
+            "reasoning": "The cwd copy under .relay/workspace is not the git worktree; fixes must be applied to /Users/khaliqgant/Projects/AgentWorkforce/relay so the feature branch and PR contain them."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1776455534306,
+          "type": "reflection",
+          "content": "PR 747 feedback fixes verified with SDK build, package build, full root build, and focused ProcessBackend executor tests",
+          "raw": {
+            "focalPoints": ["pr-747", "typescript", "process-backend"],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": ["focal:pr-747", "focal:typescript", "focal:process-backend", "confidence:0.9"]
         }
       ]
     }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-15T21:45:41.032Z",
+  "lastUpdated": "2026-04-17T19:52:14.307Z",
   "trajectories": {
     "traj_qb54w47qwod6": {
       "title": "fix-history-from-workflow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "4.0.20",
+  "version": "4.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "bundleDependencies": [
         "@agent-relay/cloud",
         "@agent-relay/config",
@@ -25,14 +25,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "4.0.20",
-        "@agent-relay/config": "4.0.20",
-        "@agent-relay/hooks": "4.0.20",
-        "@agent-relay/sdk": "4.0.20",
-        "@agent-relay/telemetry": "4.0.20",
-        "@agent-relay/trajectory": "4.0.20",
-        "@agent-relay/user-directory": "4.0.20",
-        "@agent-relay/utils": "4.0.20",
+        "@agent-relay/cloud": "4.0.28",
+        "@agent-relay/config": "4.0.28",
+        "@agent-relay/hooks": "4.0.28",
+        "@agent-relay/sdk": "4.0.28",
+        "@agent-relay/telemetry": "4.0.28",
+        "@agent-relay/trajectory": "4.0.28",
+        "@agent-relay/user-directory": "4.0.28",
+        "@agent-relay/utils": "4.0.28",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -41,6 +41,7 @@
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": "^0.1.2",
         "@sinclair/typebox": "^0.34.14",
+        "agent-trajectories": "^0.5.4",
         "chalk": "^4.1.2",
         "chokidar": "^5.0.0",
         "commander": "^12.1.0",
@@ -80,7 +81,6 @@
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
         "@vitest/coverage-v8": "^3.2.4",
-        "agent-trajectories": "^0.5.4",
         "concurrently": "^9.2.1",
         "eslint": "^8.57.1",
         "husky": "^9.1.7",
@@ -1179,7 +1179,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15238,10 +15237,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.20",
+        "@agent-relay/sdk": "4.0.28",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15257,13 +15256,13 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "4.0.20"
+      "version": "4.0.28"
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20",
+        "@agent-relay/config": "4.0.28",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15275,7 +15274,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15287,9 +15286,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.20"
+        "@agent-relay/sdk": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15298,11 +15297,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20",
-        "@agent-relay/sdk": "4.0.20",
-        "@agent-relay/trajectory": "4.0.20"
+        "@agent-relay/config": "4.0.28",
+        "@agent-relay/sdk": "4.0.28",
+        "@agent-relay/trajectory": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15311,9 +15310,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/hooks": "4.0.20"
+        "@agent-relay/hooks": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15322,11 +15321,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.20",
+        "@agent-relay/sdk": "4.0.28",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16149,9 +16148,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20"
+        "@agent-relay/config": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16160,9 +16159,9 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20",
+        "@agent-relay/config": "4.0.28",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": "^0.1.2",
         "@sinclair/typebox": "^0.34.48",
@@ -16224,7 +16223,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
         "posthog-node": "^4.0.1"
       },
@@ -16235,9 +16234,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20"
+        "@agent-relay/config": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16246,9 +16245,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/utils": "4.0.20"
+        "@agent-relay/utils": "4.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16257,9 +16256,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "4.0.20",
+      "version": "4.0.28",
       "dependencies": {
-        "@agent-relay/config": "4.0.20",
+        "@agent-relay/config": "4.0.28",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -543,7 +543,12 @@ export class AgentRelay {
       this.workspaceName ?? workspaceId,
       this.getRelaycastBaseUrl()
     );
-    return created.apiKey;
+    const workspace = created as { apiKey?: string; api_key?: string };
+    const apiKey = workspace.apiKey ?? workspace.api_key;
+    if (!apiKey) {
+      throw new Error('RelayCast.createWorkspace() did not return an API key');
+    }
+    return apiKey;
   }
 
   /**

--- a/packages/sdk/src/workflows/__tests__/process-backend-executor.test.ts
+++ b/packages/sdk/src/workflows/__tests__/process-backend-executor.test.ts
@@ -30,8 +30,8 @@ function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
 
 describe('createProcessBackendExecutor', () => {
   it('creates an environment, runs the built command, and destroys the env', async () => {
-    const destroy = vi.fn(async () => undefined);
-    const exec = vi.fn(async () => ({ output: 'hello\n', exitCode: 0 }));
+    const destroy = vi.fn<ProcessEnvironment['destroy']>(async () => undefined);
+    const exec = vi.fn<ProcessEnvironment['exec']>(async () => ({ output: 'hello\n', exitCode: 0 }));
     const env = makeEnv(exec, destroy);
     const backend = makeBackend(env);
 
@@ -53,9 +53,33 @@ describe('createProcessBackendExecutor', () => {
     expect(output).toBe('hello\n');
   });
 
+  it('passes injected env and agent cwd through execOpts (not baked into the command)', async () => {
+    const exec = vi.fn<ProcessEnvironment['exec']>(async () => ({ output: 'ok', exitCode: 0 }));
+    const env = makeEnv(exec);
+    const backend = makeBackend(env);
+
+    const executor = createProcessBackendExecutor(backend, {
+      env: { ANTHROPIC_API_KEY: 'sk-test', RELAY_WORKSPACE: 'ws_123' },
+    });
+
+    await executor.executeAgentStep(
+      makeStep({ name: 'planner' }),
+      makeAgent({ cli: 'claude', cwd: '/work/repo' }),
+      'do the thing',
+      5_000
+    );
+
+    const [command, opts] = exec.mock.calls[0]!;
+    expect(command.startsWith('claude ') || command.startsWith("'claude'")).toBe(true);
+    expect(command).not.toMatch(/ANTHROPIC_API_KEY=/);
+    expect(opts?.env).toEqual({ ANTHROPIC_API_KEY: 'sk-test', RELAY_WORKSPACE: 'ws_123' });
+    expect(opts?.cwd).toBe('/work/repo');
+    expect(opts?.timeoutSeconds).toBe(5);
+  });
+
   it('throws when the remote command exits non-zero and still destroys', async () => {
-    const destroy = vi.fn(async () => undefined);
-    const exec = vi.fn(async () => ({ output: 'boom', exitCode: 2 }));
+    const destroy = vi.fn<ProcessEnvironment['destroy']>(async () => undefined);
+    const exec = vi.fn<ProcessEnvironment['exec']>(async () => ({ output: 'boom', exitCode: 2 }));
     const env = makeEnv(exec, destroy);
     const backend = makeBackend(env);
 
@@ -68,7 +92,7 @@ describe('createProcessBackendExecutor', () => {
   });
 
   it('rejects cli:"api" because it does not run as a subprocess', async () => {
-    const env = makeEnv(vi.fn());
+    const env = makeEnv(vi.fn<ProcessEnvironment['exec']>());
     const backend = makeBackend(env);
     const executor = createProcessBackendExecutor(backend);
 
@@ -78,7 +102,7 @@ describe('createProcessBackendExecutor', () => {
   });
 
   it('passes injected env through to exec for deterministic steps', async () => {
-    const exec = vi.fn(async () => ({ output: 'ok', exitCode: 0 }));
+    const exec = vi.fn<ProcessEnvironment['exec']>(async () => ({ output: 'ok', exitCode: 0 }));
     const env = makeEnv(exec);
     const backend = makeBackend(env);
 

--- a/packages/sdk/src/workflows/__tests__/process-backend-executor.test.ts
+++ b/packages/sdk/src/workflows/__tests__/process-backend-executor.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { createProcessBackendExecutor } from '../process-backend-executor.js';
+import type { ProcessBackend, ProcessEnvironment, WorkflowStep, AgentDefinition } from '../types.js';
+
+function makeEnv(
+  exec: ProcessEnvironment['exec'],
+  destroy: ProcessEnvironment['destroy'] = vi.fn(async () => undefined)
+): ProcessEnvironment {
+  return {
+    id: 'env-1',
+    homeDir: '/home/runner',
+    exec,
+    uploadFile: vi.fn(async () => undefined),
+    destroy,
+  };
+}
+
+function makeBackend(env: ProcessEnvironment): ProcessBackend {
+  return { createEnvironment: vi.fn(async () => env) };
+}
+
+function makeStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
+  return { name: 'step-1', ...overrides } as WorkflowStep;
+}
+
+function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return { name: 'worker-1', cli: 'claude', ...overrides } as AgentDefinition;
+}
+
+describe('createProcessBackendExecutor', () => {
+  it('creates an environment, runs the built command, and destroys the env', async () => {
+    const destroy = vi.fn(async () => undefined);
+    const exec = vi.fn(async () => ({ output: 'hello\n', exitCode: 0 }));
+    const env = makeEnv(exec, destroy);
+    const backend = makeBackend(env);
+
+    const executor = createProcessBackendExecutor(backend);
+    const output = await executor.executeAgentStep(
+      makeStep({ name: 'planner' }),
+      makeAgent({ cli: 'claude' }),
+      'do the thing',
+      30_000
+    );
+
+    expect(backend.createEnvironment).toHaveBeenCalledWith('planner');
+    expect(exec).toHaveBeenCalledTimes(1);
+    const [command, opts] = exec.mock.calls[0]!;
+    expect(typeof command).toBe('string');
+    expect(command).toContain('claude');
+    expect(opts?.timeoutSeconds).toBe(30);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(output).toBe('hello\n');
+  });
+
+  it('throws when the remote command exits non-zero and still destroys', async () => {
+    const destroy = vi.fn(async () => undefined);
+    const exec = vi.fn(async () => ({ output: 'boom', exitCode: 2 }));
+    const env = makeEnv(exec, destroy);
+    const backend = makeBackend(env);
+
+    const executor = createProcessBackendExecutor(backend);
+
+    await expect(executor.executeAgentStep(makeStep(), makeAgent(), 'task')).rejects.toThrow(
+      /exited with code 2/
+    );
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects cli:"api" because it does not run as a subprocess', async () => {
+    const env = makeEnv(vi.fn());
+    const backend = makeBackend(env);
+    const executor = createProcessBackendExecutor(backend);
+
+    await expect(executor.executeAgentStep(makeStep(), makeAgent({ cli: 'api' }), 'task')).rejects.toThrow(
+      /cli "api"/
+    );
+  });
+
+  it('passes injected env through to exec for deterministic steps', async () => {
+    const exec = vi.fn(async () => ({ output: 'ok', exitCode: 0 }));
+    const env = makeEnv(exec);
+    const backend = makeBackend(env);
+
+    const executor = createProcessBackendExecutor(backend, {
+      env: { RELAY_WORKSPACE: 'ws_123' },
+    });
+
+    const result = await executor.executeDeterministicStep!(
+      makeStep({ type: 'deterministic', command: 'echo hi', timeoutMs: 5_000 }),
+      'echo hi',
+      '/work'
+    );
+
+    expect(result).toEqual({ output: 'ok', exitCode: 0 });
+    const [, opts] = exec.mock.calls[0]!;
+    expect(opts?.cwd).toBe('/work');
+    expect(opts?.env).toEqual({ RELAY_WORKSPACE: 'ws_123' });
+    expect(opts?.timeoutSeconds).toBe(5);
+  });
+});

--- a/packages/sdk/src/workflows/index.ts
+++ b/packages/sdk/src/workflows/index.ts
@@ -4,6 +4,10 @@ export * from './custom-steps.js';
 export * from './cli-session-collector.js';
 export * from './channel-messenger.js';
 export * from './process-spawner.js';
+export {
+  createProcessBackendExecutor,
+  type ProcessBackendExecutorOptions,
+} from './process-backend-executor.js';
 export * from './run-summary-table.js';
 export * from './template-resolver.js';
 export * from './verification.js';

--- a/packages/sdk/src/workflows/process-backend-executor.ts
+++ b/packages/sdk/src/workflows/process-backend-executor.ts
@@ -24,12 +24,6 @@ function commandToShell(argv: string[]): string {
   return argv.map(shellEscape).join(' ');
 }
 
-function envToExportPrefix(env: Record<string, string> | undefined): string {
-  if (!env || Object.keys(env).length === 0) return '';
-  const parts = Object.entries(env).map(([k, v]) => `${k}=${shellEscape(v)}`);
-  return parts.join(' ') + ' ';
-}
-
 export interface ProcessBackendExecutorOptions {
   /** Env vars injected into every step (e.g. auth tokens, relayfile config). */
   env?: Record<string, string>;
@@ -57,7 +51,7 @@ export function createProcessBackendExecutor(
 
       const extraArgs = agentDef.constraints?.model ? ['--model', agentDef.constraints.model] : [];
       const argv = buildCommand(agentDef.cli, extraArgs, resolvedTask);
-      const commandString = envToExportPrefix(baseEnv) + commandToShell(argv);
+      const commandString = commandToShell(argv);
 
       const env = await backend.createEnvironment(step.name);
       try {
@@ -66,6 +60,10 @@ export function createProcessBackendExecutor(
           env?: Record<string, string>;
           timeoutSeconds?: number;
         } = {};
+        if (agentDef.cwd) execOpts.cwd = agentDef.cwd;
+        if (Object.keys(baseEnv).length > 0) execOpts.env = baseEnv;
+        // timeoutSeconds is ceil-rounded from the caller's timeoutMs; a 500ms
+        // timeout becomes 1s because the backend protocol uses seconds.
         if (timeoutMs && timeoutMs > 0) {
           execOpts.timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
         }

--- a/packages/sdk/src/workflows/process-backend-executor.ts
+++ b/packages/sdk/src/workflows/process-backend-executor.ts
@@ -1,0 +1,105 @@
+/**
+ * Adapter that implements {@link RunnerStepExecutor} on top of a
+ * {@link ProcessBackend}. Relay owns agent configuration (CLI flags, env,
+ * preset); the backend only provides "where to run" — create an isolated
+ * environment, exec the command, destroy.
+ *
+ * The WorkflowRunner synthesizes one of these when a caller passes
+ * `processBackend` without an explicit `executor`, so every existing
+ * `executor.executeAgentStep(...)` call site transparently flows through
+ * the backend (e.g. a cloud sandbox) without any further plumbing.
+ */
+
+import { buildCommand } from './process-spawner.js';
+import type { ProcessBackend, AgentDefinition, WorkflowStep } from './types.js';
+import type { RunnerStepExecutor } from './runner.js';
+
+function shellEscape(value: string): string {
+  if (value === '') return "''";
+  if (/^[A-Za-z0-9_\/.:,=+@%-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function commandToShell(argv: string[]): string {
+  return argv.map(shellEscape).join(' ');
+}
+
+function envToExportPrefix(env: Record<string, string> | undefined): string {
+  if (!env || Object.keys(env).length === 0) return '';
+  const parts = Object.entries(env).map(([k, v]) => `${k}=${shellEscape(v)}`);
+  return parts.join(' ') + ' ';
+}
+
+export interface ProcessBackendExecutorOptions {
+  /** Env vars injected into every step (e.g. auth tokens, relayfile config). */
+  env?: Record<string, string>;
+}
+
+export function createProcessBackendExecutor(
+  backend: ProcessBackend,
+  options: ProcessBackendExecutorOptions = {}
+): RunnerStepExecutor {
+  const baseEnv = options.env ?? {};
+
+  return {
+    async executeAgentStep(
+      step: WorkflowStep,
+      agentDef: AgentDefinition,
+      resolvedTask: string,
+      timeoutMs?: number
+    ): Promise<string> {
+      if (agentDef.cli === 'api') {
+        throw new Error(
+          `processBackend cannot execute cli "api" agents — api agents call the Anthropic API directly. ` +
+            `Route agent "${agentDef.name}" through a subprocess CLI (claude, codex, etc.) or omit processBackend.`
+        );
+      }
+
+      const extraArgs = agentDef.constraints?.model ? ['--model', agentDef.constraints.model] : [];
+      const argv = buildCommand(agentDef.cli, extraArgs, resolvedTask);
+      const commandString = envToExportPrefix(baseEnv) + commandToShell(argv);
+
+      const env = await backend.createEnvironment(step.name);
+      try {
+        const execOpts: {
+          cwd?: string;
+          env?: Record<string, string>;
+          timeoutSeconds?: number;
+        } = {};
+        if (timeoutMs && timeoutMs > 0) {
+          execOpts.timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+        }
+        const result = await env.exec(commandString, execOpts);
+        if (result.exitCode !== 0) {
+          const tail = result.output.slice(-2000);
+          throw new Error(`Agent step "${step.name}" exited with code ${result.exitCode}: ${tail}`);
+        }
+        return result.output;
+      } finally {
+        await env.destroy().catch(() => undefined);
+      }
+    },
+
+    async executeDeterministicStep(
+      step: WorkflowStep,
+      resolvedCommand: string,
+      cwd: string
+    ): Promise<{ output: string; exitCode: number }> {
+      const env = await backend.createEnvironment(step.name);
+      try {
+        const execOpts: {
+          cwd?: string;
+          env?: Record<string, string>;
+          timeoutSeconds?: number;
+        } = { cwd };
+        if (Object.keys(baseEnv).length > 0) execOpts.env = baseEnv;
+        if (step.timeoutMs && step.timeoutMs > 0) {
+          execOpts.timeoutSeconds = Math.max(1, Math.ceil(step.timeoutMs / 1000));
+        }
+        return await env.exec(resolvedCommand, execOpts);
+      } finally {
+        await env.destroy().catch(() => undefined);
+      }
+    },
+  };
+}

--- a/packages/sdk/src/workflows/process-backend-executor.ts
+++ b/packages/sdk/src/workflows/process-backend-executor.ts
@@ -1,8 +1,8 @@
 /**
  * Adapter that implements {@link RunnerStepExecutor} on top of a
- * {@link ProcessBackend}. Relay owns agent configuration (CLI flags, env,
- * preset); the backend only provides "where to run" — create an isolated
- * environment, exec the command, destroy.
+ * {@link ProcessBackend}. Relay owns command construction (CLI flags, env,
+ * cwd, timeout); the backend only provides "where to run" — create an
+ * isolated environment, exec the command, destroy.
  *
  * The WorkflowRunner synthesizes one of these when a caller passes
  * `processBackend` without an explicit `executor`, so every existing

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -45,6 +45,7 @@ import { executeApiStep } from './api-executor.js';
 import { ChannelMessenger } from './channel-messenger.js';
 import { InMemoryWorkflowDb } from './memory-db.js';
 import { buildCommand as buildProcessCommand, spawnProcess } from './process-spawner.js';
+import { createProcessBackendExecutor } from './process-backend-executor.js';
 import { formatRunSummaryTable } from './run-summary-table.js';
 import {
   StepExecutor as WorkflowStepLifecycleExecutor,
@@ -401,7 +402,7 @@ export class WorkflowRunner {
   private readonly relayOptions: AgentRelayOptions;
   private readonly cwd: string;
   private readonly summaryDir: string;
-  private readonly executor?: RunnerStepExecutor;
+  private executor?: RunnerStepExecutor;
   private readonly envSecrets?: Record<string, string>;
   private readonly templateResolver: TemplateResolver;
   private readonly channelMessenger: ChannelMessenger;
@@ -480,6 +481,11 @@ export class WorkflowRunner {
     this.executor = options.executor;
     this.processBackend = options.processBackend;
     this.envSecrets = options.envSecrets;
+    if (!this.executor && this.processBackend) {
+      this.executor = createProcessBackendExecutor(this.processBackend, {
+        env: this.envSecrets,
+      });
+    }
     this.templateResolver = new TemplateResolver();
     this.channelMessenger = new ChannelMessenger({ postFn: (text) => this.postToChannel(text) });
   }
@@ -4049,11 +4055,10 @@ export class WorkflowRunner {
           );
           const resolvedStep = { ...step, task: ownerTask };
           const ownerStartTime = Date.now();
-          // TODO(process-backend): When processBackend is set, the broker should
-          // use it to create environments for agent processes instead of local
-          // Command::spawn(). This requires the broker's WorkerRegistry to accept
-          // a process backend. Until then, processBackend is stored but unused
-          // at runtime — the cloud still uses the executor path via RunnerStepExecutor.
+          // When processBackend is set without an explicit executor, the runner
+          // constructor synthesizes a RunnerStepExecutor that calls
+          // processBackend.createEnvironment(step.name).exec(command). Explicit
+          // executors still take precedence. See process-backend-executor.ts.
           const spawnResult = this.executor
             ? await this.executor.executeAgentStep(resolvedStep, effectiveOwner, ownerTask, timeoutMs)
             : await this.spawnAndWait(effectiveOwner, resolvedStep, timeoutMs, {

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -261,10 +261,10 @@ export interface WorkflowRunnerOptions {
   envSecrets?: Record<string, string>;
   /**
    * Process backend for remote execution environments.
-   * When set, the runner creates isolated environments via this backend
-   * for each agent step. The broker still handles agent configuration
-   * (MCP wiring, CLI flags, auth env). The backend only provides
-   * "where to run" — create environment, execute command, destroy.
+   * When set without an explicit executor, the runner wraps it in a
+   * RunnerStepExecutor that creates isolated environments for agent and
+   * deterministic steps. The runner builds CLI commands and passes auth env,
+   * cwd, and timeout; the backend provides create/exec/destroy primitives.
    *
    * When both executor and processBackend are set, executor takes precedence.
    * When neither is set, the broker spawns local child processes (default).

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -90,6 +90,7 @@ import type {
   WorkflowStepCompletionReason,
   WorkflowStepRow,
   WorkflowStepStatus,
+  ProcessBackend,
 } from './types.js';
 import { WorkflowTrajectory, type StepOutcome } from './trajectory.js';
 import {
@@ -257,6 +258,17 @@ export interface WorkflowRunnerOptions {
   summaryDir?: string;
   executor?: RunnerStepExecutor;
   envSecrets?: Record<string, string>;
+  /**
+   * Process backend for remote execution environments.
+   * When set, the runner creates isolated environments via this backend
+   * for each agent step. The broker still handles agent configuration
+   * (MCP wiring, CLI flags, auth env). The backend only provides
+   * "where to run" — create environment, execute command, destroy.
+   *
+   * When both executor and processBackend are set, executor takes precedence.
+   * When neither is set, the broker spawns local child processes (default).
+   */
+  processBackend?: ProcessBackend;
 }
 
 // ── Step executor interface ──────────────────────────────────────────────────
@@ -456,6 +468,7 @@ export class WorkflowRunner {
   /** Structured CLI session reports captured during the current run, keyed by step name. */
   private readonly agentReports = new Map<string, CliSessionReport>();
   private static readonly PTY_TASK_ARG_SIZE_LIMIT = 2 * 1024 * 1024; // 2 MB
+  private readonly processBackend?: ProcessBackend;
 
   constructor(options: WorkflowRunnerOptions = {}) {
     this.db = options.db ?? new InMemoryWorkflowDb();
@@ -465,6 +478,7 @@ export class WorkflowRunner {
     this.summaryDir = options.summaryDir ?? path.join(this.cwd, '.relay', 'summaries');
     this.workersPath = path.join(this.cwd, '.agent-relay', 'team', 'workers.json');
     this.executor = options.executor;
+    this.processBackend = options.processBackend;
     this.envSecrets = options.envSecrets;
     this.templateResolver = new TemplateResolver();
     this.channelMessenger = new ChannelMessenger({ postFn: (text) => this.postToChannel(text) });
@@ -4035,6 +4049,11 @@ export class WorkflowRunner {
           );
           const resolvedStep = { ...step, task: ownerTask };
           const ownerStartTime = Date.now();
+          // TODO(process-backend): When processBackend is set, the broker should
+          // use it to create environments for agent processes instead of local
+          // Command::spawn(). This requires the broker's WorkerRegistry to accept
+          // a process backend. Until then, processBackend is stored but unused
+          // at runtime — the cloud still uses the executor path via RunnerStepExecutor.
           const spawnResult = this.executor
             ? await this.executor.executeAgentStep(resolvedStep, effectiveOwner, ownerTask, timeoutMs)
             : await this.spawnAndWait(effectiveOwner, resolvedStep, timeoutMs, {

--- a/packages/sdk/src/workflows/types.ts
+++ b/packages/sdk/src/workflows/types.ts
@@ -864,9 +864,10 @@ export interface WorkflowStepRow {
 
 // ── ProcessBackend: cloud-injected execution environment ─────────────────────
 //
-// Relay owns agent configuration (MCP wiring, CLI flags, auth env, lifecycle).
-// Cloud owns execution environment (create VM, run command, destroy VM).
-// The broker builds a fully-configured command and calls env.exec().
+// Relay owns command construction, auth env, cwd, timeout, and step lifecycle.
+// The backend owns execution environments (create VM, run command, destroy VM).
+// uploadFile is reserved for future file asset staging; current executors run
+// commands directly with env/cwd/timeout passed through exec options.
 
 /** Backend for creating isolated execution environments (e.g. Daytona sandboxes). */
 export interface ProcessBackend {
@@ -883,7 +884,7 @@ export interface ProcessEnvironment {
   /** Execute a shell command in the environment. */
   exec(
     command: string,
-    opts?: { cwd?: string; env?: Record<string, string>; timeoutSeconds?: number },
+    opts?: { cwd?: string; env?: Record<string, string>; timeoutSeconds?: number }
   ): Promise<{ output: string; exitCode: number }>;
   /** Upload a file into the environment. */
   uploadFile(content: string | Buffer, remotePath: string): Promise<void>;

--- a/packages/sdk/src/workflows/types.ts
+++ b/packages/sdk/src/workflows/types.ts
@@ -861,3 +861,32 @@ export interface WorkflowStepRow {
   createdAt: string;
   updatedAt: string;
 }
+
+// ── ProcessBackend: cloud-injected execution environment ─────────────────────
+//
+// Relay owns agent configuration (MCP wiring, CLI flags, auth env, lifecycle).
+// Cloud owns execution environment (create VM, run command, destroy VM).
+// The broker builds a fully-configured command and calls env.exec().
+
+/** Backend for creating isolated execution environments (e.g. Daytona sandboxes). */
+export interface ProcessBackend {
+  /** Create an isolated execution environment. */
+  createEnvironment(label: string): Promise<ProcessEnvironment>;
+}
+
+/** An isolated execution environment provisioned by a ProcessBackend. */
+export interface ProcessEnvironment {
+  /** Unique identifier for this environment. */
+  id: string;
+  /** Home directory inside the environment. */
+  homeDir: string;
+  /** Execute a shell command in the environment. */
+  exec(
+    command: string,
+    opts?: { cwd?: string; env?: Record<string, string>; timeoutSeconds?: number },
+  ): Promise<{ output: string; exitCode: number }>;
+  /** Upload a file into the environment. */
+  uploadFile(content: string | Buffer, remotePath: string): Promise<void>;
+  /** Tear down the environment and release resources. */
+  destroy(): Promise<void>;
+}

--- a/workflows/wire-process-backend.ts
+++ b/workflows/wire-process-backend.ts
@@ -1,0 +1,424 @@
+/**
+ * wire-process-backend — Wire ProcessBackend into the SDK runner
+ * ================================================================
+ *
+ * The cloud repo now exports a ProcessBackend interface:
+ *
+ *   interface ProcessBackend {
+ *     createEnvironment(label): Promise<ProcessEnvironment>
+ *   }
+ *   interface ProcessEnvironment {
+ *     id: string; homeDir: string;
+ *     exec(command, opts?): Promise<{ output, exitCode }>
+ *     uploadFile(content, path): Promise<void>
+ *     destroy(): Promise<void>
+ *   }
+ *
+ * This workflow wires it into the relay SDK so the runner can use it:
+ *
+ * 1. Add ProcessBackend + ProcessEnvironment interfaces to the SDK
+ *    (packages/sdk/src/workflows/types.ts)
+ *
+ * 2. Accept processBackend in WorkflowRunnerOptions
+ *    (packages/sdk/src/workflows/runner.ts)
+ *
+ * 3. When processBackend is set AND the runner has no executor, the
+ *    runner still goes through spawnAndWait (broker handles agent config)
+ *    but the broker's spawn creates the environment via processBackend
+ *    instead of local Command::spawn().
+ *
+ *    For this TS-only first step: the runner wraps the processBackend
+ *    into a RunnerStepExecutor that:
+ *    a) Calls processBackend.createEnvironment() to get a sandbox
+ *    b) Uses the broker's existing buildNonInteractiveCommand() to get
+ *       the fully-configured command (with MCP args, model flags)
+ *    c) Calls env.exec(command, { env, cwd }) in the sandbox
+ *    d) Returns the output
+ *
+ *    This keeps the broker in the loop for agent registration and MCP
+ *    wiring while delegating process execution to the backend.
+ *
+ * The Rust broker change (replacing Command::spawn with backend.exec)
+ * is a separate follow-up. This TS adapter is the bridge.
+ *
+ * Run: agent-relay run workflows/wire-process-backend.ts
+ */
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const CHANNEL = 'wf-wire-process-backend';
+
+async function main() {
+  const result = await workflow('wire-process-backend')
+    .description(
+      'Wire ProcessBackend into the SDK runner so cloud sandboxes go through the broker',
+    )
+    .pattern('dag')
+    .channel(CHANNEL)
+    .maxConcurrency(3)
+    .timeout(1_200_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      role: 'Implements the ProcessBackend wiring in the relay SDK',
+      retries: 2,
+    })
+
+    // ── Phase 1: Read ────────────────────────────────────────────────
+    .step('read-types', {
+      type: 'deterministic',
+      command: 'cat packages/sdk/src/workflows/types.ts',
+      captureOutput: true,
+    })
+
+    .step('read-runner-options', {
+      type: 'deterministic',
+      command: 'sed -n "250,290p" packages/sdk/src/workflows/runner.ts',
+      captureOutput: true,
+    })
+
+    .step('read-runner-constructor', {
+      type: 'deterministic',
+      command: 'sed -n "460,470p" packages/sdk/src/workflows/runner.ts',
+      captureOutput: true,
+    })
+
+    .step('read-runner-fork', {
+      type: 'deterministic',
+      command: 'sed -n "4033,4055p" packages/sdk/src/workflows/runner.ts',
+      captureOutput: true,
+    })
+
+    .step('read-requires-broker', {
+      type: 'deterministic',
+      command: 'sed -n "2710,2730p" packages/sdk/src/workflows/runner.ts',
+      captureOutput: true,
+    })
+
+    .step('read-build-command', {
+      type: 'deterministic',
+      command: 'grep -n "buildNonInteractiveCommand" packages/sdk/src/workflows/runner.ts | head -10',
+      captureOutput: true,
+    })
+
+    .step('read-exports', {
+      type: 'deterministic',
+      command: 'grep -n "export" packages/sdk/src/workflows/index.ts 2>/dev/null || echo "no index.ts barrel"',
+      captureOutput: true,
+    })
+
+    .step('read-tests', {
+      type: 'deterministic',
+      command: 'ls packages/sdk/src/workflows/__tests__/*.test.ts 2>/dev/null | head -10 && echo "---" && cat packages/sdk/src/workflows/__tests__/step-executor.test.ts 2>/dev/null | head -50 || echo "no step-executor test"',
+      captureOutput: true,
+    })
+
+    // ── Phase 2: Implement ───────────────────────────────────────────
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: [
+        'read-types', 'read-runner-options', 'read-runner-constructor',
+        'read-runner-fork', 'read-requires-broker', 'read-build-command',
+        'read-exports', 'read-tests',
+      ],
+      task: `Wire ProcessBackend into the relay SDK runner. This is a BACKWARD COMPATIBLE change — when no processBackend is provided, behavior is identical to today.
+
+## Current code
+
+=== packages/sdk/src/workflows/types.ts (excerpt) ===
+{{steps.read-types.output}}
+
+=== WorkflowRunnerOptions + RunnerStepExecutor (runner.ts:250-290) ===
+{{steps.read-runner-options.output}}
+
+=== Constructor (runner.ts:460-470) ===
+{{steps.read-runner-constructor.output}}
+
+=== The fork (runner.ts:4033-4055) ===
+{{steps.read-runner-fork.output}}
+
+=== requiresBroker check (runner.ts:2710-2730) ===
+{{steps.read-requires-broker.output}}
+
+=== buildNonInteractiveCommand references ===
+{{steps.read-build-command.output}}
+
+=== Exports ===
+{{steps.read-exports.output}}
+
+=== Tests ===
+{{steps.read-tests.output}}
+
+## Changes needed
+
+### 1. Add ProcessBackend interfaces to types.ts
+
+At the end of packages/sdk/src/workflows/types.ts, add:
+
+// ── ProcessBackend: cloud-injected execution environment ─────────────────────
+//
+// Relay owns agent configuration (MCP wiring, CLI flags, auth env, lifecycle).
+// Cloud owns execution environment (create VM, run command, destroy VM).
+// The broker builds a fully-configured command and calls env.exec().
+
+export interface ProcessBackend {
+  /** Create an isolated execution environment (e.g. a Daytona sandbox). */
+  createEnvironment(label: string): Promise<ProcessEnvironment>;
+}
+
+export interface ProcessEnvironment {
+  /** Unique identifier for this environment. */
+  id: string;
+  /** Home directory inside the environment. */
+  homeDir: string;
+  /** Execute a shell command in the environment. */
+  exec(command: string, opts?: { cwd?: string; env?: Record<string, string>; timeoutSeconds?: number }): Promise<{ output: string; exitCode: number }>;
+  /** Upload a file into the environment. */
+  uploadFile(content: string | Buffer, remotePath: string): Promise<void>;
+  /** Tear down the environment and release resources. */
+  destroy(): Promise<void>;
+}
+
+### 2. Add processBackend to WorkflowRunnerOptions
+
+In packages/sdk/src/workflows/runner.ts, find the WorkflowRunnerOptions interface and add:
+
+  /**
+   * Process backend for remote execution environments.
+   * When set, the runner creates isolated environments via this backend
+   * for each agent step. The broker still handles agent configuration
+   * (MCP wiring, CLI flags, auth env). The backend only provides
+   * "where to run" — create environment, execute command, destroy.
+   *
+   * When both executor and processBackend are set, executor takes precedence.
+   * When neither is set, the broker spawns local child processes (default).
+   */
+  processBackend?: ProcessBackend;
+
+Make sure to import ProcessBackend from the types file at the top of runner.ts.
+
+### 3. Store processBackend in constructor
+
+In the constructor, after the line that sets this.executor, add:
+
+    this.processBackend = options.processBackend;
+
+And add the private field to the class:
+
+  private readonly processBackend?: ProcessBackend;
+
+### 4. Wire processBackend into the executor fork
+
+Find the fork at line ~4038:
+
+  const spawnResult = this.executor
+    ? await this.executor.executeAgentStep(...)
+    : await this.spawnAndWait(...)
+
+Change it to:
+
+  const effectiveExecutor = this.executor ?? this.processBackendExecutor;
+  const spawnResult = effectiveExecutor
+    ? await effectiveExecutor.executeAgentStep(resolvedStep, effectiveOwner, ownerTask, timeoutMs)
+    : await this.spawnAndWait(effectiveOwner, resolvedStep, timeoutMs, {
+
+### 5. Add a processBackendExecutor getter
+
+Add a private getter that lazily creates a RunnerStepExecutor from the processBackend. Add this as a private property + getter in the class:
+
+  private _processBackendExecutor?: RunnerStepExecutor;
+
+  private get processBackendExecutor(): RunnerStepExecutor | undefined {
+    if (!this.processBackend) return undefined;
+    if (this._processBackendExecutor) return this._processBackendExecutor;
+
+    const backend = this.processBackend;
+    this._processBackendExecutor = {
+      async executeAgentStep(step, agentDef, resolvedTask, timeoutMs) {
+        const env = await backend.createEnvironment(step.name);
+        try {
+          const { cmd, args } = WorkflowRunner.buildNonInteractiveCommand(
+            agentDef.cli, resolvedTask, []
+          );
+          const model = agentDef.constraints?.model;
+          const fullArgs = model ? [...args, '--model', model] : args;
+          const command = [cmd, ...fullArgs].map(a => /^[a-zA-Z0-9._\\-\\/=]+$/.test(a) ? a : "'" + a.replace(/'/g, "'\\\\''") + "'").join(' ');
+
+          const timeout = timeoutMs ? Math.max(1, Math.ceil(timeoutMs / 1000)) : undefined;
+          const result = await env.exec(command, {
+            cwd: env.homeDir,
+            timeoutSeconds: timeout,
+          });
+
+          if (result.exitCode !== 0) {
+            throw new Error('Agent step "' + step.name + '" exited with code ' + result.exitCode);
+          }
+          return result.output;
+        } finally {
+          await env.destroy().catch(() => {});
+        }
+      },
+    };
+    return this._processBackendExecutor;
+  }
+
+Note: WorkflowRunner.buildNonInteractiveCommand is a static method already on the class. Use it to build the command — this ensures the CLI-specific non-interactive flags are applied.
+
+### 6. Update requiresBroker check
+
+Find the requiresBroker check (~line 2713):
+
+  const requiresBroker =
+    !this.executor &&
+    workflow.steps.some(...)
+
+Change to:
+
+  const requiresBroker =
+    !this.executor && !this.processBackend &&
+    workflow.steps.some(...)
+
+Wait — actually NO. We WANT the broker to start when processBackend is set. The broker handles agent registration and MCP wiring. DON'T change requiresBroker. The broker should still start.
+
+Actually, looking at this more carefully: the processBackendExecutor wraps the backend into a RunnerStepExecutor. When it's set, the fork at line 4038 will use it (via effectiveExecutor), which means spawnAndWait is bypassed. But spawnAndWait is where the broker spawns agents.
+
+So for this FIRST step, the processBackendExecutor is a simple adapter that:
+- Creates an environment
+- Builds a command via buildNonInteractiveCommand (gets CLI-specific flags)
+- Runs it
+
+This does NOT go through the broker for MCP wiring. That's the same problem as before.
+
+REVISED APPROACH: Instead of the getter wrapping into executeAgentStep, DON'T change the fork. Instead, make the broker AWARE of the backend. But that requires Rust changes we can't do here.
+
+So the pragmatic TS-only approach is:
+- Export the ProcessBackend interfaces from the SDK (so the cloud can import them)
+- Accept processBackend in WorkflowRunnerOptions (forward-looking)
+- Store it on the runner
+- DON'T change the fork yet
+- Document that the full wiring requires a broker-side change
+
+This way:
+1. The interfaces are in the SDK (single source of truth)
+2. The cloud imports them from @agent-relay/sdk instead of defining its own
+3. The runner accepts the option (ready for when the broker supports it)
+4. Nothing breaks
+
+### REVISED changes:
+
+1. Add ProcessBackend + ProcessEnvironment to types.ts (as above)
+2. Add processBackend to WorkflowRunnerOptions (as above)
+3. Store it in constructor (as above)
+4. Export the new types from the barrel (if one exists)
+5. DO NOT change the fork at line 4038
+6. DO NOT change requiresBroker
+7. Add a TODO comment near the fork:
+
+  // TODO(process-backend): When processBackend is set, the broker should
+  // use it to create environments for agent processes instead of local
+  // Command::spawn(). This requires the broker's WorkerRegistry to accept
+  // a process backend. Until then, processBackend is stored but unused
+  // at runtime — the cloud still uses the executor path via RunnerStepExecutor.
+
+After making changes, run:
+  npm run build 2>&1 | tail -20
+  npm test 2>&1 | tail -30
+
+IMPORTANT: Write all changes to disk. Do NOT just output code.`,
+      verification: { type: 'exit_code' },
+    })
+
+    // ── Phase 2b: Verify edits ───────────────────────────────────────
+    .step('verify-edits', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command: [
+        'set -e',
+        'grep -q "ProcessBackend" packages/sdk/src/workflows/types.ts || (echo "MISSING: ProcessBackend in types.ts"; exit 1)',
+        'grep -q "ProcessEnvironment" packages/sdk/src/workflows/types.ts || (echo "MISSING: ProcessEnvironment in types.ts"; exit 1)',
+        'grep -q "processBackend" packages/sdk/src/workflows/runner.ts || (echo "MISSING: processBackend in runner.ts"; exit 1)',
+        'if git diff --quiet packages/sdk/src/workflows/types.ts; then echo "types.ts NOT MODIFIED"; exit 1; fi',
+        'if git diff --quiet packages/sdk/src/workflows/runner.ts; then echo "runner.ts NOT MODIFIED"; exit 1; fi',
+        'echo "All expected changes verified"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Phase 3: Test-fix-rerun ──────────────────────────────────────
+    .step('build', {
+      type: 'deterministic',
+      dependsOn: ['verify-edits'],
+      command: 'npm run build 2>&1 | tail -30',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-edits'],
+      command: 'npm test 2>&1 | tail -60',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-failures', {
+      agent: 'impl',
+      dependsOn: ['build', 'run-tests'],
+      task: `Fix any build or test failures.
+
+Build output:
+{{steps.build.output}}
+
+Test output:
+{{steps.run-tests.output}}
+
+If all passed, do nothing.
+If failures, read the failing files, fix, re-run until both pass:
+  npm run build
+  npm test`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('build-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-failures'],
+      command: 'npm run build 2>&1 | tail -20',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-failures'],
+      command: 'npm test 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Phase 4: Commit + push + PR ──────────────────────────────────
+    .step('commit', {
+      type: 'deterministic',
+      dependsOn: ['build-final', 'tests-final'],
+      command: 'git add packages/sdk/src/workflows/types.ts packages/sdk/src/workflows/runner.ts && git diff --cached --quiet && echo "NO CHANGES" && exit 1; git commit -m "feat(sdk): add ProcessBackend interface and accept in WorkflowRunnerOptions" && git push origin feat/process-backend-runner',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('open-pr', {
+      type: 'deterministic',
+      dependsOn: ['commit'],
+      command: "gh pr create --repo AgentWorkforce/relay --base main --head feat/process-backend-runner --title 'feat(sdk): add ProcessBackend interface for cloud sandbox execution' --body-file - <<'PRBODY'\n## Summary\n\nAdds ProcessBackend and ProcessEnvironment interfaces to the SDK and accepts\nprocessBackend in WorkflowRunnerOptions. This is the relay-side counterpart\nto AgentWorkforce/cloud#115.\n\n## What this does\n\n- Exports ProcessBackend + ProcessEnvironment from @agent-relay/sdk/workflows\n- WorkflowRunnerOptions accepts optional processBackend field\n- Runner stores the backend (ready for broker integration)\n\n## What this does NOT do (yet)\n\n- Does not change the this.executor fork at runner.ts:4038\n- Does not wire the broker to use the backend for spawning\n- Those require broker-side changes (Rust WorkerRegistry)\n\n## Boundary\n\n| Relay owns | Cloud provides |\n|---|---|\n| MCP wiring | createEnvironment() |\n| CLI flags | exec(command) |\n| Auth env | uploadFile() |\n| Agent lifecycle | destroy() |\n\n## Test plan\n\n- [x] npm run build passes\n- [x] npm test passes\nPRBODY",
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 2, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log(`Run status: ${result.status}`);
+  if (result.status !== 'completed') {
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/workflows/wire-process-backend.ts
+++ b/workflows/wire-process-backend.ts
@@ -2,6 +2,18 @@
  * wire-process-backend — Wire ProcessBackend into the SDK runner
  * ================================================================
  *
+ * Run:
+ *   agent-relay run workflows/wire-process-backend.ts
+ *
+ * Resume from a specific step (reuses cached outputs from the last run):
+ *   START_FROM=build agent-relay run workflows/wire-process-backend.ts
+ *   START_FROM=commit agent-relay run workflows/wire-process-backend.ts
+ *
+ * Resume a specific failed run by ID:
+ *   RESUME_RUN_ID=<run-id> agent-relay run workflows/wire-process-backend.ts
+ *
+ * ────────────────────────────────────────────────────────────────────
+ *
  * The cloud repo now exports a ProcessBackend interface:
  *
  *   interface ProcessBackend {
@@ -22,26 +34,10 @@
  * 2. Accept processBackend in WorkflowRunnerOptions
  *    (packages/sdk/src/workflows/runner.ts)
  *
- * 3. When processBackend is set AND the runner has no executor, the
- *    runner still goes through spawnAndWait (broker handles agent config)
- *    but the broker's spawn creates the environment via processBackend
- *    instead of local Command::spawn().
- *
- *    For this TS-only first step: the runner wraps the processBackend
- *    into a RunnerStepExecutor that:
- *    a) Calls processBackend.createEnvironment() to get a sandbox
- *    b) Uses the broker's existing buildNonInteractiveCommand() to get
- *       the fully-configured command (with MCP args, model flags)
- *    c) Calls env.exec(command, { env, cwd }) in the sandbox
- *    d) Returns the output
- *
- *    This keeps the broker in the loop for agent registration and MCP
- *    wiring while delegating process execution to the backend.
+ * 3. Store it on the runner with a TODO for the broker-side integration.
  *
  * The Rust broker change (replacing Command::spawn with backend.exec)
  * is a separate follow-up. This TS adapter is the bridge.
- *
- * Run: agent-relay run workflows/wire-process-backend.ts
  */
 import { workflow } from '@agent-relay/sdk/workflows';
 
@@ -206,112 +202,9 @@ And add the private field to the class:
 
   private readonly processBackend?: ProcessBackend;
 
-### 4. Wire processBackend into the executor fork
+### 4. DO NOT change the executor fork or requiresBroker
 
-Find the fork at line ~4038:
-
-  const spawnResult = this.executor
-    ? await this.executor.executeAgentStep(...)
-    : await this.spawnAndWait(...)
-
-Change it to:
-
-  const effectiveExecutor = this.executor ?? this.processBackendExecutor;
-  const spawnResult = effectiveExecutor
-    ? await effectiveExecutor.executeAgentStep(resolvedStep, effectiveOwner, ownerTask, timeoutMs)
-    : await this.spawnAndWait(effectiveOwner, resolvedStep, timeoutMs, {
-
-### 5. Add a processBackendExecutor getter
-
-Add a private getter that lazily creates a RunnerStepExecutor from the processBackend. Add this as a private property + getter in the class:
-
-  private _processBackendExecutor?: RunnerStepExecutor;
-
-  private get processBackendExecutor(): RunnerStepExecutor | undefined {
-    if (!this.processBackend) return undefined;
-    if (this._processBackendExecutor) return this._processBackendExecutor;
-
-    const backend = this.processBackend;
-    this._processBackendExecutor = {
-      async executeAgentStep(step, agentDef, resolvedTask, timeoutMs) {
-        const env = await backend.createEnvironment(step.name);
-        try {
-          const { cmd, args } = WorkflowRunner.buildNonInteractiveCommand(
-            agentDef.cli, resolvedTask, []
-          );
-          const model = agentDef.constraints?.model;
-          const fullArgs = model ? [...args, '--model', model] : args;
-          const command = [cmd, ...fullArgs].map(a => /^[a-zA-Z0-9._\\-\\/=]+$/.test(a) ? a : "'" + a.replace(/'/g, "'\\\\''") + "'").join(' ');
-
-          const timeout = timeoutMs ? Math.max(1, Math.ceil(timeoutMs / 1000)) : undefined;
-          const result = await env.exec(command, {
-            cwd: env.homeDir,
-            timeoutSeconds: timeout,
-          });
-
-          if (result.exitCode !== 0) {
-            throw new Error('Agent step "' + step.name + '" exited with code ' + result.exitCode);
-          }
-          return result.output;
-        } finally {
-          await env.destroy().catch(() => {});
-        }
-      },
-    };
-    return this._processBackendExecutor;
-  }
-
-Note: WorkflowRunner.buildNonInteractiveCommand is a static method already on the class. Use it to build the command — this ensures the CLI-specific non-interactive flags are applied.
-
-### 6. Update requiresBroker check
-
-Find the requiresBroker check (~line 2713):
-
-  const requiresBroker =
-    !this.executor &&
-    workflow.steps.some(...)
-
-Change to:
-
-  const requiresBroker =
-    !this.executor && !this.processBackend &&
-    workflow.steps.some(...)
-
-Wait — actually NO. We WANT the broker to start when processBackend is set. The broker handles agent registration and MCP wiring. DON'T change requiresBroker. The broker should still start.
-
-Actually, looking at this more carefully: the processBackendExecutor wraps the backend into a RunnerStepExecutor. When it's set, the fork at line 4038 will use it (via effectiveExecutor), which means spawnAndWait is bypassed. But spawnAndWait is where the broker spawns agents.
-
-So for this FIRST step, the processBackendExecutor is a simple adapter that:
-- Creates an environment
-- Builds a command via buildNonInteractiveCommand (gets CLI-specific flags)
-- Runs it
-
-This does NOT go through the broker for MCP wiring. That's the same problem as before.
-
-REVISED APPROACH: Instead of the getter wrapping into executeAgentStep, DON'T change the fork. Instead, make the broker AWARE of the backend. But that requires Rust changes we can't do here.
-
-So the pragmatic TS-only approach is:
-- Export the ProcessBackend interfaces from the SDK (so the cloud can import them)
-- Accept processBackend in WorkflowRunnerOptions (forward-looking)
-- Store it on the runner
-- DON'T change the fork yet
-- Document that the full wiring requires a broker-side change
-
-This way:
-1. The interfaces are in the SDK (single source of truth)
-2. The cloud imports them from @agent-relay/sdk instead of defining its own
-3. The runner accepts the option (ready for when the broker supports it)
-4. Nothing breaks
-
-### REVISED changes:
-
-1. Add ProcessBackend + ProcessEnvironment to types.ts (as above)
-2. Add processBackend to WorkflowRunnerOptions (as above)
-3. Store it in constructor (as above)
-4. Export the new types from the barrel (if one exists)
-5. DO NOT change the fork at line 4038
-6. DO NOT change requiresBroker
-7. Add a TODO comment near the fork:
+Add a TODO comment near the fork at ~line 4038:
 
   // TODO(process-backend): When processBackend is set, the broker should
   // use it to create environments for agent processes instead of local
@@ -344,13 +237,13 @@ IMPORTANT: Write all changes to disk. Do NOT just output code.`,
       failOnError: true,
     })
 
-    // ── Phase 3: Test-fix-rerun ──────────────────────────────────────
+    // ── Phase 3: Build + test gate ──────────────────────────────────
     .step('build', {
       type: 'deterministic',
       dependsOn: ['verify-edits'],
       command: 'npm run build 2>&1 | tail -30',
       captureOutput: true,
-      failOnError: false,
+      failOnError: true,
     })
 
     .step('run-tests', {
@@ -358,47 +251,13 @@ IMPORTANT: Write all changes to disk. Do NOT just output code.`,
       dependsOn: ['verify-edits'],
       command: 'npm test 2>&1 | tail -60',
       captureOutput: true,
-      failOnError: false,
-    })
-
-    .step('fix-failures', {
-      agent: 'impl',
-      dependsOn: ['build', 'run-tests'],
-      task: `Fix any build or test failures.
-
-Build output:
-{{steps.build.output}}
-
-Test output:
-{{steps.run-tests.output}}
-
-If all passed, do nothing.
-If failures, read the failing files, fix, re-run until both pass:
-  npm run build
-  npm test`,
-      verification: { type: 'exit_code' },
-    })
-
-    .step('build-final', {
-      type: 'deterministic',
-      dependsOn: ['fix-failures'],
-      command: 'npm run build 2>&1 | tail -20',
-      captureOutput: true,
       failOnError: true,
     })
 
-    .step('tests-final', {
-      type: 'deterministic',
-      dependsOn: ['fix-failures'],
-      command: 'npm test 2>&1 | tail -40',
-      captureOutput: true,
-      failOnError: true,
-    })
-
-    // ── Phase 4: Commit + push + PR ──────────────────────────────────
+    // ── Phase 4: Commit + push + PR ─────────────────────────────────
     .step('commit', {
       type: 'deterministic',
-      dependsOn: ['build-final', 'tests-final'],
+      dependsOn: ['build', 'run-tests'],
       command: 'git add packages/sdk/src/workflows/types.ts packages/sdk/src/workflows/runner.ts && git diff --cached --quiet && echo "NO CHANGES" && exit 1; git commit -m "feat(sdk): add ProcessBackend interface and accept in WorkflowRunnerOptions" && git push origin feat/process-backend-runner',
       captureOutput: true,
       failOnError: true,
@@ -407,7 +266,10 @@ If failures, read the failing files, fix, re-run until both pass:
     .step('open-pr', {
       type: 'deterministic',
       dependsOn: ['commit'],
-      command: "gh pr create --repo AgentWorkforce/relay --base main --head feat/process-backend-runner --title 'feat(sdk): add ProcessBackend interface for cloud sandbox execution' --body-file - <<'PRBODY'\n## Summary\n\nAdds ProcessBackend and ProcessEnvironment interfaces to the SDK and accepts\nprocessBackend in WorkflowRunnerOptions. This is the relay-side counterpart\nto AgentWorkforce/cloud#115.\n\n## What this does\n\n- Exports ProcessBackend + ProcessEnvironment from @agent-relay/sdk/workflows\n- WorkflowRunnerOptions accepts optional processBackend field\n- Runner stores the backend (ready for broker integration)\n\n## What this does NOT do (yet)\n\n- Does not change the this.executor fork at runner.ts:4038\n- Does not wire the broker to use the backend for spawning\n- Those require broker-side changes (Rust WorkerRegistry)\n\n## Boundary\n\n| Relay owns | Cloud provides |\n|---|---|\n| MCP wiring | createEnvironment() |\n| CLI flags | exec(command) |\n| Auth env | uploadFile() |\n| Agent lifecycle | destroy() |\n\n## Test plan\n\n- [x] npm run build passes\n- [x] npm test passes\nPRBODY",
+      command: [
+        "gh pr view feat/process-backend-runner --repo AgentWorkforce/relay --json url -q .url 2>/dev/null && echo 'PR already exists' && exit 0",
+        "gh pr create --repo AgentWorkforce/relay --base main --head feat/process-backend-runner --title 'feat(sdk): add ProcessBackend interface for cloud sandbox execution' --body \"## Summary\n\nAdds ProcessBackend and ProcessEnvironment interfaces to the SDK and accepts\nprocessBackend in WorkflowRunnerOptions. This is the relay-side counterpart\nto AgentWorkforce/cloud#115.\n\n## What this does\n\n- Exports ProcessBackend + ProcessEnvironment from @agent-relay/sdk/workflows\n- WorkflowRunnerOptions accepts optional processBackend field\n- Runner stores the backend (ready for broker integration)\n\n## What this does NOT do (yet)\n\n- Does not change the this.executor fork at runner.ts:4038\n- Does not wire the broker to use the backend for spawning\n- Those require broker-side changes (Rust WorkerRegistry)\n\n## Test plan\n\n- [x] npm run build passes\n- [x] npm test passes\"",
+      ].join(' || '),
       captureOutput: true,
       failOnError: true,
     })

--- a/workflows/wire-process-backend.ts
+++ b/workflows/wire-process-backend.ts
@@ -34,19 +34,22 @@
  * 2. Accept processBackend in WorkflowRunnerOptions
  *    (packages/sdk/src/workflows/runner.ts)
  *
- * 3. Store it on the runner with a TODO for the broker-side integration.
+ * 3. Create a ProcessBackend-backed RunnerStepExecutor when processBackend is
+ *    set and no explicit executor is provided.
  *
- * The Rust broker change (replacing Command::spawn with backend.exec)
- * is a separate follow-up. This TS adapter is the bridge.
+ * The Rust broker change (replacing Command::spawn with backend.exec) remains
+ * a separate follow-up. This TS adapter lets workflow steps run in cloud
+ * environments without changing the default local broker path.
  */
 import { workflow } from '@agent-relay/sdk/workflows';
 
 const CHANNEL = 'wf-wire-process-backend';
+const FEATURE_BRANCH = 'feat/process-backend-runner';
 
 async function main() {
   const result = await workflow('wire-process-backend')
     .description(
-      'Wire ProcessBackend into the SDK runner so cloud sandboxes go through the broker',
+      'Wire ProcessBackend into the SDK runner so cloud sandboxes can execute workflow steps',
     )
     .pattern('dag')
     .channel(CHANNEL)
@@ -152,9 +155,10 @@ At the end of packages/sdk/src/workflows/types.ts, add:
 
 // ── ProcessBackend: cloud-injected execution environment ─────────────────────
 //
-// Relay owns agent configuration (MCP wiring, CLI flags, auth env, lifecycle).
-// Cloud owns execution environment (create VM, run command, destroy VM).
-// The broker builds a fully-configured command and calls env.exec().
+// Relay owns command construction, auth env, cwd, timeout, and step lifecycle.
+// The backend owns execution environments (create VM, run command, destroy VM).
+// uploadFile is reserved for future file asset staging; current executors run
+// commands directly with env/cwd/timeout passed through exec options.
 
 export interface ProcessBackend {
   /** Create an isolated execution environment (e.g. a Daytona sandbox). */
@@ -180,10 +184,10 @@ In packages/sdk/src/workflows/runner.ts, find the WorkflowRunnerOptions interfac
 
   /**
    * Process backend for remote execution environments.
-   * When set, the runner creates isolated environments via this backend
-   * for each agent step. The broker still handles agent configuration
-   * (MCP wiring, CLI flags, auth env). The backend only provides
-   * "where to run" — create environment, execute command, destroy.
+   * When set without an explicit executor, the runner wraps it in a
+   * RunnerStepExecutor that creates isolated environments for agent and
+   * deterministic steps. The runner builds CLI commands and passes auth env,
+   * cwd, and timeout; the backend provides create/exec/destroy primitives.
    *
    * When both executor and processBackend are set, executor takes precedence.
    * When neither is set, the broker spawns local child processes (default).
@@ -192,7 +196,7 @@ In packages/sdk/src/workflows/runner.ts, find the WorkflowRunnerOptions interfac
 
 Make sure to import ProcessBackend from the types file at the top of runner.ts.
 
-### 3. Store processBackend in constructor
+### 3. Store processBackend and synthesize an executor in the constructor
 
 In the constructor, after the line that sets this.executor, add:
 
@@ -202,15 +206,31 @@ And add the private field to the class:
 
   private readonly processBackend?: ProcessBackend;
 
-### 4. DO NOT change the executor fork or requiresBroker
+Then synthesize the ProcessBackend executor only when no explicit executor was
+provided:
 
-Add a TODO comment near the fork at ~line 4038:
+    if (!this.executor && this.processBackend) {
+      this.executor = createProcessBackendExecutor(this.processBackend, {
+        env: this.envSecrets,
+      });
+    }
 
-  // TODO(process-backend): When processBackend is set, the broker should
-  // use it to create environments for agent processes instead of local
-  // Command::spawn(). This requires the broker's WorkerRegistry to accept
-  // a process backend. Until then, processBackend is stored but unused
-  // at runtime — the cloud still uses the executor path via RunnerStepExecutor.
+### 4. Add the ProcessBackend executor
+
+Add packages/sdk/src/workflows/process-backend-executor.ts. It should:
+
+- Build non-interactive CLI commands using the existing process-spawner helper.
+- Pass env, cwd, and ceil-rounded timeoutSeconds via ProcessEnvironment.exec options.
+- Shell-escape argv safely before joining into the command string.
+- Reject cli:"api" because API agents do not run as subprocesses.
+- Destroy the environment in a finally block.
+
+### 5. Keep the existing executor fork behavior
+
+Do not add a second processBackend-specific fork. The constructor makes
+this.executor point at the ProcessBackend executor when processBackend is set
+and executor is omitted, so the existing this.executor branch remains the single
+extension point. The default no-executor path still uses spawnAndWait.
 
 After making changes, run:
   npm run build 2>&1 | tail -20
@@ -229,8 +249,10 @@ IMPORTANT: Write all changes to disk. Do NOT just output code.`,
         'grep -q "ProcessBackend" packages/sdk/src/workflows/types.ts || (echo "MISSING: ProcessBackend in types.ts"; exit 1)',
         'grep -q "ProcessEnvironment" packages/sdk/src/workflows/types.ts || (echo "MISSING: ProcessEnvironment in types.ts"; exit 1)',
         'grep -q "processBackend" packages/sdk/src/workflows/runner.ts || (echo "MISSING: processBackend in runner.ts"; exit 1)',
+        'grep -q "createProcessBackendExecutor" packages/sdk/src/workflows/process-backend-executor.ts || (echo "MISSING: ProcessBackend executor"; exit 1)',
         'if git diff --quiet packages/sdk/src/workflows/types.ts; then echo "types.ts NOT MODIFIED"; exit 1; fi',
         'if git diff --quiet packages/sdk/src/workflows/runner.ts; then echo "runner.ts NOT MODIFIED"; exit 1; fi',
+        'if git diff --quiet packages/sdk/src/workflows/process-backend-executor.ts; then echo "process-backend-executor.ts NOT MODIFIED"; exit 1; fi',
         'echo "All expected changes verified"',
       ].join(' && '),
       captureOutput: true,
@@ -258,7 +280,13 @@ IMPORTANT: Write all changes to disk. Do NOT just output code.`,
     .step('commit', {
       type: 'deterministic',
       dependsOn: ['build', 'run-tests'],
-      command: 'git add packages/sdk/src/workflows/types.ts packages/sdk/src/workflows/runner.ts && git diff --cached --quiet && echo "NO CHANGES" && exit 1; git commit -m "feat(sdk): add ProcessBackend interface and accept in WorkflowRunnerOptions" && git push origin feat/process-backend-runner',
+      command: [
+        `git checkout -B ${FEATURE_BRANCH}`,
+        'git add packages/sdk/src/workflows/types.ts packages/sdk/src/workflows/runner.ts packages/sdk/src/workflows/process-backend-executor.ts packages/sdk/src/workflows/index.ts packages/sdk/src/workflows/__tests__/process-backend-executor.test.ts workflows/wire-process-backend.ts',
+        'if git diff --cached --quiet; then echo "NO CHANGES"; exit 1; fi',
+        'git commit -m "feat(sdk): add ProcessBackend executor for workflows"',
+        `git push -u origin ${FEATURE_BRANCH}`,
+      ].join(' && '),
       captureOutput: true,
       failOnError: true,
     })
@@ -267,8 +295,8 @@ IMPORTANT: Write all changes to disk. Do NOT just output code.`,
       type: 'deterministic',
       dependsOn: ['commit'],
       command: [
-        "gh pr view feat/process-backend-runner --repo AgentWorkforce/relay --json url -q .url 2>/dev/null && echo 'PR already exists' && exit 0",
-        "gh pr create --repo AgentWorkforce/relay --base main --head feat/process-backend-runner --title 'feat(sdk): add ProcessBackend interface for cloud sandbox execution' --body \"## Summary\n\nAdds ProcessBackend and ProcessEnvironment interfaces to the SDK and accepts\nprocessBackend in WorkflowRunnerOptions. This is the relay-side counterpart\nto AgentWorkforce/cloud#115.\n\n## What this does\n\n- Exports ProcessBackend + ProcessEnvironment from @agent-relay/sdk/workflows\n- WorkflowRunnerOptions accepts optional processBackend field\n- Runner stores the backend (ready for broker integration)\n\n## What this does NOT do (yet)\n\n- Does not change the this.executor fork at runner.ts:4038\n- Does not wire the broker to use the backend for spawning\n- Those require broker-side changes (Rust WorkerRegistry)\n\n## Test plan\n\n- [x] npm run build passes\n- [x] npm test passes\"",
+        `gh pr view ${FEATURE_BRANCH} --repo AgentWorkforce/relay --json url -q .url 2>/dev/null && echo 'PR already exists' && exit 0`,
+        `gh pr create --repo AgentWorkforce/relay --base main --head ${FEATURE_BRANCH} --title 'feat(sdk): add ProcessBackend executor for cloud sandbox execution' --body "## Summary\n\nAdds ProcessBackend and ProcessEnvironment interfaces to the SDK, accepts processBackend in WorkflowRunnerOptions, and creates a ProcessBackend-backed RunnerStepExecutor when no explicit executor is provided.\n\n## What this does\n\n- Exports ProcessBackend + ProcessEnvironment from @agent-relay/sdk/workflows\n- WorkflowRunnerOptions accepts optional processBackend field\n- Agent and deterministic steps can execute through ProcessEnvironment.exec\n- env, cwd, and timeoutSeconds are passed through structured exec options\n\n## Boundary\n\n- Relay builds CLI commands and passes auth env, cwd, and timeout metadata\n- ProcessBackend creates environments, executes commands, and destroys environments\n- uploadFile is part of the interface for future file asset staging and is not used by this executor yet\n\n## Test plan\n\n- [x] npm run build passes\n- [x] npm test passes"`,
       ].join(' || '),
       captureOutput: true,
       failOnError: true,


### PR DESCRIPTION
## Summary

Adds `ProcessBackend` and `ProcessEnvironment` interfaces to the SDK, accepts `processBackend` in `WorkflowRunnerOptions`, and creates a ProcessBackend-backed `RunnerStepExecutor` when no explicit executor is provided.

## What changed

- Exports `ProcessBackend` and `ProcessEnvironment` from `@agent-relay/sdk/workflows`
- `WorkflowRunnerOptions` accepts an optional `processBackend`
- Agent and deterministic workflow steps can execute through `ProcessEnvironment.exec`
- `env`, `cwd`, and ceil-rounded `timeoutSeconds` are passed through structured exec options
- `RelayCast.createWorkspace()` API-key handling now guards the optional `apiKey` shape from the latest `@relaycast/sdk` types

## Boundary

| Relay owns | ProcessBackend provides |
|---|---|
| CLI command construction and args | `createEnvironment()` |
| auth env, cwd, timeout metadata | `exec(command, opts)` |
| workflow step lifecycle | `destroy()` |

`uploadFile()` remains part of the interface for future file asset staging and is not called by the current executor.

## PR feedback addressed

- Workflow commit step now checks out `feat/process-backend-runner` before committing and pushes that branch explicitly
- Workflow task prompt no longer contains the old contradictory "stored but unused" guidance
- Public comments/docs now describe the TS executor path accurately instead of implying broker-side remote spawning is already implemented
- ProcessBackend executor keeps the previously resolved `env` and `cwd` behavior

## Test plan

- [x] `npm --prefix packages/sdk run build`
- [x] `npm run build:packages`
- [x] `npm run build`
- [x] `npx vitest run --config vitest.config.ts src/workflows/__tests__/process-backend-executor.test.ts` from `packages/sdk`