### PR TITLE
feat(cli): add --register flag to mcp-args subcommand

### DIFF
--- a/.trajectories/active/traj_o9cx33xn5u39.json
+++ b/.trajectories/active/traj_o9cx33xn5u39.json
@@ -1,0 +1,407 @@
+{
+  "id": "traj_o9cx33xn5u39",
+  "version": 1,
+  "task": {
+    "title": "add-mcp-args-register-flag-workflow",
+    "description": "Add --register flag to agent-relay-broker mcp-args subcommand so it can mint its own at_live_* token via register_agent_token; unblocks the cloud cleanup PR. claude plan → codex implement → verify gates + test-fix-rerun → claude review → PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "af395e548879905e314fe615"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-04-20T15:06:23.387Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-04-20T15:06:23.387Z"
+    },
+    {
+      "name": "planner",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T15:06:27.252Z"
+    },
+    {
+      "name": "implementer",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T15:08:32.918Z"
+    },
+    {
+      "name": "reviewer",
+      "role": "specialist",
+      "joinedAt": "2026-04-20T15:19:38.965Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_7c13y4k11k04",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T15:06:23.387Z",
+      "endedAt": "2026-04-20T15:06:27.179Z",
+      "events": [
+        {
+          "ts": 1776697583387,
+          "type": "note",
+          "content": "Purpose: Add --register flag to agent-relay-broker mcp-args subcommand so it can mint its own at_live_* token via register_agent_token; unblocks the cloud cleanup PR. claude plan → codex implement → verify gates + test-fix-rerun → claude review → PR."
+        },
+        {
+          "ts": 1776697583387,
+          "type": "note",
+          "content": "Approach: 29-step dag workflow — Parsed 29 steps, 28 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_jrn4p16b7xy6",
+      "title": "Execution: read-cli-mcp-args, read-mcp-args-command-def, read-register-agent-token",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T15:06:27.179Z",
+      "endedAt": "2026-04-20T15:06:27.243Z",
+      "events": []
+    },
+    {
+      "id": "chap_hoggsklpvgvp",
+      "title": "Convergence: read-cli-mcp-args + read-mcp-args-command-def + read-register-agent-token",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T15:06:27.243Z",
+      "endedAt": "2026-04-20T15:06:27.254Z",
+      "events": [
+        {
+          "ts": 1776697587248,
+          "type": "reflection",
+          "content": "read-cli-mcp-args + read-mcp-args-command-def + read-register-agent-token resolved. 3/3 steps completed. All steps completed on first attempt. Unblocking: plan.",
+          "raw": {
+            "confidence": 0.75,
+            "focalPoints": [
+              "read-cli-mcp-args: completed",
+              "read-mcp-args-command-def: completed",
+              "read-register-agent-token: completed"
+            ]
+          },
+          "significance": "high"
+        }
+      ]
+    },
+    {
+      "id": "chap_wexa78pbmouj",
+      "title": "Execution: plan",
+      "agentName": "planner",
+      "startedAt": "2026-04-20T15:06:27.254Z",
+      "endedAt": "2026-04-20T15:08:32.919Z",
+      "events": [
+        {
+          "ts": 1776697587254,
+          "type": "note",
+          "content": "\"plan\": Write PLAN.md at the repo root describing exactly how to add a `--register` flag to the `agent-relay-broker mcp-args` su",
+          "raw": {
+            "agent": "planner"
+          }
+        },
+        {
+          "ts": 1776697712857,
+          "type": "completion-marker",
+          "content": "\"plan\" marker-based completion — Legacy STEP_COMPLETE marker observed (4 signal(s), 1 relevant channel post(s), 3 file change(s); signals=plan, COMPLETE, PLAN.md, COMPLETE; channel=**[plan] Output:**\n```\n i  …                        thinking with xhigh effort\n                                     thinking with xhigh effort\n                 ; files=modified:.claude/settings.json, created:.claude/settings.local.json, created:PLAN.md)",
+          "raw": {
+            "stepName": "plan",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 3 file change(s)",
+              "signals": ["plan", "COMPLETE", "PLAN.md", "COMPLETE"],
+              "channelPosts": [
+                "**[plan] Output:**\n```\n i  …                        thinking with xhigh effort\n                                     thinking with xhigh effort\n                 "
+              ],
+              "files": [
+                "modified:.claude/settings.json",
+                "created:.claude/settings.local.json",
+                "created:PLAN.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776697712858,
+          "type": "finding",
+          "content": "\"plan\" completed → ✻ Crunched fo  1m 4s                                         \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_muau12kvskt3",
+      "title": "Execution: implement",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T15:08:32.919Z",
+      "endedAt": "2026-04-20T15:16:02.152Z",
+      "events": [
+        {
+          "ts": 1776697712920,
+          "type": "note",
+          "content": "\"implement\": Implement the plan below exactly",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776698162135,
+          "type": "completion-marker",
+          "content": "\"implement\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 1 relevant channel post(s), 6 file change(s); signals=COMPLETE, COMPLETE, COMPLETE, >7u, IMPL_SUMMARY.md, COMPLETE; channel=**[implement] Output:**\n```\nmented `--register` and nullable `agentToken`\n     4 +web/content/docs/reference-cli.mdx: Mirrored the CLI reference changes f\n     ; files=modified:docs/reference-cli.md, created:IMPL_SUMMARY.md, modified:src/cli_mcp_args.rs, modified:src/main.rs, created:target/.rustc_info.json, created:target/CACHEDIR.TAG)",
+          "raw": {
+            "stepName": "implement",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 1 relevant channel post(s), 6 file change(s)",
+              "signals": ["COMPLETE", "COMPLETE", "COMPLETE", ">7u", "IMPL_SUMMARY.md", "COMPLETE"],
+              "channelPosts": [
+                "**[implement] Output:**\n```\nmented `--register` and nullable `agentToken`\n     4 +web/content/docs/reference-cli.mdx: Mirrored the CLI reference changes f\n     "
+              ],
+              "files": [
+                "modified:docs/reference-cli.md",
+                "created:IMPL_SUMMARY.md",
+                "modified:src/cli_mcp_args.rs",
+                "modified:src/main.rs",
+                "created:target/.rustc_info.json",
+                "created:target/CACHEDIR.TAG"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776698162135,
+          "type": "finding",
+          "content": "\"implement\" completed → >7u\r\n╭─────────────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                          │\r\n│",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_odgcfjd56qqu",
+      "title": "Execution: verify-register-flag-added, verify-authority-functions-untouched",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T15:16:02.152Z",
+      "endedAt": "2026-04-20T15:16:02.360Z",
+      "events": []
+    },
+    {
+      "id": "chap_j2rcn7kfxkgd",
+      "title": "Convergence: verify-register-flag-added + verify-authority-functions-untouched",
+      "agentName": "orchestrator",
+      "startedAt": "2026-04-20T15:16:02.360Z",
+      "endedAt": "2026-04-20T15:16:02.800Z",
+      "events": [
+        {
+          "ts": 1776698162365,
+          "type": "reflection",
+          "content": "verify-register-flag-added + verify-authority-functions-untouched resolved. 2/2 steps completed. All steps completed on first attempt. Unblocking: cargo-check.",
+          "raw": {
+            "confidence": 0.75,
+            "focalPoints": [
+              "verify-register-flag-added: completed",
+              "verify-authority-functions-untouched: completed"
+            ]
+          },
+          "significance": "high"
+        }
+      ]
+    },
+    {
+      "id": "chap_bp45z133snuv",
+      "title": "Execution: fix-cargo-check",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T15:16:02.800Z",
+      "endedAt": "2026-04-20T15:17:19.882Z",
+      "events": [
+        {
+          "ts": 1776698162800,
+          "type": "note",
+          "content": "\"fix-cargo-check\": Review cargo check output; fix any errors; keep re-running `cargo check --lib --bin agent-relay-broker` until it is clea",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776698239235,
+          "type": "completion-marker",
+          "content": "\"fix-cargo-check\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 1 relevant channel post(s); signals=COMPLETE, COMPLETE, COMPLETE, >7u, Verification passed, **[fix-cargo-check] Output:**; channel=**[fix-cargo-check] Output:**\n```\ned (deterministic)\n  Relay message from WorkflowRunner in #wf-add-mcp-args-register-flag\n  [rw_mto4thde / 172002380279603200]:)",
+          "raw": {
+            "stepName": "fix-cargo-check",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 1 relevant channel post(s)",
+              "signals": [
+                "COMPLETE",
+                "COMPLETE",
+                "COMPLETE",
+                ">7u",
+                "Verification passed",
+                "**[fix-cargo-check] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-cargo-check] Output:**\n```\ned (deterministic)\n  Relay message from WorkflowRunner in #wf-add-mcp-args-register-flag\n  [rw_mto4thde / 172002380279603200]:"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776698239235,
+          "type": "finding",
+          "content": "\"fix-cargo-check\" completed → >7u\r\n╭─────────────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                          │\r\n│",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_5tiesns3la4x",
+      "title": "Execution: fix-mcp-args-tests",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T15:17:19.882Z",
+      "endedAt": "2026-04-20T15:18:42.639Z",
+      "events": [
+        {
+          "ts": 1776698239882,
+          "type": "note",
+          "content": "\"fix-mcp-args-tests\": mcp_args test output below",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776698322071,
+          "type": "completion-marker",
+          "content": "\"fix-mcp-args-tests\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 6 file change(s); signals=fix-mcp-args-tests, COMPLETE, COMPLETE, COMPLETE, >7u, Verification passed; files=created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/dep-test-lib-relay_broker, created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/invoked.timestamp, created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker, created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker.json, created:target/debug/.fingerprint/agent-relay-broker-9af7f0a5986454f3/dep-test-integration-test-continuity, created:target/debug/.fingerprint/agent-relay-broker-9af7f0a5986454f3/invoked.timestamp)",
+          "raw": {
+            "stepName": "fix-mcp-args-tests",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 6 file change(s)",
+              "signals": [
+                "fix-mcp-args-tests",
+                "COMPLETE",
+                "COMPLETE",
+                "COMPLETE",
+                ">7u",
+                "Verification passed"
+              ],
+              "files": [
+                "created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/dep-test-lib-relay_broker",
+                "created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/invoked.timestamp",
+                "created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker",
+                "created:target/debug/.fingerprint/agent-relay-broker-4349c207ed31ffd8/test-lib-relay_broker.json",
+                "created:target/debug/.fingerprint/agent-relay-broker-9af7f0a5986454f3/dep-test-integration-test-continuity",
+                "created:target/debug/.fingerprint/agent-relay-broker-9af7f0a5986454f3/invoked.timestamp"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776698322071,
+          "type": "finding",
+          "content": "\"fix-mcp-args-tests\" completed → >7u\r\n╭─────────────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                          │\r\n│",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_zajc4olt4rkx",
+      "title": "Execution: fix-regressions",
+      "agentName": "implementer",
+      "startedAt": "2026-04-20T15:18:42.639Z",
+      "endedAt": "2026-04-20T15:19:38.968Z",
+      "events": [
+        {
+          "ts": 1776698322639,
+          "type": "note",
+          "content": "\"fix-regressions\": Full broker test output below",
+          "raw": {
+            "agent": "implementer"
+          }
+        },
+        {
+          "ts": 1776698377262,
+          "type": "completion-marker",
+          "content": "\"fix-regressions\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 1 relevant channel post(s); signals=fix-regressions, COMPLETE, COMPLETE, COMPLETE, Verification passed, COMPLETE; channel=**[fix-regressions] Output:**\n```\nion 1 — Spawn relay agents (for real parallel coding work):\n    - mcp__relaycast__agent_add(name=\"helper-1\", cli=\"claude\", tas)",
+          "raw": {
+            "stepName": "fix-regressions",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 1 relevant channel post(s)",
+              "signals": [
+                "fix-regressions",
+                "COMPLETE",
+                "COMPLETE",
+                "COMPLETE",
+                "Verification passed",
+                "COMPLETE"
+              ],
+              "channelPosts": [
+                "**[fix-regressions] Output:**\n```\nion 1 — Spawn relay agents (for real parallel coding work):\n    - mcp__relaycast__agent_add(name=\"helper-1\", cli=\"claude\", tas"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776698377262,
+          "type": "finding",
+          "content": "\"fix-regressions\" completed → >7u\r\n╭─────────────────────────────────────────────────────╮\r\n│ >_ OpenAI Codex (v0.121.0)                          │\r\n│",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_92ay7754ba6f",
+      "title": "Execution: review",
+      "agentName": "reviewer",
+      "startedAt": "2026-04-20T15:19:38.968Z",
+      "events": [
+        {
+          "ts": 1776698378968,
+          "type": "note",
+          "content": "\"review\": Review this diff against PLAN.md + IMPL_SUMMARY.md",
+          "raw": {
+            "agent": "reviewer"
+          }
+        },
+        {
+          "ts": 1776698603086,
+          "type": "completion-evidence",
+          "content": "\"review\" verification-based completion — Verification passed (4 signal(s), 1 relevant channel post(s), 2 file change(s); signals=review, COMPLETE, review, REVIEW.md; channel=Review done. Wrote REVIEW.md at repo root.\n\nVERDICT: APPROVE — every acceptance-checklist item passes. Diff is tightly scoped to src/main.rs (flag field), src/c; files=modified:.claude/settings.json, created:REVIEW.md)",
+          "raw": {
+            "stepName": "review",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 2 file change(s)",
+              "signals": ["review", "COMPLETE", "review", "REVIEW.md"],
+              "channelPosts": [
+                "Review done. Wrote REVIEW.md at repo root.\n\nVERDICT: APPROVE — every acceptance-checklist item passes. Diff is tightly scoped to src/main.rs (flag field), src/c"
+              ],
+              "files": ["modified:.claude/settings.json", "created:REVIEW.md"]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1776698603088,
+          "type": "finding",
+          "content": "\"review\" completed → ✽",
+          "significance": "medium"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay",
+  "tags": []
+}

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-20T13:33:30.100Z",
+  "lastUpdated": "2026-04-20T15:23:23.093Z",
   "trajectories": {
     "traj_qb54w47qwod6": {
       "title": "fix-history-from-workflow",
@@ -3651,6 +3651,12 @@
       "status": "active",
       "startedAt": "2026-04-20T13:16:22.009Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/active/traj_3b3p1z4y7qlo.json"
+    },
+    "traj_o9cx33xn5u39": {
+      "title": "add-mcp-args-register-flag-workflow",
+      "status": "active",
+      "startedAt": "2026-04-20T15:06:23.387Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay-add-mcp-args-register/.trajectories/active/traj_o9cx33xn5u39.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -3656,7 +3656,7 @@
       "title": "add-mcp-args-register-flag-workflow",
       "status": "active",
       "startedAt": "2026-04-20T15:06:23.387Z",
-      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay-add-mcp-args-register/.trajectories/active/traj_o9cx33xn5u39.json"
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/active/traj_o9cx33xn5u39.json"
     }
   }
 }

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -23,22 +23,26 @@ Sample output:
     "--mcp-config",
     "{\"mcpServers\":{\"relaycast\":{\"command\":\"npx\",\"args\":[\"-y\",\"@relaycast/mcp\"]}}}"
   ],
-  "sideEffectFiles": []
+  "sideEffectFiles": [],
+  "agentToken": null
 }
 ```
 
 Flags:
 
-| Flag                              | Required | Description                                                                                                               |
-| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--cli <name>`                    | yes      | CLI name or command to compute MCP args for, such as `claude`, `codex`, `opencode`, `cursor-agent`, `gemini`, or `droid`. |
-| `--agent-name <name>`             | yes      | Relaycast agent name to inject into the MCP configuration.                                                                |
-| `--api-key <key>`                 | no       | Relaycast API key. Falls back to `RELAY_API_KEY`.                                                                         |
-| `--base-url <url>`                | no       | Relaycast base URL. Falls back to `RELAY_BASE_URL`.                                                                       |
-| `--agent-token <token>`           | no       | Pre-registered agent token to pass to the child MCP server.                                                               |
-| `--workspaces-json <json>`        | no       | Multi-workspace context JSON to pass to the child MCP server.                                                             |
-| `--default-workspace <workspace>` | no       | Default workspace ID or name to pass to the child MCP server.                                                             |
-| `--cwd <path>`                    | no       | Working directory used by CLIs that need local MCP config files. Defaults to the current directory.                       |
-| `--existing-args <json>`          | no       | Existing CLI args as a JSON string array, for example `'["--foo","--bar"]'`. Defaults to `[]`.                            |
+| Flag                              | Required | Description                                                                                                                                     |
+| --------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--cli <name>`                    | yes      | CLI name or command to compute MCP args for, such as `claude`, `codex`, `opencode`, `cursor-agent`, `gemini`, or `droid`.                       |
+| `--agent-name <name>`             | yes      | Relaycast agent name to inject into the MCP configuration.                                                                                      |
+| `--api-key <key>`                 | no       | Relaycast API key. Falls back to `RELAY_API_KEY`.                                                                                               |
+| `--base-url <url>`                | no       | Relaycast base URL. Falls back to `RELAY_BASE_URL`.                                                                                             |
+| `--agent-token <token>`           | no       | Pre-registered agent token to pass to the child MCP server.                                                                                     |
+| `--register`                      | no       | Mint a fresh Relaycast agent token with `--api-key`/`RELAY_API_KEY` and `--base-url`/`RELAY_BASE_URL`; mutually exclusive with `--agent-token`. |
+| `--workspaces-json <json>`        | no       | Multi-workspace context JSON to pass to the child MCP server.                                                                                   |
+| `--default-workspace <workspace>` | no       | Default workspace ID or name to pass to the child MCP server.                                                                                   |
+| `--cwd <path>`                    | no       | Working directory used by CLIs that need local MCP config files. Defaults to the current directory.                                             |
+| `--existing-args <json>`          | no       | Existing CLI args as a JSON string array, for example `'["--foo","--bar"]'`. Defaults to `[]`.                                                  |
+
+`agentToken` is `null` unless `--register` successfully minted and injected a fresh Relaycast agent token.
 
 `mcp-args` writes side-effect files synchronously when the target CLI requires a config file. For `opencode`, it may write `<cwd>/opencode.json`; for `cursor`, `cursor-agent`, and `agent`, it may write `<cwd>/.cursor/mcp.json`; for `gemini`, it may write `<HOME>/.gemini/trustedFolders.json`. Treat the command as compute plus configure for those CLIs, not as a side-effect-free dry run.

--- a/src/cli_mcp_args.rs
+++ b/src/cli_mcp_args.rs
@@ -47,6 +47,14 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
         bail!("--register and --agent-token are mutually exclusive; pass one or the other");
     }
 
+    // Validate all local inputs BEFORE touching the network. `--register`
+    // rotates the agent's relaycast token (POST /v1/agents/spawn), which is
+    // an observable side effect on an external system — we should not mint
+    // or rotate a token if the request is going to fail locally anyway
+    // (e.g. malformed --existing-args JSON or an unresolvable --cwd).
+    let cwd = normalize_cwd(cmd.cwd)?;
+    let existing_args = parse_existing_args(cmd.existing_args)?;
+
     // Match the broker's internal WorkerRegistry::build_mcp_args behavior:
     // each flag falls back to its RELAY_* env var so env-driven callers
     // (e.g. cloud's SandboxedStepExecutor, which sets these from
@@ -94,8 +102,6 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
     let default_workspace = cmd
         .default_workspace
         .or_else(|| std::env::var("RELAY_DEFAULT_WORKSPACE").ok());
-    let cwd = normalize_cwd(cmd.cwd)?;
-    let existing_args = parse_existing_args(cmd.existing_args)?;
 
     let args = configure_relaycast_mcp_with_token(
         &cli,
@@ -251,9 +257,63 @@ mod tests {
     use httpmock::{Method::POST, MockServer};
     use relay_broker::snippets::configure_relaycast_mcp_with_token;
     use serde_json::{json, Value};
+    use std::sync::{Mutex, MutexGuard, PoisonError};
     use tempfile::tempdir;
 
     use super::*;
+
+    // Several tests mutate process-global RELAY_* env vars. `#[tokio::test]`
+    // cases run in parallel by default, so without serialization those
+    // tests race and intermittently break CI depending on execution order.
+    // Any test that touches these env vars MUST acquire this lock for its
+    // entire duration and use `EnvGuard` to restore prior values on drop.
+    static RELAY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    const RELAY_ENV_KEYS: &[&str] = &[
+        "RELAY_API_KEY",
+        "RELAY_BASE_URL",
+        "RELAY_AGENT_TOKEN",
+        "RELAY_WORKSPACES_JSON",
+        "RELAY_DEFAULT_WORKSPACE",
+    ];
+
+    /// RAII guard that (1) holds the env mutex so parallel tests don't race,
+    /// and (2) snapshots the listed RELAY_* vars on construction and restores
+    /// them on drop. Panics during a test still restore state because Drop runs.
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(keys: &[&'static str]) -> Self {
+            let lock = RELAY_ENV_MUTEX
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            let saved = keys
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            Self { _lock: lock, saved }
+        }
+
+        /// Snapshots (and locks) the full set of RELAY_* vars this module cares
+        /// about. Prefer this over listing keys at every call site.
+        fn all() -> Self {
+            Self::new(RELAY_ENV_KEYS)
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
 
     fn command(cli: &str, cwd: &Path) -> McpArgsCommand {
         McpArgsCommand {
@@ -422,6 +482,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_without_api_key_returns_clear_error() {
+        let _env = EnvGuard::all();
         std::env::remove_var("RELAY_API_KEY");
 
         let temp = tempdir().expect("tempdir");
@@ -439,6 +500,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_without_base_url_returns_clear_error() {
+        let _env = EnvGuard::all();
         std::env::remove_var("RELAY_BASE_URL");
 
         let temp = tempdir().expect("tempdir");
@@ -456,6 +518,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_happy_path_embeds_minted_token() {
+        let _env = EnvGuard::all();
         std::env::remove_var("RELAY_API_KEY");
         std::env::remove_var("RELAY_BASE_URL");
         std::env::remove_var("RELAY_AGENT_TOKEN");
@@ -510,10 +573,57 @@ mod tests {
 
         assert!(config_json.contains("at_live_register_test_token"));
         register_mock.assert();
+    }
 
+    #[tokio::test]
+    async fn register_does_not_hit_network_when_local_validation_fails() {
+        // Locally-invalid input (malformed --existing-args JSON) must fail
+        // BEFORE the spawn endpoint is called. A POST /v1/agents/spawn
+        // rotates the agent's token, so firing it for a request that was
+        // going to fail locally anyway is an unintended external side
+        // effect.
+        let _env = EnvGuard::all();
         std::env::remove_var("RELAY_API_KEY");
         std::env::remove_var("RELAY_BASE_URL");
         std::env::remove_var("RELAY_AGENT_TOKEN");
+
+        let server = MockServer::start();
+        let spawn_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/agents/spawn");
+            then.status(200).json_body(json!({
+                "ok": true,
+                "data": {
+                    "id": "agent_should_not_be_called",
+                    "name": "test-agent",
+                    "token": "at_live_should_not_mint",
+                    "cli": "claude",
+                    "task": "relay worker session for test-agent",
+                    "channel": null,
+                    "status": "online",
+                    "created_at": "2026-01-01T00:00:00.000Z",
+                    "already_existed": false
+                }
+            }));
+        });
+
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.register = true;
+        cmd.agent_token = None;
+        cmd.api_key = Some("rk_live_test".to_string());
+        cmd.base_url = Some(server.base_url());
+        cmd.existing_args = Some("{not-json".to_string());
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("invalid existing args should abort before register");
+
+        assert!(error
+            .to_string()
+            .contains("--existing-args must be a JSON array of strings"));
+        // The spawn endpoint must NOT have been hit — token rotation is a
+        // real side effect on the relaycast backend.
+        assert_eq!(spawn_mock.hits(), 0);
     }
 
     #[tokio::test]
@@ -588,9 +698,10 @@ mod tests {
         // WorkerRegistry::build_mcp_args in the broker.
         //
         // Uses distinctive sentinel values so we can grep them out of the
-        // generated config even if other tests leak env vars. Each var is
-        // unset at the end to avoid contaminating sibling tests that assume
-        // the env is clean.
+        // generated config. EnvGuard serializes this test against other
+        // RELAY_*-touching tests and restores prior values on drop, so
+        // there's no risk of state leaking even on panic.
+        let _env = EnvGuard::all();
         std::env::set_var("RELAY_API_KEY", "rk_live_from_env");
         std::env::set_var("RELAY_BASE_URL", "https://api.env.relaycast.dev");
         std::env::set_var("RELAY_AGENT_TOKEN", "at_live_from_env");
@@ -644,12 +755,6 @@ mod tests {
             config_json.contains("env-ws"),
             "workspaces json from env missing in claude config: {config_json}"
         );
-
-        std::env::remove_var("RELAY_API_KEY");
-        std::env::remove_var("RELAY_BASE_URL");
-        std::env::remove_var("RELAY_AGENT_TOKEN");
-        std::env::remove_var("RELAY_WORKSPACES_JSON");
-        std::env::remove_var("RELAY_DEFAULT_WORKSPACE");
     }
 
     #[tokio::test]

--- a/src/cli_mcp_args.rs
+++ b/src/cli_mcp_args.rs
@@ -1,7 +1,13 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
-use anyhow::{bail, Context, Result};
-use relay_broker::snippets::configure_relaycast_mcp_with_token;
+use anyhow::{anyhow, bail, Context, Result};
+use relay_broker::{
+    relaycast_ws::{RelaycastHttpClient, RelaycastRegistrationError},
+    snippets::configure_relaycast_mcp_with_token,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::McpArgsCommand;
@@ -11,6 +17,13 @@ use crate::McpArgsCommand;
 struct McpArgsOutput {
     args: Vec<String>,
     side_effect_files: Vec<PathBuf>,
+    agent_token: Option<String>,
+}
+
+struct RegisteredMcpArgsToken {
+    api_key: String,
+    base_url: String,
+    agent_token: String,
 }
 
 pub(crate) async fn run_mcp_args(cmd: McpArgsCommand) -> Result<()> {
@@ -30,18 +43,51 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
         bail!("--agent-name must not be empty");
     }
 
+    if cmd.register && cmd.agent_token.is_some() {
+        bail!("--register and --agent-token are mutually exclusive; pass one or the other");
+    }
+
     // Match the broker's internal WorkerRegistry::build_mcp_args behavior:
     // each flag falls back to its RELAY_* env var so env-driven callers
     // (e.g. cloud's SandboxedStepExecutor, which sets these from
     // orchestrator-managed secrets) don't lose the value just because
     // they didn't repeat it on the CLI.
-    let api_key = cmd.api_key.or_else(|| std::env::var("RELAY_API_KEY").ok());
-    let base_url = cmd
-        .base_url
-        .or_else(|| std::env::var("RELAY_BASE_URL").ok());
-    let agent_token = cmd
-        .agent_token
-        .or_else(|| std::env::var("RELAY_AGENT_TOKEN").ok());
+    let registered = if cmd.register {
+        Some(
+            register_agent_token_for_mcp_args(
+                &cli,
+                &agent_name,
+                cmd.api_key.clone(),
+                cmd.base_url.clone(),
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let api_key = registered
+        .as_ref()
+        .map(|registered| registered.api_key.clone())
+        .or_else(|| cmd.api_key.or_else(|| std::env::var("RELAY_API_KEY").ok()));
+    let base_url = registered
+        .as_ref()
+        .map(|registered| registered.base_url.clone())
+        .or_else(|| {
+            cmd.base_url
+                .or_else(|| std::env::var("RELAY_BASE_URL").ok())
+        });
+    let agent_token = registered
+        .as_ref()
+        .map(|registered| registered.agent_token.clone())
+        .or_else(|| {
+            if cmd.register {
+                None
+            } else {
+                cmd.agent_token
+                    .or_else(|| std::env::var("RELAY_AGENT_TOKEN").ok())
+            }
+        });
     let workspaces_json = cmd
         .workspaces_json
         .or_else(|| std::env::var("RELAY_WORKSPACES_JSON").ok());
@@ -69,7 +115,64 @@ async fn compute_mcp_args_output(cmd: McpArgsCommand) -> Result<McpArgsOutput> {
     Ok(McpArgsOutput {
         args,
         side_effect_files,
+        agent_token: registered.map(|registered| registered.agent_token),
     })
+}
+
+async fn register_agent_token_for_mcp_args(
+    cli: &str,
+    agent_name: &str,
+    api_key: Option<String>,
+    base_url: Option<String>,
+) -> Result<RegisteredMcpArgsToken> {
+    let api_key = api_key
+        .or_else(|| std::env::var("RELAY_API_KEY").ok())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow!("--register requires an API key (pass --api-key or set RELAY_API_KEY)")
+        })?;
+    let base_url = base_url
+        .or_else(|| std::env::var("RELAY_BASE_URL").ok())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow!("--register requires a base URL (pass --base-url or set RELAY_BASE_URL)")
+        })?;
+    let cli_lower = detect_cli_name_for_mcp_args(cli).to_lowercase();
+    let client = RelaycastHttpClient::new(
+        base_url.clone(),
+        api_key.clone(),
+        agent_name.to_string(),
+        cli_lower.clone(),
+    );
+
+    let agent_token = match tokio::time::timeout(
+        Duration::from_secs(10),
+        client.register_agent_token(agent_name, Some(&cli_lower)),
+    )
+    .await
+    {
+        Ok(Ok(token)) => token,
+        Ok(Err(error)) => return Err(map_register_agent_token_error(error)),
+        Err(error) => bail!("register timed out after 10s: {error}"),
+    };
+
+    Ok(RegisteredMcpArgsToken {
+        api_key,
+        base_url,
+        agent_token,
+    })
+}
+
+fn map_register_agent_token_error(error: RelaycastRegistrationError) -> anyhow::Error {
+    match error {
+        RelaycastRegistrationError::Transport { detail, .. } => {
+            anyhow!("register transport error: {detail}")
+        }
+        auth @ RelaycastRegistrationError::Api {
+            status: 401 | 403, ..
+        } => anyhow!("register auth error: {auth}"),
+        other => anyhow!("register failed: {other}"),
+    }
 }
 
 fn parse_existing_args(existing_args: Option<String>) -> Result<Vec<String>> {
@@ -145,8 +248,9 @@ fn home_dir_from_env() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use httpmock::{Method::POST, MockServer};
     use relay_broker::snippets::configure_relaycast_mcp_with_token;
-    use serde_json::Value;
+    use serde_json::{json, Value};
     use tempfile::tempdir;
 
     use super::*;
@@ -158,6 +262,7 @@ mod tests {
             api_key: Some("rk_live_test".to_string()),
             base_url: Some("https://api.test.relaycast.dev".to_string()),
             agent_token: Some("at_live_test".to_string()),
+            register: false,
             workspaces_json: Some(r#"{"workspaces":[]}"#.to_string()),
             default_workspace: Some("default-workspace".to_string()),
             cwd: Some(cwd.to_path_buf()),
@@ -295,7 +400,133 @@ mod tests {
 
         assert!(json.get("args").is_some());
         assert!(json.get("sideEffectFiles").is_some());
+        assert_eq!(json.get("agentToken"), Some(&Value::Null));
         assert!(json.get("side_effect_files").is_none());
+    }
+
+    #[tokio::test]
+    async fn register_and_agent_token_are_mutually_exclusive() {
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.register = true;
+        cmd.agent_token = Some("at_live_explicit".to_string());
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("mutually exclusive flags error");
+        let message = error.to_string();
+
+        assert!(message.contains("--register"));
+        assert!(message.contains("--agent-token"));
+    }
+
+    #[tokio::test]
+    async fn register_without_api_key_returns_clear_error() {
+        std::env::remove_var("RELAY_API_KEY");
+
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.register = true;
+        cmd.api_key = None;
+        cmd.agent_token = None;
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("missing api key error");
+
+        assert!(error.to_string().contains("API key"));
+    }
+
+    #[tokio::test]
+    async fn register_without_base_url_returns_clear_error() {
+        std::env::remove_var("RELAY_BASE_URL");
+
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.register = true;
+        cmd.base_url = None;
+        cmd.agent_token = None;
+
+        let error = compute_mcp_args_output(cmd)
+            .await
+            .expect_err("missing base url error");
+
+        assert!(error.to_string().contains("base URL"));
+    }
+
+    #[tokio::test]
+    async fn register_happy_path_embeds_minted_token() {
+        std::env::remove_var("RELAY_API_KEY");
+        std::env::remove_var("RELAY_BASE_URL");
+        std::env::remove_var("RELAY_AGENT_TOKEN");
+
+        let server = MockServer::start();
+        let register_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents/spawn")
+                .body_contains("\"name\":\"test-agent\"")
+                .body_contains("\"cli\":\"claude\"");
+            then.status(200).json_body(json!({
+                "ok": true,
+                "data": {
+                    "id": "agent_register_test",
+                    "name": "test-agent",
+                    "token": "at_live_register_test_token",
+                    "cli": "claude",
+                    "task": "relay worker session for test-agent",
+                    "channel": null,
+                    "status": "online",
+                    "created_at": "2026-01-01T00:00:00.000Z",
+                    "already_existed": false
+                }
+            }));
+        });
+
+        let temp = tempdir().expect("tempdir");
+        let mut cmd = command("claude", temp.path());
+        cmd.register = true;
+        cmd.base_url = Some(server.base_url());
+        cmd.api_key = Some("rk_live_test".to_string());
+        cmd.agent_token = None;
+
+        let output = compute_mcp_args_output(cmd)
+            .await
+            .expect("register and compute mcp args");
+
+        assert_eq!(
+            output.agent_token,
+            Some("at_live_register_test_token".to_string())
+        );
+
+        let mcp_config_index = output
+            .args
+            .iter()
+            .position(|arg| arg == "--mcp-config")
+            .expect("claude --mcp-config arg");
+        let config_json = output
+            .args
+            .get(mcp_config_index + 1)
+            .expect("claude mcp config value");
+
+        assert!(config_json.contains("at_live_register_test_token"));
+        register_mock.assert();
+
+        std::env::remove_var("RELAY_API_KEY");
+        std::env::remove_var("RELAY_BASE_URL");
+        std::env::remove_var("RELAY_AGENT_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn output_camel_case_includes_agent_token_field() {
+        let temp = tempdir().expect("tempdir");
+        let output = compute_mcp_args_output(command("claude", temp.path()))
+            .await
+            .expect("compute mcp args");
+        let json = output_as_json(&output);
+
+        assert!(json.get("agentToken").is_some());
+        assert_eq!(json.get("agentToken"), Some(&Value::Null));
+        assert!(json.get("agent_token").is_none());
     }
 
     #[tokio::test]
@@ -373,6 +604,7 @@ mod tests {
             api_key: None,
             base_url: None,
             agent_token: None,
+            register: false,
             workspaces_json: None,
             default_workspace: None,
             cwd: Some(temp.path().to_path_buf()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,10 @@ pub(crate) struct McpArgsCommand {
     #[arg(long)]
     agent_token: Option<String>,
 
+    /// Register a fresh Relaycast agent token and inject it into the child MCP server.
+    #[arg(long)]
+    register: bool,
+
     /// Multi-workspace context JSON to pass to the child MCP server.
     #[arg(long)]
     workspaces_json: Option<String>,

--- a/web/content/docs/reference-cli.mdx
+++ b/web/content/docs/reference-cli.mdx
@@ -26,7 +26,8 @@ Sample output:
     "--mcp-config",
     "{\"mcpServers\":{\"relaycast\":{\"command\":\"npx\",\"args\":[\"-y\",\"@relaycast/mcp\"]}}}"
   ],
-  "sideEffectFiles": []
+  "sideEffectFiles": [],
+  "agentToken": null
 }
 ```
 
@@ -39,9 +40,12 @@ Flags:
 | `--api-key <key>` | no | Relaycast API key. Falls back to `RELAY_API_KEY`. |
 | `--base-url <url>` | no | Relaycast base URL. Falls back to `RELAY_BASE_URL`. |
 | `--agent-token <token>` | no | Pre-registered agent token to pass to the child MCP server. |
+| `--register` | no | Mint a fresh Relaycast agent token with `--api-key`/`RELAY_API_KEY` and `--base-url`/`RELAY_BASE_URL`; mutually exclusive with `--agent-token`. |
 | `--workspaces-json <json>` | no | Multi-workspace context JSON to pass to the child MCP server. |
 | `--default-workspace <workspace>` | no | Default workspace ID or name to pass to the child MCP server. |
 | `--cwd <path>` | no | Working directory used by CLIs that need local MCP config files. Defaults to the current directory. |
 | `--existing-args <json>` | no | Existing CLI args as a JSON string array, for example `'["--foo","--bar"]'`. Defaults to `[]`. |
+
+`agentToken` is `null` unless `--register` successfully minted and injected a fresh Relaycast agent token.
 
 `mcp-args` writes side-effect files synchronously when the target CLI requires a config file. For `opencode`, it may write `<cwd>/opencode.json`; for `cursor`, `cursor-agent`, and `agent`, it may write `<cwd>/.cursor/mcp.json`; for `gemini`, it may write `<HOME>/.gemini/trustedFolders.json`. Treat the command as compute plus configure for those CLIs, not as a side-effect-free dry run.


### PR DESCRIPTION
## Why

#759 shipped `mcp-args` but stopped at the compute step: callers still
need a pre-minted `at_live_*` token to hand in via `--agent-token`.
Cloud's SandboxedStepExecutor has no way to mint one without
reimplementing relaycast registration in TypeScript — which is exactly
the duplication the subcommand was supposed to eliminate.

This PR closes the gap with a `--register` flag that composes the
already-shipped `RelaycastHttpClient::register_agent_token` with
`configure_relaycast_mcp_with_token`.

## What changes

- New flag `--register` on `agent-relay-broker mcp-args`.
- Mutually exclusive with `--agent-token`.
- Requires resolvable `--api-key` and `--base-url` (env fallbacks honored).
- Output JSON gains `agentToken` (string | null), populated only on
  --register success.
- Zero edits to `register_agent_token` or `configure_relaycast_mcp_with_token`.

## Tests

- Mutual-exclusion unit test.
- Missing api_key / base_url unit tests.
- Happy-path test with an in-process HTTP mock that serves the relaycast
  spawn endpoint so we actually exercise the composition end-to-end.
- Output-shape test locking `agentToken` camelCase key + null default.
- Full `cargo test --bin agent-relay-broker` green.

Plus workflow smoke tests: `--help` shows the flag; mutex exits non-zero;
register-without-api-key exits non-zero; baseline no-register still emits
`args.length > 0` and `agentToken == null`.

## Follow-up

Once this merges + @agent-relay/sdk publishes, cloud's
`workflows/remove-cloud-mcp-duplication.ts` can delete the TS per-cli
MCP wiring and replace it with a single exec of
`agent-relay-broker mcp-args --register ...`. That unblocks
`hi-interactive.ts` end-to-end in cloud.

Generated by `workflows/add-mcp-args-register-flag.ts`
(claude plan → codex implement → verify gates + test-fix-rerun →
 claude review → PR).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
