### PR TITLE
fix(ci): pack github-primitive + workflow-types in smoke; publish workflow-types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -633,11 +633,15 @@ jobs:
           mkdir -p packages/sdk/bin
           (cd packages/sdk && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd "packages/${{ matrix.broker_pkg }}" && npm pack --ignore-scripts --pack-destination "$TARBALLS")
-          # The build job bumped every workspace to NEW_VERSION. The SDK's
-          # `dependencies` pins `@agent-relay/config` at that version, which
-          # is not on the registry yet at this point in the workflow — so
-          # pack it locally and install it alongside the SDK.
+          # The build job bumped every workspace to NEW_VERSION. The SDK pins
+          # several internal @agent-relay/* packages at that exact version,
+          # none of which are on the registry yet at this point in the
+          # workflow — so pack them locally and install them alongside the
+          # SDK. Keep this list in sync with packages/sdk/package.json's
+          # `dependencies` whenever a new internal dep is added.
           (cd packages/config && npm pack --ignore-scripts --pack-destination "$TARBALLS")
+          (cd packages/github-primitive && npm pack --ignore-scripts --pack-destination "$TARBALLS")
+          (cd packages/workflow-types && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           ls -lh "$TARBALLS"
 
       - name: Install tarballs into scratch project
@@ -652,9 +656,12 @@ jobs:
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
           BROKER_TGZ=$(ls "$TARBALLS"/agent-relay-broker-${{ matrix.platform }}-*.tgz | head -n1)
           CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
-          echo "Installing $SDK_TGZ + $BROKER_TGZ + $CONFIG_TGZ"
+          GITHUB_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-github-primitive-*.tgz | head -n1)
+          WORKFLOW_TYPES_TGZ=$(ls "$TARBALLS"/agent-relay-workflow-types-*.tgz | head -n1)
+          echo "Installing $SDK_TGZ + $BROKER_TGZ + $CONFIG_TGZ + $GITHUB_PRIMITIVE_TGZ + $WORKFLOW_TYPES_TGZ"
           npm install --ignore-scripts --no-audit --no-fund \
-            "$SDK_TGZ" "$BROKER_TGZ" "$CONFIG_TGZ"
+            "$SDK_TGZ" "$BROKER_TGZ" "$CONFIG_TGZ" \
+            "$GITHUB_PRIMITIVE_TGZ" "$WORKFLOW_TYPES_TGZ"
           ls node_modules/@agent-relay/
 
       - name: Resolver smoke — getBrokerBinaryPath()
@@ -705,12 +712,14 @@ jobs:
           npm init -y --silent >/dev/null
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
           CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
-          # Install SDK + config (an internal required dep whose bumped
-          # version isn't on the registry yet) but skip the broker optional
-          # deps entirely. The resolver should return null and spawn()
-          # should throw the clear error.
+          GITHUB_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-github-primitive-*.tgz | head -n1)
+          WORKFLOW_TYPES_TGZ=$(ls "$TARBALLS"/agent-relay-workflow-types-*.tgz | head -n1)
+          # Install SDK + every internal required dep whose bumped version
+          # isn't on the registry yet, but skip the broker optional deps
+          # entirely. The resolver should return null and spawn() should
+          # throw the clear error.
           npm install --ignore-scripts --no-audit --no-fund --no-optional \
-            "$SDK_TGZ" "$CONFIG_TGZ"
+            "$SDK_TGZ" "$CONFIG_TGZ" "$GITHUB_PRIMITIVE_TGZ" "$WORKFLOW_TYPES_TGZ"
           node --input-type=module -e "
             import { AgentRelayClient } from '@agent-relay/sdk';
             try {
@@ -894,6 +903,7 @@ jobs:
           - credential-proxy
           - github-primitive
           - browser-primitive
+          - workflow-types
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

The v6.0.3 publish run ([25091201135](https://github.com/AgentWorkforce/relay/actions/runs/25091201135)) shipped a half-broken release: `agent-relay@6.0.3` is on npm but pinned to `@agent-relay/sdk@6.0.3`, `@agent-relay/cloud@6.0.3`, broker packages, etc. that were never published. Users now get \`ETARGET No matching version found for @agent-relay/cloud@6.0.3\` / \`@agent-relay/github-primitive@6.0.3\` on install.

Two underlying bugs:

1. **Smoke test couldn't install the SDK tarball.** \`smoke-broker-packages\` packs SDK + broker + config locally and \`npm install\`s them into a scratch project, expecting npm to resolve everything else from the registry. But \`@agent-relay/sdk@6.0.3\` added \`@agent-relay/github-primitive\` and already pinned \`@agent-relay/workflow-types\` at the about-to-be-published version. Those aren't on the registry yet at this point in the workflow → ETARGET → smoke fails on every platform → publish-broker-packages / publish-packages / publish-sdk-only all skipped on \`needs:\`. \`Publish Main Package\` has no such gate, so it shipped anyway, pointing at the missing deps.
2. **\`@agent-relay/workflow-types\` was never in the publish matrix.** \`npm view @agent-relay/workflow-types\` returns 404 — the package has never been on npm — but the SDK declares it as an exact-version hard dependency. Even after fix #1, installs would still fail on workflow-types until it's published.

## Fix

- Pack \`github-primitive\` and \`workflow-types\` in \`smoke-broker-packages\` alongside config, and pass their tarballs to \`npm install\` (both the main install and the linux-x64 negative smoke). The SDK now resolves entirely from local tarballs without registry round-trips.
- Add \`workflow-types\` to the \`publish-packages\` matrix.

The pack list is documented as needing to stay in sync with \`packages/sdk/package.json\` \`dependencies\`.

## Recovery

This PR fixes the workflow but doesn't republish the broken 6.0.3. Once merged, we still need to either (a) bump to v6.0.4 and re-run the publish workflow, or (b) deprecate \`agent-relay@6.0.3\` and republish the missing sub-packages at 6.0.3. (a) is cleaner.

## Test plan

- [ ] Manually run the publish workflow with \`dry_run=true\` against this branch and confirm \`smoke-broker-packages\` passes on all 4 platforms.
- [ ] Confirm \`publish-broker-packages\`, \`publish-packages\`, and \`publish-sdk-only\` are no longer skipped (assuming \`package=all\`).
- [ ] On the next real release, verify \`npm install agent-relay@<version>\` succeeds on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
