### PR TITLE
feat(sdk): expose runScriptWorkflow() in @agent-relay/sdk/workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`@agent-relay/sdk/workflows` script runner** (6.1.0): Exposes `runScriptWorkflow()`, `parseTsxStderr`, `formatWorkflowParseError`, `findLocalSdkWorkspace`, `ensureLocalSdkWorkflowRuntime`, plus `RunScriptWorkflowOptions` / `ParsedWorkflowError` types. The body of `agent-relay run <script>` now lives in the SDK, so other CLIs (ricky, future tools) can drive the same `.ts` / `.tsx` / `.py` execution flow in-process instead of shelling out. The relay CLI's `run` command is unchanged externally — it now delegates to the SDK function.
 - **CLI SSH Authentication**: New SSH-based authentication for CLI local auth workflows, enabling secure agent spawning and communication (#648e7782).
 - **Multi-Repository Spawning**: Agents can now be spawned across multiple repositories in a single operation, improving orchestration flexibility (#2d2bf610).
 - **Model Hotswap**: Runtime model switching for agents, allowing dynamic provider and model changes without restart (#5a80bdc0).
@@ -39,12 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.2] - 2026-04-25
 
 ### Product Perspective
+
 #### User-Impacting Fixes
+
 - Drop darwin-x64 verify leg (macos-13 queue stuck again)
 - Re-add @agent-relay/cloud to publish-packages matrix (#788)
 
 ### Technical Perspective
+
 #### Releases
+
 - v6.0.2
 
 ---
@@ -52,24 +57,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.1] - 2026-04-25
 
 ### Product Perspective
+
 #### Breaking Changes
-- **Drop legacy agent-relay/broker* exports and shipped workspace dirs**
+
+- **Drop legacy agent-relay/broker\* exports and shipped workspace dirs**
 
 #### User-Facing Features & Improvements
-- **Restore agent-relay/* subpath exports via shim re-exports**
+
+- **Restore agent-relay/\* subpath exports via shim re-exports**
 
 #### User-Impacting Fixes
+
 - Drop dead linkResult reference
 - Allow shipped workspace packages declared as regular deps
-- Unbundle @agent-relay/* to restore optional-dep broker resolution
+- Unbundle @agent-relay/\* to restore optional-dep broker resolution
 - Walk ancestor node_modules for shadowed broker packages
 - Install broker optional-deps for CLI users
 
 ### Technical Perspective
+
 #### Performance & Reliability
+
 - Fix stale broker checks and PyPI retry
 
 #### Releases
+
 - v6.0.1
 
 ---
@@ -77,11 +89,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.0] - 2026-04-24
 
 ### Product Perspective
+
 #### User-Facing Features & Improvements
+
 - **ApplySiblingLinks — link sibling-repo packages during workflow setup (#776)** (#776)
 - **Split broker binaries into per-platform optional-dep packages** (#770)
 
 #### User-Impacting Fixes
+
 - Keep SIGWINCH on unix, background-thread poll on Windows
 - Unbreak Windows build
 - Convert rewrites to direct redirects
@@ -91,16 +106,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep broker packages as workspaces so npm ci passes
 
 ### Technical Perspective
+
 #### Performance & Reliability
+
 - Drop darwin-x64 smoke test
 - Cross-platform post-publish verification of @agent-relay/sdk
-- Skip dist check for broker-* packages in package-validation
+- Skip dist check for broker-\* packages in package-validation
 - Add cross-platform smoke test for broker optional-deps
 
 #### Dependencies & Tooling
+
 - Update Cursor models to latest (#777) (#777)
 
 #### Releases
+
 - v6.0.0
 
 ---
@@ -108,16 +127,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0] - 2026-04-22
 
 ### Product Perspective
+
 #### User-Impacting Fixes
+
 - Repair pre-existing test failures on main
 - Address Copilot review on broker resolution (#769)
 - Ship per-platform wheels with embedded broker (drop runtime download) (#769)
 
 ### Technical Perspective
+
 #### Performance & Reliability
+
 - Include publish-sdk-py in summary job
 
 #### Releases
+
 - v5.0.0
 
 ---
@@ -125,11 +149,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.40] - 2026-04-22
 
 ### Product Perspective
+
 #### User-Facing Features & Improvements
+
 - **Add browser and github workflow primitives (#718)** (#718)
 
 ### Technical Perspective
+
 #### Releases
+
 - v4.0.40
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,10 @@
       "resolved": "packages/config",
       "link": true
     },
+    "node_modules/@agent-relay/credential-proxy": {
+      "resolved": "packages/credential-proxy",
+      "link": true
+    },
     "node_modules/@agent-relay/gateway": {
       "resolved": "packages/gateway",
       "link": true
@@ -1273,6 +1277,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15423,7 +15428,7 @@
       "version": "6.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/sdk": "6.1.0",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15435,67 +15440,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "packages/acp-bridge/node_modules/@agent-relay/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
       }
     },
     "packages/brand": {
@@ -15531,7 +15475,7 @@
       "name": "@agent-relay/browser-primitive",
       "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/sdk": "6.1.0",
         "playwright": "^1.51.1"
       },
       "bin": {
@@ -15541,67 +15485,6 @@
         "@types/node": "^22.19.3",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/browser-primitive/node_modules/@agent-relay/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
       }
     },
     "packages/cloud": {
@@ -15630,76 +15513,26 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/credential-proxy": {
+      "name": "@agent-relay/credential-proxy",
+      "version": "6.0.2",
+      "dependencies": {
+        "hono": "^4.11.4",
+        "jose": "^6.1.3"
+      },
+      "devDependencies": {
+        "vitest": "^3.2.4"
+      }
+    },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
       "version": "6.0.2",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.2"
+        "@agent-relay/sdk": "6.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/gateway/node_modules/@agent-relay/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
       }
     },
     "packages/github-primitive": {
@@ -15719,73 +15552,12 @@
       "version": "6.0.2",
       "dependencies": {
         "@agent-relay/config": "6.0.2",
-        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/sdk": "6.1.0",
         "@agent-relay/trajectory": "6.0.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/hooks/node_modules/@agent-relay/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
       }
     },
     "packages/memory": {
@@ -15805,7 +15577,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/sdk": "6.1.0",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -15819,67 +15591,6 @@
       },
       "optionalDependencies": {
         "dockerode": "^4.0.0"
-      }
-    },
-    "packages/openclaw/node_modules/@agent-relay/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
       }
     },
     "packages/openclaw/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@agent-relay/cloud": "6.0.2",
         "@agent-relay/config": "6.0.2",
         "@agent-relay/hooks": "6.0.2",
-        "@agent-relay/sdk": "6.0.2",
+        "@agent-relay/sdk": "6.1.0",
         "@agent-relay/telemetry": "6.0.2",
         "@agent-relay/trajectory": "6.0.2",
         "@agent-relay/user-directory": "6.0.2",
@@ -136,10 +136,6 @@
     },
     "node_modules/@agent-relay/config": {
       "resolved": "packages/config",
-      "link": true
-    },
-    "node_modules/@agent-relay/credential-proxy": {
-      "resolved": "packages/credential-proxy",
       "link": true
     },
     "node_modules/@agent-relay/gateway": {
@@ -15441,6 +15437,67 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/acp-bridge/node_modules/@agent-relay/sdk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
+      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.2",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "6.0.2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
+    },
     "packages/brand": {
       "name": "@agent-relay/brand",
       "version": "6.0.2"
@@ -15486,6 +15543,67 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/browser-primitive/node_modules/@agent-relay/sdk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
+      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.2",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "6.0.2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
+    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
       "version": "6.0.2",
@@ -15512,17 +15630,6 @@
         "vitest": "^3.2.4"
       }
     },
-    "packages/credential-proxy": {
-      "name": "@agent-relay/credential-proxy",
-      "version": "6.0.2",
-      "dependencies": {
-        "hono": "^4.11.4",
-        "jose": "^6.1.3"
-      },
-      "devDependencies": {
-        "vitest": "^3.2.4"
-      }
-    },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
       "version": "6.0.2",
@@ -15532,6 +15639,67 @@
       "devDependencies": {
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
+      }
+    },
+    "packages/gateway/node_modules/@agent-relay/sdk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
+      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.2",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "6.0.2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
       }
     },
     "packages/github-primitive": {
@@ -15557,6 +15725,67 @@
       "devDependencies": {
         "@types/node": "^22.19.3",
         "vitest": "^3.2.4"
+      }
+    },
+    "packages/hooks/node_modules/@agent-relay/sdk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
+      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.2",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "6.0.2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
       }
     },
     "packages/memory": {
@@ -15590,6 +15819,67 @@
       },
       "optionalDependencies": {
         "dockerode": "^4.0.0"
+      }
+    },
+    "packages/openclaw/node_modules/@agent-relay/sdk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.2.tgz",
+      "integrity": "sha512-zbI25eZ6+d2ZYYOfyj+o6TheeCXtsLJUKps0vIQR37VGmuP83MbnJfndg+Z6XN5l7h3mV5cxDe1xanAaYFQhiw==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.2",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.2",
+        "@agent-relay/broker-darwin-x64": "6.0.2",
+        "@agent-relay/broker-linux-arm64": "6.0.2",
+        "@agent-relay/broker-linux-x64": "6.0.2",
+        "@agent-relay/broker-win32-x64": "6.0.2"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "6.0.2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
       }
     },
     "packages/openclaw/node_modules/@esbuild/aix-ppc64": {
@@ -16352,7 +16642,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "6.0.2",
+      "version": "6.1.0",
       "dependencies": {
         "@agent-relay/config": "6.0.2",
         "@agent-relay/github-primitive": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@agent-relay/cloud": "6.0.2",
     "@agent-relay/config": "6.0.2",
     "@agent-relay/hooks": "6.0.2",
-    "@agent-relay/sdk": "6.0.2",
+    "@agent-relay/sdk": "6.1.0",
     "@agent-relay/telemetry": "6.0.2",
     "@agent-relay/trajectory": "6.0.2",
     "@agent-relay/user-directory": "6.0.2",

--- a/packages/acp-bridge/package.json
+++ b/packages/acp-bridge/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@agent-relay/sdk": "6.0.2",
+    "@agent-relay/sdk": "6.1.0",
     "@agentclientprotocol/sdk": "^0.12.0"
   },
   "devDependencies": {

--- a/packages/browser-primitive/package.json
+++ b/packages/browser-primitive/package.json
@@ -38,7 +38,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-relay/sdk": "6.0.2",
+    "@agent-relay/sdk": "6.1.0",
     "playwright": "^1.51.1"
   },
   "devDependencies": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -23,7 +23,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-relay/sdk": "6.0.2"
+    "@agent-relay/sdk": "6.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@agent-relay/config": "6.0.2",
     "@agent-relay/trajectory": "6.0.2",
-    "@agent-relay/sdk": "6.0.2"
+    "@agent-relay/sdk": "6.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -29,7 +29,7 @@
     "postinstall": "node -e \"try{require('child_process').execSync('ldd --version 2>&1',{stdio:'pipe'})}catch{try{require('child_process').execSync('apk info gcompat 2>/dev/null',{stdio:'pipe'})}catch{console.warn('\\n\\u26a0\\ufe0f  @agent-relay/openclaw: Alpine detected without gcompat. Spawning requires glibc.\\n   Install with: apk add gcompat libstdc++\\n')}}\""
   },
   "dependencies": {
-    "@agent-relay/sdk": "6.0.2",
+    "@agent-relay/sdk": "6.1.0",
     "@relaycast/sdk": "^1.0.0",
     "ws": "^8.0.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-relay/sdk",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/src/workflows/__tests__/run-script.test.ts
+++ b/packages/sdk/src/workflows/__tests__/run-script.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+
+import {
+  parseTsxStderr,
+  formatWorkflowParseError,
+  runScriptWorkflow,
+  findLocalSdkWorkspace,
+} from '../run-script.js';
+
+describe('parseTsxStderr', () => {
+  it('extracts file/line/col/message from inline `file:line:col: ERROR:` format', () => {
+    const stderr = '/repo/workflow.ts:42:7: ERROR: Expected "}" but found end of file\n';
+    const parsed = parseTsxStderr(stderr);
+
+    expect(parsed).toEqual({
+      file: '/repo/workflow.ts',
+      line: 42,
+      column: 7,
+      message: 'Expected "}" but found end of file',
+    });
+  });
+
+  it('extracts pretty-printed `✘ [ERROR]` format', () => {
+    const stderr = `✘ [ERROR] Unexpected "$"
+
+    /repo/workflow.ts:10:4:
+      10 │   command: \`echo \${VAR}\`
+         ╵     ^
+`;
+    const parsed = parseTsxStderr(stderr);
+
+    expect(parsed).toMatchObject({
+      file: '/repo/workflow.ts',
+      line: 10,
+      column: 4,
+      message: 'Unexpected "$"',
+    });
+  });
+
+  it('strips ANSI color codes before matching', () => {
+    const stderr = '\x1b[31m/repo/workflow.ts:1:1: ERROR: bad token\x1b[0m\n';
+    const parsed = parseTsxStderr(stderr);
+
+    expect(parsed?.file).toBe('/repo/workflow.ts');
+    expect(parsed?.message).toBe('bad token');
+  });
+
+  it('returns null when stderr does not look like a parse error', () => {
+    expect(parseTsxStderr('Error: Cannot find module foo')).toBeNull();
+    expect(parseTsxStderr('')).toBeNull();
+  });
+});
+
+describe('formatWorkflowParseError', () => {
+  it('produces a WORKFLOW_PARSE_ERROR with template-literal hints when applicable', () => {
+    const err = formatWorkflowParseError({
+      file: '/repo/workflow.ts',
+      line: 12,
+      column: 4,
+      message: 'Unterminated template literal',
+    });
+
+    expect((err as Error & { code?: string }).code).toBe('WORKFLOW_PARSE_ERROR');
+    expect(err.message).toContain('/repo/workflow.ts:12:4');
+    expect(err.message).toMatch(/template literal/i);
+  });
+
+  it('falls back to the bare error when no hint is applicable', () => {
+    const err = formatWorkflowParseError({
+      file: '/repo/workflow.ts',
+      message: 'TypeScript parse error (see tsx output above)',
+    });
+
+    expect(err.message).toContain('TypeScript parse error');
+    expect(err.message).not.toMatch(/Hint:/);
+  });
+});
+
+describe('runScriptWorkflow', () => {
+  it('throws when the file does not exist', async () => {
+    await expect(runScriptWorkflow('/definitely/does/not/exist.ts')).rejects.toThrow(/File not found/);
+  });
+
+  it('rejects unsupported extensions', async () => {
+    // Use a file that exists (this test file itself) but with an unsupported ext —
+    // there is no way to make the extension unsupported on a real path other than
+    // pointing at one. Use the README as a stand-in.
+    const fakePath = path.resolve(__dirname, '../../../README.md');
+    await expect(runScriptWorkflow(fakePath)).rejects.toThrow(/Unsupported file type/);
+  });
+});
+
+describe('findLocalSdkWorkspace', () => {
+  it('returns null when no agent-relay workspace is in the ancestor chain', () => {
+    expect(findLocalSdkWorkspace('/tmp')).toBeNull();
+  });
+});

--- a/packages/sdk/src/workflows/index.ts
+++ b/packages/sdk/src/workflows/index.ts
@@ -48,3 +48,16 @@ export * from './proxy-env.js';
 export * from './budget-tracker.js';
 export { applySiblingLinks, buildSiblingLinkScript } from './sibling-links.js';
 export type { SiblingLink, SiblingLinkOptions } from './sibling-links.js';
+export {
+  runScriptWorkflow,
+  parseTsxStderr,
+  formatWorkflowParseError,
+  findLocalSdkWorkspace,
+  ensureLocalSdkWorkflowRuntime,
+} from './run-script.js';
+export type {
+  RunScriptWorkflowOptions,
+  ParsedWorkflowError,
+  LocalSdkWorkspace,
+  ExecFileSyncLike,
+} from './run-script.js';

--- a/packages/sdk/src/workflows/run-script.ts
+++ b/packages/sdk/src/workflows/run-script.ts
@@ -1,0 +1,462 @@
+/**
+ * Programmatic local runner for `.ts` / `.tsx` / `.py` workflow scripts.
+ *
+ * This is the body of the `agent-relay run <script>` command extracted into
+ * the SDK so other tools (e.g. `ricky run`) can drive the same execution
+ * flow without shelling out to the `agent-relay` binary.
+ *
+ * Behavior is preserved exactly — the relay CLI's `run` command now
+ * delegates to `runScriptWorkflow()` with no semantic change.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync, spawn as spawnProcess, spawnSync } from 'node:child_process';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ExecFileSyncLike = typeof execFileSync;
+
+export interface RunScriptWorkflowOptions {
+  /** Validate without running. Sets `DRY_RUN=true` in the child env. */
+  dryRun?: boolean;
+  /** Resume a previously failed workflow run by id. */
+  resume?: string;
+  /** Start from the given step name, skipping predecessors. */
+  startFrom?: string;
+  /** Use cached outputs from this previous run id. Pairs with `startFrom`. */
+  previousRunId?: string;
+}
+
+/**
+ * Parsed workflow parse error, normalized from whatever shape the tsx/esbuild
+ * subprocess produced on stderr. Decoupling this from any specific error class
+ * means the formatter is testable in isolation and works regardless of how
+ * the error surfaced (TransformError from tsx, Bun-bundled esbuild error, etc.).
+ */
+export interface ParsedWorkflowError {
+  file: string;
+  line?: number;
+  column?: number;
+  message: string;
+  lineText?: string;
+}
+
+export interface LocalSdkWorkspace {
+  rootDir: string;
+  sdkDir: string;
+}
+
+interface SpawnRunnerResult {
+  status: number | null;
+  stderr: string;
+  error?: NodeJS.ErrnoException;
+}
+
+// ── Diagnostics ──────────────────────────────────────────────────────────────
+
+function diag(msg: string): void {
+  try {
+    process.stderr.write(`[agent-relay] ${msg}\n`);
+  } catch {
+    try {
+      process.stdout.write(`[agent-relay] ${msg}\n`);
+    } catch {
+      // Both streams closed — silently give up. Never throw from diag().
+    }
+  }
+}
+
+// ── Local SDK workspace detection ────────────────────────────────────────────
+
+/**
+ * Walk upward from `startDir` looking for a workspace where the root
+ * `package.json` is `agent-relay` and `packages/sdk/package.json` is
+ * `@agent-relay/sdk`. Returns the matched paths or `null`.
+ */
+export function findLocalSdkWorkspace(startDir: string): LocalSdkWorkspace | null {
+  let current = path.resolve(startDir);
+  const root = path.parse(current).root;
+
+  while (true) {
+    const packageJsonPath = path.join(current, 'package.json');
+    const sdkDir = path.join(current, 'packages', 'sdk');
+    const sdkPackageJsonPath = path.join(sdkDir, 'package.json');
+
+    try {
+      if (fs.existsSync(packageJsonPath) && fs.existsSync(sdkPackageJsonPath)) {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { name?: string };
+        const sdkPkg = JSON.parse(fs.readFileSync(sdkPackageJsonPath, 'utf8')) as { name?: string };
+        if (pkg.name === 'agent-relay' && sdkPkg.name === '@agent-relay/sdk') {
+          return { rootDir: current, sdkDir };
+        }
+      }
+    } catch {
+      // Ignore parse/read errors and continue walking upward.
+    }
+
+    if (current === root) return null;
+    current = path.dirname(current);
+  }
+}
+
+/**
+ * When running inside the relay monorepo, ensure `packages/sdk/dist/workflows`
+ * is built so the script can resolve `@agent-relay/sdk/workflows`. No-op
+ * outside the monorepo or when the build is already present.
+ */
+export function ensureLocalSdkWorkflowRuntime(
+  startDir: string,
+  execRunner: ExecFileSyncLike = execFileSync
+): void {
+  const workspace = findLocalSdkWorkspace(startDir);
+  if (!workspace) return;
+
+  const workflowsEntry = path.join(workspace.sdkDir, 'dist', 'workflows', 'index.js');
+  if (fs.existsSync(workflowsEntry)) return;
+
+  console.log(
+    '[agent-relay] Detected local @agent-relay/sdk workspace without built workflows runtime; building packages/sdk...'
+  );
+  execRunner('npm', ['run', 'build:sdk'], {
+    cwd: workspace.rootDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (!fs.existsSync(workflowsEntry)) {
+    throw new Error(`Local SDK workflows runtime is still missing after build: ${workflowsEntry}`);
+  }
+}
+
+// ── Workflow parse error normalization ───────────────────────────────────────
+
+/**
+ * Parse tsx's stderr for the esbuild parse-error fingerprint and extract a
+ * normalized {@link ParsedWorkflowError}. Returns null if nothing looks like
+ * a parse error — runtime errors, module-not-found, etc. pass through.
+ *
+ * We match two common esbuild output formats:
+ *   1. `/path/file.ts:LINE:COL: ERROR: message` (most common, one-liner)
+ *   2. `✘ [ERROR] message\n\n    /path/file.ts:LINE:COL:\n      LINE │ text\n           ╵ pointer`
+ *      (pretty-printed, multi-line)
+ */
+export function parseTsxStderr(stderr: string): ParsedWorkflowError | null {
+  // Strip ANSI color codes so our regex isn't thrown off by escape sequences.
+  // eslint-disable-next-line no-control-regex
+  const clean = stderr.replace(/\x1b\[[0-9;]*m/g, '');
+
+  // Format 1: file:line:col: ERROR: message
+  const inlineMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+):\s*ERROR:\s*([^\n]+)/);
+  if (inlineMatch) {
+    return {
+      file: inlineMatch[1]!,
+      line: Number(inlineMatch[2]),
+      column: Number(inlineMatch[3]),
+      message: inlineMatch[4]!.trim(),
+    };
+  }
+
+  // Format 2: ✘ [ERROR] message ... file:line:col:
+  const prettyError = clean.match(/✘\s*\[ERROR\]\s*([^\n]+)/);
+  if (prettyError) {
+    const locationMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+):/);
+    if (locationMatch) {
+      return {
+        file: locationMatch[1]!,
+        line: Number(locationMatch[2]),
+        column: Number(locationMatch[3]),
+        message: prettyError[1]!.trim(),
+      };
+    }
+  }
+
+  // Format 3: "Transform failed with N errors" — loose fallback, any file+loc pair
+  if (/Transform failed with \d+ error/i.test(clean) || /TransformError/.test(clean)) {
+    const looseMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+)/);
+    if (looseMatch) {
+      return {
+        file: looseMatch[1]!,
+        line: Number(looseMatch[2]),
+        column: Number(looseMatch[3]),
+        message: 'TypeScript parse error (see tsx output above)',
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format a {@link ParsedWorkflowError} as an actionable workflow-author error
+ * message with hints keyed off the most common mistakes in `command:` /
+ * `task:` template literals.
+ */
+export function formatWorkflowParseError(parsed: ParsedWorkflowError): Error {
+  const where =
+    parsed.line !== undefined
+      ? `${parsed.file}:${parsed.line}${parsed.column !== undefined ? `:${parsed.column}` : ''}`
+      : parsed.file;
+
+  const hints: string[] = [];
+  const text = parsed.message;
+
+  if (/Expected "\}" but found/i.test(text) || /Unterminated template literal/i.test(text)) {
+    hints.push(
+      'Likely a JavaScript template literal metacharacter inside a `command:` or `task:` block. ' +
+        'Inside workflow .ts files every `command: \\`...\\`` is a JavaScript template literal — ' +
+        'backticks terminate it and `${...}` triggers JS interpolation before the shell ever sees the string.',
+      'Fixes: use single quotes instead of backticks in prose/commit messages; ' +
+        'for shell variables use `$VAR` (no braces) or escape as `\\${VAR}`; ' +
+        'never write literal `\\n` inside a shell comment (it becomes a real newline).'
+    );
+  }
+
+  if (/Unexpected "\$"/.test(text)) {
+    hints.push(
+      'Unexpected `$` inside a template literal usually means `${...}` was interpreted as JS interpolation. ' +
+        'Escape it as `\\${...}` or drop the braces and use plain `$VAR`.'
+    );
+  }
+
+  if (/Expected identifier/.test(text) && /template/i.test(text)) {
+    hints.push(
+      'A template literal interpolation `${...}` needs a valid JS expression inside. ' +
+        'If you meant a shell variable, escape the `$` or drop the braces.'
+    );
+  }
+
+  const lines = ['', `Workflow file failed to parse: ${where}`, `  ${text}`];
+  if (parsed.lineText) {
+    lines.push(`  | ${parsed.lineText}`);
+    if (parsed.column !== undefined && parsed.column >= 0) {
+      lines.push(`  | ${' '.repeat(parsed.column)}^`);
+    }
+  }
+  if (hints.length > 0) {
+    lines.push('');
+    for (const hint of hints) {
+      lines.push(`Hint: ${hint}`);
+    }
+  }
+  lines.push('');
+
+  const wrapped = new Error(lines.join('\n'));
+  (wrapped as Error & { code?: string }).code = 'WORKFLOW_PARSE_ERROR';
+  return wrapped;
+}
+
+// ── Spawn helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Spawn a TypeScript runner (tsx, ts-node, npx tsx) with stdin/stdout
+ * inherited and stderr tee'd to both the user's terminal and an internal
+ * buffer. The buffer is inspected on non-zero exit to produce actionable
+ * error messages for workflow parse errors.
+ *
+ * Why this instead of `spawnSync({ stdio: 'inherit' })`: sync + inherit makes
+ * it impossible to post-process stderr. Async + tee gives us the best of
+ * both worlds — live progress for the user AND captured stderr for the
+ * parse-error wrapper.
+ */
+async function spawnRunnerWithStderrCapture(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): Promise<SpawnRunnerResult> {
+  return new Promise((resolve) => {
+    const child = spawnProcess(command, args, {
+      stdio: ['inherit', 'inherit', 'pipe'],
+      env,
+    });
+
+    let stderrBuf = '';
+
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      stderrBuf += text;
+      try {
+        process.stderr.write(text);
+      } catch {
+        // stderr closed — keep buffering for post-processing.
+      }
+    });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      resolve({ status: null, stderr: stderrBuf, error: err });
+    });
+
+    child.on('close', (status) => {
+      resolve({ status, stderr: stderrBuf });
+    });
+  });
+}
+
+// ── Main entry ───────────────────────────────────────────────────────────────
+
+/**
+ * Run a `.ts`, `.tsx`, or `.py` workflow script locally.
+ *
+ * For TypeScript files, tries Node's `--experimental-strip-types` first
+ * (Node 22.6+), then falls back to `tsx`, `ts-node`, and finally `npx tsx`.
+ * For Python files, tries `python3` then `python`.
+ *
+ * Throws on non-zero exit. The error message includes the run id (when
+ * the script wrote one to `AGENT_RELAY_RUN_ID_FILE`) so callers can resume
+ * with `--start-from <step> --previous-run-id <id>`.
+ */
+export async function runScriptWorkflow(
+  filePath: string,
+  options: RunScriptWorkflowOptions = {}
+): Promise<void> {
+  diag(`runScriptWorkflow: resolving ${filePath}`);
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+  const ext = path.extname(resolved).toLowerCase();
+  const runIdFile = path.join(
+    process.cwd(),
+    '.agent-relay',
+    `script-run-id-${process.pid}-${Date.now()}.txt`
+  );
+  try {
+    fs.mkdirSync(path.dirname(runIdFile), { recursive: true });
+  } catch {
+    // Run-id hint is optional — don't abort if directory is not writable
+  }
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, AGENT_RELAY_RUN_ID_FILE: runIdFile };
+  if (options.dryRun) childEnv.DRY_RUN = 'true';
+  if (options.resume) childEnv.RESUME_RUN_ID = options.resume;
+  if (options.startFrom) childEnv.START_FROM = options.startFrom;
+  if (options.previousRunId) childEnv.PREVIOUS_RUN_ID = options.previousRunId;
+
+  const augmentErrorWithRunId = (err: any): never => {
+    try {
+      if (fs.existsSync(runIdFile)) {
+        const runId = fs.readFileSync(runIdFile, 'utf8').trim();
+        if (runId && typeof err?.message === 'string' && !err.message.includes('Run ID:')) {
+          err.message += `
+Run ID: ${runId}`;
+        }
+      }
+    } catch {
+      // Ignore run-id hint failures and preserve the original error.
+    } finally {
+      try {
+        fs.rmSync(runIdFile, { force: true });
+      } catch {
+        // Ignore cleanup failure.
+      }
+    }
+    throw err;
+  };
+  const cleanupRunIdFile = () => {
+    try {
+      fs.rmSync(runIdFile, { force: true });
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (ext === '.ts' || ext === '.tsx') {
+    diag('runScriptWorkflow: ensureLocalSdkWorkflowRuntime start');
+    ensureLocalSdkWorkflowRuntime(path.dirname(resolved));
+    diag('runScriptWorkflow: ensureLocalSdkWorkflowRuntime done');
+
+    // Wrap a runner exit in an actionable workflow parse error if the
+    // captured stderr looks like esbuild tripped on a template literal.
+    // Otherwise fall through to a plain exit-code error (stderr was
+    // already live-streamed to the terminal).
+    const wrapRunnerError = (runner: string, result: SpawnRunnerResult): Error => {
+      const parsed = parseTsxStderr(result.stderr);
+      if (parsed) {
+        return formatWorkflowParseError(parsed);
+      }
+      return new Error(`${runner} exited with code ${result.status}`);
+    };
+
+    // Prefer Node's built-in type stripping (Node 22.6+) — no extra deps,
+    // no tsx CJS resolver quirks walking node_modules. Falls through to
+    // tsx/ts-node on older Nodes (they exit non-zero with an unknown-flag
+    // error, not ENOENT, so we treat any non-zero from this runner as a
+    // "try the next runner" signal rather than a real user error).
+    const runners: Array<{ label: string; bin: string; preArgs: string[] }> = [
+      {
+        label: 'node --experimental-strip-types',
+        bin: 'node',
+        preArgs: ['--experimental-strip-types', '--no-warnings=ExperimentalWarning'],
+      },
+      { label: 'tsx', bin: 'tsx', preArgs: [] },
+      { label: 'ts-node', bin: 'ts-node', preArgs: [] },
+    ];
+    for (const { label, bin, preArgs } of runners) {
+      diag(`runScriptWorkflow: trying runner ${label}`);
+      const result = await spawnRunnerWithStderrCapture(bin, [...preArgs, resolved], childEnv);
+      if (result.error) {
+        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+          diag(`runScriptWorkflow: runner ${label} returned ENOENT — trying next`);
+          continue;
+        }
+        return augmentErrorWithRunId(result.error);
+      }
+      if (result.status !== 0) {
+        // Node exits with code 9 ("Invalid Argument") when it doesn't
+        // recognise --experimental-strip-types (Node <22.6). Only skip
+        // to the next runner for that specific exit code; any other
+        // non-zero status is a real script failure.
+        if (bin === 'node' && result.status === 9) {
+          diag(`runScriptWorkflow: runner ${label} unsupported on this Node (exit 9) — trying next`);
+          continue;
+        }
+        return augmentErrorWithRunId(wrapRunnerError(label, result));
+      }
+      diag(`runScriptWorkflow: runner ${label} completed exit=0`);
+      cleanupRunIdFile();
+      return;
+    }
+    diag('runScriptWorkflow: falling back to npx tsx');
+    const npxResult = await spawnRunnerWithStderrCapture('npx', ['tsx', resolved], childEnv);
+    if (npxResult.error) {
+      return augmentErrorWithRunId(npxResult.error);
+    }
+    if (npxResult.status !== 0) {
+      return augmentErrorWithRunId(wrapRunnerError('npx tsx', npxResult));
+    }
+    diag('runScriptWorkflow: npx tsx completed');
+    cleanupRunIdFile();
+    return;
+  }
+  if (ext === '.py') {
+    const runners = ['python3', 'python'];
+    for (const runner of runners) {
+      diag(`runScriptWorkflow: trying runner ${runner}`);
+      const spawnResult = spawnSync(runner, [resolved], {
+        stdio: 'inherit',
+        env: childEnv,
+      });
+      if (spawnResult.error) {
+        if ((spawnResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
+          diag(`runScriptWorkflow: runner ${runner} returned ENOENT — trying next`);
+          continue;
+        }
+        return augmentErrorWithRunId(spawnResult.error);
+      }
+      if (spawnResult.status !== 0) {
+        const err = new Error(`${runner} exited with code ${spawnResult.status}`);
+        return augmentErrorWithRunId(err);
+      }
+      diag(`runScriptWorkflow: runner ${runner} completed exit=0`);
+      cleanupRunIdFile();
+      return;
+    }
+    cleanupRunIdFile();
+    throw new Error('Python not found. Install Python 3.10+ to run .py workflow files.');
+  }
+  try {
+    fs.rmSync(runIdFile, { force: true });
+  } catch {
+    // Ignore cleanup failure.
+  }
+  throw new Error(`Unsupported file type: ${ext}. Use .yaml, .yml, .ts, or .py`);
+}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,7 +1,6 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
-import { execFileSync, spawn as spawnProcess, spawnSync } from 'node:child_process';
+import { spawn as spawnProcess } from 'node:child_process';
 import { Command } from 'commander';
 import { getProjectPaths } from '@agent-relay/config';
 import { readBrokerConnection } from '../lib/broker-lifecycle.js';
@@ -13,23 +12,26 @@ import {
   track,
   type WorkflowFileType as TelemetryWorkflowFileType,
 } from '@agent-relay/telemetry';
-import { runWorkflow } from '@agent-relay/sdk/workflows';
+import {
+  runWorkflow,
+  runScriptWorkflow,
+  ensureLocalSdkWorkflowRuntime,
+  findLocalSdkWorkspace,
+  parseTsxStderr,
+  formatWorkflowParseError,
+  type ParsedWorkflowError,
+} from '@agent-relay/sdk/workflows';
 import type { WorkflowEvent } from '@agent-relay/sdk/workflows';
 import { CliExit, defaultExit } from '../lib/exit.js';
 import { errorClassName } from '../lib/telemetry-helpers.js';
 
-function diag(msg: string): void {
-  try {
-    process.stderr.write(`[agent-relay] ${msg}\n`);
-  } catch {
-    // Fallback: if stderr is closed, try stdout. Never throw.
-    try {
-      process.stdout.write(`[agent-relay] ${msg}\n`);
-    } catch {
-      // Both streams closed — silently give up. Never throw from diag().
-    }
-  }
-}
+export {
+  ensureLocalSdkWorkflowRuntime,
+  findLocalSdkWorkspace,
+  parseTsxStderr,
+  formatWorkflowParseError,
+  type ParsedWorkflowError,
+};
 
 type ExitFn = (code: number) => never;
 type RunInitOptions = {
@@ -49,12 +51,6 @@ type WorkflowRunResult = {
   error?: string;
 };
 
-type LocalSdkWorkspace = {
-  rootDir: string;
-  sdkDir: string;
-};
-
-type ExecFileSyncLike = typeof execFileSync;
 export interface SetupDependencies {
   runInit: (options: RunInitOptions) => Promise<void>;
   runTelemetry: (action?: string) => Promise<void> | void;
@@ -91,7 +87,7 @@ function withDefaults(overrides: Partial<SetupDependencies> = {}): SetupDependen
     runInit: overrides.runInit ?? ((options: RunInitOptions) => runInitDefault(options, io)),
     runTelemetry: overrides.runTelemetry ?? ((action?: string) => runTelemetryDefault(action, io)),
     runYamlWorkflow: runYamlWorkflowDefault,
-    runScriptWorkflow: runScriptFile,
+    runScriptWorkflow,
     log,
     error,
     exit,
@@ -124,390 +120,6 @@ async function runYamlWorkflowDefault(
     return { status: report.valid ? 'dry-run' : 'failed', error: report.errors.join('; ') || undefined };
   }
   return result;
-}
-export function findLocalSdkWorkspace(startDir: string): LocalSdkWorkspace | null {
-  let current = path.resolve(startDir);
-  const root = path.parse(current).root;
-
-  while (true) {
-    const packageJsonPath = path.join(current, 'package.json');
-    const sdkDir = path.join(current, 'packages', 'sdk');
-    const sdkPackageJsonPath = path.join(sdkDir, 'package.json');
-
-    try {
-      if (fs.existsSync(packageJsonPath) && fs.existsSync(sdkPackageJsonPath)) {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { name?: string };
-        const sdkPkg = JSON.parse(fs.readFileSync(sdkPackageJsonPath, 'utf8')) as { name?: string };
-        if (pkg.name === 'agent-relay' && sdkPkg.name === '@agent-relay/sdk') {
-          return { rootDir: current, sdkDir };
-        }
-      }
-    } catch {
-      // Ignore parse/read errors and continue walking upward.
-    }
-
-    if (current === root) return null;
-    current = path.dirname(current);
-  }
-}
-
-export function ensureLocalSdkWorkflowRuntime(
-  startDir: string,
-  execRunner: ExecFileSyncLike = execFileSync
-): void {
-  const workspace = findLocalSdkWorkspace(startDir);
-  if (!workspace) return;
-
-  const workflowsEntry = path.join(workspace.sdkDir, 'dist', 'workflows', 'index.js');
-  if (fs.existsSync(workflowsEntry)) return;
-
-  console.log(
-    '[agent-relay] Detected local @agent-relay/sdk workspace without built workflows runtime; building packages/sdk...'
-  );
-  execRunner('npm', ['run', 'build:sdk'], {
-    cwd: workspace.rootDir,
-    stdio: 'inherit',
-    env: process.env,
-  });
-
-  if (!fs.existsSync(workflowsEntry)) {
-    throw new Error(`Local SDK workflows runtime is still missing after build: ${workflowsEntry}`);
-  }
-}
-
-/**
- * Parsed workflow parse error, normalized from whatever shape the tsx/esbuild
- * subprocess produced on stderr. Decoupling this from any specific error class
- * means the formatter is testable in isolation and works regardless of how
- * the error surfaced (TransformError from tsx, Bun-bundled esbuild error, etc.).
- */
-export interface ParsedWorkflowError {
-  file: string;
-  line?: number;
-  column?: number;
-  message: string;
-  lineText?: string;
-}
-
-/**
- * Parse tsx's stderr for the esbuild parse-error fingerprint and extract a
- * normalized {@link ParsedWorkflowError}. Returns null if nothing looks like
- * a parse error — runtime errors, module-not-found, etc. pass through.
- *
- * We match two common esbuild output formats:
- *   1. `/path/file.ts:LINE:COL: ERROR: message` (most common, one-liner)
- *   2. `✘ [ERROR] message\n\n    /path/file.ts:LINE:COL:\n      LINE │ text\n           ╵ pointer`
- *      (pretty-printed, multi-line)
- */
-export function parseTsxStderr(stderr: string): ParsedWorkflowError | null {
-  // Strip ANSI color codes so our regex isn't thrown off by escape sequences.
-  // eslint-disable-next-line no-control-regex
-  const clean = stderr.replace(/\x1b\[[0-9;]*m/g, '');
-
-  // Format 1: file:line:col: ERROR: message
-  const inlineMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+):\s*ERROR:\s*([^\n]+)/);
-  if (inlineMatch) {
-    return {
-      file: inlineMatch[1]!,
-      line: Number(inlineMatch[2]),
-      column: Number(inlineMatch[3]),
-      message: inlineMatch[4]!.trim(),
-    };
-  }
-
-  // Format 2: ✘ [ERROR] message ... file:line:col:
-  const prettyError = clean.match(/✘\s*\[ERROR\]\s*([^\n]+)/);
-  if (prettyError) {
-    const locationMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+):/);
-    if (locationMatch) {
-      return {
-        file: locationMatch[1]!,
-        line: Number(locationMatch[2]),
-        column: Number(locationMatch[3]),
-        message: prettyError[1]!.trim(),
-      };
-    }
-  }
-
-  // Format 3: "Transform failed with N errors" — loose fallback, any file+loc pair
-  if (/Transform failed with \d+ error/i.test(clean) || /TransformError/.test(clean)) {
-    const looseMatch = clean.match(/(\/[^\s:]+\.(?:ts|tsx|mts|cts)):(\d+):(\d+)/);
-    if (looseMatch) {
-      return {
-        file: looseMatch[1]!,
-        line: Number(looseMatch[2]),
-        column: Number(looseMatch[3]),
-        message: 'TypeScript parse error (see tsx output above)',
-      };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Format a {@link ParsedWorkflowError} as an actionable workflow-author error
- * message with hints keyed off the most common mistakes in `command:` /
- * `task:` template literals.
- */
-export function formatWorkflowParseError(parsed: ParsedWorkflowError): Error {
-  const where =
-    parsed.line !== undefined
-      ? `${parsed.file}:${parsed.line}${parsed.column !== undefined ? `:${parsed.column}` : ''}`
-      : parsed.file;
-
-  const hints: string[] = [];
-  const text = parsed.message;
-
-  if (/Expected "\}" but found/i.test(text) || /Unterminated template literal/i.test(text)) {
-    hints.push(
-      'Likely a JavaScript template literal metacharacter inside a `command:` or `task:` block. ' +
-        'Inside workflow .ts files every `command: \\`...\\`` is a JavaScript template literal — ' +
-        'backticks terminate it and `${...}` triggers JS interpolation before the shell ever sees the string.',
-      'Fixes: use single quotes instead of backticks in prose/commit messages; ' +
-        'for shell variables use `$VAR` (no braces) or escape as `\\${VAR}`; ' +
-        'never write literal `\\n` inside a shell comment (it becomes a real newline).'
-    );
-  }
-
-  if (/Unexpected "\$"/.test(text)) {
-    hints.push(
-      'Unexpected `$` inside a template literal usually means `${...}` was interpreted as JS interpolation. ' +
-        'Escape it as `\\${...}` or drop the braces and use plain `$VAR`.'
-    );
-  }
-
-  if (/Expected identifier/.test(text) && /template/i.test(text)) {
-    hints.push(
-      'A template literal interpolation `${...}` needs a valid JS expression inside. ' +
-        'If you meant a shell variable, escape the `$` or drop the braces.'
-    );
-  }
-
-  const lines = ['', `Workflow file failed to parse: ${where}`, `  ${text}`];
-  if (parsed.lineText) {
-    lines.push(`  | ${parsed.lineText}`);
-    if (parsed.column !== undefined && parsed.column >= 0) {
-      lines.push(`  | ${' '.repeat(parsed.column)}^`);
-    }
-  }
-  if (hints.length > 0) {
-    lines.push('');
-    for (const hint of hints) {
-      lines.push(`Hint: ${hint}`);
-    }
-  }
-  lines.push('');
-
-  const wrapped = new Error(lines.join('\n'));
-  (wrapped as Error & { code?: string }).code = 'WORKFLOW_PARSE_ERROR';
-  return wrapped;
-}
-
-/**
- * Spawn a TypeScript runner (tsx, ts-node, npx tsx) with stdin/stdout
- * inherited and stderr tee'd to both the user's terminal and an internal
- * buffer. The buffer is inspected on non-zero exit to produce actionable
- * error messages for workflow parse errors.
- *
- * Why this instead of `spawnSync({ stdio: 'inherit' })`: sync + inherit makes
- * it impossible to post-process stderr. Async + tee gives us the best of
- * both worlds — live progress for the user AND captured stderr for the
- * parse-error wrapper.
- */
-interface SpawnRunnerResult {
-  status: number | null;
-  stderr: string;
-  error?: NodeJS.ErrnoException;
-}
-
-async function spawnRunnerWithStderrCapture(
-  command: string,
-  args: string[],
-  env: NodeJS.ProcessEnv
-): Promise<SpawnRunnerResult> {
-  return new Promise((resolve) => {
-    const child = spawnProcess(command, args, {
-      stdio: ['inherit', 'inherit', 'pipe'],
-      env,
-    });
-
-    let stderrBuf = '';
-
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-      stderrBuf += text;
-      try {
-        process.stderr.write(text);
-      } catch {
-        // stderr closed — keep buffering for post-processing.
-      }
-    });
-
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      resolve({ status: null, stderr: stderrBuf, error: err });
-    });
-
-    child.on('close', (status) => {
-      resolve({ status, stderr: stderrBuf });
-    });
-  });
-}
-
-async function runScriptFile(
-  filePath: string,
-  options: { dryRun?: boolean; resume?: string; startFrom?: string; previousRunId?: string } = {}
-): Promise<void> {
-  diag(`runScriptFile: resolving ${filePath}`);
-  const resolved = path.resolve(filePath);
-  if (!fs.existsSync(resolved)) {
-    throw new Error(`File not found: ${resolved}`);
-  }
-  const ext = path.extname(resolved).toLowerCase();
-  const runIdFile = path.join(
-    process.cwd(),
-    '.agent-relay',
-    `script-run-id-${process.pid}-${Date.now()}.txt`
-  );
-  try {
-    fs.mkdirSync(path.dirname(runIdFile), { recursive: true });
-  } catch {
-    // Run-id hint is optional — don't abort if directory is not writable
-  }
-  const childEnv: NodeJS.ProcessEnv = { ...process.env, AGENT_RELAY_RUN_ID_FILE: runIdFile };
-  if (options.dryRun) childEnv.DRY_RUN = 'true';
-  if (options.resume) childEnv.RESUME_RUN_ID = options.resume;
-  if (options.startFrom) childEnv.START_FROM = options.startFrom;
-  if (options.previousRunId) childEnv.PREVIOUS_RUN_ID = options.previousRunId;
-
-  const augmentErrorWithRunId = (err: any): never => {
-    try {
-      if (fs.existsSync(runIdFile)) {
-        const runId = fs.readFileSync(runIdFile, 'utf8').trim();
-        if (runId && typeof err?.message === 'string' && !err.message.includes('Run ID:')) {
-          err.message += `
-Run ID: ${runId}`;
-        }
-      }
-    } catch {
-      // Ignore run-id hint failures and preserve the original error.
-    } finally {
-      try {
-        fs.rmSync(runIdFile, { force: true });
-      } catch {
-        // Ignore cleanup failure.
-      }
-    }
-    throw err;
-  };
-  const cleanupRunIdFile = () => {
-    try {
-      fs.rmSync(runIdFile, { force: true });
-    } catch {
-      /* ignore */
-    }
-  };
-
-  if (ext === '.ts' || ext === '.tsx') {
-    diag('runScriptFile: ensureLocalSdkWorkflowRuntime start');
-    ensureLocalSdkWorkflowRuntime(path.dirname(resolved));
-    diag('runScriptFile: ensureLocalSdkWorkflowRuntime done');
-
-    // Wrap a runner exit in an actionable workflow parse error if the
-    // captured stderr looks like esbuild tripped on a template literal.
-    // Otherwise fall through to a plain exit-code error (stderr was
-    // already live-streamed to the terminal).
-    const wrapRunnerError = (runner: string, result: SpawnRunnerResult): Error => {
-      const parsed = parseTsxStderr(result.stderr);
-      if (parsed) {
-        return formatWorkflowParseError(parsed);
-      }
-      return new Error(`${runner} exited with code ${result.status}`);
-    };
-
-    // Prefer Node's built-in type stripping (Node 22.6+) — no extra deps,
-    // no tsx CJS resolver quirks walking node_modules. Falls through to
-    // tsx/ts-node on older Nodes (they exit non-zero with an unknown-flag
-    // error, not ENOENT, so we treat any non-zero from this runner as a
-    // "try the next runner" signal rather than a real user error).
-    const runners: Array<{ label: string; bin: string; preArgs: string[] }> = [
-      {
-        label: 'node --experimental-strip-types',
-        bin: 'node',
-        preArgs: ['--experimental-strip-types', '--no-warnings=ExperimentalWarning'],
-      },
-      { label: 'tsx', bin: 'tsx', preArgs: [] },
-      { label: 'ts-node', bin: 'ts-node', preArgs: [] },
-    ];
-    for (const { label, bin, preArgs } of runners) {
-      diag(`runScriptFile: trying runner ${label}`);
-      const result = await spawnRunnerWithStderrCapture(bin, [...preArgs, resolved], childEnv);
-      if (result.error) {
-        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
-          diag(`runScriptFile: runner ${label} returned ENOENT — trying next`);
-          continue;
-        }
-        return augmentErrorWithRunId(result.error);
-      }
-      if (result.status !== 0) {
-        // Node exits with code 9 ("Invalid Argument") when it doesn't
-        // recognise --experimental-strip-types (Node <22.6). Only skip
-        // to the next runner for that specific exit code; any other
-        // non-zero status is a real script failure.
-        if (bin === 'node' && result.status === 9) {
-          diag(`runScriptFile: runner ${label} unsupported on this Node (exit 9) — trying next`);
-          continue;
-        }
-        return augmentErrorWithRunId(wrapRunnerError(label, result));
-      }
-      diag(`runScriptFile: runner ${label} completed exit=0`);
-      cleanupRunIdFile();
-      return;
-    }
-    diag('runScriptFile: falling back to npx tsx');
-    const npxResult = await spawnRunnerWithStderrCapture('npx', ['tsx', resolved], childEnv);
-    if (npxResult.error) {
-      return augmentErrorWithRunId(npxResult.error);
-    }
-    if (npxResult.status !== 0) {
-      return augmentErrorWithRunId(wrapRunnerError('npx tsx', npxResult));
-    }
-    diag('runScriptFile: npx tsx completed');
-    cleanupRunIdFile();
-    return;
-  }
-  if (ext === '.py') {
-    const runners = ['python3', 'python'];
-    for (const runner of runners) {
-      diag(`runScriptFile: trying runner ${runner}`);
-      const spawnResult = spawnSync(runner, [resolved], {
-        stdio: 'inherit',
-        env: childEnv,
-      });
-      if (spawnResult.error) {
-        if ((spawnResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
-          diag(`runScriptFile: runner ${runner} returned ENOENT — trying next`);
-          continue;
-        }
-        return augmentErrorWithRunId(spawnResult.error);
-      }
-      if (spawnResult.status !== 0) {
-        const err = new Error(`${runner} exited with code ${spawnResult.status}`);
-        return augmentErrorWithRunId(err);
-      }
-      diag(`runScriptFile: runner ${runner} completed exit=0`);
-      cleanupRunIdFile();
-      return;
-    }
-    cleanupRunIdFile();
-    throw new Error('Python not found. Install Python 3.10+ to run .py workflow files.');
-  }
-  try {
-    fs.rmSync(runIdFile, { force: true });
-  } catch {
-    // Ignore cleanup failure.
-  }
-  throw new Error(`Unsupported file type: ${ext}. Use .yaml, .yml, .ts, or .py`);
 }
 async function runInitDefault(options: RunInitOptions, io: SetupIo): Promise<void> {
   const prompt = async (question: string, defaultYes = true): Promise<boolean> => {


### PR DESCRIPTION
## Summary

Lifts the body of `agent-relay run <script>` out of the relay CLI and into the published `@agent-relay/sdk/workflows` so other tools — ricky in particular — can drive the same `.ts` / `.tsx` / `.py` execution flow in-process instead of spawning the `agent-relay` binary.

- New SDK exports from `@agent-relay/sdk/workflows`:
  - `runScriptWorkflow(filePath, options)` — main API
  - `parseTsxStderr` / `formatWorkflowParseError` — workflow parse-error normalizer
  - `findLocalSdkWorkspace` / `ensureLocalSdkWorkflowRuntime` — dev-mode SDK auto-build helpers
  - Types: `RunScriptWorkflowOptions`, `ParsedWorkflowError`, `LocalSdkWorkspace`, `ExecFileSyncLike`
- `@agent-relay/sdk` 6.0.2 → 6.1.0 (additive). Root `@agent-relay/sdk` dep updated to match.
- `relay/src/cli/commands/setup.ts`: ~390 lines of helper functions deleted and replaced with imports from `@agent-relay/sdk/workflows`. The CLI's `run` command body is unchanged in shape — it just delegates to the SDK function, and `setup.ts` still re-exports the helpers so any internal consumer importing from it keeps working.
- 9 unit tests added in `packages/sdk/src/workflows/__tests__/run-script.test.ts` (parse-error normalizer, formatter hints, missing-file error, unsupported-extension error, workspace detector).

Net diff: −408 / +625 (the SDK gains the run-script body + tests; the CLI shrinks).

## Why

Other AgentWorkforce tools want `<tool> run <script>` semantics that match `agent-relay run <script>` exactly. Today they shell out to the `agent-relay` binary, which means: (1) ~1-2s npx cold-start; (2) PATH / `--no-install` resolution issues for users with global vs local installs; (3) drift risk if relay changes its execution semantics. With this PR the runner is callable as a single import.

## Test plan

- [x] `vitest run` in `packages/sdk` (run-script tests) — **9 passed**
- [x] `vitest run src/cli/` (full relay CLI suite) — **178 passed, 5 skipped**
- [x] `tsc --noEmit` at repo root — clean
- [ ] Smoke test once published: a non-relay CLI imports `runScriptWorkflow` and runs a `.ts` workflow end-to-end (will follow up in the ricky-side PR that lands once 6.1.0 publishes)

## Compatibility

- `@agent-relay/sdk@6.0.x` consumers see only additive surface — no removed exports.
- `agent-relay run <file>` CLI behavior is byte-for-byte unchanged. Same telemetry, same exit codes, same log lines (the `[agent-relay]` diag breadcrumbs come from the same code, just imported from a new location).
- `setup.ts` still re-exports the helpers for any internal callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
