### PR TITLE
feat(sdk): add onAgentActivityChanged hook

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -38,6 +38,9 @@ const relay = new AgentRelay();
 // Event hooks
 relay.onMessageReceived = (msg) => console.log(`${msg.from}: ${msg.text}`);
 relay.onAgentIdle = ({ name, idleSecs }) => console.log(`${name} idle for ${idleSecs}s`);
+relay.onAgentActivityChanged = ({ name, active, pendingDeliveries }) => {
+  updateThinkingBadge(name, active ? `Thinking (${pendingDeliveries})` : 'Idle');
+};
 
 // Spawn agents using shorthand spawners
 const worker = await relay.claude.spawn({

--- a/packages/sdk/src/__tests__/agent-activity.test.ts
+++ b/packages/sdk/src/__tests__/agent-activity.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { BrokerEvent } from '../protocol.js';
+import { AgentRelay, type AgentActivityChange } from '../relay.js';
+
+function createMockFacadeClient() {
+  const listeners = new Set<(event: BrokerEvent) => void>();
+
+  const client = {
+    onEvent: vi.fn((listener: (event: BrokerEvent) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  };
+
+  const emit = (event: BrokerEvent) => {
+    for (const listener of Array.from(listeners)) {
+      listener(event);
+    }
+  };
+
+  return { client, emit };
+}
+
+function wireRelay(relay: AgentRelay, client: ReturnType<typeof createMockFacadeClient>['client']): void {
+  (relay as any).client = client;
+  (relay as any).wireEvents(client);
+}
+
+describe('AgentRelay onAgentActivityChanged', () => {
+  it('emits active on first delivery event', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+
+    expect(changes).toEqual([
+      {
+        name: 'worker-1',
+        active: true,
+        pendingDeliveries: 1,
+        reason: 'delivery_queued',
+        eventId: 'e1',
+      },
+    ]);
+  });
+
+  it('does not emit repeated active transitions while already active', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+    emit({ kind: 'delivery_injected', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 2 });
+    emit({ kind: 'delivery_active', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', pattern: 'output' });
+    emit({ kind: 'delivery_ack', name: 'worker-1', delivery_id: 'd1', event_id: 'e1' });
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.reason).toBe('delivery_queued');
+  });
+
+  it('emits inactive on relay_inbound', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+    emit({
+      kind: 'relay_inbound',
+      event_id: 'reply-1',
+      from: 'worker-1',
+      target: '#general',
+      body: 'done',
+    });
+
+    expect(changes.at(-1)).toEqual({
+      name: 'worker-1',
+      active: false,
+      pendingDeliveries: 0,
+      reason: 'relay_inbound',
+      eventId: 'reply-1',
+    });
+  });
+
+  it('emits inactive on agent_idle', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_ack', name: 'worker-1', delivery_id: 'd1', event_id: 'e1' });
+    emit({ kind: 'agent_idle', name: 'worker-1', idle_secs: 30 });
+
+    expect(changes.at(-1)).toEqual({
+      name: 'worker-1',
+      active: false,
+      pendingDeliveries: 0,
+      reason: 'agent_idle',
+      eventId: undefined,
+    });
+  });
+
+  it('concurrent deliveries do not flip inactive too early', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd2', event_id: 'e2', timestamp: 2 });
+    emit({ kind: 'delivery_failed', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', reason: 'timeout' });
+
+    expect(changes).toHaveLength(1);
+
+    emit({ kind: 'delivery_failed', name: 'worker-1', delivery_id: 'd2', event_id: 'e2', reason: 'timeout' });
+
+    expect(changes.at(-1)).toEqual({
+      name: 'worker-1',
+      active: false,
+      pendingDeliveries: 0,
+      reason: 'delivery_failed',
+      eventId: 'e2',
+    });
+  });
+
+  it('emits inactive on exit and release', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+    emit({ kind: 'agent_exited', name: 'worker-1', code: 0, signal: undefined });
+    emit({ kind: 'delivery_queued', name: 'worker-2', delivery_id: 'd2', event_id: 'e2', timestamp: 2 });
+    emit({ kind: 'agent_released', name: 'worker-2' });
+
+    expect(changes).toContainEqual({
+      name: 'worker-1',
+      active: false,
+      pendingDeliveries: 0,
+      reason: 'agent_exited',
+      eventId: undefined,
+    });
+    expect(changes).toContainEqual({
+      name: 'worker-2',
+      active: false,
+      pendingDeliveries: 0,
+      reason: 'agent_released',
+      eventId: undefined,
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/agent-activity.test.ts
+++ b/packages/sdk/src/__tests__/agent-activity.test.ts
@@ -96,7 +96,7 @@ describe('AgentRelay onAgentActivityChanged', () => {
     const changes: AgentActivityChange[] = [];
     relay.onAgentActivityChanged = (change) => changes.push(change);
 
-    emit({ kind: 'delivery_ack', name: 'worker-1', delivery_id: 'd1', event_id: 'e1' });
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
     emit({ kind: 'agent_idle', name: 'worker-1', idle_secs: 30 });
 
     expect(changes.at(-1)).toEqual({
@@ -106,6 +106,35 @@ describe('AgentRelay onAgentActivityChanged', () => {
       reason: 'agent_idle',
       eventId: undefined,
     });
+  });
+
+  it('does not reactivate an agent when delivery_ack arrives after idle', () => {
+    const relay = new AgentRelay();
+    const { client, emit } = createMockFacadeClient();
+    wireRelay(relay, client);
+    const changes: AgentActivityChange[] = [];
+    relay.onAgentActivityChanged = (change) => changes.push(change);
+
+    emit({ kind: 'delivery_queued', name: 'worker-1', delivery_id: 'd1', event_id: 'e1', timestamp: 1 });
+    emit({ kind: 'agent_idle', name: 'worker-1', idle_secs: 30 });
+    emit({ kind: 'delivery_ack', name: 'worker-1', delivery_id: 'd1', event_id: 'e1' });
+
+    expect(changes).toEqual([
+      {
+        name: 'worker-1',
+        active: true,
+        pendingDeliveries: 1,
+        reason: 'delivery_queued',
+        eventId: 'e1',
+      },
+      {
+        name: 'worker-1',
+        active: false,
+        pendingDeliveries: 0,
+        reason: 'agent_idle',
+        eventId: undefined,
+      },
+    ]);
   });
 
   it('concurrent deliveries do not flip inactive too early', () => {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -1466,7 +1466,9 @@ export class AgentRelay {
           break;
         }
         case 'delivery_ack': {
-          this.markAgentDeliveryPending(event.name, event.delivery_id, event.event_id, 'delivery_ack');
+          // No-op for activity tracking. delivery_ack can arrive late, after
+          // relay_inbound / idle / exit already cleared activity, so re-adding
+          // pending state here would incorrectly flip the agent back to active.
           break;
         }
         case 'delivery_failed': {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -166,6 +166,25 @@ export interface DeliveryState {
   updatedAt: number;
 }
 
+export type AgentActivityReason =
+  | 'delivery_queued'
+  | 'delivery_injected'
+  | 'delivery_active'
+  | 'delivery_ack'
+  | 'delivery_failed'
+  | 'relay_inbound'
+  | 'agent_idle'
+  | 'agent_exited'
+  | 'agent_released';
+
+export interface AgentActivityChange {
+  name: string;
+  active: boolean;
+  pendingDeliveries: number;
+  reason: AgentActivityReason;
+  eventId?: string;
+}
+
 export interface SpawnLifecycleContext {
   name: string;
   cli: string;
@@ -347,6 +366,11 @@ type InternalAgent = Agent & {
   _setChannels: (channels: string[]) => void;
 };
 
+interface AgentActivityState {
+  active: boolean;
+  pendingDeliveries: Map<string, string>;
+}
+
 // ── AgentRelay facade ───────────────────────────────────────────────────────
 
 export class AgentRelay {
@@ -361,6 +385,7 @@ export class AgentRelay {
   onDeliveryUpdate: EventHook<BrokerEvent> = null;
   onAgentExitRequested: EventHook<{ name: string; reason: string }> = null;
   onAgentIdle: EventHook<{ name: string; idleSecs: number }> = null;
+  onAgentActivityChanged: EventHook<AgentActivityChange> = null;
   onChannelSubscribed: ((agent: string, channels: string[]) => void) | null = null;
   onChannelUnsubscribed: ((agent: string, channels: string[]) => void) | null = null;
 
@@ -400,6 +425,7 @@ export class AgentRelay {
   private readonly exitedAgents = new Set<string>();
   private readonly idleAgents = new Set<string>();
   private readonly deliveryStates = new Map<string, DeliveryState>();
+  private readonly agentActivityStates = new Map<string, AgentActivityState>();
   private readonly outputListeners = new Map<string, Set<OutputListener>>();
   private readonly exitResolvers = new Map<
     string,
@@ -1040,6 +1066,7 @@ export class AgentRelay {
     this.exitedAgents.clear();
     this.idleAgents.clear();
     this.deliveryStates.clear();
+    this.agentActivityStates.clear();
     this.outputListeners.clear();
     for (const entry of this.exitResolvers.values()) {
       entry.resolve('released');
@@ -1072,9 +1099,95 @@ export class AgentRelay {
     this.deliveryStates.set(eventId, { eventId, to, status, updatedAt });
   }
 
+  private ensureAgentActivityState(name: string): AgentActivityState {
+    const existing = this.agentActivityStates.get(name);
+    if (existing) {
+      return existing;
+    }
+    const state: AgentActivityState = {
+      active: false,
+      pendingDeliveries: new Map<string, string>(),
+    };
+    this.agentActivityStates.set(name, state);
+    return state;
+  }
+
+  private getDeliveryActivityKey(deliveryId: string, eventId: string): string {
+    return deliveryId || eventId;
+  }
+
+  private markAgentDeliveryPending(
+    name: string,
+    deliveryId: string,
+    eventId: string,
+    reason: AgentActivityReason
+  ): void {
+    const state = this.ensureAgentActivityState(name);
+    state.pendingDeliveries.set(this.getDeliveryActivityKey(deliveryId, eventId), eventId);
+    this.setAgentActivity(name, state, state.pendingDeliveries.size > 0, reason, eventId);
+  }
+
+  private closeAgentDelivery(
+    name: string,
+    reason: AgentActivityReason,
+    eventId?: string,
+    deliveryId?: string
+  ): void {
+    const state = this.agentActivityStates.get(name);
+    if (!state) return;
+
+    const key = deliveryId && eventId ? this.getDeliveryActivityKey(deliveryId, eventId) : undefined;
+    if (key) {
+      state.pendingDeliveries.delete(key);
+    } else if (eventId) {
+      const matchingEntry = Array.from(state.pendingDeliveries.entries()).find(([, pendingEventId]) => {
+        return pendingEventId === eventId;
+      });
+      if (matchingEntry) {
+        state.pendingDeliveries.delete(matchingEntry[0]);
+      } else {
+        const oldestKey = state.pendingDeliveries.keys().next().value as string | undefined;
+        if (oldestKey) {
+          state.pendingDeliveries.delete(oldestKey);
+        }
+      }
+    }
+
+    this.setAgentActivity(name, state, state.pendingDeliveries.size > 0, reason, eventId);
+  }
+
+  private clearAgentDeliveries(name: string, reason: AgentActivityReason, eventId?: string): void {
+    const state = this.agentActivityStates.get(name);
+    if (!state) return;
+    state.pendingDeliveries.clear();
+    this.setAgentActivity(name, state, false, reason, eventId);
+  }
+
+  private setAgentActivity(
+    name: string,
+    state: AgentActivityState,
+    active: boolean,
+    reason: AgentActivityReason,
+    eventId?: string
+  ): void {
+    if (state.active === active) {
+      return;
+    }
+    state.active = active;
+    this.onAgentActivityChanged?.({
+      name,
+      active,
+      pendingDeliveries: state.pendingDeliveries.size,
+      reason,
+      eventId,
+    });
+  }
+
   private resolveEventTimestamp(candidate?: unknown): number {
     return typeof candidate === 'number' ? candidate : Date.now();
   }
+
+
 
   private addAgentChannels(name: string, channels: string[]): void {
     const agent = this.knownAgents.get(name) as InternalAgent | undefined;
@@ -1238,10 +1351,12 @@ export class AgentRelay {
     this.unsubEvent = client.onEvent((event: BrokerEvent) => {
       switch (event.kind) {
         case 'relay_inbound': {
+          this.closeAgentDelivery(event.from, 'relay_inbound', event.event_id);
           if (this.knownAgents.has(event.from)) {
             this.messageReadyAgents.add(event.from);
             this.exitedAgents.delete(event.from);
           }
+          this.clearAgentDeliveries(event.from, 'relay_inbound', event.event_id);
           const msg: Message = {
             eventId: event.event_id,
             from: event.from,
@@ -1264,6 +1379,7 @@ export class AgentRelay {
         }
         case 'agent_released': {
           const agent = this.knownAgents.get(event.name) ?? this.ensureAgentHandle(event.name, 'pty', []);
+          this.clearAgentDeliveries(event.name, 'agent_released');
           this.exitedAgents.add(event.name);
           this.readyAgents.delete(event.name);
           this.messageReadyAgents.delete(event.name);
@@ -1279,6 +1395,7 @@ export class AgentRelay {
         }
         case 'agent_exited': {
           const agent = this.knownAgents.get(event.name) ?? this.ensureAgentHandle(event.name, 'pty', []);
+          this.clearAgentDeliveries(event.name, 'agent_exited');
           this.exitedAgents.add(event.name);
           this.readyAgents.delete(event.name);
           this.messageReadyAgents.delete(event.name);
@@ -1320,6 +1437,7 @@ export class AgentRelay {
           break;
         }
         case 'delivery_queued': {
+          this.markAgentDeliveryPending(event.name, event.delivery_id, event.event_id, 'delivery_queued');
           this.updateDeliveryState(
             event.event_id,
             event.name,
@@ -1329,6 +1447,7 @@ export class AgentRelay {
           break;
         }
         case 'delivery_injected': {
+          this.markAgentDeliveryPending(event.name, event.delivery_id, event.event_id, 'delivery_injected');
           this.updateDeliveryState(
             event.event_id,
             event.name,
@@ -1338,6 +1457,7 @@ export class AgentRelay {
           break;
         }
         case 'delivery_active': {
+          this.markAgentDeliveryPending(event.name, event.delivery_id, event.event_id, 'delivery_active');
           this.updateDeliveryState(event.event_id, event.name, 'active', this.resolveEventTimestamp());
           break;
         }
@@ -1345,7 +1465,12 @@ export class AgentRelay {
           this.updateDeliveryState(event.event_id, event.name, 'verified', this.resolveEventTimestamp());
           break;
         }
+        case 'delivery_ack': {
+          this.markAgentDeliveryPending(event.name, event.delivery_id, event.event_id, 'delivery_ack');
+          break;
+        }
         case 'delivery_failed': {
+          this.closeAgentDelivery(event.name, 'delivery_failed', event.event_id, event.delivery_id);
           this.updateDeliveryState(event.event_id, event.name, 'failed', this.resolveEventTimestamp());
           break;
         }
@@ -1362,6 +1487,7 @@ export class AgentRelay {
           break;
         }
         case 'agent_idle': {
+          this.clearAgentDeliveries(event.name, 'agent_idle');
           this.idleAgents.add(event.name);
           this.onAgentIdle?.({
             name: event.name,
@@ -1689,6 +1815,7 @@ export class AgentRelay {
     this.messageReadyAgents.delete(name);
     this.exitedAgents.delete(name);
     this.idleAgents.delete(name);
+    this.agentActivityStates.delete(name);
   }
 
   private normalizeReleaseOptions(reasonOrOptions?: string | ReleaseOptions): ReleaseOptions {

--- a/web/content/docs/event-handlers.mdx
+++ b/web/content/docs/event-handlers.mdx
@@ -83,6 +83,10 @@ relay.onAgentExitRequested = ({ name, reason }) => {
 relay.onAgentIdle = ({ name, idleSecs }) => {
   console.log(`idle: ${name}`, idleSecs);
 };
+
+relay.onAgentActivityChanged = ({ name, active, pendingDeliveries, reason }) => {
+  console.log(`activity: ${name}`, { active, pendingDeliveries, reason });
+};
 ```
 
 ```python Python
@@ -120,6 +124,16 @@ relay.on_delivery_update = lambda event: print("delivery update", event["type"])
 
 - `onWorkerOutput` / `on_worker_output`: raw stdout or stderr from a worker.
 - `onDeliveryUpdate` / `on_delivery_update`: broker-level delivery events when you need transport visibility.
+- `onAgentActivityChanged`: high-level derived activity signal for UI badges like “thinking” without hand-rolling delivery event inference.
+
+```typescript
+const thinkingByAgent = new Map<string, boolean>();
+
+relay.onAgentActivityChanged = ({ name, active }) => {
+  thinkingByAgent.set(name, active);
+  renderThinkingBadge(name, active);
+};
+```
 
 ## Good uses for handlers
 

--- a/web/content/docs/typescript-sdk.mdx
+++ b/web/content/docs/typescript-sdk.mdx
@@ -158,6 +158,7 @@ relay.onAgentReleased  = (agent: Agent) => { ... }
 relay.onAgentExited    = (agent: Agent) => { ... }
 relay.onAgentReady     = (agent: Agent) => { ... }
 relay.onAgentIdle      = ({ name, idleSecs }) => { ... }
+relay.onAgentActivityChanged = ({ name, active, pendingDeliveries, reason }) => { ... }
 relay.onAgentExitRequested = ({ name, reason }) => { ... }
 relay.onWorkerOutput   = ({ name, stream, chunk }) => { ... }
 relay.onDeliveryUpdate = (event: BrokerEvent) => { ... }


### PR DESCRIPTION
## Summary
- add a first-class `onAgentActivityChanged` hook to `AgentRelay`
- derive activity state from existing broker delivery and lifecycle events
- add focused SDK tests and docs for rendering a simple thinking badge

## Semantics
- `active=true` when the SDK sees an in-flight delivery for an agent
- activity starts on `delivery_queued`, `delivery_injected`, `delivery_active`, or `delivery_ack`
- activity ends on `relay_inbound`, `agent_idle`, `agent_exited`, `agent_released`, or `delivery_failed` when no pending deliveries remain
- concurrent deliveries are tracked per agent so the hook does not flip inactive too early
- duplicate active transitions are suppressed when derived state does not change

## Testing
- attempted: `npm test -- --run packages/sdk/src/__tests__/agent-activity.test.ts`
- blocked in this environment because the repo build depends on `turbo`, which is not installed here

Closes #681
