### PR TITLE
fix(sdk): export A2A communicate subpaths

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -57,6 +57,26 @@
       "import": "./dist/communicate/index.js",
       "default": "./dist/communicate/index.js"
     },
+    "./communicate/a2a-types": {
+      "types": "./dist/communicate/a2a-types.d.ts",
+      "import": "./dist/communicate/a2a-types.js",
+      "default": "./dist/communicate/a2a-types.js"
+    },
+    "./communicate/a2a-server": {
+      "types": "./dist/communicate/a2a-server.d.ts",
+      "import": "./dist/communicate/a2a-server.js",
+      "default": "./dist/communicate/a2a-server.js"
+    },
+    "./communicate/a2a-transport": {
+      "types": "./dist/communicate/a2a-transport.d.ts",
+      "import": "./dist/communicate/a2a-transport.js",
+      "default": "./dist/communicate/a2a-transport.js"
+    },
+    "./communicate/a2a-bridge": {
+      "types": "./dist/communicate/a2a-bridge.d.ts",
+      "import": "./dist/communicate/a2a-bridge.js",
+      "default": "./dist/communicate/a2a-bridge.js"
+    },
     "./communicate/adapters/pi": {
       "types": "./dist/communicate/adapters/pi.d.ts",
       "import": "./dist/communicate/adapters/pi.js",


### PR DESCRIPTION
## Summary
- export the existing A2A communicate modules from `@agent-relay/sdk`
- expose `a2a-types`, `a2a-server`, `a2a-transport`, and `a2a-bridge` as supported SDK subpaths
- unblock downstream consumers like Sage from using A2A support without local imports or copied code

## Why
The A2A implementation already exists in Relay source, but the SDK package export surface does not expose it. Downstream consumers hit runtime/module resolution failures like:

- `Missing "./communicate/a2a-transport" specifier in "@agent-relay/sdk" package`

This fixes the actual upstream package boundary instead of papering over it downstream.

## Validation
- attempted clean-worktree SDK build validation
- clean worktree surfaced a broader existing workspace/local-package resolution issue around `@agent-relay/config`, unrelated to this export change
- the export fix itself is focused and isolated to `packages/sdk/package.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
