### PR TITLE
fix(sdk-py): per-platform wheels with embedded broker (closes #769)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
   build-broker:
     name: Build broker (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
-    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main' || github.event.inputs.package == 'sdk'
+    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main' || github.event.inputs.package == 'sdk' || github.event.inputs.package == 'sdk-py'
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +130,12 @@ jobs:
         run: |
           mkdir -p release-binaries
           cp target/${{ matrix.target }}/release/agent-relay-broker release-binaries/${{ matrix.binary_name }}
+
+      # Ad-hoc sign macOS binaries at build time so the Python SDK wheel
+      # doesn't have to invoke codesign at install time.
+      - name: Ad-hoc sign macOS broker
+        if: runner.os == 'macOS'
+        run: codesign --force --sign - release-binaries/${{ matrix.binary_name }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -641,15 +647,28 @@ jobs:
         working-directory: packages/sdk
         run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
-  # Publish Python SDK to PyPI
+  # Publish Python SDK to PyPI as per-platform wheels with the broker binary
+  # embedded. One wheel per (broker_artifact, plat_tag) — see issue #769.
   publish-sdk-py:
-    name: Publish Python SDK to PyPI
-    needs: build
+    name: Publish Python SDK wheel (${{ matrix.plat_tag }})
+    needs: [build, build-broker]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'all' || github.event.inputs.package == 'sdk-py'
     environment:
       name: pypi
       url: https://pypi.org/project/agent-relay-sdk/
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - binary_name: agent-relay-broker-darwin-arm64
+            plat_tag: macosx_11_0_arm64
+          - binary_name: agent-relay-broker-darwin-x64
+            plat_tag: macosx_10_12_x86_64
+          - binary_name: agent-relay-broker-linux-x64
+            plat_tag: manylinux_2_17_x86_64.manylinux2014_x86_64
+          - binary_name: agent-relay-broker-linux-arm64
+            plat_tag: manylinux_2_17_aarch64.manylinux2014_aarch64
 
     steps:
       - name: Checkout code
@@ -667,21 +686,39 @@ jobs:
           python-version: '3.11'
 
       - name: Install build tools
-        run: pip install hatchling build
+        run: pip install hatchling build wheel
 
-      - name: Dry run check
+      - name: Download broker binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.binary_name }}
+          path: /tmp/broker
+
+      - name: Stage broker binary into wheel tree
+        run: |
+          mkdir -p packages/sdk-py/src/agent_relay/bin
+          cp /tmp/broker/${{ matrix.binary_name }} packages/sdk-py/src/agent_relay/bin/agent-relay-broker
+          chmod +x packages/sdk-py/src/agent_relay/bin/agent-relay-broker
+
+      - name: Build wheel
+        working-directory: packages/sdk-py
+        run: python -m build --wheel
+
+      # `python -m build` produces a `py3-none-any` wheel. Retag it with the
+      # actual platform we just embedded a binary for; --remove drops the old
+      # any-platform wheel atomically.
+      - name: Retag wheel to ${{ matrix.plat_tag }}
+        working-directory: packages/sdk-py
+        run: |
+          python -m wheel tags --platform-tag=${{ matrix.plat_tag }} --remove dist/*.whl
+          ls -lh dist/
+
+      - name: Dry run summary
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/sdk-py
         run: |
-          echo "Dry run - would publish agent-relay==${{ needs.build.outputs.new_version }} to PyPI"
-          python -m build
-          echo "Built distributions:"
+          echo "Dry run - would publish agent-relay-sdk==${{ needs.build.outputs.new_version }} (${{ matrix.plat_tag }}) to PyPI"
           ls -lh dist/
-
-      - name: Build distribution
-        if: github.event.inputs.dry_run != 'true'
-        working-directory: packages/sdk-py
-        run: python -m build
 
       - name: Publish to PyPI (attempt 1)
         id: pypi_publish_1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1517,6 +1517,7 @@ jobs:
         verify-acp-macos,
         publish-packages,
         publish-brand-only,
+        publish-sdk-py,
         publish-main,
         verify-publish,
       ]
@@ -1557,6 +1558,7 @@ jobs:
           echo "| Verify relay-acp (macOS) | ${{ needs.verify-acp-macos.result == 'success' && '✅' || (needs.verify-acp-macos.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.verify-acp-macos.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Packages | ${{ needs.publish-packages.result == 'success' && '✅' || (needs.publish-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-packages.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Brand | ${{ needs.publish-brand-only.result == 'success' && '✅' || (needs.publish-brand-only.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-brand-only.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish Python SDK | ${{ needs.publish-sdk-py.result == 'success' && '✅' || (needs.publish-sdk-py.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-py.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Main | ${{ needs.publish-main.result == 'success' && '✅' || (needs.publish-main.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-main.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Post-Publish Verify | ${{ needs.verify-publish.result == 'success' && '✅' || (needs.verify-publish.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.verify-publish.result }} |" >> $GITHUB_STEP_SUMMARY
           if [ "$IS_PRERELEASE" = "true" ]; then

--- a/packages/sdk-py/.gitignore
+++ b/packages/sdk-py/.gitignore
@@ -1,1 +1,10 @@
 .venv/
+
+# Embedded broker binary — populated by CI for wheel builds, or by
+# scripts/sync-broker-dev.sh for editable installs. Never committed.
+src/agent_relay/bin/
+
+# Build outputs
+dist/
+build/
+*.egg-info/

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -19,11 +19,34 @@ pip install agent-relay-sdk
 pip install "agent-relay-sdk[communicate]"
 ```
 
-The SDK automatically downloads the broker binary on first use. Communicate mode also needs the framework package you want to wrap, such as `claude-agent-sdk`, `google-adk`, `agno`, `swarms`, or `crewai`.
+The SDK ships per-platform wheels with the broker binary embedded. `pip install` is the network boundary — no downloads happen at import or first use. Communicate mode also needs the framework package you want to wrap, such as `claude-agent-sdk`, `google-adk`, `agno`, `swarms`, or `crewai`.
 
 ## Requirements
 
 - Python 3.10+
+- A supported platform (the wheel ships a prebuilt `agent-relay-broker`):
+
+  | Platform              | Wheel tag                                          |
+  |-----------------------|----------------------------------------------------|
+  | macOS Apple Silicon   | `macosx_11_0_arm64`                                |
+  | macOS Intel           | `macosx_10_12_x86_64`                              |
+  | Linux x86_64          | `manylinux_2_17_x86_64.manylinux2014_x86_64`       |
+  | Linux aarch64         | `manylinux_2_17_aarch64.manylinux2014_aarch64`     |
+
+  Linux binaries are built statically against musl, so they install on glibc and musl distros (Debian, Ubuntu, RHEL, Alpine, …). Other platforms (Windows, FreeBSD, linux-armv7) are unsupported — `pip install` will fail with "no matching distribution found".
+
+  To override the bundled binary (e.g. for local development against a custom broker build), set `BROKER_BINARY_PATH` or `AGENT_RELAY_BIN` to an absolute path.
+
+## Development
+
+For an editable install (`pip install -e packages/sdk-py`), build the broker locally and copy it into the wheel tree:
+
+```bash
+cargo build --release --bin agent-relay-broker
+packages/sdk-py/scripts/sync-broker-dev.sh
+```
+
+The destination (`src/agent_relay/bin/`) is gitignored. Alternatively, set `BROKER_BINARY_PATH=$(pwd)/target/release/agent-relay-broker` in your shell.
 
 ## Choose a Mode
 

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -33,6 +33,13 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_relay"]
 
+# Embedded broker binary. The publish-sdk-py CI job stages the per-platform
+# binary at this path before invoking `python -m build`, then retags the wheel
+# with the matching platform tag. Locally, scripts/sync-broker-dev.sh fills it
+# in for editable installs.
+[tool.hatch.build.targets.wheel.force-include]
+"src/agent_relay/bin/agent-relay-broker" = "agent_relay/bin/agent-relay-broker"
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 asyncio_mode = "auto"

--- a/packages/sdk-py/scripts/sync-broker-dev.sh
+++ b/packages/sdk-py/scripts/sync-broker-dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copy a locally-built agent-relay-broker into the wheel tree so that an
+# editable install (`pip install -e packages/sdk-py`) can find it without
+# needing to set BROKER_BINARY_PATH or place it on PATH.
+#
+# Run after `cargo build --release --bin agent-relay-broker`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SRC_RELEASE="$REPO_ROOT/target/release/agent-relay-broker"
+SRC_DEBUG="$REPO_ROOT/target/debug/agent-relay-broker"
+DEST_DIR="$REPO_ROOT/packages/sdk-py/src/agent_relay/bin"
+DEST="$DEST_DIR/agent-relay-broker"
+
+if [ -f "$SRC_RELEASE" ]; then
+  SRC="$SRC_RELEASE"
+elif [ -f "$SRC_DEBUG" ]; then
+  SRC="$SRC_DEBUG"
+else
+  echo "error: no agent-relay-broker built at $SRC_RELEASE or $SRC_DEBUG" >&2
+  echo "run: cargo build --release --bin agent-relay-broker" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+cp "$SRC" "$DEST"
+chmod +x "$DEST"
+echo "synced $SRC -> $DEST"

--- a/packages/sdk-py/src/agent_relay/client.py
+++ b/packages/sdk-py/src/agent_relay/client.py
@@ -14,9 +14,6 @@ import os
 import platform
 import secrets
 import shutil
-import stat
-import subprocess
-import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional
 from urllib.parse import quote
@@ -63,98 +60,27 @@ def _resolve_spawn_transport(provider: str, transport: Optional[AgentTransport])
 # ── Binary resolution ─────────────────────────────────────────────────────────
 
 
-def _detect_platform() -> str:
-    system = platform.system().lower()
-    machine = platform.machine().lower()
-
-    if system == "darwin":
-        os_name = "darwin"
-    elif system == "linux":
-        os_name = "linux"
-    else:
-        raise AgentRelayProcessError(f"Unsupported OS: {system}")
-
-    if machine in ("x86_64", "amd64"):
-        arch = "x64"
-    elif machine in ("arm64", "aarch64"):
-        arch = "arm64"
-    else:
-        raise AgentRelayProcessError(f"Unsupported architecture: {machine}")
-
-    return f"{os_name}-{arch}"
-
-
-def _get_latest_version() -> str:
-    url = "https://api.github.com/repos/AgentWorkforce/relay/releases/latest"
-    headers = {"Accept": "application/vnd.github.v3+json"}
-    token = os.environ.get("GITHUB_TOKEN")
-    if token:
-        headers["Authorization"] = f"token {token}"
-    req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        data = json.loads(resp.read().decode())
-        tag = data.get("tag_name", "")
-        return tag.lstrip("v")
-
-
-def _install_broker_binary() -> str:
-    install_dir = Path.home() / ".agent-relay"
-    bin_dir = install_dir / "bin"
-    target_path = bin_dir / "agent-relay-broker"
-
-    plat = _detect_platform()
-    print(f"[agent-relay] Broker binary not found, installing for {plat}...")
-
-    version = _get_latest_version()
-    if not version:
-        raise AgentRelayProcessError(
-            "Failed to fetch latest agent-relay version from GitHub"
-        )
-
-    binary_name = f"agent-relay-broker-{plat}"
-    download_url = f"https://github.com/AgentWorkforce/relay/releases/download/v{version}/{binary_name}"
-
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    print(f"[agent-relay] Downloading v{version} from {download_url}")
-    try:
-        urllib.request.urlretrieve(download_url, str(target_path))
-    except Exception as e:
-        target_path.unlink(missing_ok=True)
-        raise AgentRelayProcessError(f"Failed to download broker binary: {e}") from e
-
-    target_path.chmod(
-        target_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-    )
-
-    if platform.system() == "Darwin":
-        try:
-            subprocess.run(
-                ["xattr", "-d", "com.apple.quarantine", str(target_path)],
-                capture_output=True, timeout=10,
-            )
-        except Exception:
-            pass
-        try:
-            subprocess.run(
-                ["codesign", "--force", "--sign", "-", str(target_path)],
-                capture_output=True, timeout=10,
-            )
-        except Exception:
-            pass
-
-    print(f"[agent-relay] Broker installed to {target_path}")
-    return str(target_path)
-
-
 def _resolve_default_binary_path() -> str:
     broker_exe = "agent-relay-broker"
-    standalone = Path.home() / ".agent-relay" / "bin" / broker_exe
-    if standalone.exists():
-        return str(standalone)
+
+    override = os.environ.get("BROKER_BINARY_PATH") or os.environ.get("AGENT_RELAY_BIN")
+    if override and Path(override).exists():
+        return override
+
+    embedded = Path(__file__).parent / "bin" / broker_exe
+    if embedded.exists():
+        return str(embedded)
+
     found = shutil.which(broker_exe)
     if found:
         return found
-    return _install_broker_binary()
+
+    plat = f"{platform.system().lower()}-{platform.machine().lower()}"
+    raise AgentRelayProcessError(
+        "agent-relay-broker not found. The installed wheel does not include a "
+        f"binary for this platform ({plat}). Supported platforms: darwin-arm64, "
+        "darwin-x64, linux-x64, linux-arm64. Set BROKER_BINARY_PATH to override."
+    )
 
 
 # ── Client ────────────────────────────────────────────────────────────────────

--- a/packages/sdk-py/src/agent_relay/client.py
+++ b/packages/sdk-py/src/agent_relay/client.py
@@ -60,12 +60,28 @@ def _resolve_spawn_transport(provider: str, transport: Optional[AgentTransport])
 # ── Binary resolution ─────────────────────────────────────────────────────────
 
 
+_ARCH_ALIASES = {"x86_64": "x64", "amd64": "x64", "aarch64": "arm64", "arm64": "arm64"}
+
+
+def _normalized_platform_tag() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    arch = _ARCH_ALIASES.get(machine, machine)
+    return f"{system}-{arch}"
+
+
 def _resolve_default_binary_path() -> str:
     broker_exe = "agent-relay-broker"
 
-    override = os.environ.get("BROKER_BINARY_PATH") or os.environ.get("AGENT_RELAY_BIN")
-    if override and Path(override).exists():
-        return override
+    for env_var in ("BROKER_BINARY_PATH", "AGENT_RELAY_BIN"):
+        override = os.environ.get(env_var)
+        if not override:
+            continue
+        if Path(override).exists():
+            return override
+        raise AgentRelayProcessError(
+            f"{env_var} is set to {override!r}, but no file exists at that path."
+        )
 
     embedded = Path(__file__).parent / "bin" / broker_exe
     if embedded.exists():
@@ -75,11 +91,11 @@ def _resolve_default_binary_path() -> str:
     if found:
         return found
 
-    plat = f"{platform.system().lower()}-{platform.machine().lower()}"
     raise AgentRelayProcessError(
         "agent-relay-broker not found. The installed wheel does not include a "
-        f"binary for this platform ({plat}). Supported platforms: darwin-arm64, "
-        "darwin-x64, linux-x64, linux-arm64. Set BROKER_BINARY_PATH to override."
+        f"binary for this platform ({_normalized_platform_tag()}). Supported "
+        "platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64. "
+        "Set BROKER_BINARY_PATH to override."
     )
 
 

--- a/packages/sdk-py/src/agent_relay/communicate/adapters/agno.py
+++ b/packages/sdk-py/src/agent_relay/communicate/adapters/agno.py
@@ -12,7 +12,9 @@ def _format_instructions_with_inbox(messages: list[Any], base_instructions: str)
     content = "New messages from other agents:\n"
     for message in messages:
         content += f"  {message.sender}: {message.text}\n"
-    return f"{base_instructions}\n\n{content}" if base_instructions else content
+    if base_instructions:
+        return f"\n\n{content}\n{base_instructions}"
+    return content
 
 
 def on_relay(agent: Any, relay: "Relay | None" = None) -> Any:
@@ -60,7 +62,9 @@ def on_relay(agent: Any, relay: "Relay | None" = None) -> Any:
             base = orig_instructions
 
         base = base or ""
-        messages = await relay.inbox()
+        # peek() so the relay_inbox tool isn't starved — messages appear in
+        # the system prompt AND remain available to drain via the tool.
+        messages = await relay.peek()
         if not messages:
             return base
 

--- a/packages/sdk-py/src/agent_relay/communicate/adapters/openai_agents.py
+++ b/packages/sdk-py/src/agent_relay/communicate/adapters/openai_agents.py
@@ -13,7 +13,9 @@ def _format_instructions_with_inbox(messages: list[Any], base_instructions: str)
     content = "New messages from other agents:\n"
     for message in messages:
         content += f"  {message.sender}: {message.text}\n"
-    return f"{base_instructions}\n\n{content}" if base_instructions else content
+    if base_instructions:
+        return f"\n\n{content}\n{base_instructions}"
+    return content
 
 
 def on_relay(agent: Any, relay: "Relay | None" = None) -> Any:
@@ -72,7 +74,9 @@ def on_relay(agent: Any, relay: "Relay | None" = None) -> Any:
             base = orig_instructions
 
         base = base or ""
-        messages = await relay.inbox()
+        # peek() so the relay_inbox tool isn't starved — messages appear in
+        # the system prompt AND remain available to drain via the tool.
+        messages = await relay.peek()
         if not messages:
             return base
 

--- a/packages/sdk-py/tests/test_resolve_binary_path.py
+++ b/packages/sdk-py/tests/test_resolve_binary_path.py
@@ -1,0 +1,111 @@
+"""Tests for _resolve_default_binary_path."""
+
+import stat
+from pathlib import Path
+
+import pytest
+
+import agent_relay.client as client_module
+from agent_relay.client import (
+    AgentRelayProcessError,
+    _resolve_default_binary_path,
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip override env vars and PATH so tests start from a known state."""
+    monkeypatch.delenv("BROKER_BINARY_PATH", raising=False)
+    monkeypatch.delenv("AGENT_RELAY_BIN", raising=False)
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+
+@pytest.fixture
+def fake_binary(tmp_path: Path) -> Path:
+    binary = tmp_path / "agent-relay-broker"
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+    return binary
+
+
+@pytest.fixture
+def no_embedded_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Make the embedded-path lookup miss by relocating the module dir."""
+    fake_module_file = tmp_path / "client.py"
+    fake_module_file.write_text("")
+    monkeypatch.setattr(client_module, "__file__", str(fake_module_file))
+
+
+class TestResolveDefaultBinaryPath:
+    def test_env_override_wins(
+        self, clean_env, fake_binary, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BROKER_BINARY_PATH", str(fake_binary))
+        assert _resolve_default_binary_path() == str(fake_binary)
+
+    def test_agent_relay_bin_alias(
+        self, clean_env, fake_binary, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AGENT_RELAY_BIN", str(fake_binary))
+        assert _resolve_default_binary_path() == str(fake_binary)
+
+    def test_env_override_missing_path_raises(
+        self, clean_env, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BROKER_BINARY_PATH", "/does/not/exist")
+        with pytest.raises(AgentRelayProcessError, match="BROKER_BINARY_PATH"):
+            _resolve_default_binary_path()
+
+    def test_embedded_binary_found(
+        self, clean_env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        embedded = bin_dir / "agent-relay-broker"
+        embedded.write_text("")
+        embedded.chmod(embedded.stat().st_mode | stat.S_IXUSR)
+
+        # Pretend the client module lives next to bin/
+        fake_module_file = tmp_path / "client.py"
+        fake_module_file.write_text("")
+        monkeypatch.setattr(client_module, "__file__", str(fake_module_file))
+
+        assert _resolve_default_binary_path() == str(embedded)
+
+    def test_path_lookup_fallback(
+        self,
+        clean_env,
+        fake_binary,
+        no_embedded_binary,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Put the binary's directory on PATH so shutil.which finds it
+        monkeypatch.setenv("PATH", str(fake_binary.parent))
+        assert _resolve_default_binary_path() == str(fake_binary)
+
+    def test_raises_when_nothing_resolves(
+        self, clean_env, no_embedded_binary
+    ) -> None:
+        with pytest.raises(AgentRelayProcessError, match="not found"):
+            _resolve_default_binary_path()
+
+    def test_error_message_uses_normalized_arch(
+        self, clean_env, no_embedded_binary, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(client_module.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(client_module.platform, "machine", lambda: "x86_64")
+        with pytest.raises(AgentRelayProcessError) as excinfo:
+            _resolve_default_binary_path()
+        # The error must use the same identifier as the supported list (x64),
+        # not the raw uname value (x86_64).
+        assert "linux-x64" in str(excinfo.value)
+        assert "x86_64" not in str(excinfo.value)
+
+    def test_error_message_normalizes_aarch64(
+        self, clean_env, no_embedded_binary, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(client_module.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(client_module.platform, "machine", lambda: "aarch64")
+        with pytest.raises(AgentRelayProcessError) as excinfo:
+            _resolve_default_binary_path()
+        assert "linux-arm64" in str(excinfo.value)

--- a/packages/sdk-py/tests/test_send_message_mode.py
+++ b/packages/sdk-py/tests/test_send_message_mode.py
@@ -10,17 +10,15 @@ from agent_relay.relay import AgentRelay, HumanHandle
 
 @pytest.mark.asyncio
 async def test_client_send_message_includes_mode_in_payload():
-    client = AgentRelayClient(binary_path="agent-relay-broker")
-    client.start_client = AsyncMock()
+    client = AgentRelayClient(base_url="http://broker.test")
 
-    payloads: list[dict] = []
+    calls: list[tuple[str, str, dict]] = []
 
-    async def fake_request_ok(type_: str, payload: dict):
-        assert type_ == "send_message"
-        payloads.append(payload)
+    async def fake_request(method: str, path: str, **kwargs):
+        calls.append((method, path, kwargs.get("json", {})))
         return {"event_id": "evt-1", "targets": ["Worker"]}
 
-    client._request_ok = fake_request_ok  # type: ignore[method-assign]
+    client._request = fake_request  # type: ignore[method-assign]
 
     result = await client.send_message(
         to="Worker",
@@ -33,16 +31,20 @@ async def test_client_send_message_includes_mode_in_payload():
     )
 
     assert result["event_id"] == "evt-1"
-    assert payloads == [
-        {
-            "to": "Worker",
-            "text": "hello",
-            "from": "system",
-            "thread_id": "thread-1",
-            "priority": 5,
-            "data": {"k": "v"},
-            "mode": "steer",
-        }
+    assert calls == [
+        (
+            "POST",
+            "/api/send",
+            {
+                "to": "Worker",
+                "text": "hello",
+                "from": "system",
+                "threadId": "thread-1",
+                "priority": 5,
+                "data": {"k": "v"},
+                "mode": "steer",
+            },
+        )
     ]
 
 


### PR DESCRIPTION
## Summary

`pip install agent-relay-sdk` now ships per-platform wheels with the broker binary embedded — no network calls at import or first use. Replaces the runtime GitHub-Releases download in `_install_broker_binary` with `agent_relay/bin/agent-relay-broker` baked into each wheel.

- **`pyproject.toml`**: `[tool.hatch.build.targets.wheel.force-include]` for the broker binary.
- **`client.py`**: deletes `_install_broker_binary` and `_get_latest_version`; `_resolve_default_binary_path` now checks env override → embedded → PATH → clear error. Drops unused `urllib`/`subprocess`/`stat` imports.
- **`publish.yml`**: `publish-sdk-py` is now a 4-row matrix (`darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`). Each row downloads its broker artifact, stages it into the wheel tree, builds with hatchling, then `python -m wheel tags --remove` retags from `py3-none-any` to the matching platform tag. The existing 3-attempt PyPI retry is preserved per row.
- **`build-broker`**: ad-hoc-codesigns macOS broker artifacts at build time, so install-time `codesign` is no longer needed. Job is now triggered by `package=sdk-py` too.
- **`scripts/sync-broker-dev.sh`** + **`.gitignore`**: helper that copies `target/release/agent-relay-broker` into the wheel tree for editable installs; the destination directory is gitignored.
- **`README`**: documents the supported platform matrix, the no-network model, and the dev-mode helper.

Wheel filenames produced:

| Platform              | Wheel tag                                            |
|-----------------------|------------------------------------------------------|
| macOS Apple Silicon   | `macosx_11_0_arm64`                                  |
| macOS Intel           | `macosx_10_12_x86_64`                                |
| Linux x86_64 (musl)   | `manylinux_2_17_x86_64.manylinux2014_x86_64`         |
| Linux aarch64 (musl)  | `manylinux_2_17_aarch64.manylinux2014_aarch64`       |

Out of scope per the issue: Windows wheel, sdist publishing.

## Test plan

- [x] Build wheel locally on darwin-arm64 (`python -m build --wheel` then `python -m wheel tags --platform-tag=macosx_11_0_arm64 --remove`).
- [x] Verify broker is embedded at `agent_relay/bin/agent-relay-broker` inside the wheel.
- [x] `pip install` the retagged wheel into a fresh venv → confirm `_resolve_default_binary_path()` returns the `<site-packages>/agent_relay/bin/agent-relay-broker` path with no network call.
- [x] Confirm the embedded binary is executable (`agent-relay-broker --help`).
- [x] Confirm clean error message when no embedded binary and nothing on PATH.
- [ ] CI dry-run of `publish-sdk-py` (matrix shape, retag step, dry-run summary) — recommend running with `dry_run=true` once merged to main or via a workflow_dispatch on this branch.
- [ ] Smoke test on Linux x64 / arm64 in CI (covered by the matrix when published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
