### PR TITLE
feat(sdk): bundle @agent-relay/github-primitive at /github subpath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,13 @@
 {
   "name": "agent-relay",
-  "version": "5.0.0",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "bundleDependencies": [
-        "@agent-relay/cloud",
-        "@agent-relay/config",
-        "@agent-relay/hooks",
-        "@agent-relay/sdk",
-        "@agent-relay/telemetry",
-        "@agent-relay/trajectory",
-        "@agent-relay/user-directory",
-        "@agent-relay/utils",
         "@relaycast/sdk",
         "@relayfile/local-mount"
       ],
@@ -26,14 +18,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "5.0.0",
-        "@agent-relay/config": "5.0.0",
-        "@agent-relay/hooks": "5.0.0",
-        "@agent-relay/sdk": "5.0.0",
-        "@agent-relay/telemetry": "5.0.0",
-        "@agent-relay/trajectory": "5.0.0",
-        "@agent-relay/user-directory": "5.0.0",
-        "@agent-relay/utils": "5.0.0",
+        "@agent-relay/cloud": "6.0.2",
+        "@agent-relay/config": "6.0.2",
+        "@agent-relay/hooks": "6.0.2",
+        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/telemetry": "6.0.2",
+        "@agent-relay/trajectory": "6.0.2",
+        "@agent-relay/user-directory": "6.0.2",
+        "@agent-relay/utils": "6.0.2",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -5688,7 +5680,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5709,7 +5701,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7189,7 +7181,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -13098,7 +13090,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -15432,10 +15424,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "5.0.0",
+        "@agent-relay/sdk": "6.0.2",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15451,38 +15443,38 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "5.0.0"
+      "version": "6.0.2"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/browser-primitive": {
       "name": "@agent-relay/browser-primitive",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/sdk": "5.0.0",
+        "@agent-relay/sdk": "6.0.2",
         "playwright": "^1.51.1"
       },
       "bin": {
@@ -15496,9 +15488,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0",
+        "@agent-relay/config": "6.0.2",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15510,7 +15502,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15522,7 +15514,7 @@
     },
     "packages/credential-proxy": {
       "name": "@agent-relay/credential-proxy",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
         "hono": "^4.11.4",
         "jose": "^6.1.3"
@@ -15533,9 +15525,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/sdk": "5.0.0"
+        "@agent-relay/sdk": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15544,9 +15536,9 @@
     },
     "packages/github-primitive": {
       "name": "@agent-relay/github-primitive",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/workflow-types": "5.0.0"
+        "@agent-relay/workflow-types": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15556,11 +15548,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0",
-        "@agent-relay/sdk": "5.0.0",
-        "@agent-relay/trajectory": "5.0.0"
+        "@agent-relay/config": "6.0.2",
+        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/trajectory": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15569,9 +15561,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/hooks": "5.0.0"
+        "@agent-relay/hooks": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15580,11 +15572,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "5.0.0",
+        "@agent-relay/sdk": "6.0.2",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16349,9 +16341,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0"
+        "@agent-relay/config": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16360,11 +16352,11 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0",
-        "@agent-relay/github-primitive": "5.0.0",
-        "@agent-relay/workflow-types": "5.0.0",
+        "@agent-relay/config": "6.0.2",
+        "@agent-relay/github-primitive": "6.0.2",
+        "@agent-relay/workflow-types": "6.0.2",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -16382,14 +16374,14 @@
         "@types/ws": "^8.5.10"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "5.0.0",
-        "@agent-relay/broker-darwin-x64": "5.0.0",
-        "@agent-relay/broker-linux-arm64": "5.0.0",
-        "@agent-relay/broker-linux-x64": "5.0.0",
-        "@agent-relay/broker-win32-x64": "5.0.0"
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "5.0.0",
+        "@agent-relay/credential-proxy": "6.0.2",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -16427,7 +16419,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
         "posthog-node": "^5.29.2"
       },
@@ -16462,9 +16454,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0"
+        "@agent-relay/config": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16473,9 +16465,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/utils": "5.0.0"
+        "@agent-relay/utils": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16484,9 +16476,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/config": "5.0.0",
+        "@agent-relay/config": "6.0.2",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {
@@ -16496,7 +16488,7 @@
     },
     "packages/workflow-types": {
       "name": "@agent-relay/workflow-types",
-      "version": "5.0.0"
+      "version": "6.0.2"
     },
     "web": {
       "version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,10 @@
       "resolved": "packages/utils",
       "link": true
     },
+    "node_modules/@agent-relay/workflow-types": {
+      "resolved": "packages/workflow-types",
+      "link": true
+    },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.12.0.tgz",
@@ -5665,7 +5669,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5686,7 +5690,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7166,7 +7170,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -13075,7 +13079,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -15446,15 +15450,6 @@
         "vitest": "^3.2.4"
       }
     },
-    "packages/browser-primitive/node_modules/@agent-relay/config": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.9.tgz",
-      "integrity": "sha512-bSYU1q/mCpbNScGCjo32GOi22+TIkVy96vzaLwXkyZrv+hsVlIGtIlpZe3GCYRK+hvKizKTsXc9V0PHaNR8d8Q==",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
-      }
-    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
       "version": "5.0.0",
