### PR TITLE
ci(publish): drop darwin-x64 smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -544,13 +544,10 @@ jobs:
             binary_file: agent-relay-broker
             pkg_os: darwin
             pkg_cpu: arm64
-          - platform: darwin-x64
-            os: macos-13
-            broker_pkg: broker-darwin-x64
-            binary_name: agent-relay-broker-darwin-x64
-            binary_file: agent-relay-broker
-            pkg_os: darwin
-            pkg_cpu: x64
+          # darwin-x64 smoke is intentionally omitted: GitHub's macos-13
+          # (Intel) runner pool is capacity-constrained and routinely queues
+          # for hours. The x86_64-apple-darwin broker binary is still
+          # cross-compiled and published; we just don't exercise it in CI.
           - platform: linux-x64
             os: ubuntu-latest
             broker_pkg: broker-linux-x64


### PR DESCRIPTION
GitHub's macos-13 (Intel) runner pool is capacity-constrained and routinely queues for hours, blocking releases. The x86_64-apple-darwin broker binary is still cross-compiled and published; we just no longer exercise it end-to-end in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
