### PR TITLE
fix(broker): unbreak Windows build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4864,7 +4864,9 @@ fn record_thread_history_event(history: &mut VecDeque<Value>, event: Value) {
 /// Uses `crossterm::terminal::size()`, which is cross-platform:
 /// TIOCGWINSZ on unix, GetConsoleScreenBufferInfo on Windows.
 fn get_terminal_size() -> Option<(u16, u16)> {
-    crossterm::terminal::size().ok().map(|(cols, rows)| (rows, cols))
+    crossterm::terminal::size()
+        .ok()
+        .map(|(cols, rows)| (rows, cols))
 }
 
 /// Detect Claude Code auto-suggestion ghost text.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1172,7 +1172,13 @@ async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Result<()> {
     let mut lease_check = tokio::time::interval(Duration::from_secs(10));
     lease_check.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+    // Graceful-shutdown signal: SIGTERM on unix, Ctrl+Break/Close on Windows.
+    // `tokio::signal::ctrl_c()` is handled in its own select! arm below and
+    // works on both platforms.
+    #[cfg(unix)]
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    #[cfg(windows)]
+    let mut sigterm = tokio::signal::windows::ctrl_shutdown()?;
 
     while !shutdown {
         tokio::select! {
@@ -4853,26 +4859,12 @@ fn record_thread_history_event(history: &mut VecDeque<Value>, event: Value) {
     history.push_back(event);
 }
 
-/// Get current terminal size via ioctl.
-#[cfg(unix)]
+/// Get current terminal size. Returns (rows, cols).
+///
+/// Uses `crossterm::terminal::size()`, which is cross-platform:
+/// TIOCGWINSZ on unix, GetConsoleScreenBufferInfo on Windows.
 fn get_terminal_size() -> Option<(u16, u16)> {
-    use nix::libc;
-    use nix::pty::Winsize;
-
-    let mut winsize = Winsize {
-        ws_row: 0,
-        ws_col: 0,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-
-    unsafe {
-        if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut winsize) == 0 {
-            Some((winsize.ws_row, winsize.ws_col))
-        } else {
-            None
-        }
-    }
+    crossterm::terminal::size().ok().map(|(cols, rows)| (rows, cols))
 }
 
 /// Detect Claude Code auto-suggestion ghost text.

--- a/src/pty_worker.rs
+++ b/src/pty_worker.rs
@@ -174,10 +174,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
     let mut effective_args = inline_cli_args;
     effective_args.extend(cmd.args.clone());
 
-    #[cfg(unix)]
     let (init_rows, init_cols) = get_terminal_size().unwrap_or((24, 80));
-    #[cfg(not(unix))]
-    let (init_rows, init_cols) = (24u16, 80u16);
     let (pty, mut pty_rx) =
         PtySession::spawn(&resolved_cli, &effective_args, init_rows, init_cols)?;
     let mut terminal_query_parser = TerminalQueryParser::default();
@@ -207,10 +204,9 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
         Some(Duration::from_secs(cmd.idle_threshold_secs))
     };
 
-    // --- SIGWINCH (terminal resize) ---
-    let mut sigwinch =
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-            .expect("failed to register SIGWINCH handler");
+    // Terminal resize arrives from the broker as a `resize_pty` protocol
+    // frame on stdin (see the frame handler below) — the worker itself
+    // never observes the user's TTY, since its stdout is a pipe.
 
     let mut auto_enter_interval = tokio::time::interval(Duration::from_secs(2));
     auto_enter_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -927,13 +923,6 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             "idle_secs": idle_secs,
                         })).await;
                     }
-                }
-            }
-
-            // --- SIGWINCH: forward terminal resize to PTY ---
-            _ = sigwinch.recv() => {
-                if let Some((rows, cols)) = get_terminal_size() {
-                    let _ = pty.resize(rows, cols);
                 }
             }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -700,10 +700,13 @@ pub(crate) async fn run_wrap(
     let mut reap_tick = tokio::time::interval(Duration::from_secs(5));
     reap_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    // SIGWINCH (terminal resize)
-    let mut sigwinch =
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-            .expect("failed to register SIGWINCH handler");
+    // Terminal resize: polled cross-platform. We can't use SIGWINCH (unix-only)
+    // or crossterm::event::EventStream (steals keystrokes from the stdin
+    // passthrough because it reads /dev/tty / CONIN$). A cheap size query
+    // every 200ms keeps the PTY in sync with perceptibly no latency.
+    let mut resize_poll = tokio::time::interval(Duration::from_millis(200));
+    resize_poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut last_terminal_size = get_terminal_size();
 
     let mut running = true;
     let mut stdout = tokio::io::stdout();
@@ -1300,10 +1303,14 @@ pub(crate) async fn run_wrap(
                 }
             }
 
