### PR TITLE
fix: patch protobufjs for Dependabot alert #200

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "4.0.29",
+  "version": "4.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "bundleDependencies": [
         "@agent-relay/cloud",
         "@agent-relay/config",
@@ -25,14 +25,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "4.0.29",
-        "@agent-relay/config": "4.0.29",
-        "@agent-relay/hooks": "4.0.29",
-        "@agent-relay/sdk": "4.0.29",
-        "@agent-relay/telemetry": "4.0.29",
-        "@agent-relay/trajectory": "4.0.29",
-        "@agent-relay/user-directory": "4.0.29",
-        "@agent-relay/utils": "4.0.29",
+        "@agent-relay/cloud": "4.0.30",
+        "@agent-relay/config": "4.0.30",
+        "@agent-relay/hooks": "4.0.30",
+        "@agent-relay/sdk": "4.0.30",
+        "@agent-relay/telemetry": "4.0.30",
+        "@agent-relay/trajectory": "4.0.30",
+        "@agent-relay/user-directory": "4.0.30",
+        "@agent-relay/utils": "4.0.30",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -1179,7 +1179,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -12309,9 +12308,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15244,10 +15243,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.29",
+        "@agent-relay/sdk": "4.0.30",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15263,13 +15262,13 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "4.0.29"
+      "version": "4.0.30"
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29",
+        "@agent-relay/config": "4.0.30",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15281,7 +15280,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15293,9 +15292,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.29"
+        "@agent-relay/sdk": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15304,11 +15303,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29",
-        "@agent-relay/sdk": "4.0.29",
-        "@agent-relay/trajectory": "4.0.29"
+        "@agent-relay/config": "4.0.30",
+        "@agent-relay/sdk": "4.0.30",
+        "@agent-relay/trajectory": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15317,9 +15316,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/hooks": "4.0.29"
+        "@agent-relay/hooks": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15328,11 +15327,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "4.0.29",
+        "@agent-relay/sdk": "4.0.30",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16155,9 +16154,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29"
+        "@agent-relay/config": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16166,9 +16165,9 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29",
+        "@agent-relay/config": "4.0.30",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": "^0.1.2",
         "@sinclair/typebox": "^0.34.48",
@@ -16230,7 +16229,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
         "posthog-node": "^5.29.2"
       },
@@ -16261,9 +16260,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29"
+        "@agent-relay/config": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16272,9 +16271,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/utils": "4.0.29"
+        "@agent-relay/utils": "4.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16283,9 +16282,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "4.0.29",
+      "version": "4.0.30",
       "dependencies": {
-        "@agent-relay/config": "4.0.29",
+        "@agent-relay/config": "4.0.30",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
   "overrides": {
     "flatted": "^3.4.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "protobufjs": "^7.5.5"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm override forcing `protobufjs` to `^7.5.5`
- refresh `package-lock.json` so the resolved transitive version is `7.5.5`
- clear the vulnerable `protobufjs < 7.5.5` path behind Dependabot alert #200

## Validation
- `npm audit --omit=dev --json | jq '{critical:(.metadata.vulnerabilities.critical // 0), protobufjs:(.vulnerabilities.protobufjs // null)}'`

Closes dependabot alert #200.