### PR TITLE
fix(credential-proxy): bootstrap for first publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,15 +411,23 @@ jobs:
             const path = require('path');
             const version = '$NEW_VERSION';
 
-            // Update root package internal dependencies (both regular and dev)
-            const rootPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            for (const depType of ['dependencies', 'devDependencies']) {
-              for (const dep of Object.keys(rootPkg[depType] || {})) {
-                if (dep.startsWith('@agent-relay/')) {
-                  rootPkg[depType][dep] = version;
+            // Update @agent-relay/* references across dependencies,
+            // devDependencies, and peerDependencies so sibling packages
+            // stay pinned to the same version we're about to publish.
+            const DEP_SECTIONS = ['dependencies', 'devDependencies', 'peerDependencies'];
+            const rewriteInternalRefs = (pkg) => {
+              for (const depType of DEP_SECTIONS) {
+                for (const dep of Object.keys(pkg[depType] || {})) {
+                  if (dep.startsWith('@agent-relay/')) {
+                    pkg[depType][dep] = version;
+                  }
                 }
               }
-            }
+            };
+
+            // Update root package internal dependencies
+            const rootPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            rewriteInternalRefs(rootPkg);
             fs.writeFileSync('package.json', JSON.stringify(rootPkg, null, 2) + '\n');
 
             // Update all sub-packages: version + internal dependencies
@@ -434,14 +442,7 @@ jobs:
                 console.log('@agent-relay/' + dir);
                 console.log('v' + version);
 
-                // Update internal dependencies (both regular and dev)
-                for (const depType of ['dependencies', 'devDependencies']) {
-                  for (const dep of Object.keys(pkg[depType] || {})) {
-                    if (dep.startsWith('@agent-relay/')) {
-                      pkg[depType][dep] = version;
-                    }
-                  }
-                }
+                rewriteInternalRefs(pkg);
                 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15405,7 +15405,7 @@
     },
     "packages/credential-proxy": {
       "name": "@agent-relay/credential-proxy",
-      "version": "4.0.10",
+      "version": "4.0.35",
       "dependencies": {
         "hono": "^4.11.4",
         "jose": "^6.1.3"
@@ -16251,7 +16251,7 @@
         "@types/ws": "^8.5.10"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "4.0.10",
+        "@agent-relay/credential-proxy": "4.0.35",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",

--- a/packages/credential-proxy/README.md
+++ b/packages/credential-proxy/README.md
@@ -1,0 +1,71 @@
+# @agent-relay/credential-proxy
+
+JWT-authenticated credential proxy for upstream LLM providers. Lets sandboxed
+agents call provider APIs (OpenAI, Anthropic, OpenRouter) without being given
+raw provider credentials — the proxy holds the keys, agents present per-session
+JWTs, and the proxy enforces per-credential token budgets.
+
+## What it is
+
+A Hono app plus a handful of helpers:
+
+- `createCredentialProxyApp(options)` — mounts the HTTP router (`/health`,
+  `/usage`, and a catch-all provider-forwarding route under `*`). Use it
+  directly in Node (via `@hono/node-server`) or bind it inside a Cloudflare
+  Worker.
+- `mintProxyToken(...)` / `verifyProxyToken(...)` — JWT helpers built on
+  [`jose`](https://github.com/panva/jose). HS256 by default, audience
+  `relay-llm-proxy`.
+- `MeteringCollector` + `checkBudget` — in-memory usage accounting with
+  pessimistic reservations so concurrent requests can't bypass the declared
+  budget.
+- Provider adapters under `providers/` — translate incoming JWT claims to the
+  correct upstream HTTP request for OpenAI / Anthropic / OpenRouter.
+
+## Environment variables
+
+Required at runtime (the host of the proxy):
+
+| Variable                            | Purpose                                                      |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `CREDENTIAL_PROXY_JWT_SECRET`       | HS256 secret the proxy uses to verify per-session JWTs.      |
+| `CREDENTIAL_PROXY_ADMIN_JWT_SECRET` | Secret for admin-scoped tokens (e.g. the `/usage` endpoint). |
+| `CREDENTIAL_PROXY_ADMIN_AUDIENCE`   | Audience claim the proxy requires on admin tokens.           |
+| `OPENAI_API_KEY`                    | Upstream credential for the OpenAI provider adapter.         |
+| `ANTHROPIC_API_KEY`                 | Upstream credential for the Anthropic provider adapter.      |
+| `OPENROUTER_API_KEY`                | Upstream credential for the OpenRouter provider adapter.     |
+
+Only the provider keys you actually forward to need to be set — missing keys
+surface as `502 credential_unavailable` on the relevant route.
+
+The agent side (whichever process mints tokens and launches the sandboxed CLI)
+uses `CREDENTIAL_PROXY_JWT_SECRET` to sign tokens and puts them into the agent's
+environment as `CREDENTIAL_PROXY_TOKEN` (alias: `RELAY_LLM_PROXY_TOKEN`) plus
+`RELAY_LLM_PROXY` / `RELAY_LLM_PROXY_URL` so the SDK's `proxy-env` helpers can
+wire up per-CLI `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` overrides.
+
+## Usage
+
+```ts
+import { serve } from '@hono/node-server';
+import { createCredentialProxyApp } from '@agent-relay/credential-proxy';
+
+const app = createCredentialProxyApp({
+  // Defaults to process.env.CREDENTIAL_PROXY_JWT_SECRET / ADMIN_JWT_SECRET.
+});
+
+serve({ fetch: app.fetch, port: Number(process.env.PORT ?? 3001) });
+```
+
+For the SDK-side wiring that lets workflow agents use the proxy transparently,
+see [`@agent-relay/sdk/workflows`'s proxy-env
+module](../sdk/src/workflows/proxy-env.ts) and the `credentialProxy` field on
+`SwarmConfig`.
+
+## Development
+
+```bash
+npm run build      # tsc → dist/
+npm run test       # vitest
+npm run dev        # builds then runs the proxy on PORT (default 3001)
+```

--- a/packages/credential-proxy/package.json
+++ b/packages/credential-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-relay/credential-proxy",
-  "version": "4.0.10",
+  "version": "4.0.35",
   "description": "JWT-authenticated credential proxy for upstream LLM providers",
   "type": "module",
   "main": "dist/index.js",
@@ -17,8 +17,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "npx tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
     "test": "vitest run",
+    "test:watch": "vitest",
     "dev": "npm run build && PORT=${PORT:-3001} node dist/index.js"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -147,7 +147,7 @@
     "yaml": "^2.7.0"
   },
   "peerDependencies": {
-    "@agent-relay/credential-proxy": "4.0.10",
+    "@agent-relay/credential-proxy": "4.0.35",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
     "@google/adk": ">=0.5.0",
     "@langchain/langgraph": ">=1.2.0",


### PR DESCRIPTION
## Summary

The first publish of \`@agent-relay/credential-proxy\` (added in #717) would
have failed because of a version + script mismatch that I caught while
triaging the \`Install Test (Node 18)\` failure on that PR:

- \`packages/credential-proxy/package.json\` was at \`4.0.10\` while every
  sibling \`@agent-relay/*\` package is at \`4.0.35\`.
- \`@agent-relay/sdk\`'s \`peerDependencies\` pinned \`credential-proxy\` to the
  exact string \`4.0.10\` — so any consumer installing the next SDK release
  would send npm to \`GET /@agent-relay/credential-proxy@4.0.10\`, which will
  never exist.
- The release workflow's version-bump script (\`.github/workflows/publish.yml\`)
  rewrites \`@agent-relay/*\` references under \`dependencies\` and
  \`devDependencies\` but not \`peerDependencies\` — so even after a release the
  SDK peer would stay frozen at whatever string it was authored with.

## Changes

- **Version sync** — \`packages/credential-proxy\` → \`4.0.35\` to match
  siblings; SDK's \`peerOptional\` updated in lockstep.
- **Version-bump script** — refactored to iterate \`['dependencies',
  'devDependencies', 'peerDependencies']\` through a shared helper so future
  releases don't drift the peer again.
- **Build script parity** — \`"build": "tsc -p tsconfig.json"\` (drops the
  unnecessary \`npx\` prefix), adds \`clean\` and \`test:watch\` to match what
  \`@agent-relay/memory\` and friends ship.
- **README** — documents what the package does, the env vars it needs
  (\`CREDENTIAL_PROXY_JWT_SECRET\`, \`CREDENTIAL_PROXY_ADMIN_JWT_SECRET\`,
  \`CREDENTIAL_PROXY_ADMIN_AUDIENCE\`, provider keys), and where the SDK
  wiring lives. Without it the package would have published with only
  \`dist/\` inside the tarball.

No runtime behavior change — the only shipped-bits delta is version numbers
and the new README. Everything downstream (SDK proxy-env wiring, cloud
sandbox plumbing) keeps working.

## Test plan

- [x] \`tsc --noEmit\` clean against \`packages/credential-proxy/tsconfig.json\`
- [x] \`vitest run\` in \`packages/credential-proxy\` → 16 passing
- [x] \`vitest run src/workflows/__tests__/proxy-env.test.ts\` in SDK → 20 passing
- [x] \`rm -rf dist && npm run build\` produces \`dist/index.js\` + \`dist/index.d.ts\`
- [x] \`npm pack --dry-run\` tarball now includes \`README.md\` and shows \`version: 4.0.35\`
- [ ] After merge: confirm next release publishes \`@agent-relay/credential-proxy\`
      with matching version to SDK, and that \`Install Test (Node 18)\` passes
      on a consumer installing the released SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
