### PR TITLE
fix(sdk): find broker in package-root bin/ without relying on postinstall

### DIFF
--- a/packages/sdk/src/broker-path.ts
+++ b/packages/sdk/src/broker-path.ts
@@ -90,6 +90,25 @@ function getSdkBinDirs(): string[] {
   return binDirs;
 }
 
+// The `agent-relay` npm tarball ships platform-specific brokers at its
+// top-level `bin/` (not inside `packages/sdk/bin/`). Walk up from the SDK
+// module looking for any ancestor with a `bin/` directory so we can find
+// the binary without depending on postinstall to copy it.
+function getAncestorBinDirs(): string[] {
+  const binDirs: string[] = [];
+  const start = getCurrentModuleDir();
+  if (!start) return binDirs;
+
+  let current = resolve(start);
+  for (let i = 0; i < 6; i++) {
+    addUniquePath(binDirs, join(current, 'bin'));
+    const parent = resolve(current, '..');
+    if (parent === current) break;
+    current = parent;
+  }
+  return binDirs;
+}
+
 function getDevelopmentBinaryPaths(ext: string, binDirs: string[]): string[] {
   const binaryPaths: string[] = [];
   const repoRoots = new Set<string>();
@@ -146,14 +165,18 @@ function getSourceCheckoutBinaryPaths(ext: string, binDirs: string[]): string[] 
  *   2. Local Cargo build when the SDK is loaded from an agent-relay source checkout
  *   3. SDK's bin/ directory (resolved via CJS globals, createRequire, or import.meta.url)
  *   4. Platform-specific name (agent-relay-broker-{platform}-{arch}) in bin/
- *   5. Common Cargo development paths (target/release and target/debug)
- *   6. PATH lookup via `which` / `where`
+ *   5. Ancestor bin/ directories (the `agent-relay` tarball ships platform-
+ *      specific broker binaries at its package-root `bin/` — finding them
+ *      here removes the postinstall copy dependency)
+ *   6. Common Cargo development paths (target/release and target/debug)
+ *   7. PATH lookup via `which` / `where`
  *
  * @returns Absolute path to the broker binary, or null if not found
  */
 export function getBrokerBinaryPath(): string | null {
   const ext = process.platform === 'win32' ? '.exe' : '';
   const binDirs = getSdkBinDirs();
+  const ancestorBinDirs = getAncestorBinDirs();
   const platformSpecific = `${BROKER_NAME}-${process.platform}-${process.arch}${ext}`;
   const override = process.env.BROKER_BINARY_PATH ?? process.env.AGENT_RELAY_BIN;
 
@@ -189,14 +212,28 @@ export function getBrokerBinaryPath(): string | null {
     }
   }
 
-  // 4. Common development paths for local Cargo builds.
+  // 4. Ancestor bin/ directories (the agent-relay tarball ships brokers at
+  // its package-root bin/ — exact name first for parity with bundled SDKs,
+  // then platform-specific name for the prebuilt-only case).
+  for (const binDir of ancestorBinDirs) {
+    const exactPath = join(binDir, `${BROKER_NAME}${ext}`);
+    if (existsSync(exactPath)) {
+      return exactPath;
+    }
+    const platformPath = join(binDir, platformSpecific);
+    if (existsSync(platformPath)) {
+      return platformPath;
+    }
+  }
+
+  // 5. Common development paths for local Cargo builds.
   for (const developmentPath of getDevelopmentBinaryPaths(ext, binDirs)) {
     if (existsSync(developmentPath)) {
       return developmentPath;
     }
   }
 
-  // 5. PATH lookup
+  // 6. PATH lookup
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which';
     const result = execFileSync(cmd, [BROKER_NAME], {


### PR DESCRIPTION
## Summary

Closes the ENOENT path that bit Falko (and anyone whose postinstall step is skipped or fails).

The published \`agent-relay\` tarball contains platform-specific brokers at its **top-level** \`bin/\`:

\`\`\`
package/bin/agent-relay-broker-darwin-arm64
package/bin/agent-relay-broker-darwin-x64
package/bin/agent-relay-broker-linux-arm64
package/bin/agent-relay-broker-linux-x64
\`\`\`

But \`getBrokerBinaryPath()\` only searched \`packages/sdk/bin/\`. That directory is populated by \`scripts/postinstall.js\` copying from the top-level \`bin/\`. Any environment that skips postinstall (\`--ignore-scripts\`, Bun, pnpm policies, corporate proxies blocking the fallback download) ends up with \`packages/sdk/bin/\` empty, the resolver returns \`null\`, \`AgentRelayClient.spawn()\` falls back to the bare string \`'agent-relay-broker'\`, and Node emits:

\`\`\`
spawn agent-relay-broker ENOENT (pid=unknown; cwd=...; command=agent-relay-broker init --name ... --channels general; stdout_tail=<empty>; stderr_tail=<empty>)
\`\`\`

even though the binary is sitting right there in the install.

**Fix**: walk up to 6 ancestors of the SDK module and also check \`bin/agent-relay-broker\` and \`bin/agent-relay-broker-{platform}-{arch}\`. The resolver now finds the shipped binary directly — no postinstall copy required. Dev checkouts are unaffected because the source-checkout Cargo path is still tried first.

## Test plan

Verified against the real published tarball (\`agent-relay@4.0.37\`) unpacked with \`--ignore-scripts\`:

- [x] \`broker-path.js\` loaded from \`package/packages/sdk/dist/\` → resolves to \`package/bin/agent-relay-broker-darwin-arm64\`.
- [x] \`broker-path.js\` loaded from \`package/node_modules/@agent-relay/sdk/dist/\` (bundled-dep layout) → same result.
- [x] Dev checkout (\`/Users/will/Projects/relay/packages/sdk/dist/broker-path.js\`) → still resolves to \`target/release/agent-relay-broker\` (source-checkout path still wins).
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
