### PR TITLE
feat(cloud): send workflowPath so the launcher can skip the $HOME upload

### DIFF
--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { relativizeWorkflowPath } from './workflows.js';
 
@@ -40,8 +40,11 @@ describe('relativizeWorkflowPath', () => {
     expect(result).toBe('nested/workflow.ts');
   });
 
-  it('returns null for an absolute path outside cwd', () => {
-    const outside = path.resolve(os.tmpdir(), 'not-in-cwd', 'workflow.ts');
+  it('returns null for an absolute path outside cwd', async () => {
+    // realpath() so the comparison is symlink-stable on macOS (same
+    // reason we realpath() tmpRoot above).
+    const outsideDir = await realpath(os.tmpdir());
+    const outside = path.resolve(outsideDir, 'not-in-cwd', 'workflow.ts');
     const result = relativizeWorkflowPath(outside);
     expect(result).toBeNull();
   });

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { mkdtemp, realpath, rm } from 'node:fs/promises';
+
+import { relativizeWorkflowPath } from './workflows.js';
+
+describe('relativizeWorkflowPath', () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    // On macOS os.tmpdir() is a symlink (e.g. /var → /private/var), so
+    // after chdir() process.cwd() returns the realpath. Resolve both up
+    // front so assertions that build absolute paths relative to the
+    // temp dir compare apples to apples.
+    tmpRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), 'relativize-workflow-')));
+    process.chdir(tmpRoot);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns a forward-slash relative path for a sibling of cwd', () => {
+    const result = relativizeWorkflowPath('workflows/foo.ts');
+    assert.equal(result, 'workflows/foo.ts');
+  });
+
+  it('strips a leading ./', () => {
+    const result = relativizeWorkflowPath('./workflows/foo.ts');
+    assert.equal(result, 'workflows/foo.ts');
+  });
+
+  it('relativizes an absolute path that lives inside cwd', () => {
+    const abs = path.join(tmpRoot, 'nested', 'workflow.ts');
+    const result = relativizeWorkflowPath(abs);
+    assert.equal(result, 'nested/workflow.ts');
+  });
+
+  it('returns null for an absolute path outside cwd', () => {
+    const outside = path.resolve(os.tmpdir(), 'not-in-cwd', 'workflow.ts');
+    const result = relativizeWorkflowPath(outside);
+    assert.equal(result, null);
+  });
+
+  it('returns null for a path that escapes cwd via ..', () => {
+    const result = relativizeWorkflowPath('../escaped.ts');
+    assert.equal(result, null);
+  });
+
+  it('returns null when the arg resolves to cwd itself', () => {
+    const result = relativizeWorkflowPath('.');
+    assert.equal(result, null);
+  });
+});

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, beforeEach, afterEach } from 'node:test';
-import assert from 'node:assert/strict';
 import path from 'node:path';
 import os from 'node:os';
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { relativizeWorkflowPath } from './workflows.js';
 
@@ -27,33 +26,33 @@ describe('relativizeWorkflowPath', () => {
 
   it('returns a forward-slash relative path for a sibling of cwd', () => {
     const result = relativizeWorkflowPath('workflows/foo.ts');
-    assert.equal(result, 'workflows/foo.ts');
+    expect(result).toBe('workflows/foo.ts');
   });
 
   it('strips a leading ./', () => {
     const result = relativizeWorkflowPath('./workflows/foo.ts');
-    assert.equal(result, 'workflows/foo.ts');
+    expect(result).toBe('workflows/foo.ts');
   });
 
   it('relativizes an absolute path that lives inside cwd', () => {
     const abs = path.join(tmpRoot, 'nested', 'workflow.ts');
     const result = relativizeWorkflowPath(abs);
-    assert.equal(result, 'nested/workflow.ts');
+    expect(result).toBe('nested/workflow.ts');
   });
 
   it('returns null for an absolute path outside cwd', () => {
     const outside = path.resolve(os.tmpdir(), 'not-in-cwd', 'workflow.ts');
     const result = relativizeWorkflowPath(outside);
-    assert.equal(result, null);
+    expect(result).toBeNull();
   });
 
   it('returns null for a path that escapes cwd via ..', () => {
     const result = relativizeWorkflowPath('../escaped.ts');
-    assert.equal(result, null);
+    expect(result).toBeNull();
   });
 
   it('returns null when the arg resolves to cwd itself', () => {
     const result = relativizeWorkflowPath('.');
-    assert.equal(result, null);
+    expect(result).toBeNull();
   });
 });

