### PR TITLE
fix(ci): drop darwin-x64 verify leg (macos-13 queue still stuck)

### DIFF
--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -48,9 +48,10 @@ jobs:
           - platform: darwin-arm64
             os: macos-14
             expected_pkg: '@agent-relay/broker-darwin-arm64'
-          - platform: darwin-x64
-            os: macos-13
-            expected_pkg: '@agent-relay/broker-darwin-x64'
+          # darwin-x64 verify is intentionally omitted: GitHub's macos-13
+          # (Intel) runner pool is capacity-constrained and routinely queues
+          # for hours. Mirrors the same omission in publish.yml's
+          # smoke-broker-packages matrix.
           - platform: linux-x64
             os: ubuntu-latest
             expected_pkg: '@agent-relay/broker-linux-x64'


### PR DESCRIPTION
## Summary

\`verify-publish-sdk.yml\` had its own \`darwin-x64\` matrix entry on \`macos-13\` that I missed when [#788](https://github.com/AgentWorkforce/relay/pull/788) dropped the equivalent leg from \`publish.yml\`'s \`smoke-broker-packages\` matrix. The macos-13 Intel pool is still capacity-starved — run [24918788548](https://github.com/AgentWorkforce/relay/actions/runs/24918788548) had this verify job sitting in \`queued\` for hours while every other leg finished, and required force-cancel via the GitHub API to clear.

## Fix

Same as before: drop the leg with a comment pointing at the matching omission in \`publish.yml\`. The x86_64-apple-darwin broker is still cross-compiled and published; we just don't run a darwin-x64 verify against an Intel host.

```diff
   - platform: darwin-arm64
     os: macos-14
     expected_pkg: '@agent-relay/broker-darwin-arm64'
-  - platform: darwin-x64
-    os: macos-13
-    expected_pkg: '@agent-relay/broker-darwin-x64'
+  # darwin-x64 verify is intentionally omitted: GitHub's macos-13
+  # (Intel) runner pool is capacity-constrained and routinely queues
+  # for hours. Mirrors the same omission in publish.yml's
+  # smoke-broker-packages matrix.
   - platform: linux-x64
```

## Test plan

- [ ] Re-dispatch the next publish; confirm no \`Verify @agent-relay/sdk (darwin-x64)\` job appears and the workflow completes without the macos-13 queue hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
