### PR TITLE
fix(sdk-py): retry get_session on 503 + correct quickstart idle wait

### DIFF
--- a/packages/sdk-py/src/agent_relay/client.py
+++ b/packages/sdk-py/src/agent_relay/client.py
@@ -251,8 +251,22 @@ class AgentRelayClient:
         client._stderr_task = stderr_task
         client._process = process
 
-        # Get session metadata
-        session = await client.get_session()
+        # Broker may still be connecting to Relaycast after binding its API
+        # listener. Retry get_session with backoff while it returns 503.
+        # Mirrors packages/sdk/src/client.ts.
+        session: Optional[dict[str, Any]] = None
+        last_error: Optional[Exception] = None
+        for attempt in range(10):
+            try:
+                session = await client.get_session()
+                break
+            except AgentRelayProtocolError as err:
+                last_error = err
+                is_503 = err.code == "http_503" or "Service Unavailable" in str(err)
+                if not is_503 or attempt >= 9:
+                    raise
+                await asyncio.sleep(1.0)
+        assert session is not None, last_error
         client.workspace_key = session.get("workspace_key")
 
         # Start event stream

--- a/web/content/docs/quickstart.mdx
+++ b/web/content/docs/quickstart.mdx
@@ -113,9 +113,9 @@ async def main():
 
     # Wait for everyone to finish, then shut down.
     await asyncio.gather(
-        relay.wait_for_agent_idle("Planner"),
-        relay.wait_for_agent_idle("Coder"),
-        relay.wait_for_agent_idle("Reviewer"),
+        planner.wait_for_idle(),
+        coder.wait_for_idle(),
+        reviewer.wait_for_idle(),
     )
     await relay.shutdown()
 


### PR DESCRIPTION
## Summary

Two linked fixes that unblock the Python quickstart example:

- **Python SDK**: `AgentRelayClient.spawn()` called `get_session()` exactly once. If the broker is still connecting to Relaycast it returns 503, which killed the client before any agent could spawn. Mirror the TypeScript SDK's retry-on-503 loop (10 attempts, 1s backoff — `packages/sdk/src/client.ts:265-279`).
- **Docs**: the Python quickstart referenced `relay.wait_for_agent_idle(name)`, which doesn't exist on `AgentRelay`. Idle-waiting lives on the `Agent` handle (`wait_for_idle()`), mirroring the `planner.waitForIdle()` usage in the TypeScript example directly above it.

## Test plan

- [x] Ran the updated quickstart Python script end-to-end — 3 agents spawned, Planner posted to `#general`, Coder responded, all three went idle, broker shut down with exit 0.
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