@@ -15507,21 +15502,12 @@
       "name": "@agent-relay/github-primitive",
       "version": "5.0.0",
       "dependencies": {
-        "@agent-relay/sdk": "5.0.0"
+        "@agent-relay/workflow-types": "5.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/github-primitive/node_modules/@agent-relay/config": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.9.tgz",
-      "integrity": "sha512-bSYU1q/mCpbNScGCjo32GOi22+TIkVy96vzaLwXkyZrv+hsVlIGtIlpZe3GCYRK+hvKizKTsXc9V0PHaNR8d8Q==",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
       }
     },
     "packages/hooks": {
@@ -16333,6 +16319,8 @@
       "version": "5.0.0",
       "dependencies": {
         "@agent-relay/config": "5.0.0",
+        "@agent-relay/github-primitive": "5.0.0",
+        "@agent-relay/workflow-types": "5.0.0",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -16454,6 +16442,10 @@
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
       }
+    },
+    "packages/workflow-types": {
+      "name": "@agent-relay/workflow-types",
+      "version": "5.0.0"
     },
     "web": {
       "version": "0.0.1",

--- a/packages/github-primitive/package.json
+++ b/packages/github-primitive/package.json
@@ -32,7 +32,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-relay/sdk": "5.0.0"
+    "@agent-relay/workflow-types": "5.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/packages/github-primitive/src/workflow-step.ts
+++ b/packages/github-primitive/src/workflow-step.ts
@@ -1,4 +1,4 @@
-import type { RunnerStepExecutor, WorkflowStep } from '@agent-relay/sdk/workflows';
+import type { RunnerStepExecutor, WorkflowStep } from '@agent-relay/workflow-types';
 
 import { GitHubClient } from './client.js';
 import type {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -120,7 +120,7 @@
     "directory": "packages/sdk"
   },
   "scripts": {
-    "prebuild": "npm --prefix ../config run build",
+    "prebuild": "npm --prefix ../workflow-types run build && npm --prefix ../github-primitive run build && npm --prefix ../config run build",
     "build": "npx tsc -p tsconfig.build.json",
     "build:full": "tsc -p tsconfig.json && npm run bundle:binary",
     "bundle:binary": "node ./scripts/bundle-agent-relay.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -101,6 +101,11 @@
       "types": "./dist/broker-path.d.ts",
       "import": "./dist/broker-path.js",
       "default": "./dist/broker-path.js"
+    },
+    "./github": {
+      "types": "./dist/github.d.ts",
+      "import": "./dist/github.js",
+      "default": "./dist/github.js"
     }
   },
   "files": [
@@ -135,6 +140,8 @@
   },
   "dependencies": {
     "@agent-relay/config": "5.0.0",
+    "@agent-relay/github-primitive": "5.0.0",
+    "@agent-relay/workflow-types": "5.0.0",
     "@relaycast/sdk": "^1.1.0",
     "@relayfile/sdk": ">=0.1.2 <1",
     "@sinclair/typebox": "^0.34.48",

--- a/packages/sdk/src/github.ts
+++ b/packages/sdk/src/github.ts
@@ -1,0 +1,17 @@
+/**
+ * Bundled GitHub workflow primitive.
+ *
+ * Re-exports the full surface of `@agent-relay/github-primitive` so
+ * workflow authors can import it from the SDK without a separate
+ * install:
+ *
+ *   import { createGitHubStep, GitHubClient } from '@agent-relay/sdk/github';
+ *
+ * `createGitHubStep` is the one most workflow authors reach for — it
+ * produces an integration-type `.step(...)` config you drop straight
+ * into `workflow(...)`. `GitHubClient` is the underlying typed client;
+ * same methods, runnable outside a workflow too.
+ */
+
+export * from '@agent-relay/github-primitive';
+export * from '@agent-relay/github-primitive/workflow-step';

--- a/packages/sdk/src/github.ts
+++ b/packages/sdk/src/github.ts
@@ -14,4 +14,3 @@
  */
 
 export * from '@agent-relay/github-primitive';
-export * from '@agent-relay/github-primitive/workflow-step';

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -22,7 +22,8 @@ import type {
   WorkflowStep,
 } from './types.js';
 import { JsonFileWorkflowDb } from './file-db.js';
-import { WorkflowRunner, type WorkflowEventListener, type RunnerStepExecutor } from './runner.js';
+import { WorkflowRunner, type WorkflowEventListener } from './runner.js';
+import type { RunnerStepExecutor } from './types.js';
 import { formatDryRunReport } from './dry-run-format.js';
 import { createDefaultEventLogger, type LogLevel } from './default-logger.js';
 import { runInCloud, type CloudRunOptions } from './cloud-runner.js';

--- a/packages/sdk/src/workflows/process-backend-executor.ts
+++ b/packages/sdk/src/workflows/process-backend-executor.ts
@@ -11,8 +11,7 @@
  */
 
 import { buildCommand } from './process-spawner.js';
-import type { ProcessBackend, AgentDefinition, WorkflowStep } from './types.js';
-import type { RunnerStepExecutor } from './runner.js';
+import type { ProcessBackend, AgentDefinition, WorkflowStep, RunnerStepExecutor } from './types.js';
 
 function shellEscape(value: string): string {
   if (value === '') return "''";

--- a/packages/sdk/src/workflows/runner.ts
+++ b/packages/sdk/src/workflows/runner.ts
@@ -107,6 +107,7 @@ import type {
   WorkflowStepRow,
   WorkflowStepStatus,
   ProcessBackend,
+  RunnerStepExecutor,
 } from './types.js';
 import { WorkflowTrajectory, type StepOutcome } from './trajectory.js';
 import {
@@ -309,34 +310,6 @@ export interface WorkflowRunnerOptions {
    * When neither is set, the broker spawns local child processes (default).
    */
   processBackend?: ProcessBackend;
-}
-
-// ── Step executor interface ──────────────────────────────────────────────────
-
-/**
- * Extension point for delegating step execution to an external backend
- * (e.g. Daytona sandboxes) while keeping the runner's DAG/retry/verification
- * machinery intact.
- */
-export interface RunnerStepExecutor {
-  executeAgentStep(
-    step: WorkflowStep,
-    agentDef: AgentDefinition,
-    resolvedTask: string,
-    timeoutMs?: number
-  ): Promise<string>;
-
-  executeDeterministicStep?(
-    step: WorkflowStep,
-    resolvedCommand: string,
-    cwd: string
-  ): Promise<{ output: string; exitCode: number }>;
-
-  executeIntegrationStep?(
-    step: WorkflowStep,
-    resolvedParams: Record<string, string>,
-    context: { workspaceId?: string }
-  ): Promise<{ output: string; success: boolean }>;
 }
 
 // ── Internal step state ─────────────────────────────────────────────────────

--- a/packages/sdk/src/workflows/types.ts
+++ b/packages/sdk/src/workflows/types.ts
@@ -6,6 +6,20 @@
  */
 
 export * from '@agent-relay/workflow-types';
+export type {
+  AccessPreset,
+  AgentCli,
+  AgentDefinition,
+  AgentPermissions,
+  AgentPreset,
+  NetworkPermission,
+  PermissionProfileDefinition,
+  RunnerStepExecutor,
+  SwarmPattern,
+  VerificationCheck,
+  WorkflowStep,
+  WorkflowStepType,
+} from '@agent-relay/workflow-types';
 
 import type {
   AccessPreset,

--- a/packages/sdk/src/workflows/types.ts
+++ b/packages/sdk/src/workflows/types.ts
@@ -5,6 +5,19 @@
  * and database row representations.
  */
 
+export * from '@agent-relay/workflow-types';
+
+import type {
+  AccessPreset,
+  AgentDefinition,
+  AgentPermissions,
+  NetworkPermission,
+  PermissionProfileDefinition,
+  SwarmPattern,
+  WorkflowStep,
+  WorkflowStepType,
+} from '@agent-relay/workflow-types';
+
 // ── relay.yaml top-level config ─────────────────────────────────────────────
 
 /** Top-level relay.yaml configuration file structure. */
@@ -109,233 +122,6 @@ export interface SwarmConfig {
    * Default: 5000 (5 seconds). Set to 0 to disable.
    */
   completionGracePeriodMs?: number;
-}
-
-export type SwarmPattern =
-  | 'fan-out'
-  | 'pipeline'
-  | 'hub-spoke'
-  | 'consensus'
-  | 'mesh'
-  | 'handoff'
-  | 'cascade'
-  | 'dag'
-  | 'debate'
-  | 'hierarchical'
-  // Additional patterns
-  | 'map-reduce'
-  | 'scatter-gather'
-  | 'supervisor'
-  | 'reflection'
-  | 'red-team'
-  | 'verifier'
-  | 'auction'
-  | 'escalation'
-  | 'saga'
-  | 'circuit-breaker'
-  | 'blackboard'
-  | 'swarm'
-  | 'competitive'
-  | 'review-loop';
-
-// ── Agent definitions ───────────────────────────────────────────────────────
-
-export type AgentPreset = 'lead' | 'worker' | 'reviewer' | 'analyst';
-
-/** Optional credential settings for a workflow agent. */
-export interface AgentCredentialConfig {
-  /** Opt the agent into credential proxy mode. */
-  proxy?: boolean;
-  /** Override the provider used for proxy credential resolution. */
-  provider?: string;
-}
-
-/** Definition of an agent participating in a workflow. */
-export interface AgentDefinition {
-  name: string;
-  cli: AgentCli;
-  role?: string;
-  task?: string;
-  channels?: string[];
-  constraints?: AgentConstraints;
-  /**
-   * Permission configuration controlling file access, network, and exec restrictions.
-   * Omitting this field preserves the default behavior: inherit dotfiles + readwrite access.
-   */
-  permissions?: AgentPermissions;
-  /** When false, the agent runs as a non-interactive subprocess (no PTY, no relay messaging).
-   *  It receives its task as a CLI prompt argument and returns stdout as output.
-   *  Default: true (interactive PTY mode). */
-  interactive?: boolean;
-  /** Working directory for this agent, resolved relative to the YAML file. */
-  cwd?: string;
-  /** Sets this agent's working directory to a named entry from the top-level `paths` array.
-   *  Mutually exclusive with `cwd`. If omitted, the agent runs in the runner's
-   *  working directory (the directory containing the workflow YAML file). */
-  workdir?: string;
-  /** Additional paths the agent needs read/write access to. */
-  additionalPaths?: string[];
-  /**
-   * Role preset that automatically configures interactive mode and injects
-   * appropriate task guardrails. Overrides are still accepted.
-   *   lead     → interactive PTY, relay-aware, coordinates workers via channels
-   *   worker   → interactive: false, produces structured output, no sub-agents
-   *   reviewer → interactive: false, reads artifacts, produces verdict, no sub-agents
-   *   analyst  → interactive: false, reads code/files, writes findings, no sub-agents
-   */
-  preset?: AgentPreset;
-  /** Optional credential proxy settings for this agent. */
-  credentials?: AgentCredentialConfig;
-  /** System prompt / skills for API-mode agents (cli: 'api'). */
-  skills?: string;
-}
-
-export type AgentCli =
-  | 'claude'
-  | 'codex'
-  | 'gemini'
-  | 'aider'
-  | 'goose'
-  | 'opencode'
-  | 'droid'
-  | 'cursor'
-  | 'cursor-agent'
-  | 'agent'
-  | 'api';
-
-/** Resource and behavioral constraints for an agent. */
-export interface AgentConstraints {
-  maxTokens?: number;
-  timeoutMs?: number;
-  retries?: number;
-  model?: string;
-  /** Silence duration in seconds before the agent is considered idle (0 = disabled, default: 30). */
-  idleThresholdSecs?: number;
-}
-
-// ── Permission types ────────────────────────────────────────────────────────
-
-/**
- * Access preset for role-based permission shortcuts.
- *
- *   readonly    → read all non-ignored files, write nothing
- *   readwrite   → read and write all non-ignored files (default behavior)
- *   restricted  → read/write only explicitly listed paths
- *   full        → read and write everything, including normally-ignored files
- */
-export type AccessPreset = 'readonly' | 'readwrite' | 'restricted' | 'full';
-
-/** Fine-grained network permission with allowlist/denylist. */
-export interface NetworkPermissions {
-  /** Host:port pairs the agent may connect to (e.g. ['registry.npmjs.org:443']). */
-  allow?: string[];
-  /** Host:port patterns to block (e.g. ['*'] to deny all except allowed). */
-  deny?: string[];
-}
-
-/** Network permission: boolean to allow/deny all, or object for fine-grained control. */
-export type NetworkPermission = boolean | NetworkPermissions;
-
-/** Glob-based file permission scopes for an agent. */
-export interface FilePermissions {
-  /** Glob patterns the agent may read (e.g. ['src/**', 'docs/**']). */
-  read?: string[];
-  /** Glob patterns the agent may write (e.g. ['src/tests/**']). */
-  write?: string[];
-  /** Glob patterns the agent must never access (e.g. ['.env', 'secrets/**']).
-   *  Deny rules take precedence over read/write grants. */
-  deny?: string[];
-}
-
-/** Reusable named permission profile shared by one or more agents. */
-export interface PermissionProfileDefinition {
-  /** Human-readable summary of the profile's intended use. */
-  description?: string;
-
-  /** Explain why this profile exists or what constraint it is protecting. */
-  why?: string;
-
-  /** Role-based access preset. Expands into file permission rules.
-   *  Default: 'readwrite'. */
-  access?: AccessPreset;
-
-  /** Inherit patterns from .agentignore and .agentreadonly dotfiles.
-   *  Default: true. Set to false to ignore dotfiles for this agent. */
-  inherit?: boolean;
-
-  /** Explicit glob-based file read/write/deny rules.
-   *  Merged on top of the access preset and inherited dotfile patterns. */
-  files?: FilePermissions;
-
-  /** Raw relayauth scopes appended verbatim to the minted token.
-   *  For power users who need fine-grained control beyond file globs.
-   *  Example: ['relayfile:fs:read:/src/**', 'relayfile:fs:write:/tests/**'] */
-  scopes?: string[];
-
-  /** Network access control.
-   *  - undefined: no restriction
-   *  - false: deny all network access
-   *  - { allow, deny }: fine-grained host:port allowlist/denylist */
-  network?: NetworkPermission;
-
-  /** Allowlist of shell commands the agent may execute.
-   *  When set, only commands matching these prefixes are permitted.
-   *  Example: ['npm test', 'npm run lint', 'git diff']
-   *  Default: undefined (no restriction). */
-  exec?: string[];
-}
-
-/**
- * Permission configuration for a workflow agent.
- *
- * All fields are optional — omitting `permissions` entirely preserves the
- * existing default behavior (inherit dotfiles, readwrite access).
- *
- * Resolution order (later overrides earlier):
- *   1. Dotfile patterns (.agentignore / .agentreadonly) when `inherit` is true
- *   2. `access` preset expands into base file rules
- *   3. Explicit `files` globs merge on top
- *   4. `deny` patterns always win (applied last)
- *   5. `scopes` are appended verbatim to the token
- */
-export interface AgentPermissions {
-  /** Human-readable summary of what this permission block is for. */
-  description?: string;
-
-  /** Reference a reusable entry from the top-level `permission_profiles` map. */
-  profile?: string;
-
-  /** Explain why these permissions are needed or intentionally constrained. */
-  why?: string;
-
-  /** Role-based access preset. Expands into file permission rules.
-   *  Default: 'readwrite'. */
-  access?: AccessPreset;
-
-  /** Inherit patterns from .agentignore and .agentreadonly dotfiles.
-   *  Default: true. Set to false to ignore dotfiles for this agent. */
-  inherit?: boolean;
-
-  /** Explicit glob-based file read/write/deny rules.
-   *  Merged on top of the access preset and inherited dotfile patterns. */
-  files?: FilePermissions;
-
-  /** Raw relayauth scopes appended verbatim to the minted token.
-   *  For power users who need fine-grained control beyond file globs.
-   *  Example: ['relayfile:fs:read:/src/**', 'relayfile:fs:write:/tests/**'] */
-  scopes?: string[];
-
-  /** Network access control.
-   *  - undefined: no restriction
-   *  - false: deny all network access
-   *  - { allow, deny }: fine-grained host:port allowlist/denylist */
-  network?: NetworkPermission;
-
-  /** Allowlist of shell commands the agent may execute.
-   *  When set, only commands matching these prefixes are permitted.
-   *  Example: ['npm test', 'npm run lint', 'git diff']
-   *  Default: undefined (no restriction). */
-  exec?: string[];
 }
 
 // ── Compiled / resolved permissions ─────────────────────────────────────────
@@ -475,9 +261,6 @@ export interface WorkflowDefinition {
   onError?: 'fail' | 'skip' | 'retry';
 }
 
-/** Step type: agent (LLM-powered), deterministic (shell command), worktree (git worktree setup), or integration (external service). */
-export type WorkflowStepType = 'agent' | 'deterministic' | 'worktree' | 'integration';
-
 // ── Custom step definitions ─────────────────────────────────────────────────
 
 /** Parameter definition for a custom step. */
@@ -522,111 +305,6 @@ export interface CustomStepDefinition {
 export interface CustomStepsConfig {
   /** Map of step name to step definition. */
   steps: Record<string, CustomStepDefinition>;
-}
-
-/**
- * A single step within a workflow.
- *
- * Steps can be either:
- * - Agent steps (type: undefined or "agent"): Spawn an LLM agent to execute a task
- * - Deterministic steps (type: "deterministic"): Execute a shell command
- */
-export interface WorkflowStep {
-  /** Unique step name within the workflow. */
-  name: string;
-  /** Step type: "agent" (default) or "deterministic". */
-  type?: WorkflowStepType;
-  /** Reference to a custom step definition from .relay/steps.yaml. */
-  use?: string;
-  /** Step names that must complete before this step runs. */
-  dependsOn?: string[];
-  /** Timeout in milliseconds. */
-  timeoutMs?: number;
-
-  // ── Agent step fields ──────────────────────────────────────────────────────
-  /** Name of the agent to execute this step (required for agent steps). */
-  agent?: string;
-  /** Task description for the agent (required for agent steps). */
-  task?: string;
-  /** Verification check to validate step output. */
-  verification?: VerificationCheck;
-  /** Number of retry attempts on failure. */
-  retries?: number;
-  /** Maximum iterations for steps that may need to retry (e.g., fix-failures). */
-  maxIterations?: number;
-  /** Explicit working directory for this step. */
-  cwd?: string;
-
-  // ── Deterministic step fields ──────────────────────────────────────────────
-  /** Shell command to execute (required for deterministic steps). */
-  command?: string;
-  /** Sets this step's working directory to a named entry from the top-level `paths` array.
-   *  If omitted, the step inherits the agent's workdir, or falls back to the runner's
-   *  working directory. */
-  workdir?: string;
-  /** Fail if command exit code is non-zero. Default: true. */
-  failOnError?: boolean;
-  /** Capture stdout as step output for downstream steps. Default: true. */
-  captureOutput?: boolean;
-
-  // ── Integration step fields ────────────────────────────────────────────────
-  /** Integration name: 'github', 'linear', 'slack' (required for integration steps). */
-  integration?: string;
-  /** Action within the integration, e.g. 'create-pr', 'create-branch' (required for integration steps). */
-  action?: string;
-  /** Action parameters, supports {{steps.X.output}} interpolation. */
-  params?: Record<string, string>;
-
-  // ── Worktree step fields ──────────────────────────────────────────────────
-  /** Branch name for the worktree (required for worktree steps). */
-  branch?: string;
-  /** Base branch to create the worktree from. Default: HEAD. */
-  baseBranch?: string;
-  /** Explicit path for the worktree. Default: .worktrees/<step-name>. */
-  path?: string;
-  /** Create the branch if it doesn't exist. Default: true. */
-  createBranch?: boolean;
-}
-
-/** Type guard: Check if a step is a deterministic (shell command) step. */
-export function isDeterministicStep(step: WorkflowStep): boolean {
-  return step.type === 'deterministic';
-}
-
-/** Type guard: Check if a step is a worktree (git worktree setup) step. */
-export function isWorktreeStep(step: WorkflowStep): boolean {
-  return step.type === 'worktree';
-}
-
-/** Type guard: Check if a step is an integration (external service) step. */
-export function isIntegrationStep(step: WorkflowStep): boolean {
-  return step.type === 'integration';
-}
-
-/** Type guard: Check if a step uses a custom step definition. */
-export function isCustomStep(step: WorkflowStep): boolean {
-  return step.use !== undefined;
-}
-
-/** Type guard: Check if a step is an agent (LLM-powered) step. */
-export function isAgentStep(step: WorkflowStep): boolean {
-  return step.type !== 'deterministic' && step.type !== 'worktree' && step.type !== 'integration';
-}
-
-// Legacy type aliases for backward compatibility
-export type AgentWorkflowStep = WorkflowStep;
-export type DeterministicWorkflowStep = WorkflowStep;
-
-/** Verification check to validate a step's output. */
-export interface VerificationCheck {
-  type: 'output_contains' | 'exit_code' | 'file_exists' | 'custom';
-  value: string;
-  description?: string;
-  timeoutMs?: number;
-  /** Name of the agent to analyze verification failures before retrying. */
-  diagnosticAgent?: string;
-  /** Timeout for the diagnostic agent in milliseconds. Default: 60_000. */
-  diagnosticTimeout?: number;
 }
 
 /** Diagnostic output captured after a verification failure analysis run. */

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -6,7 +6,10 @@
     "baseUrl": ".",
     "paths": {
       "@agent-relay/config": ["../config/dist/index.d.ts"],
-      "@agent-relay/config/*": ["../config/dist/*"]
+      "@agent-relay/config/*": ["../config/dist/*"],
+      "@agent-relay/workflow-types": ["../workflow-types/dist/index.d.ts"],
+      "@agent-relay/github-primitive": ["../github-primitive/dist/index.d.ts"],
+      "@agent-relay/github-primitive/workflow-step": ["../github-primitive/dist/workflow-step.d.ts"]
     },
     "strict": true,
     "declaration": true,

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,7 +4,10 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {
-      "@agent-relay/config": ["../config/src/index.ts"]
+      "@agent-relay/config": ["../config/src/index.ts"],
+      "@agent-relay/workflow-types": ["../workflow-types/src/index.ts"],
+      "@agent-relay/github-primitive": ["../github-primitive/src/index.ts"],
+      "@agent-relay/github-primitive/workflow-step": ["../github-primitive/src/workflow-step.ts"]
     },
     "noEmit": true
   },

--- a/packages/workflow-types/package.json
+++ b/packages/workflow-types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@agent-relay/workflow-types",
+  "version": "5.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/workflow-types/src/index.ts
+++ b/packages/workflow-types/src/index.ts
@@ -1,0 +1,367 @@
+/**
+ * Shared workflow types for Agent Relay packages.
+ *
+ * This package is intentionally a leaf dependency so workflow integrations can
+ * share the public workflow type surface without depending on the full SDK.
+ */
+
+export type SwarmPattern =
+  | 'fan-out'
+  | 'pipeline'
+  | 'hub-spoke'
+  | 'consensus'
+  | 'mesh'
+  | 'handoff'
+  | 'cascade'
+  | 'dag'
+  | 'debate'
+  | 'hierarchical'
+  // Additional patterns
+  | 'map-reduce'
+  | 'scatter-gather'
+  | 'supervisor'
+  | 'reflection'
+  | 'red-team'
+  | 'verifier'
+  | 'auction'
+  | 'escalation'
+  | 'saga'
+  | 'circuit-breaker'
+  | 'blackboard'
+  | 'swarm'
+  | 'competitive'
+  | 'review-loop';
+
+// ── Agent definitions ───────────────────────────────────────────────────────
+
+export type AgentPreset = 'lead' | 'worker' | 'reviewer' | 'analyst';
+
+/** Optional credential settings for a workflow agent. */
+export interface AgentCredentialConfig {
+  /** Opt the agent into credential proxy mode. */
+  proxy?: boolean;
+  /** Override the provider used for proxy credential resolution. */
+  provider?: string;
+}
+
+/** Definition of an agent participating in a workflow. */
+export interface AgentDefinition {
+  name: string;
+  cli: AgentCli;
+  role?: string;
+  task?: string;
+  channels?: string[];
+  constraints?: AgentConstraints;
+  /**
+   * Permission configuration controlling file access, network, and exec restrictions.
+   * Omitting this field preserves the default behavior: inherit dotfiles + readwrite access.
+   */
+  permissions?: AgentPermissions;
+  /** When false, the agent runs as a non-interactive subprocess (no PTY, no relay messaging).
+   *  It receives its task as a CLI prompt argument and returns stdout as output.
+   *  Default: true (interactive PTY mode). */
+  interactive?: boolean;
+  /** Working directory for this agent, resolved relative to the YAML file. */
+  cwd?: string;
+  /** Sets this agent's working directory to a named entry from the top-level `paths` array.
+   *  Mutually exclusive with `cwd`. If omitted, the agent runs in the runner's
+   *  working directory (the directory containing the workflow YAML file). */
+  workdir?: string;
+  /** Additional paths the agent needs read/write access to. */
+  additionalPaths?: string[];
+  /**
+   * Role preset that automatically configures interactive mode and injects
+   * appropriate task guardrails. Overrides are still accepted.
+   *   lead     → interactive PTY, relay-aware, coordinates workers via channels
+   *   worker   → interactive: false, produces structured output, no sub-agents
+   *   reviewer → interactive: false, reads artifacts, produces verdict, no sub-agents
+   *   analyst  → interactive: false, reads code/files, writes findings, no sub-agents
+   */
+  preset?: AgentPreset;
+  /** Optional credential proxy settings for this agent. */
+  credentials?: AgentCredentialConfig;
+  /** System prompt / skills for API-mode agents (cli: 'api'). */
+  skills?: string;
+}
+
+export type AgentCli =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'aider'
+  | 'goose'
+  | 'opencode'
+  | 'droid'
+  | 'cursor'
+  | 'cursor-agent'
+  | 'agent'
+  | 'api';
+
+/** Resource and behavioral constraints for an agent. */
+export interface AgentConstraints {
+  maxTokens?: number;
+  timeoutMs?: number;
+  retries?: number;
+  model?: string;
+  /** Silence duration in seconds before the agent is considered idle (0 = disabled, default: 30). */
+  idleThresholdSecs?: number;
+}
+
+// ── Permission types ────────────────────────────────────────────────────────
+
+/**
+ * Access preset for role-based permission shortcuts.
+ *
+ *   readonly    → read all non-ignored files, write nothing
+ *   readwrite   → read and write all non-ignored files (default behavior)
+ *   restricted  → read/write only explicitly listed paths
+ *   full        → read and write everything, including normally-ignored files
+ */
+export type AccessPreset = 'readonly' | 'readwrite' | 'restricted' | 'full';
+
+/** Fine-grained network permission with allowlist/denylist. */
+export interface NetworkPermissions {
+  /** Host:port pairs the agent may connect to (e.g. ['registry.npmjs.org:443']). */
+  allow?: string[];
+  /** Host:port patterns to block (e.g. ['*'] to deny all except allowed). */
+  deny?: string[];
+}
+
+/** Network permission: boolean to allow/deny all, or object for fine-grained control. */
+export type NetworkPermission = boolean | NetworkPermissions;
+
+/** Glob-based file permission scopes for an agent. */
+export interface FilePermissions {
+  /** Glob patterns the agent may read (e.g. ['src/**', 'docs/**']). */
+  read?: string[];
+  /** Glob patterns the agent may write (e.g. ['src/tests/**']). */
+  write?: string[];
+  /** Glob patterns the agent must never access (e.g. ['.env', 'secrets/**']).
+   *  Deny rules take precedence over read/write grants. */
+  deny?: string[];
+}
+
+/** Reusable named permission profile shared by one or more agents. */
+export interface PermissionProfileDefinition {
+  /** Human-readable summary of the profile's intended use. */
+  description?: string;
+
+  /** Explain why this profile exists or what constraint it is protecting. */
+  why?: string;
+
+  /** Role-based access preset. Expands into file permission rules.
+   *  Default: 'readwrite'. */
+  access?: AccessPreset;
+
+  /** Inherit patterns from .agentignore and .agentreadonly dotfiles.
+   *  Default: true. Set to false to ignore dotfiles for this agent. */
+  inherit?: boolean;
+
+  /** Explicit glob-based file read/write/deny rules.
+   *  Merged on top of the access preset and inherited dotfile patterns. */
+  files?: FilePermissions;
+
+  /** Raw relayauth scopes appended verbatim to the minted token.
+   *  For power users who need fine-grained control beyond file globs.
+   *  Example: ['relayfile:fs:read:/src/**', 'relayfile:fs:write:/tests/**'] */
+  scopes?: string[];
+
+  /** Network access control.
+   *  - undefined: no restriction
+   *  - false: deny all network access
+   *  - { allow, deny }: fine-grained host:port allowlist/denylist */
+  network?: NetworkPermission;
+
+  /** Allowlist of shell commands the agent may execute.
+   *  When set, only commands matching these prefixes are permitted.
+   *  Example: ['npm test', 'npm run lint', 'git diff']
+   *  Default: undefined (no restriction). */
+  exec?: string[];
+}
+
+/**
+ * Permission configuration for a workflow agent.
+ *
+ * All fields are optional — omitting `permissions` entirely preserves the
+ * existing default behavior (inherit dotfiles, readwrite access).
+ *
+ * Resolution order (later overrides earlier):
+ *   1. Dotfile patterns (.agentignore / .agentreadonly) when `inherit` is true
+ *   2. `access` preset expands into base file rules
+ *   3. Explicit `files` globs merge on top
+ *   4. `deny` patterns always win (applied last)
+ *   5. `scopes` are appended verbatim to the token
+ */
+export interface AgentPermissions {
+  /** Human-readable summary of what this permission block is for. */
+  description?: string;
+
+  /** Reference a reusable entry from the top-level `permission_profiles` map. */
+  profile?: string;
+
+  /** Explain why these permissions are needed or intentionally constrained. */
+  why?: string;
+
+  /** Role-based access preset. Expands into file permission rules.
+   *  Default: 'readwrite'. */
+  access?: AccessPreset;
+
+  /** Inherit patterns from .agentignore and .agentreadonly dotfiles.
+   *  Default: true. Set to false to ignore dotfiles for this agent. */
+  inherit?: boolean;
+
+  /** Explicit glob-based file read/write/deny rules.
+   *  Merged on top of the access preset and inherited dotfile patterns. */
+  files?: FilePermissions;
+
+  /** Raw relayauth scopes appended verbatim to the minted token.
+   *  For power users who need fine-grained control beyond file globs.
+   *  Example: ['relayfile:fs:read:/src/**', 'relayfile:fs:write:/tests/**'] */
+  scopes?: string[];
+
+  /** Network access control.
+   *  - undefined: no restriction
+   *  - false: deny all network access
+   *  - { allow, deny }: fine-grained host:port allowlist/denylist */
+  network?: NetworkPermission;
+
+  /** Allowlist of shell commands the agent may execute.
+   *  When set, only commands matching these prefixes are permitted.
+   *  Example: ['npm test', 'npm run lint', 'git diff']
+   *  Default: undefined (no restriction). */
+  exec?: string[];
+}
+
+/** Step type: agent (LLM-powered), deterministic (shell command), worktree (git worktree setup), or integration (external service). */
+export type WorkflowStepType = 'agent' | 'deterministic' | 'worktree' | 'integration';
+
+/**
+ * A single step within a workflow.
+ *
+ * Steps can be either:
+ * - Agent steps (type: undefined or "agent"): Spawn an LLM agent to execute a task
+ * - Deterministic steps (type: "deterministic"): Execute a shell command
+ */
+export interface WorkflowStep {
+  /** Unique step name within the workflow. */
+  name: string;
+  /** Step type: "agent" (default) or "deterministic". */
+  type?: WorkflowStepType;
+  /** Reference to a custom step definition from .relay/steps.yaml. */
+  use?: string;
+  /** Step names that must complete before this step runs. */
+  dependsOn?: string[];
+  /** Timeout in milliseconds. */
+  timeoutMs?: number;
+
+  // ── Agent step fields ──────────────────────────────────────────────────────
+  /** Name of the agent to execute this step (required for agent steps). */
+  agent?: string;
+  /** Task description for the agent (required for agent steps). */
+  task?: string;
+  /** Verification check to validate step output. */
+  verification?: VerificationCheck;
+  /** Number of retry attempts on failure. */
+  retries?: number;
+  /** Maximum iterations for steps that may need to retry (e.g., fix-failures). */
+  maxIterations?: number;
+  /** Explicit working directory for this step. */
+  cwd?: string;
+
+  // ── Deterministic step fields ──────────────────────────────────────────────
+  /** Shell command to execute (required for deterministic steps). */
+  command?: string;
+  /** Sets this step's working directory to a named entry from the top-level `paths` array.
+   *  If omitted, the step inherits the agent's workdir, or falls back to the runner's
+   *  working directory. */
+  workdir?: string;
+  /** Fail if command exit code is non-zero. Default: true. */
+  failOnError?: boolean;
+  /** Capture stdout as step output for downstream steps. Default: true. */
+  captureOutput?: boolean;
+
+  // ── Integration step fields ────────────────────────────────────────────────
+  /** Integration name: 'github', 'linear', 'slack' (required for integration steps). */
+  integration?: string;
+  /** Action within the integration, e.g. 'create-pr', 'create-branch' (required for integration steps). */
+  action?: string;
+  /** Action parameters, supports {{steps.X.output}} interpolation. */
+  params?: Record<string, string>;
+
+  // ── Worktree step fields ──────────────────────────────────────────────────
+  /** Branch name for the worktree (required for worktree steps). */
+  branch?: string;
+  /** Base branch to create the worktree from. Default: HEAD. */
+  baseBranch?: string;
+  /** Explicit path for the worktree. Default: .worktrees/<step-name>. */
+  path?: string;
+  /** Create the branch if it doesn't exist. Default: true. */
+  createBranch?: boolean;
+}
+
+/** Type guard: Check if a step is a deterministic (shell command) step. */
+export function isDeterministicStep(step: WorkflowStep): boolean {
+  return step.type === 'deterministic';
+}
+
+/** Type guard: Check if a step is a worktree (git worktree setup) step. */
+export function isWorktreeStep(step: WorkflowStep): boolean {
+  return step.type === 'worktree';
+}
+
+/** Type guard: Check if a step is an integration (external service) step. */
+export function isIntegrationStep(step: WorkflowStep): boolean {
+  return step.type === 'integration';
+}
+
+/** Type guard: Check if a step uses a custom step definition. */
+export function isCustomStep(step: WorkflowStep): boolean {
+  return step.use !== undefined;
+}
+
+/** Type guard: Check if a step is an agent (LLM-powered) step. */
+export function isAgentStep(step: WorkflowStep): boolean {
+  return step.type !== 'deterministic' && step.type !== 'worktree' && step.type !== 'integration';
+}
+
+// Legacy type aliases for backward compatibility
+export type AgentWorkflowStep = WorkflowStep;
+export type DeterministicWorkflowStep = WorkflowStep;
+
+/** Verification check to validate a step's output. */
+export interface VerificationCheck {
+  type: 'output_contains' | 'exit_code' | 'file_exists' | 'custom';
+  value: string;
+  description?: string;
+  timeoutMs?: number;
+  /** Name of the agent to analyze verification failures before retrying. */
+  diagnosticAgent?: string;
+  /** Timeout for the diagnostic agent in milliseconds. Default: 60_000. */
+  diagnosticTimeout?: number;
+}
+
+/**
+ * Extension point for delegating step execution to an external backend
+ * (e.g. Daytona sandboxes) while keeping the runner's DAG/retry/verification
+ * machinery intact.
+ */
+export interface RunnerStepExecutor {
+  executeAgentStep(
+    step: WorkflowStep,
+    agentDef: AgentDefinition,
+    resolvedTask: string,
+    timeoutMs?: number
+  ): Promise<string>;
+
+  executeDeterministicStep?(
+    step: WorkflowStep,
+    resolvedCommand: string,
+    cwd: string
+  ): Promise<{ output: string; exitCode: number }>;
+
+  executeIntegrationStep?(
+    step: WorkflowStep,
+    resolvedParams: Record<string, string>,
+    context: { workspaceId?: string }
+  ): Promise<{ output: string; success: boolean }>;
+}

--- a/packages/workflow-types/tsconfig.json
+++ b/packages/workflow-types/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
Bundles `@agent-relay/github-primitive` into the SDK so workflow authors get it with `npm install @agent-relay/sdk` — no separate install. Import via the new `@agent-relay/sdk/github` subpath.

Required breaking an existing circular dep between `@agent-relay/sdk` and `@agent-relay/github-primitive` (github-primitive imports `WorkflowStep` + `RunnerStepExecutor` from SDK; SDK would now depend on github-primitive → cycle). Fixed by extracting the shared type surface to a new leaf package `@agent-relay/workflow-types`.

Companion to docs [relay#778](https://github.com/AgentWorkforce/relay/pull/778) which already documents the bundled shape — that doc becomes accurate on this merge.

## What's in this PR

### New leaf package: `@agent-relay/workflow-types`
Holds the public type surface both SDK and github-primitive need:
- `WorkflowStep`, `WorkflowStepType`, `VerificationCheck`
- `AgentDefinition` + transitive (`AgentCli`, `AgentPreset`, `AgentConstraints`, `AgentPermissions`, `AgentCredentialConfig`, `AccessPreset`, `FilePermissions`, `NetworkPermissions`, `NetworkPermission`, `PermissionProfileDefinition`)
- `RunnerStepExecutor`
- `SwarmPattern`
- Type guards (`isDeterministicStep`, `isWorktreeStep`, `isIntegrationStep`, `isCustomStep`, `isAgentStep`)
- Legacy aliases (`AgentWorkflowStep`, `DeterministicWorkflowStep`)

### `@agent-relay/sdk`
- `packages/sdk/src/workflows/types.ts` trimmed ~350 lines → now `export * from '@agent-relay/workflow-types'` for the moved names. Every existing public export on the SDK is preserved — **zero API change for SDK consumers**.
- `packages/sdk/src/workflows/runner.ts` — `RunnerStepExecutor` definition removed, imported from workflow-types.
- `packages/sdk/src/github.ts` — new barrel: `export * from '@agent-relay/github-primitive'` + `export * from '@agent-relay/github-primitive/workflow-step'`.
- `packages/sdk/package.json`:
  - `dependencies` gains `@agent-relay/github-primitive: 5.0.0` and `@agent-relay/workflow-types: 5.0.0`.
  - `exports` gains `./github` → `./dist/github.js`.

### `@agent-relay/github-primitive`
- Dep swap: drop `@agent-relay/sdk`, add `@agent-relay/workflow-types`. Breaks the cycle.
- One-line import change in `src/workflow-step.ts`: `'@agent-relay/sdk/workflows'` → `'@agent-relay/workflow-types'`.

## Verification
Authored by a Codex agent under the running-headless-orchestrator pattern; verified by re-running the builds post-commit:

```
cd packages/workflow-types && npm run build    # clean
cd packages/github-primitive && npm run build  # clean (no SDK dep resolved)
cd packages/sdk && npm run check               # clean (tsc --noEmit)
cd packages/sdk && npm run build               # clean
```

No behavior change. No public API change for SDK consumers. The only user-visible addition is the new `@agent-relay/sdk/github` subpath.

## Why a leaf package, not inlined types
Considered inlining the two types into `github-primitive` as local duck-types (smaller scope, no new package). Rejected because the types would drift silently from SDK's definitions over time — they ARE the public contract between SDK and the integration step. The leaf package makes the contract explicit; any future `@agent-relay/*` primitive package can consume it the same way.

## After merge
- [relay#778](https://github.com/AgentWorkforce/relay/pull/778) docs become accurate (`import { createGitHubStep } from '@agent-relay/sdk/github'` works)
- Users can drop `npm install @agent-relay/github-primitive` — same symbols via the SDK
- Pattern available for future workflow-specific primitives (Linear, Slack, etc.) to ship similarly

## Test plan
- [x] `npm run build` clean in workflow-types, github-primitive, sdk
- [x] `npm run check` clean in sdk
- [ ] `npm test` per package (if the workspace has integration tests that exercise these types)
- [ ] Verify `import { createGitHubStep } from '@agent-relay/sdk/github'` works in a consumer project post-install

🤖 Generated by a Codex agent orchestrated via running-headless-orchestrator
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
