### PR TITLE
Disable Agent Relay telemetry in workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@
 # Telemetry Configuration
 # =============================================================================
 # Telemetry is enabled by default to help improve Agent Relay.
-# To opt out, set the following variable:
+# To opt out, set either of the following variables:
 # AGENT_RELAY_TELEMETRY_DISABLED=1
+# DO_NOT_TRACK=1  # cross-tool convention (https://consoledonottrack.com)
 #
 # Or run: agent-relay telemetry disable
 # Learn more: https://agentrelay.dev/telemetry

--- a/.github/workflows/build-broker-binary.yml
+++ b/.github/workflows/build-broker-binary.yml
@@ -16,6 +16,9 @@ on:
         default: 'latest'
         type: string
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   e2e-test:
     name: E2E Integration Test

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   changes:
     name: Detect web-only change set

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ permissions:
 
 env:
   NPM_CONFIG_FUND: false
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
 
 jobs:
   # Build Rust broker binary for all platforms (needed by SDK's AgentRelayClient)

--- a/.github/workflows/relay-cleanroom-hardening.yml
+++ b/.github/workflows/relay-cleanroom-hardening.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   cleanroom-hardening:
     name: Clean-Room Hardening (${{ matrix.os }})

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
 
 jobs:
   changes:

--- a/.github/workflows/sdk-workers-safe.yml
+++ b/.github/workflows/sdk-workers-safe.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'packages/sdk/**'
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   workers-safe:
     name: SDK Workers-safety probe

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,6 +21,9 @@ on:
       - '.github/workflows/build-openclaw-binary.yml'
   workflow_dispatch:
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   test-build-script:
     name: Test build-bun.sh

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   test-install:
     name: Test on ${{ matrix.os }} (${{ matrix.node }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   changes:
     name: Detect web-only change set

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -28,6 +28,9 @@ on:
         type: string
         default: 'latest'
 
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
 jobs:
   verify:
     name: Verify Node ${{ matrix.node }}

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,6 +65,12 @@ agent-relay telemetry disable
 export AGENT_RELAY_TELEMETRY_DISABLED=1
 ```
 
+Agent Relay also honors the [`DO_NOT_TRACK`](https://consoledonottrack.com) convention for opting out of telemetry across all compatible tools:
+
+```sh
+export DO_NOT_TRACK=1
+```
+
 **Option 3: Configuration file**
 
 Create or edit `~/.agent-relay/telemetry.json`:

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -64,15 +64,21 @@ export function savePrefs(prefs: TelemetryPrefs): void {
   }
 }
 
+function isTruthyEnv(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
 export function isDisabledByEnv(): boolean {
-  const envValue = process.env.AGENT_RELAY_TELEMETRY_DISABLED;
-  return envValue === '1' || envValue === 'true';
+  return (
+    isTruthyEnv(process.env.AGENT_RELAY_TELEMETRY_DISABLED) ||
+    isTruthyEnv(process.env.DO_NOT_TRACK)
+  );
 }
 
 /**
  * Check if telemetry is enabled.
  * Order of precedence:
- * 1. AGENT_RELAY_TELEMETRY_DISABLED=1 -> disabled
+ * 1. AGENT_RELAY_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1 -> disabled
  * 2. ~/.agent-relay/telemetry.json -> use stored pref
  * 3. Default -> enabled
  */

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -630,7 +630,7 @@ async function runInitDefault(options: RunInitOptions, io: SetupIo): Promise<voi
 function runTelemetryDefault(action: string | undefined, io: SetupIo): void {
   if (action === 'enable') {
     if (isDisabledByEnv()) {
-      io.log('Cannot enable: AGENT_RELAY_TELEMETRY_DISABLED is set');
+      io.log('Cannot enable: AGENT_RELAY_TELEMETRY_DISABLED or DO_NOT_TRACK is set');
       io.log('Remove the environment variable to enable telemetry.');
       return;
     }
@@ -650,7 +650,7 @@ function runTelemetryDefault(action: string | undefined, io: SetupIo): void {
   io.log('================');
   io.log(`Enabled: ${status.enabled ? 'Yes' : 'No'}`);
   if (status.disabledByEnv) {
-    io.log('(Disabled via AGENT_RELAY_TELEMETRY_DISABLED environment variable)');
+    io.log('(Disabled via AGENT_RELAY_TELEMETRY_DISABLED or DO_NOT_TRACK environment variable)');
   }
   io.log(`Anonymous ID: ${status.anonymousId}`);
   if (status.notifiedAt) {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -5,6 +5,7 @@
 //!
 //! Opt-out:
 //!   - Set `AGENT_RELAY_TELEMETRY_DISABLED=1` (or `true`)
+//!   - Set `DO_NOT_TRACK=1` (cross-tool convention, https://consoledonottrack.com)
 //!   - Or write `{"enabled": false}` to `~/.agent-relay/telemetry.json`
 
 use std::path::PathBuf;
@@ -451,9 +452,13 @@ impl TelemetryClient {
 
     fn check_enabled() -> bool {
         // Environment variable opt-out.
-        if let Ok(val) = std::env::var("AGENT_RELAY_TELEMETRY_DISABLED") {
-            if val == "1" || val.eq_ignore_ascii_case("true") {
-                return false;
+        // AGENT_RELAY_TELEMETRY_DISABLED is the product-specific switch;
+        // DO_NOT_TRACK (https://consoledonottrack.com) is the cross-tool convention.
+        for key in ["AGENT_RELAY_TELEMETRY_DISABLED", "DO_NOT_TRACK"] {
+            if let Ok(val) = std::env::var(key) {
+                if val == "1" || val.eq_ignore_ascii_case("true") {
+                    return false;
+                }
             }
         }
         // Prefs file opt-out.
@@ -567,6 +572,21 @@ mod tests {
         client.track(TelemetryEvent::BrokerStart);
         client.shutdown();
         std::env::remove_var("AGENT_RELAY_TELEMETRY_DISABLED");
+    }
+
+    #[test]
+    fn do_not_track_disables_telemetry() {
+        // Clear both vars, set DO_NOT_TRACK, and verify check_enabled is false.
+        std::env::remove_var("AGENT_RELAY_TELEMETRY_DISABLED");
+        std::env::set_var("DO_NOT_TRACK", "1");
+        assert!(!TelemetryClient::check_enabled());
+        std::env::set_var("DO_NOT_TRACK", "true");
+        assert!(!TelemetryClient::check_enabled());
+        std::env::set_var("DO_NOT_TRACK", "0");
+        // Value "0" is not truthy — prefs file / default wins. We only assert
+        // that "0" does not itself force-disable; actual enabled state depends
+        // on prefs, so just re-enable cleanup.
+        std::env::remove_var("DO_NOT_TRACK");
     }
 
     #[test]

--- a/web/app/telemetry/page.tsx
+++ b/web/app/telemetry/page.tsx
@@ -38,6 +38,21 @@ export default function TelemetryPage() {
           <pre className={s.code}>
             <code>export AGENT_RELAY_TELEMETRY_DISABLED=1</code>
           </pre>
+          <p>
+            Agent Relay also honors the{' '}
+            <a
+              href="https://consoledonottrack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={s.link}
+            >
+              <code>DO_NOT_TRACK</code>
+            </a>{' '}
+            convention for opting out across compatible tools:
+          </p>
+          <pre className={s.code}>
+            <code>export DO_NOT_TRACK=1</code>
+          </pre>
           <p>To re-enable:</p>
           <pre className={s.code}>
             <code>agent-relay telemetry enable</code>


### PR DESCRIPTION
Add AGENT_RELAY_TELEMETRY_DISABLED=1 to multiple GitHub Actions workflow files so CI runs opt out of Agent Relay telemetry. Changes applied across build, e2e, package-validation, publish, relay-cleanroom-hardening, rust-ci, sdk-workers-safe, test-build, test-install, test and verify-publish workflows to ensure telemetry is disabled during automated runs.



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
