### PR TITLE
fix(workflows): mark run failed under continue-on-error when steps fail

### DIFF
--- a/packages/sdk/src/__tests__/completion-pipeline.test.ts
+++ b/packages/sdk/src/__tests__/completion-pipeline.test.ts
@@ -617,6 +617,30 @@ describe('Completion Pipeline', () => {
       expect(mockRelayInstance.spawnPty).toHaveBeenCalledTimes(2);
     }, 15000);
 
+    it('should mark the run failed even with errorHandling.strategy=continue when a step fails', async () => {
+      // Regression: previously `allCompleted` counted failed steps as success
+      // whenever continueOnError was true, so the summary table would render
+      // "FAILED 1 passed, 1 failed" while run.status landed on 'completed'.
+      // Any wrapper that keys off run.status (e.g. the cloud orchestrator's
+      // bootstrap) would then propagate a false success.
+      mockSpawnOutputs = [
+        'worker output\n',
+        'OWNER_DECISION: INCOMPLETE_FAIL\nREASON: relaycast unavailable\n',
+      ];
+
+      const config: RelayYamlConfig = {
+        ...makeSupervisedConfig({}),
+        errorHandling: { strategy: 'continue' },
+      };
+
+      const run = await runner.execute(config, 'default');
+
+      expect(run.status).toBe('failed');
+      const steps = await db.getStepsByRunId(run.id);
+      expect(steps[0]?.status).toBe('failed');
+      expect(steps[0]?.completionReason).toBe('failed_owner_decision');
+    }, 15000);
+
     it('should still complete by owner decision when COMPLETE and verification both pass', async () => {
       mockSpawnOutputs = [
         'worker output with expected content\n',

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -2974,13 +2974,14 @@ export class WorkflowRunner {
       this.log(`Executing ${workflow.steps.length} steps (pattern: ${config.swarm.pattern})`);
       await this.executeSteps(workflow, stepStates, agentMap, config.errorHandling, runId);
 
-      const errorStrategy = config.errorHandling?.strategy ?? workflow.onError ?? 'fail-fast';
-      const continueOnError = errorStrategy === 'continue' || errorStrategy === 'skip';
+      // A run is successful iff every step completed or was skipped. Under
+      // continue-on-error we keep executing past a failure, but the run
+      // itself still "failed" — otherwise the final status contradicts the
+      // summary table ("1 passed, 3 failed" but run.status=completed) and
+      // downstream wrappers that key off run.status (e.g. the cloud
+      // orchestrator's bootstrap) silently report success.
       const allCompleted = [...stepStates.values()].every(
-        (s) =>
-          s.row.status === 'completed' ||
-          s.row.status === 'skipped' ||
-          (continueOnError && s.row.status === 'failed')
+        (s) => s.row.status === 'completed' || s.row.status === 'skipped'
       );
 
       if (allCompleted) {


### PR DESCRIPTION
## Summary
Repros a real production miscount: under `errorHandling.strategy: 'continue'` (or `workflow.onError: 'skip'`), a run with failing steps lands in `run.status: 'completed'`. The summary table is correct ("FAILED 1 passed, 3 failed, 1 skipped") but the runner logs "Workflow completed successfully" and `run.status === 'completed'`, so any wrapper keying off that status silently ships a false success.

The offending check:

\`\`\`ts
const allCompleted = [...stepStates.values()].every(
  s =>
    s.row.status === 'completed'
    || s.row.status === 'skipped'
    || (continueOnError && s.row.status === 'failed')
);
\`\`\`

The `continueOnError` clause conflates *"keep running past failures"* with *"count failures as success"*. They're not the same thing. Continue-on-error controls execution flow, not outcome reporting.

## Fix
Drop the `continueOnError` clause. If any step ends in `failed`, the run is `failed`. The summary table and run status now agree.

## Regression test
Added in `completion-pipeline.test.ts`:
- 1-step supervised config with `errorHandling: { strategy: 'continue' }`
- Queues `OWNER_DECISION: INCOMPLETE_FAIL`
- Asserts `run.status === 'failed'` and step `completionReason === 'failed_owner_decision'`

Before the fix: `Expected "failed" / Received "completed"` (exact production bug shape). After: passes. Full `completion-pipeline.test.ts` (69 tests), `error-scenarios.test.ts` + `orchestration-upgrades.test.ts` (90 tests) all green. One pre-existing unrelated failure in `workflow-runner.test.ts` for a trajectory-chapters test reproduces on plain main — not touched by this PR.

## Context
This surfaced via AgentWorkforce/cloud#236 — `agent-relay cloud run workflows/hi-interactive.ts` logged `Run status: completed / PASSED` despite 3 of 4 agents failing to post to the workflow channel. The cloud side has its own bootstrap wrapper that also defensively treats process exit 0 as success (addressed in that PR), but the SDK-side bug is the upstream root cause: as long as `allCompleted` is true, the runner actively declares success and emits `run:completed` — every downstream consumer takes that at face value.

## Test plan
- [x] New regression test passes (and fails pre-fix with the exact production error)
- [x] `completion-pipeline.test.ts`, `error-scenarios.test.ts`, `orchestration-upgrades.test.ts` all green
- [ ] Verify via a real `agent-relay cloud run workflows/hi-interactive.ts` after publish — expect `Run status: failed` matching the summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
