### PR TITLE
fix: bundle @agent-relay/cloud (not published at lockstep version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "web"
   ],
   "bundledDependencies": [
+    "@agent-relay/cloud",
     "@relaycast/sdk",
     "@relayfile/local-mount"
   ],


### PR DESCRIPTION
## Summary

`agent-relay@6.0.1` was published, but `npm install agent-relay@6.0.1` fails on every platform with:

```
npm error code ETARGET
npm error notarget No matching version found for @agent-relay/cloud@6.0.1
```

`@agent-relay/cloud` is the only workspace package whose npm namespace isn't owned by this repo's publish flow. The `publish-packages` job in `.github/workflows/publish.yml` ships every other internal package (sdk, hooks, config, telemetry, trajectory, user-directory, utils) but cloud is absent from the matrix. The latest registry version of `@agent-relay/cloud` is `2.0.23`, not 6.x.

Under the previous bundled-everything model this was invisible: the workspace cloud at the lockstep version got bundled into the agent-relay tarball and users never tried to fetch from registry. After #788 unbundled `@agent-relay/*`, agent-relay's regular dep on `@agent-relay/cloud@6.0.1` causes `npm install` to fail because that version doesn't exist on npm.

## Fix

Keep `@agent-relay/cloud` bundled. It's safe — cloud's only `@agent-relay` dependency is `@agent-relay/config` (also at 6.0.1, also published normally), and cloud is not in the SDK chain, so bundling it doesn't re-introduce the broker shadow-copy problem #788 just spent five commits eliminating.

## Verification

Locally packed this branch and installed into a scratch project. Tree:

```
node_modules/agent-relay/node_modules/@agent-relay/cloud/    ← bundled
node_modules/agent-relay/node_modules/@agent-relay/config/   ← bundled (transitively via cloud)
node_modules/@agent-relay/sdk/                               ← hoisted from registry
node_modules/@agent-relay/broker-darwin-arm64/bin/agent-relay-broker ← real Mach-O executable, hoisted via SDK optional-dep
```

Tarball size: 1.5 MB → 4.0 MB. Most of the increase is cloud's `@aws-sdk/client-s3` transitive deps. Still 6× smaller than the original 24.2 MB pre-#788.

## Long-term follow-ups

- Either publish `@agent-relay/cloud` from this repo at the lockstep version (figure out the namespace ownership story), or rename the workspace to avoid the collision. For now bundling restores correctness without picking a side.

## Test plan

- [ ] After merge + republish: confirm `npm install agent-relay@<new>` succeeds on a fresh machine and the broker spawns.
- [ ] The Alpine Linux install test (https://github.com/AgentWorkforce/relay/actions/runs/24919294286) should pass once a republish lands with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
