### PR TITLE
fix: use workflow db home fallback in cloud

### DIFF
--- a/packages/sdk/src/__tests__/file-db.test.ts
+++ b/packages/sdk/src/__tests__/file-db.test.ts
@@ -13,7 +13,7 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import os from 'node:os';
 import path from 'node:path';
 
-import { JsonFileWorkflowDb } from '../workflows/file-db.js';
+import { JsonFileWorkflowDb, shouldUseWorkflowDbHomeFallback } from '../workflows/file-db.js';
 import type { WorkflowRunRow, WorkflowStepRow } from '../workflows/types.js';
 
 function makeRun(overrides: Partial<WorkflowRunRow> = {}): WorkflowRunRow {
@@ -47,6 +47,23 @@ describe('JsonFileWorkflowDb', () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'filedb-test-'));
+  });
+
+  it('enables home fallback for cloud and relayfile workflow environments', () => {
+    expect(shouldUseWorkflowDbHomeFallback({ DAYTONA_SANDBOX_ID: 'sandbox-id' })).toBe(true);
+    expect(shouldUseWorkflowDbHomeFallback({ RELAY_CLOUD_PROVISIONING_DONE: '1' })).toBe(true);
+    expect(
+      shouldUseWorkflowDbHomeFallback({
+        RELAYFILE_TOKEN: 'token',
+        RELAYFILE_WORKSPACE_ID: 'rw_test123',
+      })
+    ).toBe(true);
+    expect(
+      shouldUseWorkflowDbHomeFallback({
+        RELAYFILE_TOKEN: 'token',
+      })
+    ).toBe(false);
+    expect(shouldUseWorkflowDbHomeFallback({})).toBe(false);
   });
 
   afterEach(() => {

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -21,7 +21,7 @@ import type {
   WorkflowRunRow,
   WorkflowStep,
 } from './types.js';
-import { JsonFileWorkflowDb } from './file-db.js';
+import { JsonFileWorkflowDb, shouldUseWorkflowDbHomeFallback } from './file-db.js';
 import { WorkflowRunner, type WorkflowEventListener, type RunnerStepExecutor } from './runner.js';
 import { formatDryRunReport } from './dry-run-format.js';
 import { createDefaultEventLogger, type LogLevel } from './default-logger.js';
@@ -408,7 +408,10 @@ export class WorkflowBuilder {
     const config = this.toConfig();
     const runnerCwd = options.cwd ?? process.cwd();
     const dbPath = path.join(runnerCwd, '.agent-relay', 'workflow-runs.jsonl');
-    const db = new JsonFileWorkflowDb(dbPath);
+    const db = new JsonFileWorkflowDb({
+      filePath: dbPath,
+      homeFallback: shouldUseWorkflowDbHomeFallback(),
+    });
 
     const runner = new WorkflowRunner({
       cwd: options.cwd,

--- a/packages/sdk/src/workflows/cli.ts
+++ b/packages/sdk/src/workflows/cli.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 
 import type { WorkflowEvent } from './runner.js';
 import { WorkflowRunner } from './runner.js';
-import { JsonFileWorkflowDb } from './file-db.js';
+import { JsonFileWorkflowDb, shouldUseWorkflowDbHomeFallback } from './file-db.js';
 
 function printUsage(): void {
   console.log(
@@ -328,7 +328,10 @@ async function main(): Promise<void> {
 
   // Use a file-backed DB so runs survive process restarts and --resume works.
   const dbPath = path.join(process.cwd(), '.agent-relay', 'workflow-runs.jsonl');
-  const fileDb = new JsonFileWorkflowDb(dbPath);
+  const fileDb = new JsonFileWorkflowDb({
+    filePath: dbPath,
+    homeFallback: shouldUseWorkflowDbHomeFallback(),
+  });
   if (!fileDb.isWritable()) {
     console.warn(
       `[workflow] warning: cannot write to ${dbPath} — run state will not be persisted (--resume unavailable)`

--- a/packages/sdk/src/workflows/file-db.ts
+++ b/packages/sdk/src/workflows/file-db.ts
@@ -40,6 +40,16 @@ export interface JsonFileWorkflowDbOptions {
   homeFallback?: boolean;
 }
 
+export function shouldUseWorkflowDbHomeFallback(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.DAYTONA_SANDBOX_ID || env.RELAY_CLOUD_PROVISIONING_DONE === '1') {
+    return true;
+  }
+
+  return Boolean(
+    env.RELAYFILE_TOKEN && (env.RELAYFILE_WORKSPACE_ID || env.RELAYFILE_WORKSPACE || env.RELAY_WORKSPACE_ID)
+  );
+}
+
 /**
  * JSONL-backed WorkflowDb for the CLI.
  *


### PR DESCRIPTION
## Summary
- add cloud/relayfile environment detection for workflow DB home fallback
- enable that fallback from both `WorkflowBuilder.run()` and the workflow CLI
- cover the detector in `file-db.test.ts`

## Why
Cloud and relayfile-mounted workspaces can make `.agent-relay/workflow-runs.jsonl` read-only. The JSONL DB already has a home fallback; the builder and CLI just were not opting into it, so cloud runs lost resume state with EACCES warnings.

## Validation
- `npm --prefix packages/sdk run check`
- `cd packages/sdk && npx vitest run src/__tests__/file-db.test.ts`

## Sequence
Independent relay-side fix. It complements the cloud filesystem PRs by preserving workflow run state outside the mounted workspace.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
