### PR TITLE
fix(sdk): FileDb in-memory cache authoritative — fixes stale status after disk write failures

### DIFF
--- a/packages/sdk/src/__tests__/file-db.test.ts
+++ b/packages/sdk/src/__tests__/file-db.test.ts
@@ -134,6 +134,30 @@ describe('JsonFileWorkflowDb', () => {
     expect(resolved).toContain(path.join('.agent-relay', 'workflow-runs-workflow-runs.jsonl'));
   });
 
+  // Regression for PR #757 Codex review feedback: the primary path's
+  // directory can be writable while the jsonl file itself is read-only
+  // (relayfile-mount chmods synced files to 0o444 while leaving the
+  // parent dir at 0o755). The old dir-only probe would accept the
+  // primary path, every append would lazy-fail, and homeFallback
+  // would never kick in despite the caller explicitly opting in.
+  it('opt-in homeFallback: true → read-only file with writable dir still falls back', () => {
+    const writableDir = path.join(tmpDir, 'project');
+    mkdirSync(writableDir, { recursive: true });
+    const primaryPath = path.join(writableDir, 'workflow-runs.jsonl');
+    writeFileSync(primaryPath, ''); // create the file so chmod targets it
+    chmodSync(primaryPath, 0o444); // file read-only; dir still 0o755
+
+    const db = new JsonFileWorkflowDb({
+      filePath: primaryPath,
+      homeFallback: true,
+    });
+
+    const resolved = db.getStoragePath();
+    expect(db.isWritable()).toBe(true);
+    expect(resolved.startsWith(os.homedir())).toBe(true);
+    expect(resolved).not.toBe(primaryPath);
+  });
+
   it('notifies onWriteFailure on every failed append', async () => {
     const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
     const failures: Array<{ err: unknown; filePath: string }> = [];

--- a/packages/sdk/src/__tests__/file-db.test.ts
+++ b/packages/sdk/src/__tests__/file-db.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for JsonFileWorkflowDb — in-memory cache is authoritative.
+ *
+ * Regression: before this file existed, `getRun` re-read the jsonl from
+ * disk on every call. If a write failed (EACCES in cloud, ENOSPC, etc.)
+ * the cache-less implementation would return stale data, which in turn
+ * caused `WorkflowRunner.execute()` to report a completed run as
+ * `status: 'running'` to callers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { JsonFileWorkflowDb } from '../workflows/file-db.js';
+import type { WorkflowRunRow, WorkflowStepRow } from '../workflows/types.js';
+
+function makeRun(overrides: Partial<WorkflowRunRow> = {}): WorkflowRunRow {
+  const now = new Date().toISOString();
+  return {
+    id: 'run_test',
+    workflowName: 'test',
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeStep(overrides: Partial<WorkflowStepRow> = {}): WorkflowStepRow {
+  const now = new Date().toISOString();
+  return {
+    id: 'step_test',
+    runId: 'run_test',
+    stepName: 'test-step',
+    status: 'pending',
+    attempts: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('JsonFileWorkflowDb', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'filedb-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      // Restore perms in case a test made the dir read-only.
+      chmodSync(tmpDir, 0o755);
+    } catch {
+      /* no-op */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a run through cache without re-reading disk', async () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
+    expect(db.isWritable()).toBe(true);
+
+    await db.insertRun(makeRun({ id: 'run_1', status: 'running' }));
+    await db.updateRun('run_1', { status: 'completed' });
+
+    const run = await db.getRun('run_1');
+    expect(run?.status).toBe('completed');
+
+    // The new write should also be durable.
+    const raw = readFileSync(dbPath, 'utf8');
+    expect(raw).toContain('"status":"completed"');
+  });
+
+  it('returns the latest run status even when the disk write silently fails', async () => {
+    // Deny writes to the storage directory so appendFileSync throws EACCES.
+    // On directories the mode controls whether new entries can be added —
+    // existing files inside become effectively read-only for append.
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
+    await db.insertRun(makeRun({ id: 'run_1', status: 'running' }));
+
+    // Revoke directory write permission AFTER the initial insert so the
+    // next append fails while the cache should still track the update.
+    chmodSync(tmpDir, 0o555);
+
+    await db.updateRun('run_1', { status: 'completed' });
+
+    // The in-memory mirror must reflect the update regardless of disk state.
+    const run = await db.getRun('run_1');
+    expect(run?.status).toBe('completed');
+  });
+
+  it('keeps cache state authoritative when disk writes lazy-fail (default, no fallback)', async () => {
+    // With homeFallback default (false), the constructor is optimistic about
+    // an unwritable directory — writable=true, first append() throws lazily.
+    // The key invariant: cache state is NOT lost even when the durable write
+    // never lands. This is the regression guard for the "workflow passes but
+    // reports status: running" bug.
+    const unwritableDir = path.join(tmpDir, 'unwritable');
+    mkdirSync(unwritableDir, { recursive: true });
+    chmodSync(unwritableDir, 0o555);
+    const blockedPath = path.join(unwritableDir, 'workflow-runs.jsonl');
+
+    const db = new JsonFileWorkflowDb(blockedPath); // default homeFallback: false
+    expect(db.isWritable()).toBe(true);
+
+    await db.insertRun(makeRun({ id: 'run_mem', status: 'running' }));
+    await db.updateRun('run_mem', { status: 'completed' });
+
+    const run = await db.getRun('run_mem');
+    expect(run?.status).toBe('completed');
+    // The jsonl was never created — disk writes all failed.
+    expect(existsSync(blockedPath)).toBe(false);
+  });
+
+  it('opt-in homeFallback: true → unwritable path routes to $HOME/.agent-relay', () => {
+    const unwritableDir = path.join(tmpDir, 'unwritable');
+    mkdirSync(unwritableDir, { recursive: true });
+    chmodSync(unwritableDir, 0o555);
+    const blockedPath = path.join(unwritableDir, 'workflow-runs.jsonl');
+
+    const db = new JsonFileWorkflowDb({
+      filePath: blockedPath,
+      homeFallback: true,
+    });
+
+    const resolved = db.getStoragePath();
+    expect(db.isWritable()).toBe(true);
+    expect(resolved.startsWith(os.homedir())).toBe(true);
+    expect(resolved).toContain(path.join('.agent-relay', 'workflow-runs-workflow-runs.jsonl'));
+  });
+
+  it('notifies onWriteFailure on every failed append', async () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const failures: Array<{ err: unknown; filePath: string }> = [];
+    const db = new JsonFileWorkflowDb({
+      filePath: dbPath,
+      homeFallback: false,
+      onWriteFailure: (err, filePath) => failures.push({ err, filePath }),
+    });
+
+    await db.insertRun(makeRun({ id: 'run_1', status: 'running' }));
+
+    // Making the file itself read-only forces appendFileSync to throw.
+    // (Directory chmod alone is insufficient because appending to an
+    // already-open inode doesn't require directory write.)
+    chmodSync(dbPath, 0o444);
+
+    await db.updateRun('run_1', { status: 'completed' });
+    await db.updateRun('run_1', { status: 'completed' }); // second failure — listener should fire again
+
+    expect(failures.length).toBeGreaterThanOrEqual(2);
+    expect(failures[0].filePath).toBe(dbPath);
+
+    // The cache still reflects the latest state regardless of the write failure.
+    const run = await db.getRun('run_1');
+    expect(run?.status).toBe('completed');
+  });
+
+  it('replays existing jsonl on construction (--resume path)', async () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+
+    {
+      const db = new JsonFileWorkflowDb(dbPath);
+      await db.insertRun(makeRun({ id: 'run_replay', status: 'running' }));
+      await db.insertStep(makeStep({ id: 'step_1', runId: 'run_replay', status: 'pending' }));
+      await db.updateStep('step_1', { status: 'completed' });
+      await db.updateRun('run_replay', { status: 'completed' });
+    }
+
+    // Fresh instance should see the replayed state.
+    const reloaded = new JsonFileWorkflowDb(dbPath);
+    const run = await reloaded.getRun('run_replay');
+    expect(run?.status).toBe('completed');
+
+    const steps = await reloaded.getStepsByRunId('run_replay');
+    expect(steps).toHaveLength(1);
+    expect(steps[0].status).toBe('completed');
+  });
+
+  it('cache insert/update is visible to getStepsByRunId without a disk round-trip', async () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
+
+    await db.insertStep(makeStep({ id: 's1', runId: 'r1', stepName: 'a', status: 'pending' }));
+    await db.insertStep(makeStep({ id: 's2', runId: 'r1', stepName: 'b', status: 'pending' }));
+    await db.updateStep('s1', { status: 'completed' });
+
+    const steps = await db.getStepsByRunId('r1');
+    expect(steps.map((s) => `${s.stepName}=${s.status}`).sort()).toEqual(['a=completed', 'b=pending']);
+  });
+
+  it('hasStepOutputs still works relative to the resolved storage path', () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
+
+    const outputsDir = path.join(tmpDir, 'step-outputs', 'run_x');
+    mkdirSync(outputsDir, { recursive: true });
+    // Drop a file so readdirSync reports length > 0.
+    writeFileSync(path.join(outputsDir, 'out.txt'), 'hi');
+
+    expect(db.hasStepOutputs('run_x')).toBe(true);
+    expect(db.hasStepOutputs('run_y')).toBe(false);
+    expect(existsSync(dbPath)).toBe(false); // no writes happened yet
+  });
+});

