### PR TITLE
fix: upgrade posthog-node from v4 to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "4.0.28",
+  "version": "4.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "bundleDependencies": [
         "@agent-relay/cloud",
         "@agent-relay/config",
@@ -25,14 +25,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "4.0.28",
-        "@agent-relay/config": "4.0.28",
-        "@agent-relay/hooks": "4.0.28",
-        "@agent-relay/sdk": "4.0.28",
-        "@agent-relay/telemetry": "4.0.28",
-        "@agent-relay/trajectory": "4.0.28",
-        "@agent-relay/user-directory": "4.0.28",
-        "@agent-relay/utils": "4.0.28",
+        "@agent-relay/cloud": "4.0.29",
+        "@agent-relay/config": "4.0.29",
+        "@agent-relay/hooks": "4.0.29",
+        "@agent-relay/sdk": "4.0.29",
+        "@agent-relay/telemetry": "4.0.29",
+        "@agent-relay/trajectory": "4.0.29",
+        "@agent-relay/user-directory": "4.0.29",
+        "@agent-relay/utils": "4.0.29",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -1179,6 +1179,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3462,6 +3463,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+      "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
+      "license": "MIT"
     },
     "node_modules/@posthog/next": {
       "version": "0.1.0",
@@ -15237,10 +15244,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.28",
+        "@agent-relay/sdk": "4.0.29",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15256,13 +15263,13 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "4.0.28"
+      "version": "4.0.29"
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28",
+        "@agent-relay/config": "4.0.29",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15274,7 +15281,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15286,9 +15293,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.28"
+        "@agent-relay/sdk": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15297,11 +15304,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28",
-        "@agent-relay/sdk": "4.0.28",
-        "@agent-relay/trajectory": "4.0.28"
+        "@agent-relay/config": "4.0.29",
+        "@agent-relay/sdk": "4.0.29",
+        "@agent-relay/trajectory": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15310,9 +15317,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/hooks": "4.0.28"
+        "@agent-relay/hooks": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15321,11 +15328,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.28",
+        "@agent-relay/sdk": "4.0.29",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16148,9 +16155,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28"
+        "@agent-relay/config": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16159,9 +16166,9 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28",
+        "@agent-relay/config": "4.0.29",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": "^0.1.2",
         "@sinclair/typebox": "^0.34.48",
@@ -16223,20 +16230,40 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "posthog-node": "^4.0.1"
+        "posthog-node": "^5.29.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
       }
     },
+    "packages/telemetry/node_modules/posthog-node": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.29.2.tgz",
+      "integrity": "sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.25.2"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28"
+        "@agent-relay/config": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16245,9 +16272,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/utils": "4.0.28"
+        "@agent-relay/utils": "4.0.29"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16256,9 +16283,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "4.0.28",
+      "version": "4.0.29",
       "dependencies": {
-        "@agent-relay/config": "4.0.28",
+        "@agent-relay/config": "4.0.29",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -23,7 +23,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "posthog-node": "^4.0.1"
+    "posthog-node": "^5.29.2"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",


### PR DESCRIPTION
## Summary
Upgrades PostHog Node.js SDK from v4 to v5 to fix serde errors.

## Changes
- **packages/telemetry/package.json**: posthog-node ^4.0.1 → ^5.29.2
- **package-lock.json**: Updated dependency tree

## Why
Fixes missing field 'type' serde errors in PostHog events.

## Test Plan
- [ ] Telemetry events send successfully
- [ ] No serde errors in logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