--- a/packages/cloud/src/workflows.ts
+++ b/packages/cloud/src/workflows.ts
@@ -261,6 +261,20 @@ export async function runWorkflow(
 
     requestBody.runId = prepared.runId;
     requestBody.s3CodeKey = prepared.s3CodeKey;
+
+    // Send the workflow's path inside the synced tarball so the cloud
+    // launcher can set WORKFLOW_FILE directly — no $HOME upload dance,
+    // sibling-relative imports (e.g. `../shared/models.ts`) resolve
+    // against the repo layout. The tarball was produced from
+    // process.cwd(), so relativize the user-typed argument against cwd.
+    //
+    // Absolute paths outside cwd OR paths that would escape the tarball
+    // via `..` are dropped silently — the server falls back to the
+    // legacy $HOME upload path in that case.
+    const workflowPath = relativizeWorkflowPath(workflowArg);
+    if (workflowPath) {
+      requestBody.workflowPath = workflowPath;
+    }
   }
 
   const t3 = Date.now();
@@ -571,4 +585,27 @@ function normalizeEntryPath(entryPath: string): string {
 
 function scopedCodeKey(prefix: string, key: string): string {
   return [prefix, key].filter(Boolean).join('/');
+}
+
+/**
+ * Turn the user-typed workflow path into a path **relative to the tarball
+ * root** (process.cwd()) that the cloud launcher can append to
+ * `/project/` to locate the file inside the synced code tree.
+ *
+ * Returns `null` when the result would escape the tarball (absolute
+ * outside cwd, or contains `..`). Callers drop the hint in that case —
+ * the server falls back to the legacy $HOME upload path, which still
+ * works (it just breaks sibling-relative imports, the pre-existing
+ * behaviour this field was added to fix).
+ */
+export function relativizeWorkflowPath(workflowArg: string): string | null {
+  const absolute = path.resolve(process.cwd(), workflowArg);
+  let rel = path.relative(process.cwd(), absolute);
+  if (rel.length === 0) return null;
+  // Normalize to forward slashes so the server-side validator (which
+  // runs on Linux Lambda) gets the same shape regardless of the CLI OS.
+  rel = rel.split(path.sep).join('/');
+  if (rel.startsWith('../') || rel === '..') return null;
+  if (path.isAbsolute(rel)) return null;
+  return rel;
 }


### PR DESCRIPTION
## Summary

Companion to `AgentWorkforce/cloud#276`. When a user runs
`agent-relay cloud run <file> --sync-code`, send the workflow's path
relative to the tarball root in the run request body.

The cloud launcher uses that path to set `WORKFLOW_FILE` directly at
`/project/<path>` and skip uploading the file to `$HOME` — which means
sibling-relative imports like `../shared/models.ts` resolve against the
repo layout instead of `$HOME` (where they currently break).

## Why

Today, the launcher uploads the workflow source to `$HOME/workflow.ts`, discarding the repo-relative path. When bun runs the file there, `../shared/models.ts` resolves against `$HOME` instead of the repo. The in-sandbox rediscovery matcher that tries to reverse-engineer the path via sha256 fails silently on the first byte-level mismatch (line endings, tarball normalization). See `cloud#276` for the full write-up.

Preserving the path end-to-end removes the rediscovery guesswork entirely.

## Change

- `packages/cloud/src/workflows.ts`:
  - New exported helper `relativizeWorkflowPath(workflowArg)` — normalizes to a forward-slash relative path against `process.cwd()` (the tarball root), returns `null` for absolute-outside-cwd or `..`-escaping paths.
  - In the `runWorkflow` sync-code branch, compute the relative path and set `requestBody.workflowPath` when it's safe. Server falls back to the legacy `$HOME` upload path when absent.
- `packages/cloud/src/workflows.test.ts` — 6 cases covering sibling paths, leading `./`, absolute-inside-cwd, absolute-outside-cwd, `..`-escape, and the edge case of cwd itself.

## Rollout

1. Merge + publish as `agent-relay@4.0.37`.
2. Users on the new CLI → `workflowPath` gets sent → cloud uses it (requires `cloud#276` in prod).
3. Users on older CLIs → no field → cloud falls back to current `$HOME` upload behaviour (still works, just without sibling-relative import support — same as today).

## Test plan

- [x] `npx tsx --test packages/cloud/src/workflows.test.ts` — 6/6 pass.
- [x] TypeScript compilation clean.
- [ ] After both this and `cloud#276` ship, re-run NightCTO's failing workflow: `agent-relay cloud run workflows/security-runtime/01-broker-runtime-execution.ts --sync-code`. Should succeed end-to-end with no rediscovery-matcher warn log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