--- a/packages/sdk/src/__tests__/file-db.test.ts
+++ b/packages/sdk/src/__tests__/file-db.test.ts
@@ -206,6 +206,38 @@ describe('JsonFileWorkflowDb', () => {
     expect(steps[0].status).toBe('completed');
   });
 
+  // Regression for PR #757 Devin review: InMemoryWorkflowDb shallow-copies
+  // on insert, JsonFileWorkflowDb previously stored the caller's object by
+  // reference. The runner inserts a row and also keeps it in its own map,
+  // then mutates state.row.status directly before calling updateStep/Run —
+  // if the cache held the same reference, those mutations would silently
+  // bypass updateStep's append + timestamp handling.
+  it('insertRun/insertStep do not alias the caller object into the cache', async () => {
+    const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
+    const db = new JsonFileWorkflowDb(dbPath);
+
+    const run = makeRun({ id: 'run_alias', status: 'running' });
+    await db.insertRun(run);
+
+    // Mutate the caller's object post-insert — shouldn't reach the cache.
+    run.status = 'failed';
+    run.error = 'direct mutation should not leak into the db';
+
+    const cached = await db.getRun('run_alias');
+    expect(cached?.status).toBe('running');
+    expect(cached?.error).toBeUndefined();
+
+    const step = makeStep({ id: 'step_alias', runId: 'run_alias', status: 'pending' });
+    await db.insertStep(step);
+    step.status = 'failed';
+    step.error = 'same hazard';
+
+    const cachedSteps = await db.getStepsByRunId('run_alias');
+    expect(cachedSteps).toHaveLength(1);
+    expect(cachedSteps[0].status).toBe('pending');
+    expect(cachedSteps[0].error).toBeUndefined();
+  });
+
   it('cache insert/update is visible to getStepsByRunId without a disk round-trip', async () => {
     const dbPath = path.join(tmpDir, 'workflow-runs.jsonl');
     const db = new JsonFileWorkflowDb(dbPath);

--- a/packages/sdk/src/workflows/file-db.ts
+++ b/packages/sdk/src/workflows/file-db.ts
@@ -62,10 +62,10 @@ export interface JsonFileWorkflowDbOptions {
  * Storage path resolution:
  *   1. Try the caller-supplied file path. If the parent directory is
  *      writable, use it.
- *   2. If (1) fails and `homeFallback` is true (default), try
- *      `$HOME/.agent-relay/workflow-runs-<basename>.jsonl`. This is
- *      outside any workspace mount in cloud sandboxes and almost
- *      always writable by the agent.
+ *   2. If (1) fails and `homeFallback` is true (opt-in, default false),
+ *      try `$HOME/.agent-relay/workflow-runs-<basename>.jsonl`. This is
+ *      outside any workspace mount in cloud sandboxes and almost always
+ *      writable by the agent.
  *   3. If both fail, run in memory-only mode. The workflow still
  *      executes correctly; `--resume` won't be available for this run.
  *
@@ -226,7 +226,14 @@ export class JsonFileWorkflowDb implements WorkflowDb {
   // ── WorkflowDb interface ─────────────────────────────────────────────────
 
   async insertRun(run: WorkflowRunRow): Promise<void> {
-    this.cache.runs.set(run.id, run);
+    // Shallow-copy so later mutations on the caller's object don't silently
+    // alias into the cache. Matches InMemoryWorkflowDb semantics. The runner
+    // keeps inserted rows in its own stepStates map and occasionally mutates
+    // state.row.status directly before calling updateRun — without this copy
+    // the mutation would land in the cache and bypass updateRun's
+    // updatedAt + append path, causing exactly the observability hazard this
+    // cache is meant to prevent.
+    this.cache.runs.set(run.id, { ...run });
     this.append({ kind: 'run', row: run });
   }
 
@@ -247,7 +254,8 @@ export class JsonFileWorkflowDb implements WorkflowDb {
   }
 
   async insertStep(step: WorkflowStepRow): Promise<void> {
-    this.cache.steps.set(step.id, step);
+    // Shallow-copy to prevent caller-mutation aliasing — see insertRun.
+    this.cache.steps.set(step.id, { ...step });
     this.append({ kind: 'step', row: step });
   }
 

--- a/packages/sdk/src/workflows/file-db.ts
+++ b/packages/sdk/src/workflows/file-db.ts
@@ -142,14 +142,24 @@ export class JsonFileWorkflowDb implements WorkflowDb {
       const isLastCandidate = i === candidates.length - 1;
       try {
         mkdirSync(path.dirname(candidate), { recursive: true });
-        // If there's a later fallback to try, actively probe write
-        // permission so we know whether to move on. If this is already
-        // the last candidate, skip the probe and be optimistic — an
-        // unwritable directory will surface as a lazy append() failure
-        // handled by the cache + onWriteFailure path. Matches the
+        // If there's a later fallback to try, actively probe writability
+        // so we know whether to move on. Two levels matter:
+        //   1. Directory must be writable to create the jsonl file.
+        //   2. If the jsonl file already exists, IT must also be writable
+        //      — a writable directory does not guarantee a writable file.
+        //      Relayfile-mount, for example, can sync a file and chmod it
+        //      to 0o444 while leaving the parent dir at 0o755; the old
+        //      dir-only check would accept the path and every append would
+        //      then lazy-fail, bypassing the fallback.
+        // If this is already the last candidate, skip the probe and be
+        // optimistic — an unwritable path will surface as a lazy append()
+        // failure handled by the cache + onWriteFailure path. Matches the
         // pre-cache "warn on first failure" semantic callers expect.
         if (!isLastCandidate) {
           accessSync(path.dirname(candidate), fsConstants.W_OK);
+          if (existsSync(candidate)) {
+            accessSync(candidate, fsConstants.W_OK);
+          }
         }
         return { resolvedPath: candidate, writable: true };
       } catch {

--- a/packages/sdk/src/workflows/file-db.ts
+++ b/packages/sdk/src/workflows/file-db.ts
@@ -1,4 +1,13 @@
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import {
+  accessSync,
+  appendFileSync,
+  constants as fsConstants,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import type { WorkflowRunRow, WorkflowStepRow } from './types.js';
@@ -7,41 +16,104 @@ import type { WorkflowDb } from './runner.js';
 type DbEntry = { kind: 'run'; row: WorkflowRunRow } | { kind: 'step'; row: WorkflowStepRow };
 
 /**
+ * Optional hook: fired whenever a persistence write fails (e.g. EACCES,
+ * ENOSPC). Surfaced so the CLI, dashboard, or bootstrap can decide how
+ * to react beyond the single console.warn. Not called for the initial
+ * "directory unwritable" detection — that's stored in {@link isWritable}.
+ */
+export type DbWriteFailureListener = (err: unknown, filePath: string) => void;
+
+export interface JsonFileWorkflowDbOptions {
+  /** Override the resolved filePath. Kept for tests / advanced callers. */
+  filePath?: string;
+  /** Notified on every underlying write error. */
+  onWriteFailure?: DbWriteFailureListener;
+  /**
+   * When true, if the preferred file path is unwritable, fall back to
+   * `$HOME/.agent-relay/workflow-runs-<basename>.jsonl` so `--resume`
+   * still works in environments where the workflow cwd is read-only
+   * (cloud sandboxes with restrictive workspace ACLs).
+   *
+   * Defaults to `false` — strict "write to this path or run in-memory"
+   * semantics, matching the pre-cache behavior. Opt-in via `true`.
+   */
+  homeFallback?: boolean;
+}
+
+/**
  * JSONL-backed WorkflowDb for the CLI.
  *
- * Each insert/update appends a line to the file. On read, we scan from the
- * bottom and take the last record for each ID — so updates naturally shadow
- * earlier inserts without rewriting the file.
+ * Design: the **in-memory cache is the single source of truth** for the
+ * process lifetime. Every mutation updates the cache synchronously and
+ * then best-effort appends to the jsonl file for durability / `--resume`.
  *
- * This makes writes O(1) and reads O(n) where n = number of lines (small for
- * typical workflows). Resume only reads once at startup, so the read cost is
- * paid once per CLI invocation.
+ * This matters because the runtime correctness of a running workflow
+ * must not depend on disk writes succeeding. If the storage path is
+ * unwritable (ACL-restricted workspace, full disk, ENOSPC), the workflow
+ * still progresses through its state machine correctly — we just lose
+ * the ability to resume a future process from that run.
  *
- * File: .agent-relay/workflow-runs.jsonl in the workflow cwd.
+ * Read paths used to re-snapshot the jsonl on every call, which meant
+ * a failed `updateRun(..., { status: 'completed' })` would leave a
+ * subsequent `getRun` returning the stale 'running' row from disk.
+ * That bug surfaced as workflows passing per-step but reporting
+ * `status: 'running'` to callers.
+ *
+ * Storage path resolution:
+ *   1. Try the caller-supplied file path. If the parent directory is
+ *      writable, use it.
+ *   2. If (1) fails and `homeFallback` is true (default), try
+ *      `$HOME/.agent-relay/workflow-runs-<basename>.jsonl`. This is
+ *      outside any workspace mount in cloud sandboxes and almost
+ *      always writable by the agent.
+ *   3. If both fail, run in memory-only mode. The workflow still
+ *      executes correctly; `--resume` won't be available for this run.
+ *
+ * File: `.agent-relay/workflow-runs.jsonl` in the workflow cwd by default.
  */
 export class JsonFileWorkflowDb implements WorkflowDb {
   private readonly filePath: string;
 
-  /** Whether the storage directory is writable. False = silent no-op mode. */
+  /** Whether persistence is active. False = in-memory-only mode. */
   private readonly writable: boolean;
   private appendFailedOnce = false;
+  private readonly onWriteFailure?: DbWriteFailureListener;
 
-  constructor(filePath: string) {
-    this.filePath = filePath;
-    let writable = false;
-    try {
-      mkdirSync(path.dirname(filePath), { recursive: true });
-      writable = true;
-    } catch {
-      // Permission denied or read-only fs — run in memory-only mode.
-      // The workflow executes normally; resume won't be available for this run.
-    }
+  /**
+   * Authoritative in-memory mirror. Every mutation updates this; reads
+   * return from here. The jsonl file is only consulted at construction
+   * (to replay prior state for `--resume`) and is otherwise write-only.
+   */
+  private readonly cache: {
+    runs: Map<string, WorkflowRunRow>;
+    steps: Map<string, WorkflowStepRow>;
+  };
+
+  constructor(filePathOrOptions: string | JsonFileWorkflowDbOptions) {
+    const options: JsonFileWorkflowDbOptions =
+      typeof filePathOrOptions === 'string' ? { filePath: filePathOrOptions } : filePathOrOptions;
+    this.onWriteFailure = options.onWriteFailure;
+
+    const requestedPath = options.filePath ?? path.join('.agent-relay', 'workflow-runs.jsonl');
+    const homeFallback = options.homeFallback ?? false;
+
+    const { resolvedPath, writable } = JsonFileWorkflowDb.resolveStoragePath(requestedPath, homeFallback);
+    this.filePath = resolvedPath;
     this.writable = writable;
+
+    // Load existing state from disk (for --resume) once at construction.
+    // From this point on, the cache is authoritative.
+    this.cache = JsonFileWorkflowDb.loadSnapshot(this.filePath);
   }
 
-  /** Returns false if the storage directory could not be created (permission error). */
+  /** Returns false if persistence is not active (in-memory-only mode). */
   isWritable(): boolean {
     return this.writable;
+  }
+
+  /** Resolved path on disk. For tests + diagnostics. */
+  getStoragePath(): string {
+    return this.filePath;
   }
 
   hasStepOutputs(runId: string): boolean {
@@ -55,31 +127,51 @@ export class JsonFileWorkflowDb implements WorkflowDb {
 
   // ── Private helpers ─────────────────────────────────────────────────────
 
-  private append(entry: DbEntry): void {
-    if (!this.writable) return;
-    try {
-      appendFileSync(this.filePath, JSON.stringify(entry) + '\n', 'utf8');
-    } catch (err) {
-      if (!this.appendFailedOnce) {
-        this.appendFailedOnce = true;
-        console.warn(
-          '[workflow] warning: failed to write run state to ' +
-            this.filePath +
-            ' — --resume will not be available for this run. Use --start-from instead. ' +
-            'Error: ' +
-            (err instanceof Error ? err.message : String(err))
-        );
+  private static resolveStoragePath(
+    requestedPath: string,
+    homeFallback: boolean
+  ): { resolvedPath: string; writable: boolean } {
+    const candidates: string[] = [requestedPath];
+    if (homeFallback) {
+      const base = path.basename(requestedPath) || 'workflow-runs.jsonl';
+      candidates.push(path.join(os.homedir(), '.agent-relay', `workflow-runs-${base}`));
+    }
+
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i];
+      const isLastCandidate = i === candidates.length - 1;
+      try {
+        mkdirSync(path.dirname(candidate), { recursive: true });
+        // If there's a later fallback to try, actively probe write
+        // permission so we know whether to move on. If this is already
+        // the last candidate, skip the probe and be optimistic — an
+        // unwritable directory will surface as a lazy append() failure
+        // handled by the cache + onWriteFailure path. Matches the
+        // pre-cache "warn on first failure" semantic callers expect.
+        if (!isLastCandidate) {
+          accessSync(path.dirname(candidate), fsConstants.W_OK);
+        }
+        return { resolvedPath: candidate, writable: true };
+      } catch {
+        // Try the next candidate; if this was the last, fall through
+        // to memory-only.
       }
     }
+
+    // Memory-only mode. Path is reported for diagnostics but nothing
+    // is written to it.
+    return { resolvedPath: requestedPath, writable: false };
   }
 
-  /** Read all lines and build the latest snapshot for each ID. */
-  private snapshot(): { runs: Map<string, WorkflowRunRow>; steps: Map<string, WorkflowStepRow> } {
+  private static loadSnapshot(filePath: string): {
+    runs: Map<string, WorkflowRunRow>;
+    steps: Map<string, WorkflowStepRow>;
+  } {
     const runs = new Map<string, WorkflowRunRow>();
     const steps = new Map<string, WorkflowStepRow>();
     let raw = '';
     try {
-      raw = readFileSync(this.filePath, 'utf8');
+      raw = readFileSync(filePath, 'utf8');
     } catch {
       return { runs, steps };
     }
@@ -100,37 +192,68 @@ export class JsonFileWorkflowDb implements WorkflowDb {
     return { runs, steps };
   }
 
+  private append(entry: DbEntry): void {
+    if (!this.writable) return;
+    try {
+      appendFileSync(this.filePath, JSON.stringify(entry) + '\n', 'utf8');
+    } catch (err) {
+      // Notify every failure so callers can aggregate / surface.
+      this.onWriteFailure?.(err, this.filePath);
+      // Warn to console once per process — subsequent failures are noise.
+      if (!this.appendFailedOnce) {
+        this.appendFailedOnce = true;
+        console.warn(
+          '[workflow] warning: failed to write run state to ' +
+            this.filePath +
+            ' — --resume will not be available for this run. Use --start-from instead. ' +
+            'Error: ' +
+            (err instanceof Error ? err.message : String(err))
+        );
+      }
+    }
+  }
+
   // ── WorkflowDb interface ─────────────────────────────────────────────────
 
   async insertRun(run: WorkflowRunRow): Promise<void> {
+    this.cache.runs.set(run.id, run);
     this.append({ kind: 'run', row: run });
   }
 
   async updateRun(id: string, patch: Partial<WorkflowRunRow>): Promise<void> {
-    const { runs } = this.snapshot();
-    const existing = runs.get(id);
+    const existing = this.cache.runs.get(id);
     if (!existing) return;
-    this.append({ kind: 'run', row: { ...existing, ...patch, updatedAt: new Date().toISOString() } });
+    const updated: WorkflowRunRow = {
+      ...existing,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    };
+    this.cache.runs.set(id, updated);
+    this.append({ kind: 'run', row: updated });
   }
 
   async getRun(id: string): Promise<WorkflowRunRow | null> {
-    const { runs } = this.snapshot();
-    return runs.get(id) ?? null;
+    return this.cache.runs.get(id) ?? null;
   }
 
   async insertStep(step: WorkflowStepRow): Promise<void> {
+    this.cache.steps.set(step.id, step);
     this.append({ kind: 'step', row: step });
   }
 
   async updateStep(id: string, patch: Partial<WorkflowStepRow>): Promise<void> {
-    const { steps } = this.snapshot();
-    const existing = steps.get(id);
+    const existing = this.cache.steps.get(id);
     if (!existing) return;
-    this.append({ kind: 'step', row: { ...existing, ...patch, updatedAt: new Date().toISOString() } });
+    const updated: WorkflowStepRow = {
+      ...existing,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    };
+    this.cache.steps.set(id, updated);
+    this.append({ kind: 'step', row: updated });
   }
 
   async getStepsByRunId(runId: string): Promise<WorkflowStepRow[]> {
-    const { steps } = this.snapshot();
-    return Array.from(steps.values()).filter((s) => s.runId === runId);
+    return Array.from(this.cache.steps.values()).filter((s) => s.runId === runId);
   }
 }


### PR DESCRIPTION
## Problem

\`JsonFileWorkflowDb\` re-reads the backing jsonl on every \`getRun\` / \`getStepsByRunId\`. When the filesystem denies writes — as it does in a cloud Daytona sandbox where the relayfile workspace ACL marks \`/project/.agent-relay/\` read-only — every state mutation is silently dropped and subsequent reads return the pre-failure row.

Observed failure: workflows pass every step, post to channels correctly, write every deliverable file, and still report \`status: 'running'\` to the caller. Concrete trace from a live cloud run:

\`\`\`
[workflow] completed
Workflow \"hi-interactive-workflow\" — COMPLETED
  5 passed, 0 failed, 0 skipped
[workflow 01:48] Shutting down broker...
Run status: running                      ← execute() returns stale row
FAILED                                   ← caller's status check fails
Bootstrap fatal error: ... bun exit 1    ← non-zero exit kills the run
```

The warn that fires in this scenario also confirms it:

```
[workflow] warning: failed to write run state to /project/.agent-relay/workflow-runs.jsonl
  — --resume will not be available for this run. Use --start-from instead.
  Error: EACCES: permission denied, open
```

## Fix

**The in-memory cache is now the single source of truth.** Every mutation updates the cache synchronously. The jsonl file becomes a best-effort persistence layer — used once at construction to replay state for `--resume`, and otherwise write-only. Runtime correctness no longer depends on disk writes succeeding.

Three pieces:

1. **Cache-first reads**: `getRun` / `getStepsByRunId` return from the in-memory map. `snapshot()` is only called once, at construction, to replay whatever exists on disk.

2. **Structured failure signal**: new `JsonFileWorkflowDbOptions.onWriteFailure` listener fires on every failed append. Callers (CLI, dashboard, cloud bootstrap) can aggregate / surface write failures beyond the once-per-process `console.warn`.

3. **Opt-in `$HOME` fallback**: `JsonFileWorkflowDbOptions.homeFallback = true` routes to `$HOME/.agent-relay/workflow-runs-<base>.jsonl` when the preferred path is unwritable. Default is `false` — strict path semantics, matching the pre-cache behavior (the existing `'should warn once when append fails'` test passes unchanged). \`--resume\` in cloud is tracked as follow-up work.

Plain-string construction is preserved: \`new JsonFileWorkflowDb(path)\` still works identically. Callers opt in to the new options via \`new JsonFileWorkflowDb({ filePath, onWriteFailure, homeFallback })\`.

## Test plan

- [x] New `packages/sdk/src/__tests__/file-db.test.ts` — 8 tests covering round-trip, **stale-disk cache consistency (the regression guard)**, strict-default memory-only, opt-in `$HOME` fallback, failure listener semantics, replay-on-construction for `--resume`, step cache, and `hasStepOutputs` path resolution.
- [x] Existing `resume-fallback.test.ts` (including `'should warn once when append fails'`) still passes — optimistic `writable=true` when the unwritable path is the only candidate preserves lazy-failure semantics that test relies on.
- [x] Existing `builder-resume-persistence.test.ts` passes.
- [x] Ran the full SDK vitest suite; the two failures that remain (`models.test.ts` package-entry, `workflow-runner.test.ts > should record review completion in trajectory…`) also fail on unmodified `main` — pre-existing flakes, not caused by this PR.
- [ ] After merge + release: rerun `hi-interactive.ts` in cloud; runner should return `status: 'completed'` and the bootstrap should not report FAILED.

## Follow-up (not in this PR)

The cloud orchestrator agent still has no `fs:write` scope on `/project/.agent-relay/`, so `--resume` can't round-trip even with this fix — the jsonl isn't persisted across processes. Three options: (1) grant the scope in the workspace ACL, (2) have the cloud bootstrap construct `JsonFileWorkflowDb` with `homeFallback: true`, (3) accept `--resume` as local-only. Captured in the trail trajectory; will revisit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
