### PR TITLE
fix(ci): re-add @agent-relay/cloud to publish-packages matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -884,6 +884,7 @@ jobs:
           - hooks
           - user-directory
           - config
+          - cloud
           - sdk
           - telemetry
           - acp-bridge


### PR DESCRIPTION
## Summary

`agent-relay@6.0.1` shipped broken because installing it failed with:

```
npm error notarget No matching version found for @agent-relay/cloud@6.0.1
```

`@agent-relay/cloud` is a workspace in this repo (\`packages/cloud/\`) that was historically published to npm at the lockstep version. Commit \`c8c8dad5\` ("additional clean", Jan 27 2026) silently dropped \`- cloud\` from the \`publish-packages\` matrix in \`.github/workflows/publish.yml\`. The workspace kept getting version-bumped to stay in lockstep with every release but was never republished, so the registry's latest \`@agent-relay/cloud\` froze at \`2.0.23\` while the workspace climbed to \`6.0.1\`.

Under the previous bundled-everything architecture this was invisible — the workspace cloud got bundled into the agent-relay tarball at pack time, and users' \`npm install\` got it from the bundle without ever consulting the registry. After #788 unbundled \`@agent-relay/*\`, the CLI's regular dep on \`@agent-relay/cloud@<lockstep>\` began going to the registry like every other internal dep, where the lockstep version didn't exist.

## Fix

One line: re-add \`- cloud\` to the publish-packages matrix.

```diff
   matrix:
     package:
       - policy
       - memory
       - utils
       - trajectory
       - hooks
       - user-directory
       - config
+      - cloud
       - sdk
       - telemetry
       ...
```

## Why this is the right fix (not bundling)

The npm registry's \`@agent-relay/cloud@2.0.23\` declares its \`repository\` as this repo, \`packages/cloud\`. It's the same code base, just stale. There's no namespace collision and no other repo owns this name — the only thing that broke was the publish step.

[#790](https://github.com/AgentWorkforce/relay/pull/790) tried to fix this by adding \`@agent-relay/cloud\` back to \`bundledDependencies\`. That works around the symptom but freezes the bundling architecture for one workspace, costs ~2.5 MB of tarball size (cloud's @aws-sdk/client-s3 transitive deps), and reintroduces a special case we just spent #788 eliminating. Closing #790 in favor of this.

## Test plan

- [ ] Re-dispatch \`Publish Package\` after merge with version 6.0.2.
- [ ] Confirm \`Publish cloud\` job appears in the run and succeeds.
- [ ] Confirm \`@agent-relay/cloud@6.0.2\` shows up on the registry alongside the other \`@agent-relay/*@6.0.2\` packages.
- [ ] Confirm \`npm install agent-relay@6.0.2\` succeeds on a fresh machine and the broker spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
