### PR TITLE
feat(cli): add agent-relay mcp-args subcommand

### DIFF
--- a/.trajectories/active/traj_3b3p1z4y7qlo.json
+++ b/.trajectories/active/traj_3b3p1z4y7qlo.json
@@ -1,0 +1,281 @@
+{
+  "id": "traj_3b3p1z4y7qlo",
+  "version": 1,
+  "task": {
+    "title": "add-mcp-args-subcommand-workflow",
+    "description": "Add agent-relay mcp-args CLI subcommand as the single source of truth for relaycast MCP wiring, callable by cloud and other external consumers. claude plan → codex implement → cargo test-fix-rerun → claude review → PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "7b3cd6bed0179c78ce57fa38"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-04-20T13:16:22.009Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-04-20T13:16:22.009Z"
+    },
+    {
+      "name": "planner",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T13:16:29.180Z"
+    },
+    {
+      "name": "implementer",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T13:19:33.400Z"
+    },
+    {
+      "name": "reviewer",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T13:30:02.548Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cuzudcu6eor3",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T13:16:22.009Z",
+      "endedAt": "2026-04-20T13:16:29.186Z",
+      "events": [
+        {
+          "ts": 1776690982009,
+          "type": "note",
+          "content": "Purpose: Add agent-relay mcp-args CLI subcommand as the single source of truth for relaycast MCP wiring, callable by cloud and other external consumers. claude plan → codex implement → cargo test-fix-rerun → claude review → PR."
+        },
+        {
+          "ts": 1776690982009,
+          "type": "note",
+          "content": "Approach: 17-step dag workflow — Parsed 17 steps, 16 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_z8ltm9fwj5ax",
+      "title": "Execution: plan",
+      "agentName": "planner",
+      "startedAt": "2026-04-20T13:16:29.186Z",
+      "endedAt": "2026-04-20T13:19:33.406Z",
+      "events": [
+        {
+          "ts": 1776690989186,
+          "type": "note",
+          "content": "\"plan\": Write PLAN.md at the repo root specifying the agent-relay mcp-args subcommand",
+          "raw": {
+            "agent": "planner"
+          }
+        },
+        {
+          "ts": 1776691171951,
+          "type": "completion-marker",
+          "content": "\"plan\" marker-based completion — Legacy STEP_COMPLETE marker observed (5 signal(s), 1 relevant channel post(s), 3 file change(s); signals=plan, COMPLETE, PLAN.md, plan, COMPLETE; channel=**[plan] Output:**\n```\n      1.0k tokens · thought for 15s)\n⏺ Write(PLAN.md)                                      \n· Spinning… (1m 50s · ↓ 2.2k tokens · thought; files=modified:.claude/settings.json, modified:.relay/workspaces.json, created:PLAN.md)",
+          "raw": {
+            "stepName": "plan",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 3 file change(s)",
+              "signals": ["plan", "COMPLETE", "PLAN.md", "plan", "COMPLETE"],
+              "channelPosts": [
+                "**[plan] Output:**\n```\n      1.0k tokens · thought for 15s)\n⏺ Write(PLAN.md)                                      \n· Spinning… (1m 50s · ↓ 2.2k tokens · thought"
+              ],
+              "files": [
+                "modified:.claude/settings.json",
+                "modified:.relay/workspaces.json",
+                "created:PLAN.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776691171952,
+          "type": "finding",
+          "content": "\"plan\" completed → ✻ Baked for 1m 58s                                                \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_duqavff7i711",
+      "title": "Execution: implement",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T13:19:33.406Z",
+      "endedAt": "2026-04-20T13:27:25.166Z",
+      "events": [
+        {
+          "ts": 1776691173406,
+          "type": "note",
+          "content": "\"implement\": Implement the plan",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776691643013,
+          "type": "completion-marker",
+          "content": "\"implement\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 1 relevant channel post(s), 6 file change(s); signals=COMPLETE, COMPLETE, COMPLETE, >7u, IMPL_SUMMARY.md, plan; channel=**[implement] Output:**\n```\nOMPLETE — PLAN.md written at repo\n  root. Covers: new `McpArgs` Commands variant with full flag set (--cli,\n  --agent-name, --api-ke; files=created:docs/reference-cli.md, created:IMPL_SUMMARY.md, created:src/cli_mcp_args.rs, modified:src/main.rs, modified:target/debug/.fingerprint/agent-relay-broker-20bacfdb6f5a091b/bin-agent-relay-broker, modified:target/debug/.fingerprint/agent-relay-broker-20bacfdb6f5a091b/bin-agent-relay-broker.json)",
+          "raw": {
+            "stepName": "implement",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 1 relevant channel post(s), 6 file change(s)",
+              "signals": ["COMPLETE", "COMPLETE", "COMPLETE", ">7u", "IMPL_SUMMARY.md", "plan"],
+              "channelPosts": [
+                "**[implement] Output:**\n```\nOMPLETE — PLAN.md written at repo\n  root. Covers: new `McpArgs` Commands variant with full flag set (--cli,\n  --agent-name, --api-ke"
+              ],
+              "files": [
+                "created:docs/reference-cli.md",
+                "created:IMPL_SUMMARY.md",
+                "created:src/cli_mcp_args.rs",
+                "modified:src/main.rs",
+                "modified:target/debug/.fingerprint/agent-relay-broker-20bacfdb6f5a091b/bin-agent-relay-broker",
+                "modified:target/debug/.fingerprint/agent-relay-broker-20bacfdb6f5a091b/bin-agent-relay-broker.json"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776691643013,
+          "type": "finding",
+          "content": "\"implement\" completed → >7u\r\n╭─────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                  │\r\n│                ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_dcdi1cpop7qh",
+      "title": "Execution: fix-compile-errors",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T13:27:25.166Z",
+      "endedAt": "2026-04-20T13:28:40.188Z",
+      "events": [
+        {
+          "ts": 1776691645166,
+          "type": "note",
+          "content": "\"fix-compile-errors\": cargo check output below",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776691716145,
+          "type": "completion-marker",
+          "content": "\"fix-compile-errors\" marker-based completion — Legacy STEP_COMPLETE marker observed (5 signal(s); signals=fix-compile-errors, COMPLETE, COMPLETE, COMPLETE, Verification passed)",
+          "raw": {
+            "stepName": "fix-compile-errors",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "5 signal(s)",
+              "signals": ["fix-compile-errors", "COMPLETE", "COMPLETE", "COMPLETE", "Verification passed"]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776691716145,
+          "type": "finding",
+          "content": "\"fix-compile-errors\" completed → >7u\r\n╭─────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                  │\r\n│                ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_6m8fqidbd15a",
+      "title": "Execution: fix-test-failures",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T13:28:40.188Z",
+      "endedAt": "2026-04-20T13:30:02.551Z",
+      "events": [
+        {
+          "ts": 1776691720189,
+          "type": "note",
+          "content": "\"fix-test-failures\": cargo test output below",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776691793281,
+          "type": "completion-marker",
+          "content": "\"fix-test-failures\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 2 relevant channel post(s); signals=COMPLETE, COMPLETE, Verification passed, COMPLETE, COMPLETE, COMPLETE; channel=OWNER_DECISION: COMPLETE\nREASON: `cargo test --bin agent-relay-broker` passes locally with 312 passed, 0 failed, 2 ignored; no source changes were needed.\nSTEP_ | **[fix-test-failures] Output:**\n```\nequires\n• The broker task is specifically the fix-test-failures step. The supplied cargo\n  test --bin agent-relay-broker out)",
+          "raw": {
+            "stepName": "fix-test-failures",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 2 relevant channel post(s)",
+              "signals": ["COMPLETE", "COMPLETE", "Verification passed", "COMPLETE", "COMPLETE", "COMPLETE"],
+              "channelPosts": [
+                "OWNER_DECISION: COMPLETE\nREASON: `cargo test --bin agent-relay-broker` passes locally with 312 passed, 0 failed, 2 ignored; no source changes were needed.\nSTEP_",
+                "**[fix-test-failures] Output:**\n```\nequires\n• The broker task is specifically the fix-test-failures step. The supplied cargo\n  test --bin agent-relay-broker out"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776691793281,
+          "type": "finding",
+          "content": "\"fix-test-failures\" completed → >7u\r\n╭─────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                  │\r\n│                ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_y94ptwg1at9q",
+      "title": "Execution: review",
+      "agentName": "reviewer",
+      "startedAt": "2026-04-20T13:30:02.551Z",
+      "events": [
+        {
+          "ts": 1776691802551,
+          "type": "note",
+          "content": "\"review\": Review against PLAN.md + IMPL_SUMMARY.md",
+          "raw": {
+            "agent": "reviewer"
+          }
+        },
+        {
+          "ts": 1776692010091,
+          "type": "completion-evidence",
+          "content": "\"review\" verification-based completion — Verification passed (2 signal(s), 6 file change(s); signals=review, REVIEW.md; files=modified:.claude/settings.json, created:REVIEW.md, modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/dep-test-lib-relay_broker, modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/invoked.timestamp, modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker, modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker.json)",
+          "raw": {
+            "stepName": "review",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "2 signal(s), 6 file change(s)",
+              "signals": ["review", "REVIEW.md"],
+              "files": [
+                "modified:.claude/settings.json",
+                "created:REVIEW.md",
+                "modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/dep-test-lib-relay_broker",
+                "modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/invoked.timestamp",
+                "modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker",
+                "modified:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker.json"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776692010091,
+          "type": "finding",
+          "content": "\"review\" completed → ✢",
+          "significance": "medium"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay",
+  "tags": []
+}

--- a/.trajectories/completed/2026-04/traj_3b3p1z4y7qlo.json
+++ b/.trajectories/completed/2026-04/traj_3b3p1z4y7qlo.json
@@ -1,0 +1,149 @@
+{
+  "id": "traj_3b3p1z4y7qlo",
+  "version": 1,
+  "task": {
+    "title": "add-mcp-args-subcommand-workflow",
+    "description": "Add agent-relay mcp-args CLI subcommand as the single source of truth for relaycast MCP wiring, callable by cloud and other external consumers. claude plan → codex implement → cargo test-fix-rerun → claude review → PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "7b3cd6bed0179c78ce57fa38"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-04-20T13:16:22.009Z",
+  "completedAt": "2026-04-20T13:26:35.142Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-04-20T13:16:22.009Z"
+    },
+    {
+      "name": "planner",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T13:16:29.180Z"
+    },
+    {
+      "name": "implementer",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T13:19:33.400Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cuzudcu6eor3",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T13:16:22.009Z",
+      "endedAt": "2026-04-20T13:16:29.186Z",
+      "events": [
+        {
+          "ts": 1776690982009,
+          "type": "note",
+          "content": "Purpose: Add agent-relay mcp-args CLI subcommand as the single source of truth for relaycast MCP wiring, callable by cloud and other external consumers. claude plan → codex implement → cargo test-fix-rerun → claude review → PR."
+        },
+        {
+          "ts": 1776690982009,
+          "type": "note",
+          "content": "Approach: 17-step dag workflow — Parsed 17 steps, 16 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_z8ltm9fwj5ax",
+      "title": "Execution: plan",
+      "agentName": "planner",
+      "startedAt": "2026-04-20T13:16:29.186Z",
+      "endedAt": "2026-04-20T13:19:33.406Z",
+      "events": [
+        {
+          "ts": 1776690989186,
+          "type": "note",
+          "content": "\"plan\": Write PLAN.md at the repo root specifying the agent-relay mcp-args subcommand",
+          "raw": {
+            "agent": "planner"
+          }
+        },
+        {
+          "ts": 1776691171951,
+          "type": "completion-marker",
+          "content": "\"plan\" marker-based completion — Legacy STEP_COMPLETE marker observed (5 signal(s), 1 relevant channel post(s), 3 file change(s); signals=plan, COMPLETE, PLAN.md, plan, COMPLETE; channel=**[plan] Output:**\n```\n      1.0k tokens · thought for 15s)\n⏺ Write(PLAN.md)                                      \n· Spinning… (1m 50s · ↓ 2.2k tokens · thought; files=modified:.claude/settings.json, modified:.relay/workspaces.json, created:PLAN.md)",
+          "raw": {
+            "stepName": "plan",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 3 file change(s)",
+              "signals": ["plan", "COMPLETE", "PLAN.md", "plan", "COMPLETE"],
+              "channelPosts": [
+                "**[plan] Output:**\n```\n      1.0k tokens · thought for 15s)\n⏺ Write(PLAN.md)                                      \n· Spinning… (1m 50s · ↓ 2.2k tokens · thought"
+              ],
+              "files": [
+                "modified:.claude/settings.json",
+                "modified:.relay/workspaces.json",
+                "created:PLAN.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776691171952,
+          "type": "finding",
+          "content": "\"plan\" completed → ✻ Baked for 1m 58s                                                \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_duqavff7i711",
+      "title": "Execution: implement",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T13:19:33.406Z",
+      "endedAt": "2026-04-20T13:26:35.142Z",
+      "events": [
+        {
+          "ts": 1776691173406,
+          "type": "note",
+          "content": "\"implement\": Implement the plan",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776691284836,
+          "type": "decision",
+          "content": "Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token: Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token",
+          "raw": {
+            "question": "Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token",
+            "chosen": "Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token",
+            "alternatives": [],
+            "reasoning": "The plan requires a new entry point without changing existing PTY/headless spawn paths or snippet helper signatures; a bin-local compute helper lets tests inspect JSON payloads without capturing stdout."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1776691489834,
+          "type": "decision",
+          "content": "Added reference-cli docs as a new mirrored page: Added reference-cli docs as a new mirrored page",
+          "raw": {
+            "question": "Added reference-cli docs as a new mirrored page",
+            "chosen": "Added reference-cli docs as a new mirrored page",
+            "alternatives": [],
+            "reasoning": "docs/reference-cli.md was absent; creating the markdown page and MDX mirror satisfies the requested section and keeps docs-sync pairing intact."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added agent-relay-broker mcp-args subcommand with JSON output, side-effect file reporting, docs, and regression tests",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay",
+  "tags": []
+}

--- a/.trajectories/completed/2026-04/traj_3b3p1z4y7qlo.md
+++ b/.trajectories/completed/2026-04/traj_3b3p1z4y7qlo.md
@@ -1,0 +1,48 @@
+# Trajectory: add-mcp-args-subcommand-workflow
+
+> **Status:** ✅ Completed
+> **Task:** 7b3cd6bed0179c78ce57fa38
+> **Confidence:** 92%
+> **Started:** April 20, 2026 at 03:16 PM
+> **Completed:** April 20, 2026 at 03:26 PM
+
+---
+
+## Summary
+
+Added agent-relay-broker mcp-args subcommand with JSON output, side-effect file reporting, docs, and regression tests
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token
+
+- **Chose:** Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token
+- **Reasoning:** The plan requires a new entry point without changing existing PTY/headless spawn paths or snippet helper signatures; a bin-local compute helper lets tests inspect JSON payloads without capturing stdout.
+
+### Added reference-cli docs as a new mirrored page
+
+- **Chose:** Added reference-cli docs as a new mirrored page
+- **Reasoning:** docs/reference-cli.md was absent; creating the markdown page and MDX mirror satisfies the requested section and keeps docs-sync pairing intact.
+
+---
+
+## Chapters
+
+### 1. Planning
+
+_Agent: orchestrator_
+
+### 2. Execution: plan
+
+_Agent: planner_
+
+### 3. Execution: implement
+
+_Agent: implementer_
+
+- Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token: Implement mcp-args as a bin-local module that delegates argument computation to configure_relaycast_mcp_with_token
+- Added reference-cli docs as a new mirrored page: Added reference-cli docs as a new mirrored page

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T19:52:14.307Z",
+  "lastUpdated": "2026-04-20T13:33:30.100Z",
   "trajectories": {
     "traj_qb54w47qwod6": {
       "title": "fix-history-from-workflow",
@@ -3645,6 +3645,12 @@
       "startedAt": "2026-04-15T21:32:51.980Z",
       "completedAt": "2026-04-15T21:45:41.024Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/completed/2026-04/traj_222ha5671idc.json"
+    },
+    "traj_3b3p1z4y7qlo": {
+      "title": "add-mcp-args-subcommand-workflow",
+      "status": "active",
+      "startedAt": "2026-04-20T13:16:22.009Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/active/traj_3b3p1z4y7qlo.json"
     }
   }
 }

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1,0 +1,44 @@
+# CLI reference
+
+Reference for broker-level command surfaces that are useful to integrations.
+
+## `mcp-args`
+
+Compute per-CLI MCP args without spawning.
+
+```bash
+agent-relay-broker mcp-args \
+  --cli claude \
+  --agent-name reviewer \
+  --api-key rk_live_example \
+  --base-url https://api.relaycast.dev \
+  --cwd /Users/me/project
+```
+
+Sample output:
+
+```json
+{
+  "args": [
+    "--mcp-config",
+    "{\"mcpServers\":{\"relaycast\":{\"command\":\"npx\",\"args\":[\"-y\",\"@relaycast/mcp\"]}}}"
+  ],
+  "sideEffectFiles": []
+}
+```
+
+Flags:
+
+| Flag                              | Required | Description                                                                                                               |
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--cli <name>`                    | yes      | CLI name or command to compute MCP args for, such as `claude`, `codex`, `opencode`, `cursor-agent`, `gemini`, or `droid`. |
+| `--agent-name <name>`             | yes      | Relaycast agent name to inject into the MCP configuration.                                                                |
+| `--api-key <key>`                 | no       | Relaycast API key. Falls back to `RELAY_API_KEY`.                                                                         |
+| `--base-url <url>`                | no       | Relaycast base URL. Falls back to `RELAY_BASE_URL`.                                                                       |
+| `--agent-token <token>`           | no       | Pre-registered agent token to pass to the child MCP server.                                                               |
+| `--workspaces-json <json>`        | no       | Multi-workspace context JSON to pass to the child MCP server.                                                             |
+| `--default-workspace <workspace>` | no       | Default workspace ID or name to pass to the child MCP server.                                                             |
+| `--cwd <path>`                    | no       | Working directory used by CLIs that need local MCP config files. Defaults to the current directory.                       |
+| `--existing-args <json>`          | no       | Existing CLI args as a JSON string array, for example `'["--foo","--bar"]'`. Defaults to `[]`.                            |
+
+`mcp-args` writes side-effect files synchronously when the target CLI requires a config file. For `opencode`, it may write `<cwd>/opencode.json`; for `cursor`, `cursor-agent`, and `agent`, it may write `<cwd>/.cursor/mcp.json`; for `gemini`, it may write `<HOME>/.gemini/trustedFolders.json`. Treat the command as compute plus configure for those CLIs, not as a side-effect-free dry run.

--- a/src/cli_mcp_args.rs
+++ b/src/cli_mcp_args.rs
@@ -1,0 +1,363 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use relay_broker::snippets::configure_relaycast_mcp_with_token;
+use serde::{Deserialize, Serialize};
+
+use crate::McpArgsCommand;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpArgsOutput {
+    args: Vec<String>,
+    side_effect_files: Vec<PathBuf>,
+}
+
+pub(crate) async fn run_mcp_args(cmd: McpArgsCommand) -> Result<()> {
+    let output = compute_mcp_args_output(cmd).await?;
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
+    let cli = cmd.cli.trim().to_string();
+    if cli.is_empty() {
+        bail!("--cli must not be empty");
+    }
+
+    let agent_name = cmd.agent_name.trim().to_string();
+    if agent_name.is_empty() {
+        bail!("--agent-name must not be empty");
+    }
+
+    let api_key = cmd.api_key.or_else(|| std::env::var("RELAY_API_KEY").ok());
+    let base_url = cmd
+        .base_url
+        .or_else(|| std::env::var("RELAY_BASE_URL").ok());
+    let cwd = normalize_cwd(cmd.cwd)?;
+    let existing_args = parse_existing_args(cmd.existing_args)?;
+
+    let args = configure_relaycast_mcp_with_token(
+        &cli,
+        &agent_name,
+        api_key.as_deref(),
+        base_url.as_deref(),
+        &existing_args,
+        &cwd,
+        cmd.agent_token.as_deref(),
+        cmd.workspaces_json.as_deref(),
+        cmd.default_workspace.as_deref(),
+    )
+    .await?;
+
+    let side_effect_files = side_effect_files_for(&cli, &existing_args, &cwd)?;
+
+    Ok(McpArgsOutput {
+        args,
+        side_effect_files,
+    })
+}
+
+fn parse_existing_args(existing_args: Option<String>) -> Result<Vec<String>> {
+    match existing_args {
+        Some(raw) => serde_json::from_str::<Vec<String>>(&raw)
+            .with_context(|| "--existing-args must be a JSON array of strings"),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn normalize_cwd(cwd: Option<PathBuf>) -> Result<PathBuf> {
+    let cwd = match cwd {
+        Some(cwd) => cwd,
+        None => std::env::current_dir().context("failed to determine current directory")?,
+    };
+
+    absolutize_path(cwd)
+}
+
+fn absolutize_path(path: PathBuf) -> Result<PathBuf> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Ok(canonical);
+    }
+
+    if path.is_absolute() {
+        return Ok(path);
+    }
+
+    Ok(std::env::current_dir()
+        .context("failed to determine current directory")?
+        .join(path))
+}
+
+fn side_effect_files_for(cli: &str, existing_args: &[String], cwd: &Path) -> Result<Vec<PathBuf>> {
+    let cli_lower = detect_cli_name_for_mcp_args(cli).to_lowercase();
+
+    if cli_lower == "opencode" && !existing_args.iter().any(|arg| arg == "--agent") {
+        return Ok(vec![cwd.join("opencode.json")]);
+    }
+
+    if cli_lower == "cursor" || cli_lower == "cursor-agent" || cli_lower == "agent" {
+        return Ok(vec![cwd.join(".cursor").join("mcp.json")]);
+    }
+
+    if cli_lower == "gemini" {
+        return Ok(home_dir_from_env()
+            .map(|home| home.join(".gemini").join("trustedFolders.json"))
+            .into_iter()
+            .collect());
+    }
+
+    Ok(Vec::new())
+}
+
+fn detect_cli_name_for_mcp_args(cli: &str) -> String {
+    let command = shlex::split(cli)
+        .and_then(|parts| parts.first().cloned())
+        .unwrap_or_else(|| cli.trim().to_string());
+
+    Path::new(&command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command.as_str())
+        .to_string()
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .and_then(|home| absolutize_path(PathBuf::from(home)).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_broker::snippets::configure_relaycast_mcp_with_token;
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn command(cli: &str, cwd: &Path) -> McpArgsCommand {
+        McpArgsCommand {
+            cli: cli.to_string(),
+            agent_name: "test-agent".to_string(),
+            api_key: Some("rk_live_test".to_string()),
+            base_url: Some("https://api.test.relaycast.dev".to_string()),
+            agent_token: Some("at_live_test".to_string()),
+            workspaces_json: Some(r#"{"workspaces":[]}"#.to_string()),
+            default_workspace: Some("default-workspace".to_string()),
+            cwd: Some(cwd.to_path_buf()),
+            existing_args: None,
+        }
+    }
+
+    fn output_as_json(output: &McpArgsOutput) -> Value {
+        let json = serde_json::to_string_pretty(output).expect("serialize output");
+        serde_json::from_str(&json).expect("parse output json")
+    }
+
+    #[tokio::test]
+    async fn claude_output_contains_mcp_config_json() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("claude", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        let mcp_config_index = output
+            .args
+            .iter()
+            .position(|arg| arg == "--mcp-config")
+            .expect("claude --mcp-config arg");
+        let config_json = output
+            .args
+            .get(mcp_config_index + 1)
+            .expect("claude mcp config value");
+        let config: Value = serde_json::from_str(config_json).expect("valid mcp config json");
+
+        assert!(config
+            .pointer("/mcpServers/relaycast")
+            .is_some_and(Value::is_object));
+        assert!(output.side_effect_files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn codex_output_contains_relaycast_config_args() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("codex", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        assert!(output.args.contains(&"--config".to_string()));
+        assert!(output
+            .args
+            .contains(&"mcp_servers.relaycast.command=\"npx\"".to_string()));
+        assert!(output
+            .args
+            .contains(&"mcp_servers.relaycast.args=[\"-y\", \"@relaycast/mcp\"]".to_string()));
+        assert!(output.side_effect_files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn opencode_output_writes_config_and_returns_agent_args() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("opencode", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        assert_eq!(output.args, vec!["--agent", "relaycast"]);
+        assert_eq!(
+            output.side_effect_files,
+            vec![temp.path().canonicalize().unwrap().join("opencode.json")]
+        );
+        assert!(temp.path().join("opencode.json").is_file());
+    }
+
+    #[tokio::test]
+    async fn cursor_output_writes_config_and_returns_no_args() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("cursor-agent", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        assert!(output.args.is_empty());
+        assert_eq!(
+            output.side_effect_files,
+            vec![temp
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join(".cursor")
+                .join("mcp.json")]
+        );
+        assert!(temp.path().join(".cursor").join("mcp.json").is_file());
+    }
+
+    #[test]
+    fn opencode_existing_agent_arg_suppresses_side_effect_file() {
+        let temp = tempdir().expect("tempdir");
+        let files = side_effect_files_for(
+            "opencode",
+            &["--agent".to_string(), "custom".to_string()],
+            temp.path(),
+        )
+        .expect("side effect files");
+
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_cli_returns_error() {
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("   ", temp.path());
+        cmd.cli = "   ".to_string();
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("empty cli error");
+        assert!(error.to_string().contains("--cli must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn invalid_existing_args_json_returns_error() {
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.existing_args = Some("{not-json".to_string());
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("invalid existing args error");
+        assert!(error
+            .to_string()
+            .contains("--existing-args must be a JSON array of strings"));
+    }
+
+    #[tokio::test]
+    async fn output_serializes_camel_case_side_effect_files() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("opencode", temp.path()))
+            .await
+            .expect("compute mcp args");
+        let json = output_as_json(&output);
+
+        assert!(json.get("args").is_some());
+        assert!(json.get("sideEffectFiles").is_some());
+        assert!(json.get("side_effect_files").is_none());
+    }
+
+    #[tokio::test]
+    async fn claude_output_matches_authority_function() {
+        let temp = tempdir().expect("tempdir");
+        let cmd = command("claude", temp.path());
+        let output = compute_mcp_args_output(cmd.clone())
+            .await
+            .expect("compute mcp args");
+
+        let expected = configure_relaycast_mcp_with_token(
+            "claude",
+            "test-agent",
+            Some("rk_live_test"),
+            Some("https://api.test.relaycast.dev"),
+            &[],
+            &temp.path().canonicalize().unwrap(),
+            Some("at_live_test"),
+            Some(r#"{"workspaces":[]}"#),
+            Some("default-workspace"),
+        )
+        .await
+        .expect("authority mcp args");
+
+        assert_eq!(output.args, expected);
+    }
+
+    #[tokio::test]
+    async fn codex_output_matches_authority_function() {
+        let temp = tempdir().expect("tempdir");
+        let cmd = command("codex", temp.path());
+        let output = compute_mcp_args_output(cmd.clone())
+            .await
+            .expect("compute mcp args");
+
+        let expected = configure_relaycast_mcp_with_token(
+            "codex",
+            "test-agent",
+            Some("rk_live_test"),
+            Some("https://api.test.relaycast.dev"),
+            &[],
+            &temp.path().canonicalize().unwrap(),
+            Some("at_live_test"),
+            Some(r#"{"workspaces":[]}"#),
+            Some("default-workspace"),
+        )
+        .await
+        .expect("authority mcp args");
+
+        assert_eq!(output.args, expected);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a gemini executable because the authority shells out to `gemini mcp add`"]
+    async fn gemini_output_returns_no_args_and_tracks_trusted_folders_file() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("gemini", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        assert!(output.args.is_empty());
+        assert!(output
+            .side_effect_files
+            .iter()
+            .any(|path| path.ends_with(".gemini/trustedFolders.json")));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a droid executable because the authority shells out to `droid mcp add`"]
+    async fn droid_output_returns_no_args_and_no_known_side_effect_files() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("droid", temp.path()))
+            .await
+            .expect("compute mcp args");
+
+        assert!(output.args.is_empty());
+        assert!(output.side_effect_files.is_empty());
+    }
+}

--- a/src/cli_mcp_args.rs
+++ b/src/cli_mcp_args.rs
@@ -30,10 +30,24 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
         bail!("--agent-name must not be empty");
     }
 
+    // Match the broker's internal WorkerRegistry::build_mcp_args behavior:
+    // each flag falls back to its RELAY_* env var so env-driven callers
+    // (e.g. cloud's SandboxedStepExecutor, which sets these from
+    // orchestrator-managed secrets) don't lose the value just because
+    // they didn't repeat it on the CLI.
     let api_key = cmd.api_key.or_else(|| std::env::var("RELAY_API_KEY").ok());
     let base_url = cmd
         .base_url
         .or_else(|| std::env::var("RELAY_BASE_URL").ok());
+    let agent_token = cmd
+        .agent_token
+        .or_else(|| std::env::var("RELAY_AGENT_TOKEN").ok());
+    let workspaces_json = cmd
+        .workspaces_json
+        .or_else(|| std::env::var("RELAY_WORKSPACES_JSON").ok());
+    let default_workspace = cmd
+        .default_workspace
+        .or_else(|| std::env::var("RELAY_DEFAULT_WORKSPACE").ok());
     let cwd = normalize_cwd(cmd.cwd)?;
     let existing_args = parse_existing_args(cmd.existing_args)?;
 
@@ -44,9 +58,9 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
         base_url.as_deref(),
         &existing_args,
         &cwd,
-        cmd.agent_token.as_deref(),
-        cmd.workspaces_json.as_deref(),
-        cmd.default_workspace.as_deref(),
+        agent_token.as_deref(),
+        workspaces_json.as_deref(),
+        default_workspace.as_deref(),
     )
     .await?;
 
@@ -332,6 +346,78 @@ mod tests {
         .expect("authority mcp args");
 
         assert_eq!(output.args, expected);
+    }
+
+    #[tokio::test]
+    async fn env_vars_fill_in_when_cli_flags_omitted() {
+        // When callers set RELAY_* env vars but don't repeat them on the CLI
+        // (e.g. cloud's SandboxedStepExecutor, which exports these from
+        // orchestrator-managed secrets), compute_mcp_args_output must fall
+        // back to the env rather than dropping the value. Mirrors
+        // WorkerRegistry::build_mcp_args in the broker.
+        //
+        // Uses distinctive sentinel values so we can grep them out of the
+        // generated config even if other tests leak env vars. Each var is
+        // unset at the end to avoid contaminating sibling tests that assume
+        // the env is clean.
+        std::env::set_var("RELAY_API_KEY", "rk_live_from_env");
+        std::env::set_var("RELAY_BASE_URL", "https://api.env.relaycast.dev");
+        std::env::set_var("RELAY_AGENT_TOKEN", "at_live_from_env");
+        std::env::set_var("RELAY_WORKSPACES_JSON", r#"{"workspaces":["env-ws"]}"#);
+        std::env::set_var("RELAY_DEFAULT_WORKSPACE", "env-default-workspace");
+
+        let temp = tempdir().expect("tempdir");
+        let cmd = McpArgsCommand {
+            cli: "claude".to_string(),
+            agent_name: "test-agent".to_string(),
+            api_key: None,
+            base_url: None,
+            agent_token: None,
+            workspaces_json: None,
+            default_workspace: None,
+            cwd: Some(temp.path().to_path_buf()),
+            existing_args: None,
+        };
+
+        let output = compute_mcp_args_output(cmd)
+            .await
+            .expect("compute mcp args with env fallback");
+
+        let mcp_config_index = output
+            .args
+            .iter()
+            .position(|arg| arg == "--mcp-config")
+            .expect("claude --mcp-config arg");
+        let config_json = output
+            .args
+            .get(mcp_config_index + 1)
+            .expect("claude mcp config value");
+
+        // The config is built from the values the compute function resolved,
+        // so if env fallback works the sentinel values show up in the env
+        // block or the RELAY_API_KEY that claude's injection path writes.
+        assert!(
+            config_json.contains("https://api.env.relaycast.dev"),
+            "base url from env missing in claude config: {config_json}"
+        );
+        assert!(
+            config_json.contains("at_live_from_env"),
+            "agent token from env missing in claude config: {config_json}"
+        );
+        assert!(
+            config_json.contains("env-default-workspace"),
+            "default workspace from env missing in claude config: {config_json}"
+        );
+        assert!(
+            config_json.contains("env-ws"),
+            "workspaces json from env missing in claude config: {config_json}"
+        );
+
+        std::env::remove_var("RELAY_API_KEY");
+        std::env::remove_var("RELAY_BASE_URL");
+        std::env::remove_var("RELAY_AGENT_TOKEN");
+        std::env::remove_var("RELAY_WORKSPACES_JSON");
+        std::env::remove_var("RELAY_DEFAULT_WORKSPACE");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 mod broker;
+mod cli_mcp_args;
 mod helpers;
 mod listen_api;
 mod pty_worker;
@@ -104,6 +105,9 @@ enum Commands {
     Init(InitCommand),
     Pty(PtyCommand),
     Headless(HeadlessCommand),
+    /// Compute MCP injection args and side-effect config file paths for a CLI
+    /// without spawning it. Outputs JSON to stdout.
+    McpArgs(McpArgsCommand),
     /// Run ad-hoc swarm execution via the relay broker
     Swarm(swarm::SwarmArgs),
     /// Internal: wraps a CLI in a PTY with interactive passthrough.
@@ -117,6 +121,45 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+}
+
+#[derive(Debug, clap::Args, Clone)]
+pub(crate) struct McpArgsCommand {
+    /// CLI name or command to compute MCP args for.
+    #[arg(long)]
+    cli: String,
+
+    /// Relaycast agent name to inject into the MCP configuration.
+    #[arg(long)]
+    agent_name: String,
+
+    /// Relaycast API key. Falls back to RELAY_API_KEY when omitted.
+    #[arg(long)]
+    api_key: Option<String>,
+
+    /// Relaycast base URL. Falls back to RELAY_BASE_URL when omitted.
+    #[arg(long)]
+    base_url: Option<String>,
+
+    /// Pre-registered agent token to pass to the child MCP server.
+    #[arg(long)]
+    agent_token: Option<String>,
+
+    /// Multi-workspace context JSON to pass to the child MCP server.
+    #[arg(long)]
+    workspaces_json: Option<String>,
+
+    /// Default workspace ID/name to pass to the child MCP server.
+    #[arg(long)]
+    default_workspace: Option<String>,
+
+    /// Working directory used by CLIs that need local MCP config files.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+
+    /// Existing CLI args as a JSON string array, e.g. '["--foo","--bar"]'.
+    #[arg(long)]
+    existing_args: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -710,6 +753,7 @@ async fn main() -> Result<()> {
         Commands::Init(_) => "init",
         Commands::Pty(_) => "pty",
         Commands::Headless(_) => "headless",
+        Commands::McpArgs(_) => "mcp_args",
         Commands::Swarm(_) => "swarm",
         Commands::Wrap { .. } => "wrap",
     };
@@ -721,6 +765,7 @@ async fn main() -> Result<()> {
         Commands::Init(cmd) => run_init(cmd, telemetry).await,
         Commands::Pty(cmd) => pty_worker::run_pty_worker(cmd).await,
         Commands::Headless(cmd) => run_headless_worker(cmd).await,
+        Commands::McpArgs(cmd) => cli_mcp_args::run_mcp_args(cmd).await,
         Commands::Swarm(args) => swarm::run_swarm(args).await,
         Commands::Wrap { cli, args } => wrap::run_wrap(cli, args, false, telemetry).await,
     }

--- a/web/content/docs/reference-cli.mdx
+++ b/web/content/docs/reference-cli.mdx
@@ -1,0 +1,47 @@
+---
+title: 'CLI reference'
+description: 'Broker-level command surfaces that are useful to integrations.'
+---
+
+Reference for broker-level command surfaces that are useful to integrations.
+
+## `mcp-args`
+
+Compute per-CLI MCP args without spawning.
+
+```bash
+agent-relay-broker mcp-args \
+  --cli claude \
+  --agent-name reviewer \
+  --api-key rk_live_example \
+  --base-url https://api.relaycast.dev \
+  --cwd /Users/me/project
+```
+
+Sample output:
+
+```json
+{
+  "args": [
+    "--mcp-config",
+    "{\"mcpServers\":{\"relaycast\":{\"command\":\"npx\",\"args\":[\"-y\",\"@relaycast/mcp\"]}}}"
+  ],
+  "sideEffectFiles": []
+}
+```
+
+Flags:
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `--cli <name>` | yes | CLI name or command to compute MCP args for, such as `claude`, `codex`, `opencode`, `cursor-agent`, `gemini`, or `droid`. |
+| `--agent-name <name>` | yes | Relaycast agent name to inject into the MCP configuration. |
+| `--api-key <key>` | no | Relaycast API key. Falls back to `RELAY_API_KEY`. |
+| `--base-url <url>` | no | Relaycast base URL. Falls back to `RELAY_BASE_URL`. |
+| `--agent-token <token>` | no | Pre-registered agent token to pass to the child MCP server. |
+| `--workspaces-json <json>` | no | Multi-workspace context JSON to pass to the child MCP server. |
+| `--default-workspace <workspace>` | no | Default workspace ID or name to pass to the child MCP server. |
+| `--cwd <path>` | no | Working directory used by CLIs that need local MCP config files. Defaults to the current directory. |
+| `--existing-args <json>` | no | Existing CLI args as a JSON string array, for example `'["--foo","--bar"]'`. Defaults to `[]`. |
+
+`mcp-args` writes side-effect files synchronously when the target CLI requires a config file. For `opencode`, it may write `<cwd>/opencode.json`; for `cursor`, `cursor-agent`, and `agent`, it may write `<cwd>/.cursor/mcp.json`; for `gemini`, it may write `<HOME>/.gemini/trustedFolders.json`. Treat the command as compute plus configure for those CLIs, not as a side-effect-free dry run.

--- a/web/lib/docs-nav.ts
+++ b/web/lib/docs-nav.ts
@@ -57,6 +57,7 @@ export const docsNav: NavGroup[] = [
       { title: 'Run workflows', slug: 'cli-workflows' },
       { title: 'Cloud commands', slug: 'cli-cloud-commands' },
       { title: 'On the relay', slug: 'cli-on-the-relay' },
+      { title: 'CLI reference', slug: 'reference-cli' },
     ],
   },
   {


### PR DESCRIPTION
Expose configure_relaycast_mcp_with_token as a CLI subcommand so external consumers (cloud SandboxedStepExecutor, debugging tools) can get identical MCP wiring without reimplementing it. Delegates to the existing Rust function — zero duplication. Includes parity test asserting subcommand output matches the broker internal build_mcp_args for the same inputs. Unblocks deletion of the TypeScript MCP branching AgentWorkforce/cloud#226 added. Generated by workflows/add-mcp-args-subcommand.ts (claude plan → codex implement → cargo-test-fix-rerun → claude review).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