-            // SIGWINCH: forward terminal resize to PTY
-            _ = sigwinch.recv() => {
-                if let Some((rows, cols)) = get_terminal_size() {
-                    let _ = pty.resize(rows, cols);
+            // Poll terminal size; forward to PTY when it changes.
+            _ = resize_poll.tick() => {
+                let size = get_terminal_size();
+                if size != last_terminal_size {
+                    last_terminal_size = size;
+                    if let Some((rows, cols)) = size {
+                        let _ = pty.resize(rows, cols);
+                    }
                 }
             }
         }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -700,13 +700,39 @@ pub(crate) async fn run_wrap(
     let mut reap_tick = tokio::time::interval(Duration::from_secs(5));
     reap_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    // Terminal resize: polled cross-platform. We can't use SIGWINCH (unix-only)
-    // or crossterm::event::EventStream (steals keystrokes from the stdin
-    // passthrough because it reads /dev/tty / CONIN$). A cheap size query
-    // every 200ms keeps the PTY in sync with perceptibly no latency.
-    let mut resize_poll = tokio::time::interval(Duration::from_millis(200));
-    resize_poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    let mut last_terminal_size = get_terminal_size();
+    // Terminal resize notifications.
+    //
+    // Unix: SIGWINCH is event-driven, fires exactly when the TTY resizes,
+    // zero CPU when idle.
+    //
+    // Windows: no SIGWINCH, and crossterm's `EventStream` can't be used
+    // alongside our stdin passthrough — reading CONIN$ consumes keypresses
+    // that we need to forward to the child PTY. A dedicated background
+    // thread polls the console size at 100ms and notifies via a channel
+    // only when it actually changes. The main select! loop stays
+    // event-driven; polling happens off the hot path.
+    #[cfg(unix)]
+    let mut resize_signal =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+            .expect("failed to register SIGWINCH handler");
+    #[cfg(windows)]
+    let mut resize_signal = {
+        let (tx, rx) = mpsc::channel::<()>(4);
+        std::thread::spawn(move || {
+            let mut last = crossterm::terminal::size().ok();
+            loop {
+                std::thread::sleep(Duration::from_millis(100));
+                let current = crossterm::terminal::size().ok();
+                if current != last {
+                    last = current;
+                    if tx.blocking_send(()).is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+        rx
+    };
 
     let mut running = true;
     let mut stdout = tokio::io::stdout();
@@ -1303,14 +1329,10 @@ pub(crate) async fn run_wrap(
                 }
             }
 
-            // Poll terminal size; forward to PTY when it changes.
-            _ = resize_poll.tick() => {
-                let size = get_terminal_size();
-                if size != last_terminal_size {
-                    last_terminal_size = size;
-                    if let Some((rows, cols)) = size {
-                        let _ = pty.resize(rows, cols);
-                    }
+            // Terminal resize: forward current size to PTY.
+            _ = resize_signal.recv() => {
+                if let Some((rows, cols)) = get_terminal_size() {
+                    let _ = pty.resize(rows, cols);
                 }
             }
         }


### PR DESCRIPTION
## Summary

The Publish Package workflow [failed on its Windows broker build](https://github.com/AgentWorkforce/relay/actions/runs/24891319229/job/72884138536) because three unix-only APIs were called unconditionally:

- `tokio::signal::unix::signal(SignalKind::window_change)` — SIGWINCH — in `src/wrap.rs` and `src/pty_worker.rs`
- `tokio::signal::unix::signal(SignalKind::terminate)` — SIGTERM — in `src/main.rs::run_init`
- `get_terminal_size()` was `#[cfg(unix)]` but invoked without cfg guards from `pty_worker.rs:935` and `wrap.rs:1305`

On Windows, `tokio::signal::unix` doesn't exist, leaving `sigwinch`/`sigterm` with unresolved types that cascaded through the giant `tokio::select!` blocks as `E0277: the size for values of type [u8] cannot be known at compilation time` errors. `get_terminal_size` surfaced as `E0425: cannot find function ... in this scope`.

## Fixes — functional parity, not cfg-skips

- **`get_terminal_size()`** now uses `crossterm::terminal::size()` (TIOCGWINSZ on unix, `GetConsoleScreenBufferInfo` on Windows). Dropped the `#[cfg(unix)]` gate.
- **`wrap.rs`** polls `get_terminal_size()` every 200ms to detect resize. `crossterm::event::EventStream` was *not* viable — it reads `/dev/tty`/`CONIN$` and would steal keystrokes from the stdin passthrough that forwards user input to the child PTY. Polling uses a pure size query, no input consumption, imperceptible latency.
- **`pty_worker.rs`** removes the SIGWINCH handler entirely. The worker's stdout is a pipe, so `get_terminal_size()` always returned None and the arm was already a no-op on unix. Resize already flows in correctly via the `resize_pty` protocol frame from the broker (handled at the existing frame dispatcher).
- **`run_init`** splits SIGTERM: unix keeps `SignalKind::terminate()`; Windows uses `tokio::signal::windows::ctrl_shutdown()`. Ctrl+C continues to work cross-platform via the existing `tokio::signal::ctrl_c()` arm.

## Test plan

- [x] `cargo check --target x86_64-pc-windows-gnu` — clean (was: 9 errors)
- [x] `cargo build` on darwin — clean
- [x] `cargo test --lib` — 232 passed
- [ ] CI Windows MSVC build passes
- [ ] Manual: resize terminal while running `agent-relay-broker wrap ...` on macOS/Linux, verify child process sees new dimensions within ~200ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
