### PR TITLE
communicate: add Codex app-server adapter

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -107,6 +107,22 @@ await client.release('Worker1');
 await client.shutdown();
 ```
 
+### Communicate Mode
+
+Use communicate adapters when an agent framework owns the run loop and you want it to exchange Relaycast messages with other agents.
+
+```ts
+import { Relay, onRelay } from '@agent-relay/sdk/communicate';
+
+const relay = new Relay('CodexWorker');
+const codex = onRelay('CodexWorker', { framework: 'codex', cwd: process.cwd() }, relay);
+
+await codex.ready;
+await codex.send('Review the current branch and report risks.');
+```
+
+The Codex adapter uses `codex app-server` over stdio JSON-RPC instead of the foreground PTY path. That gives background workers structured `thread/*`, `turn/*`, and `item/*` events for steering and completion; it does not render the Codex TUI. On startup it ensures the `relaycast` MCP server is present in Codex config so the agent can use Relaycast tools in addition to injected inbox messages.
+
 ### Provider + Transport Spawning (Opencode/Claude)
 
 Use provider-first spawn helpers and set `transport` when you want headless mode.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -87,6 +87,11 @@
       "import": "./dist/communicate/adapters/claude-sdk.js",
       "default": "./dist/communicate/adapters/claude-sdk.js"
     },
+    "./communicate/adapters/codex": {
+      "types": "./dist/communicate/adapters/codex.d.ts",
+      "import": "./dist/communicate/adapters/codex.js",
+      "default": "./dist/communicate/adapters/codex.js"
+    },
     "./communicate/adapters/ai-sdk": {
       "types": "./dist/communicate/adapters/ai-sdk.d.ts",
       "import": "./dist/communicate/adapters/ai-sdk.js",

--- a/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { test } from 'vitest';
+
+const jsonRpcModulePath = '../../../communicate/adapters/codex-jsonrpc.js';
+
+async function loadJsonRpcModule(): Promise<any> {
+  return import(jsonRpcModulePath);
+}
+
+function createFakeTransport() {
+  const clientStdin = new PassThrough();
+  const clientStdout = new PassThrough();
+  const clientStderr = new PassThrough();
+  const exitCallbacks: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
+
+  return {
+    peerInput: clientStdin,
+    peerOutput: clientStdout,
+    transport: {
+      stdin: clientStdin,
+      stdout: clientStdout,
+      stderr: clientStderr,
+      kill() {
+        return true;
+      },
+      onExit(callback: (code: number | null, signal: NodeJS.Signals | null) => void) {
+        exitCallbacks.push(callback);
+      },
+    },
+    emitExit(code: number | null = 0, signal: NodeJS.Signals | null = null) {
+      for (const callback of exitCallbacks) {
+        callback(code, signal);
+      }
+    },
+  };
+}
+
+async function readJsonLine(input: PassThrough): Promise<any> {
+  const [chunk] = await once(input, 'data');
+  const line = chunk.toString().trim();
+  return JSON.parse(line);
+}
+
+function writeJsonLine(output: PassThrough, message: unknown): void {
+  output.write(`${JSON.stringify(message)}\n`);
+}
+
+test('CodexJsonRpcClient performs initialize handshake and initialized notification', async () => {
+  const { CodexJsonRpcClient } = await loadJsonRpcModule();
+  const fake = createFakeTransport();
+  const client = new CodexJsonRpcClient(fake.transport);
+
+  const initializePromise = client.initialize({
+    clientInfo: {
+      version: '6.0.3',
+    },
+    capabilities: {
+      experimentalApi: false,
+    },
+  });
+
+  const initializeRequest = await readJsonLine(fake.peerInput);
+  assert.equal(initializeRequest.jsonrpc, '2.0');
+  assert.equal(initializeRequest.method, 'initialize');
+  assert.deepEqual(initializeRequest.params.clientInfo, {
+    name: 'agent_relay',
+    title: 'Agent Relay',
+    version: '6.0.3',
+  });
+  assert.deepEqual(initializeRequest.params.capabilities, {
+    experimentalApi: false,
+  });
+
+  writeJsonLine(fake.peerOutput, {
+    jsonrpc: '2.0',
+    id: initializeRequest.id,
+    result: {
+      userAgent: 'codex-cli 0.124.0',
+      codexHome: '/tmp/codex-home',
+      platformFamily: 'unix',
+      platformOs: 'macos',
+    },
+  });
+
+  const initializedNotification = await readJsonLine(fake.peerInput);
+  assert.deepEqual(initializedNotification, {
+    jsonrpc: '2.0',
+    method: 'initialized',
+  });
+
+  const response = await initializePromise;
+  assert.equal(response.userAgent, 'codex-cli 0.124.0');
+});
+
+test('CodexJsonRpcClient resolves requests and dispatches server notifications', async () => {
+  const { CodexJsonRpcClient } = await loadJsonRpcModule();
+  const fake = createFakeTransport();
+  const client = new CodexJsonRpcClient(fake.transport);
+  const seenNotifications: any[] = [];
+  let resolveNotification!: () => void;
+  const notificationPromise = new Promise<void>((resolve) => {
+    resolveNotification = resolve;
+  });
+
+  client.onNotification((notification: any) => {
+    seenNotifications.push(notification);
+    resolveNotification();
+  });
+
+  const requestPromise = client.request('thread/start', { cwd: '/repo' });
+  const request = await readJsonLine(fake.peerInput);
+  assert.equal(request.method, 'thread/start');
+  assert.deepEqual(request.params, { cwd: '/repo' });
+
+  writeJsonLine(fake.peerOutput, {
+    jsonrpc: '2.0',
+    id: request.id,
+    result: {
+      thread: {
+        id: 'thread-1',
+      },
+    },
+  });
+  writeJsonLine(fake.peerOutput, {
+    jsonrpc: '2.0',
+    method: 'turn/completed',
+    params: {
+      threadId: 'thread-1',
+      turn: {
+        id: 'turn-1',
+      },
+    },
+  });
+
+  assert.deepEqual(await requestPromise, { thread: { id: 'thread-1' } });
+  await notificationPromise;
+  assert.deepEqual(seenNotifications, [
+    {
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+        },
+      },
+    },
+  ]);
+});
+
+test('CodexJsonRpcClient rejects JSON-RPC error responses', async () => {
+  const { CodexJsonRpcClient, CodexJsonRpcError } = await loadJsonRpcModule();
+  const fake = createFakeTransport();
+  const client = new CodexJsonRpcClient(fake.transport);
+
+  const requestPromise = client.request('turn/steer', { threadId: 'thread-1' });
+  const request = await readJsonLine(fake.peerInput);
+
+  writeJsonLine(fake.peerOutput, {
+    jsonrpc: '2.0',
+    id: request.id,
+    error: {
+      code: -32602,
+      message: 'Invalid params',
+    },
+  });
+
+  await assert.rejects(requestPromise, CodexJsonRpcError);
+});

--- a/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
@@ -168,3 +168,43 @@ test('CodexJsonRpcClient rejects JSON-RPC error responses', async () => {
 
   await assert.rejects(requestPromise, CodexJsonRpcError);
 });
+
+test('spawnCodexAppServer merges env overrides with the parent environment', async () => {
+  const { spawnCodexAppServer } = await loadJsonRpcModule();
+  const parentValue = `parent-${Date.now()}`;
+  process.env.CODEX_ADAPTER_PARENT_ENV = parentValue;
+
+  try {
+    const transport = spawnCodexAppServer({
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          'console.log(JSON.stringify({',
+          'parent: process.env.CODEX_ADAPTER_PARENT_ENV ?? null,',
+          'child: process.env.CODEX_ADAPTER_CHILD_ENV ?? null,',
+          '}));',
+        ].join(' '),
+      ],
+      env: {
+        CODEX_ADAPTER_CHILD_ENV: 'child',
+      },
+    });
+    let output = '';
+    transport.stdout.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+
+    const [code] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
+      transport.onExit((exitCode, signal) => resolve([exitCode, signal]));
+    });
+
+    assert.equal(code, 0);
+    assert.deepEqual(JSON.parse(output.trim()), {
+      parent: parentValue,
+      child: 'child',
+    });
+  } finally {
+    delete process.env.CODEX_ADAPTER_PARENT_ENV;
+  }
+});

--- a/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
@@ -209,6 +209,24 @@ test('spawnCodexAppServer merges env overrides with the parent environment', asy
   }
 });
 
+test('spawnCodexAppServer.onExit fires when the child has already exited before registration', async () => {
+  const { spawnCodexAppServer } = await loadJsonRpcModule();
+  const transport = spawnCodexAppServer({
+    command: process.execPath,
+    args: ['-e', 'process.exit(0)'],
+  });
+
+  // Wait long enough for the child to exit before we register onExit.
+  await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+  const [code] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
+    transport.onExit((exitCode: number | null, exitSignal: NodeJS.Signals | null) =>
+      resolve([exitCode, exitSignal])
+    );
+  });
+  assert.equal(code, 0);
+});
+
 test('spawnCodexAppServer surfaces spawn errors through onExit instead of crashing', async () => {
   const { spawnCodexAppServer } = await loadJsonRpcModule();
   const transport = spawnCodexAppServer({

--- a/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex-jsonrpc.test.ts
@@ -208,3 +208,20 @@ test('spawnCodexAppServer merges env overrides with the parent environment', asy
     delete process.env.CODEX_ADAPTER_PARENT_ENV;
   }
 });
+
+test('spawnCodexAppServer surfaces spawn errors through onExit instead of crashing', async () => {
+  const { spawnCodexAppServer } = await loadJsonRpcModule();
+  const transport = spawnCodexAppServer({
+    command: '/nonexistent/codex-binary-for-test',
+    args: [],
+  });
+
+  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
+    transport.onExit((exitCode: number | null, exitSignal: NodeJS.Signals | null) =>
+      resolve([exitCode, exitSignal])
+    );
+  });
+
+  assert.equal(code, null);
+  assert.equal(signal, null);
+});

--- a/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
@@ -56,6 +56,10 @@ class FakeCodexClient {
   }
 
   async request<T = unknown>(method: string, params?: any): Promise<T> {
+    if (this.closed) {
+      throw new Error('client closed');
+    }
+
     this.requests.push({ method, params });
 
     if (method === 'mcpServerStatus/list') {
@@ -212,6 +216,27 @@ test('Codex onRelay fails fast when the app-server version is too old', async ()
   assert.equal(requestsFor(client, 'thread/start').length, 0);
 });
 
+test('Codex onRelay omits threadId when resuming by path only', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+
+  const handle = onRelay(
+    'CodexTester',
+    {
+      framework: 'codex',
+      clientFactory: () => client,
+      resumePath: '/tmp/codex-thread.jsonl',
+    },
+    new FakeRelay()
+  );
+  await handle.ready;
+
+  const resumeRequest = lastRequest(client, 'thread/resume');
+  assert.equal(Object.hasOwn(resumeRequest.params, 'threadId'), false);
+  assert.equal(resumeRequest.params.path, '/tmp/codex-thread.jsonl');
+  assert.equal(handle.threadId, 'thread-resumed');
+});
+
 test('Codex item/completed drains relay inbox and steers the active turn', async () => {
   const { onRelay } = await loadCodexAdapterModule();
   const client = new FakeCodexClient(['relaycast']);
@@ -299,12 +324,51 @@ test('Codex fork creates an ephemeral fork handle on the same app-server client'
   assert.equal(lastRequest(client, 'turn/start').params.threadId, 'thread-fork-2');
 });
 
+test('Codex fork keeps the shared app-server client open until the last handle closes', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  const fork = await handle.fork({
+    name: 'CodexFork',
+    relay: new FakeRelay(),
+  });
+
+  await handle.close();
+  assert.equal(client.closed, false);
+
+  await fork.send('Continue on fork.');
+  assert.equal(lastRequest(client, 'turn/start').params.threadId, 'thread-fork-2');
+
+  await fork.close();
+  assert.equal(client.closed, true);
+});
+
 test('communicate onRelay routes framework codex targets to the Codex adapter', async () => {
   const { onRelay } = await loadCommunicateModule();
   const client = new FakeCodexClient(['relaycast']);
   const handle = onRelay(
     'CodexTopLevel',
     {
+      framework: 'codex',
+      clientFactory: () => client,
+    },
+    new FakeRelay()
+  );
+
+  await handle.ready;
+
+  assert.equal(handle.threadId, 'thread-1');
+  assert.equal(requestsFor(client, 'thread/start').length, 1);
+});
+
+test('communicate onRelay routes direct framework codex targets to the Codex adapter', async () => {
+  const { onRelay } = await loadCommunicateModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay(
+    {
+      name: 'CodexDirect',
       framework: 'codex',
       clientFactory: () => client,
     },

--- a/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
@@ -1,0 +1,318 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+const codexAdapterModulePath = '../../../communicate/adapters/codex.js';
+const communicateModulePath = '../../../communicate/index.js';
+
+async function loadCodexAdapterModule(): Promise<any> {
+  return import(codexAdapterModulePath);
+}
+
+async function loadCommunicateModule(): Promise<any> {
+  return import(communicateModulePath);
+}
+
+class FakeRelay {
+  inboxCalls = 0;
+  private queuedMessages: any[] = [];
+
+  queue(...messages: any[]): void {
+    this.queuedMessages.push(...messages);
+  }
+
+  async inbox(): Promise<any[]> {
+    this.inboxCalls += 1;
+    const drained = [...this.queuedMessages];
+    this.queuedMessages = [];
+    return drained;
+  }
+}
+
+class FakeCodexClient {
+  readonly requests: Array<{ method: string; params: any }> = [];
+  readonly initializeCalls: any[] = [];
+  private readonly listeners = new Set<(notification: any) => void | Promise<void>>();
+  private readonly mcpServerNames = new Set<string>();
+  private threadCounter = 1;
+  private turnCounter = 1;
+
+  closed = false;
+  userAgent = 'codex-cli 0.124.0';
+
+  constructor(mcpServerNames: string[] = []) {
+    for (const name of mcpServerNames) {
+      this.mcpServerNames.add(name);
+    }
+  }
+
+  async initialize(options: any): Promise<any> {
+    this.initializeCalls.push(options);
+    return {
+      userAgent: this.userAgent,
+      codexHome: '/tmp/codex-home',
+      platformFamily: 'unix',
+      platformOs: 'macos',
+    };
+  }
+
+  async request<T = unknown>(method: string, params?: any): Promise<T> {
+    this.requests.push({ method, params });
+
+    if (method === 'mcpServerStatus/list') {
+      return {
+        data: [...this.mcpServerNames].map((name) => ({ name })),
+        nextCursor: null,
+      } as T;
+    }
+
+    if (method === 'config/value/write') {
+      this.mcpServerNames.add('relaycast');
+      return {} as T;
+    }
+
+    if (method === 'config/mcpServer/reload') {
+      return {} as T;
+    }
+
+    if (method === 'thread/start') {
+      return {
+        thread: {
+          id: `thread-${this.threadCounter++}`,
+        },
+      } as T;
+    }
+
+    if (method === 'thread/resume') {
+      return {
+        thread: {
+          id: params.threadId || 'thread-resumed',
+        },
+      } as T;
+    }
+
+    if (method === 'thread/fork') {
+      return {
+        thread: {
+          id: `thread-fork-${this.threadCounter++}`,
+        },
+      } as T;
+    }
+
+    if (method === 'turn/start') {
+      return {
+        turn: {
+          id: `turn-${this.turnCounter++}`,
+        },
+      } as T;
+    }
+
+    if (method === 'turn/steer' || method === 'turn/interrupt' || method === 'thread/unsubscribe') {
+      return {} as T;
+    }
+
+    throw new Error(`Unexpected request: ${method}`);
+  }
+
+  onNotification(listener: (notification: any) => void | Promise<void>): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async emit(notification: any): Promise<void> {
+    for (const listener of [...this.listeners]) {
+      await listener(notification);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function requestsFor(client: FakeCodexClient, method: string): Array<{ method: string; params: any }> {
+  return client.requests.filter((request) => request.method === method);
+}
+
+function lastRequest(client: FakeCodexClient, method: string): { method: string; params: any } {
+  const requests = requestsFor(client, method);
+  assert.ok(requests.length > 0, `Expected request ${method}`);
+  return requests[requests.length - 1];
+}
+
+test('Codex onRelay initializes app-server, installs relaycast MCP, and starts a thread', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient();
+  const relay = new FakeRelay();
+
+  const handle = onRelay(
+    'CodexTester',
+    {
+      framework: 'codex',
+      cwd: '/repo',
+      model: 'gpt-5.2',
+      clientFactory: () => client,
+    },
+    relay
+  );
+
+  await handle.ready;
+
+  assert.equal(handle.threadId, 'thread-1');
+  assert.equal(client.initializeCalls.length, 1);
+  assert.deepEqual(client.initializeCalls[0].capabilities, {
+    experimentalApi: false,
+    optOutNotificationMethods: null,
+  });
+
+  assert.deepEqual(
+    client.requests.map((request) => request.method),
+    ['mcpServerStatus/list', 'config/value/write', 'config/mcpServer/reload', 'thread/start']
+  );
+  assert.deepEqual(lastRequest(client, 'config/value/write').params, {
+    keyPath: 'mcp_servers.relaycast',
+    value: {
+      command: 'agent-relay',
+      args: ['mcp'],
+    },
+    mergeStrategy: 'upsert',
+  });
+  assert.equal(lastRequest(client, 'thread/start').params.cwd, '/repo');
+  assert.equal(lastRequest(client, 'thread/start').params.model, 'gpt-5.2');
+});
+
+test('Codex onRelay does not rewrite config when relaycast MCP is already registered', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  assert.equal(requestsFor(client, 'config/value/write').length, 0);
+  assert.equal(requestsFor(client, 'config/mcpServer/reload').length, 0);
+  assert.equal(requestsFor(client, 'thread/start').length, 1);
+});
+
+test('Codex onRelay fails fast when the app-server version is too old', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  client.userAgent = 'codex-cli 0.123.0';
+
+  const handle = onRelay(
+    'CodexTester',
+    {
+      framework: 'codex',
+      clientFactory: () => client,
+    },
+    new FakeRelay()
+  );
+
+  await assert.rejects(handle.ready, /older than the supported minimum 0\.124\.0/);
+  assert.equal(requestsFor(client, 'thread/start').length, 0);
+});
+
+test('Codex item/completed drains relay inbox and steers the active turn', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const relay = new FakeRelay();
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, relay);
+  await handle.ready;
+
+  await client.emit({
+    method: 'turn/started',
+    params: {
+      threadId: 'thread-1',
+      turn: {
+        id: 'turn-live',
+      },
+    },
+  });
+  relay.queue({
+    sender: 'Lead',
+    text: 'Need the status now.',
+    messageId: 'message-1',
+  });
+
+  await client.emit({
+    method: 'item/completed',
+    params: {
+      threadId: 'thread-1',
+      turnId: 'turn-live',
+      item: {},
+    },
+  });
+
+  const steer = lastRequest(client, 'turn/steer');
+  assert.equal(steer.params.threadId, 'thread-1');
+  assert.equal(steer.params.expectedTurnId, 'turn-live');
+  assert.match(steer.params.input[0].text, /New messages from other agents:/);
+  assert.match(steer.params.input[0].text, /Relay message from Lead: Need the status now\./);
+});
+
+test('Codex turn/completed queues relay inbox for the next turn/start input', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const relay = new FakeRelay();
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, relay);
+  await handle.ready;
+
+  relay.queue({
+    sender: 'Reviewer',
+    text: 'Please include tests.',
+    messageId: 'message-2',
+  });
+  await client.emit({
+    method: 'turn/completed',
+    params: {
+      threadId: 'thread-1',
+      turn: {
+        id: 'turn-finished',
+      },
+    },
+  });
+
+  await handle.send('Continue implementation.');
+
+  const turnStart = lastRequest(client, 'turn/start');
+  assert.equal(turnStart.params.threadId, 'thread-1');
+  assert.match(turnStart.params.input[0].text, /Relay message from Reviewer: Please include tests\./);
+  assert.match(turnStart.params.input[0].text, /Continue implementation\./);
+});
+
+test('Codex fork creates an ephemeral fork handle on the same app-server client', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  const fork = await handle.fork({
+    name: 'CodexFork',
+    relay: new FakeRelay(),
+  });
+  await fork.send('Work from the fork.');
+
+  const forkRequest = lastRequest(client, 'thread/fork');
+  assert.equal(forkRequest.params.threadId, 'thread-1');
+  assert.equal(forkRequest.params.ephemeral, true);
+  assert.equal(fork.threadId, 'thread-fork-2');
+  assert.equal(lastRequest(client, 'turn/start').params.threadId, 'thread-fork-2');
+});
+
+test('communicate onRelay routes framework codex targets to the Codex adapter', async () => {
+  const { onRelay } = await loadCommunicateModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay(
+    'CodexTopLevel',
+    {
+      framework: 'codex',
+      clientFactory: () => client,
+    },
+    new FakeRelay()
+  );
+
+  await handle.ready;
+
+  assert.equal(handle.threadId, 'thread-1');
+  assert.equal(requestsFor(client, 'thread/start').length, 1);
+});

--- a/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
@@ -363,6 +363,43 @@ test('communicate onRelay routes framework codex targets to the Codex adapter', 
   assert.equal(requestsFor(client, 'thread/start').length, 1);
 });
 
+test('Codex turn/completed clears activeTurnId when payload uses params.turnId', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  await client.emit({
+    method: 'turn/started',
+    params: { threadId: 'thread-1', turnId: 'turn-via-id' },
+  });
+  assert.equal(handle.currentTurnId, 'turn-via-id');
+
+  await client.emit({
+    method: 'turn/completed',
+    params: { threadId: 'thread-1', turnId: 'turn-via-id' },
+  });
+  assert.equal(handle.currentTurnId, undefined);
+});
+
+test('Codex turn/completed for a different turnId leaves the active turn intact', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+  const client = new FakeCodexClient(['relaycast']);
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  await client.emit({
+    method: 'turn/started',
+    params: { threadId: 'thread-1', turnId: 'turn-live' },
+  });
+
+  await client.emit({
+    method: 'turn/completed',
+    params: { threadId: 'thread-1', turnId: 'turn-other' },
+  });
+  assert.equal(handle.currentTurnId, 'turn-live');
+});
+
 test('Codex interrupt keeps activeTurnId when the turn/interrupt request fails', async () => {
   const { onRelay } = await loadCodexAdapterModule();
 

--- a/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
+++ b/packages/sdk/src/__tests__/communicate/adapters/codex.test.ts
@@ -363,6 +363,42 @@ test('communicate onRelay routes framework codex targets to the Codex adapter', 
   assert.equal(requestsFor(client, 'thread/start').length, 1);
 });
 
+test('Codex interrupt keeps activeTurnId when the turn/interrupt request fails', async () => {
+  const { onRelay } = await loadCodexAdapterModule();
+
+  class InterruptFailingClient extends FakeCodexClient {
+    failInterrupt = false;
+    async request<T = unknown>(method: string, params?: any): Promise<T> {
+      if (method === 'turn/interrupt' && this.failInterrupt) {
+        this.requests.push({ method, params });
+        throw new Error('interrupt boom');
+      }
+      return super.request<T>(method, params);
+    }
+  }
+
+  const client = new InterruptFailingClient(['relaycast']);
+  const handle = onRelay('CodexTester', { framework: 'codex', clientFactory: () => client }, new FakeRelay());
+  await handle.ready;
+
+  await client.emit({
+    method: 'turn/started',
+    params: { threadId: 'thread-1', turn: { id: 'turn-live' } },
+  });
+
+  client.failInterrupt = true;
+  await assert.rejects(handle.interrupt(), /interrupt boom/);
+
+  client.failInterrupt = false;
+  const response = await handle.interrupt();
+  assert.ok(response, 'expected a second interrupt to succeed because activeTurnId was preserved');
+
+  const interrupts = requestsFor(client, 'turn/interrupt');
+  assert.equal(interrupts.length, 2);
+  assert.equal(interrupts[0].params.turnId, 'turn-live');
+  assert.equal(interrupts[1].params.turnId, 'turn-live');
+});
+
 test('communicate onRelay routes direct framework codex targets to the Codex adapter', async () => {
   const { onRelay } = await loadCommunicateModule();
   const client = new FakeCodexClient(['relaycast']);

--- a/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
+++ b/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
@@ -113,7 +113,7 @@ export class CodexJsonRpcError extends Error {
 export function spawnCodexAppServer(options: SpawnCodexAppServerOptions = {}): CodexJsonRpcTransport {
   const child = spawn(options.command ?? 'codex', options.args ?? DEFAULT_CODEX_APP_SERVER_ARGS, {
     cwd: options.cwd,
-    env: options.env,
+    env: options.env ? { ...process.env, ...options.env } : undefined,
     stdio: 'pipe',
   });
 

--- a/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
+++ b/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
@@ -1,0 +1,330 @@
+import { spawn } from 'node:child_process';
+import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue | undefined };
+export type JsonObject = { [key: string]: JsonValue | undefined };
+export type JsonRpcId = string | number;
+
+export type CodexJsonRpcNotification = {
+  method: string;
+  params?: unknown;
+};
+
+export type CodexClientInfo = {
+  name: string;
+  title?: string | null;
+  version: string;
+};
+
+export type CodexInitializeCapabilities = {
+  experimentalApi: boolean;
+  optOutNotificationMethods?: string[] | null;
+};
+
+export type CodexInitializeParams = {
+  clientInfo: CodexClientInfo;
+  capabilities: CodexInitializeCapabilities | null;
+};
+
+export type CodexInitializeResponse = {
+  userAgent: string;
+  codexHome: string;
+  platformFamily: string;
+  platformOs: string;
+};
+
+export interface CodexJsonRpcTransport {
+  stdin: Writable;
+  stdout: Readable;
+  stderr?: Readable;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  onExit(callback: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+}
+
+export interface SpawnCodexAppServerOptions {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface CodexJsonRpcClientOptions {
+  requestTimeoutMs?: number;
+}
+
+export interface CodexInitializeOptions {
+  clientInfo?: Partial<CodexClientInfo>;
+  capabilities?: CodexInitializeCapabilities | null;
+  timeoutMs?: number;
+}
+
+type PendingRequest = {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timeout: NodeJS.Timeout;
+};
+
+type NotificationListener = (notification: CodexJsonRpcNotification) => void | Promise<void>;
+
+type WireRequest = {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+};
+
+type WireNotification = {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+};
+
+type WireResponse = {
+  jsonrpc?: '2.0';
+  id?: JsonRpcId | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+  method?: string;
+  params?: unknown;
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_CODEX_APP_SERVER_ARGS = ['app-server', '--listen', 'stdio://'];
+const STDERR_TAIL_LIMIT = 8_192;
+
+export class CodexJsonRpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(`Codex JSON-RPC error ${code}: ${message}`);
+    this.name = 'CodexJsonRpcError';
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export function spawnCodexAppServer(options: SpawnCodexAppServerOptions = {}): CodexJsonRpcTransport {
+  const child = spawn(options.command ?? 'codex', options.args ?? DEFAULT_CODEX_APP_SERVER_ARGS, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: 'pipe',
+  });
+
+  return {
+    stdin: child.stdin,
+    stdout: child.stdout,
+    stderr: child.stderr,
+    kill: (signal?: NodeJS.Signals | number) => child.kill(signal),
+    onExit: (callback) => {
+      child.once('exit', callback);
+    },
+  };
+}
+
+export class CodexJsonRpcClient {
+  private readonly lineReader: ReadlineInterface;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly notificationListeners = new Set<NotificationListener>();
+  private readonly requestTimeoutMs: number;
+
+  private nextId = 1;
+  private closed = false;
+  private stderrTail = '';
+
+  constructor(
+    private readonly transport: CodexJsonRpcTransport,
+    options: CodexJsonRpcClientOptions = {}
+  ) {
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+    this.lineReader = createInterface({
+      input: transport.stdout,
+      crlfDelay: Infinity,
+    });
+    this.lineReader.on('line', (line) => this.handleLine(line));
+    this.lineReader.on('close', () => this.handleClose('stdout closed'));
+
+    transport.stderr?.on('data', (chunk: Buffer | string) => {
+      this.stderrTail = `${this.stderrTail}${chunk.toString()}`.slice(-STDERR_TAIL_LIMIT);
+    });
+
+    transport.onExit((code, signal) => {
+      const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
+      this.handleClose(`process exited with ${exitReason}`);
+    });
+  }
+
+  async initialize(options: CodexInitializeOptions = {}): Promise<CodexInitializeResponse> {
+    const params: CodexInitializeParams = {
+      clientInfo: {
+        name: options.clientInfo?.name ?? 'agent_relay',
+        title: options.clientInfo?.title ?? 'Agent Relay',
+        version: options.clientInfo?.version ?? process.env.npm_package_version ?? '0.0.0',
+      },
+      capabilities: options.capabilities ?? {
+        experimentalApi: false,
+      },
+    };
+
+    const response = await this.request<CodexInitializeResponse>('initialize', params, {
+      timeoutMs: options.timeoutMs,
+    });
+    await this.notify('initialized');
+    return response;
+  }
+
+  request<T = unknown>(method: string, params?: unknown, options: { timeoutMs?: number } = {}): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(new Error('Codex JSON-RPC client is closed'));
+    }
+
+    const id = this.nextId++;
+    const request: WireRequest = {
+      jsonrpc: '2.0',
+      id,
+      method,
+    };
+    if (params !== undefined) {
+      request.params = params;
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(String(id));
+        reject(new Error(`Codex JSON-RPC request timed out: ${method}`));
+      }, options.timeoutMs ?? this.requestTimeoutMs);
+
+      this.pending.set(String(id), {
+        resolve: (value) => resolve(value as T),
+        reject,
+        timeout,
+      });
+
+      try {
+        this.write(request);
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(String(id));
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    const notification: WireNotification = {
+      jsonrpc: '2.0',
+      method,
+    };
+    if (params !== undefined) {
+      notification.params = params;
+    }
+    this.write(notification);
+  }
+
+  onNotification(listener: NotificationListener): () => void {
+    this.notificationListeners.add(listener);
+    return () => {
+      this.notificationListeners.delete(listener);
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.rejectAll(new Error('Codex JSON-RPC client closed'));
+    this.lineReader.close();
+    this.transport.stdin.end();
+    this.transport.kill('SIGTERM');
+  }
+
+  private write(message: WireRequest | WireNotification): void {
+    this.transport.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+
+    let message: WireResponse;
+    try {
+      message = JSON.parse(trimmed) as WireResponse;
+    } catch (error) {
+      process.emitWarning(
+        `Ignoring invalid Codex JSON-RPC line: ${error instanceof Error ? error.message : String(error)}`,
+        'CodexJsonRpcWarning'
+      );
+      return;
+    }
+
+    if (message.id !== undefined && message.id !== null) {
+      this.handleResponse(message);
+      return;
+    }
+
+    if (typeof message.method === 'string') {
+      this.handleNotification({
+        method: message.method,
+        params: message.params,
+      });
+    }
+  }
+
+  private handleResponse(message: WireResponse): void {
+    const pending = this.pending.get(String(message.id));
+    if (!pending) {
+      return;
+    }
+
+    this.pending.delete(String(message.id));
+    clearTimeout(pending.timeout);
+
+    if (message.error) {
+      pending.reject(new CodexJsonRpcError(message.error.code, message.error.message, message.error.data));
+      return;
+    }
+
+    pending.resolve(message.result);
+  }
+
+  private handleNotification(notification: CodexJsonRpcNotification): void {
+    for (const listener of [...this.notificationListeners]) {
+      Promise.resolve(listener(notification)).catch((error) => {
+        process.emitWarning(
+          `Codex notification listener failed: ${error instanceof Error ? error.message : String(error)}`,
+          'CodexJsonRpcWarning'
+        );
+      });
+    }
+  }
+
+  private handleClose(reason: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    const stderr = this.stderrTail.trim();
+    const details = stderr ? `${reason}. stderr: ${stderr}` : reason;
+    this.rejectAll(new Error(`Codex app-server ${details}`));
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
+++ b/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
@@ -139,8 +139,12 @@ export function spawnCodexAppServer(options: SpawnCodexAppServerOptions = {}): C
       };
       child.once('exit', settle);
       child.once('error', () => settle(null, null));
+      // Cover the race where the child terminated before this listener was
+      // registered — emitted 'exit'/'error' events are not replayed.
       if (lastSpawnError) {
         settle(null, null);
+      } else if (child.exitCode !== null || child.signalCode !== null) {
+        settle(child.exitCode, child.signalCode ?? null);
       }
     },
   };

--- a/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
+++ b/packages/sdk/src/communicate/adapters/codex-jsonrpc.ts
@@ -117,13 +117,31 @@ export function spawnCodexAppServer(options: SpawnCodexAppServerOptions = {}): C
     stdio: 'pipe',
   });
 
+  let lastSpawnError: Error | undefined;
+  // Spawn failures (e.g. ENOENT for a missing `codex` binary) emit 'error' and
+  // can crash the process if nothing is listening. Capture the error so exit
+  // callbacks observe a clean transport teardown instead.
+  child.on('error', (error: Error) => {
+    lastSpawnError = error;
+  });
+
   return {
     stdin: child.stdin,
     stdout: child.stdout,
     stderr: child.stderr,
     kill: (signal?: NodeJS.Signals | number) => child.kill(signal),
     onExit: (callback) => {
-      child.once('exit', callback);
+      let settled = false;
+      const settle = (code: number | null, signal: NodeJS.Signals | null): void => {
+        if (settled) return;
+        settled = true;
+        callback(code, signal);
+      };
+      child.once('exit', settle);
+      child.once('error', () => settle(null, null));
+      if (lastSpawnError) {
+        settle(null, null);
+      }
     },
   };
 }

--- a/packages/sdk/src/communicate/adapters/codex.ts
+++ b/packages/sdk/src/communicate/adapters/codex.ts
@@ -1,0 +1,582 @@
+import { Relay } from '../core.js';
+import { formatRelayMessage, type Message } from '../types.js';
+import {
+  CodexJsonRpcClient,
+  type CodexInitializeOptions,
+  type CodexInitializeResponse,
+  type CodexJsonRpcNotification,
+  type JsonObject,
+  type JsonValue,
+  spawnCodexAppServer,
+} from './codex-jsonrpc.js';
+
+export const MINIMUM_CODEX_APP_SERVER_VERSION = '0.124.0';
+
+export type CodexUserInput =
+  | { type: 'text'; text: string; text_elements: unknown[] }
+  | { type: 'image'; url: string }
+  | { type: 'localImage'; path: string }
+  | { type: 'skill'; name: string; path: string }
+  | { type: 'mention'; name: string; path: string };
+
+export type CodexMcpServerConfig = JsonObject & {
+  command: string;
+  args?: string[];
+};
+
+export interface CodexAdapterOptions {
+  /** Discriminator for the top-level communicate onRelay() auto-detect helper. */
+  framework?: 'codex';
+  cwd?: string;
+  model?: string;
+  modelProvider?: string;
+  serviceTier?: JsonValue;
+  approvalPolicy?: JsonValue;
+  approvalsReviewer?: JsonValue;
+  sandbox?: JsonValue;
+  permissionProfile?: JsonValue;
+  config?: JsonObject;
+  serviceName?: string;
+  baseInstructions?: string;
+  developerInstructions?: string;
+  personality?: JsonValue;
+  ephemeral?: boolean;
+  experimentalRawEvents?: boolean;
+  persistExtendedHistory?: boolean;
+  resumeThreadId?: string;
+  resumePath?: string;
+  excludeTurns?: boolean;
+
+  command?: string;
+  args?: string[];
+  env?: NodeJS.ProcessEnv;
+  requestTimeoutMs?: number;
+  initializeTimeoutMs?: number;
+  experimentalApi?: boolean;
+  minimumCodexVersion?: string | false;
+
+  ensureRelaycastMcp?: boolean;
+  relaycastMcpServer?: CodexMcpServerConfig;
+
+  clientFactory?: () => CodexJsonRpcClientLike;
+  clientInfo?: CodexInitializeOptions['clientInfo'];
+  notificationOptOutMethods?: string[];
+  onNotification?: (notification: CodexJsonRpcNotification) => void | Promise<void>;
+}
+
+export interface CodexForkOptions extends Omit<
+  CodexAdapterOptions,
+  'clientFactory' | 'framework' | 'resumeThreadId' | 'resumePath'
+> {
+  name?: string;
+  relay?: RelayLike;
+}
+
+export interface CodexJsonRpcClientLike {
+  initialize(options?: CodexInitializeOptions): Promise<CodexInitializeResponse>;
+  request<T = unknown>(method: string, params?: unknown, options?: { timeoutMs?: number }): Promise<T>;
+  onNotification(listener: (notification: CodexJsonRpcNotification) => void | Promise<void>): () => void;
+  close(): Promise<void>;
+}
+
+export interface CodexTurn {
+  id: string;
+  status?: string;
+}
+
+export interface CodexThread {
+  id: string;
+}
+
+export interface CodexThreadStartResponse {
+  thread: CodexThread;
+}
+
+export interface CodexTurnStartResponse {
+  turn: CodexTurn;
+}
+
+export interface CodexTurnSteerResponse {
+  [key: string]: unknown;
+}
+
+export interface CodexTurnInterruptResponse {
+  [key: string]: unknown;
+}
+
+export interface CodexHandle {
+  readonly name: string;
+  readonly ready: Promise<void>;
+  readonly threadId: string | undefined;
+  readonly currentTurnId: string | undefined;
+
+  send(text: string): Promise<CodexTurnStartResponse>;
+  steer(text: string): Promise<CodexTurnSteerResponse>;
+  interrupt(): Promise<CodexTurnInterruptResponse | undefined>;
+  fork(options?: CodexForkOptions): Promise<CodexHandle>;
+  close(): Promise<void>;
+  onNotification(listener: (notification: CodexJsonRpcNotification) => void | Promise<void>): () => void;
+}
+
+type RelayLike = {
+  inbox(): Promise<Message[]>;
+};
+
+type ListMcpServerStatusResponse = {
+  data: Array<{ name: string }>;
+  nextCursor?: string | null;
+};
+
+type CodexThreadResponse = {
+  thread: CodexThread;
+};
+
+type CodexNotificationParams = {
+  threadId?: string;
+  turnId?: string;
+  turn?: CodexTurn;
+};
+
+type CodexHandleState = {
+  client?: CodexJsonRpcClientLike;
+  ownsClient?: boolean;
+  threadId?: string;
+  ready?: Promise<void>;
+  autoStart?: boolean;
+};
+
+const DEFAULT_RELAYCAST_MCP_SERVER: CodexMcpServerConfig = {
+  command: 'agent-relay',
+  args: ['mcp'],
+};
+
+function textInput(text: string): CodexUserInput {
+  return {
+    type: 'text',
+    text,
+    text_elements: [],
+  };
+}
+
+function pruneUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function threadOverrides(options: CodexAdapterOptions | CodexForkOptions): Record<string, unknown> {
+  return pruneUndefined({
+    model: options.model,
+    modelProvider: options.modelProvider,
+    serviceTier: options.serviceTier,
+    cwd: options.cwd,
+    approvalPolicy: options.approvalPolicy,
+    approvalsReviewer: options.approvalsReviewer,
+    sandbox: options.sandbox,
+    permissionProfile: options.permissionProfile,
+    config: options.config,
+    baseInstructions: options.baseInstructions,
+    developerInstructions: options.developerInstructions,
+    personality: options.personality,
+  });
+}
+
+function buildThreadStartParams(options: CodexAdapterOptions): Record<string, unknown> {
+  return pruneUndefined({
+    ...threadOverrides(options),
+    serviceName: options.serviceName,
+    ephemeral: options.ephemeral,
+    experimentalRawEvents: options.experimentalRawEvents ?? false,
+    persistExtendedHistory: options.persistExtendedHistory ?? true,
+  });
+}
+
+function buildThreadResumeParams(options: CodexAdapterOptions): Record<string, unknown> {
+  return pruneUndefined({
+    ...threadOverrides(options),
+    threadId: options.resumeThreadId ?? '',
+    path: options.resumePath,
+    excludeTurns: options.excludeTurns ?? true,
+    persistExtendedHistory: options.persistExtendedHistory ?? true,
+  });
+}
+
+function buildThreadForkParams(threadId: string, options: CodexForkOptions): Record<string, unknown> {
+  return pruneUndefined({
+    ...threadOverrides(options),
+    threadId,
+    ephemeral: options.ephemeral ?? true,
+    excludeTurns: options.excludeTurns ?? true,
+    persistExtendedHistory: options.persistExtendedHistory ?? true,
+  });
+}
+
+async function drainInbox(relay: RelayLike): Promise<string | undefined> {
+  const messages = await relay.inbox();
+  if (messages.length === 0) {
+    return undefined;
+  }
+
+  return `New messages from other agents:\n${messages.map((message) => formatRelayMessage(message)).join('\n')}`;
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map((part) => Number.parseInt(part, 10));
+  const rightParts = right.split('.').map((part) => Number.parseInt(part, 10));
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = Number.isFinite(leftParts[index]) ? leftParts[index] : 0;
+    const rightPart = Number.isFinite(rightParts[index]) ? rightParts[index] : 0;
+    if (leftPart !== rightPart) {
+      return leftPart > rightPart ? 1 : -1;
+    }
+  }
+
+  return 0;
+}
+
+function extractVersion(userAgent: string): string | undefined {
+  return userAgent.match(/\b(\d+\.\d+\.\d+)\b/u)?.[1];
+}
+
+export function assertMinimumCodexVersion(userAgent: string, minimumVersion: string | false): void {
+  if (minimumVersion === false) {
+    return;
+  }
+
+  const detected = extractVersion(userAgent);
+  if (!detected) {
+    throw new Error(`Could not determine codex app-server version from userAgent: ${userAgent}`);
+  }
+
+  if (compareVersions(detected, minimumVersion) < 0) {
+    throw new Error(
+      `codex app-server ${detected} is older than the supported minimum ${minimumVersion}. ` +
+        'Upgrade Codex before using the communicate adapter.'
+    );
+  }
+}
+
+function createDefaultClient(options: CodexAdapterOptions): CodexJsonRpcClientLike {
+  return new CodexJsonRpcClient(
+    spawnCodexAppServer({
+      command: options.command,
+      args: options.args,
+      cwd: options.cwd,
+      env: options.env,
+    }),
+    {
+      requestTimeoutMs: options.requestTimeoutMs,
+    }
+  );
+}
+
+export class CodexRelayHandle implements CodexHandle {
+  readonly ready: Promise<void>;
+
+  private readonly client: CodexJsonRpcClientLike;
+  private readonly ownsClient: boolean;
+  private readonly unsubscribeClientNotifications: () => void;
+  private readonly notificationListeners = new Set<
+    (notification: CodexJsonRpcNotification) => void | Promise<void>
+  >();
+
+  private activeTurnId: string | undefined;
+  private nextTurnPrefix: string | undefined;
+  private inboxQueue: Promise<void> = Promise.resolve();
+  private closed = false;
+  private currentThreadId: string | undefined;
+
+  constructor(
+    readonly name: string,
+    private readonly options: CodexAdapterOptions,
+    private readonly relay: RelayLike,
+    state: CodexHandleState = {}
+  ) {
+    this.client = state.client ?? options.clientFactory?.() ?? createDefaultClient(options);
+    this.ownsClient = state.ownsClient ?? !state.client;
+    this.currentThreadId = state.threadId;
+    this.unsubscribeClientNotifications = this.client.onNotification((notification) =>
+      this.handleNotification(notification)
+    );
+
+    if (state.ready) {
+      this.ready = state.ready;
+    } else if (state.autoStart === false) {
+      this.ready = Promise.resolve();
+    } else {
+      this.ready = this.start();
+    }
+  }
+
+  get threadId(): string | undefined {
+    return this.currentThreadId;
+  }
+
+  get currentTurnId(): string | undefined {
+    return this.activeTurnId;
+  }
+
+  async send(text: string): Promise<CodexTurnStartResponse> {
+    const threadId = await this.requireThreadId();
+    const prompt = this.consumeNextTurnPrefix(text);
+    const response = await this.client.request<CodexTurnStartResponse>('turn/start', {
+      threadId,
+      input: [textInput(prompt)],
+    });
+
+    this.activeTurnId = response.turn.id;
+    return response;
+  }
+
+  async steer(text: string): Promise<CodexTurnSteerResponse> {
+    const threadId = await this.requireThreadId();
+    if (!this.activeTurnId) {
+      throw new Error(`Cannot steer Codex thread ${threadId}; there is no active turn.`);
+    }
+
+    return this.client.request<CodexTurnSteerResponse>('turn/steer', {
+      threadId,
+      input: [textInput(text)],
+      expectedTurnId: this.activeTurnId,
+    });
+  }
+
+  async interrupt(): Promise<CodexTurnInterruptResponse | undefined> {
+    const threadId = await this.requireThreadId();
+    if (!this.activeTurnId) {
+      return undefined;
+    }
+
+    const turnId = this.activeTurnId;
+    this.activeTurnId = undefined;
+    return this.client.request<CodexTurnInterruptResponse>('turn/interrupt', {
+      threadId,
+      turnId,
+    });
+  }
+
+  async fork(options: CodexForkOptions = {}): Promise<CodexHandle> {
+    const sourceThreadId = await this.requireThreadId();
+    const response = await this.client.request<CodexThreadResponse>(
+      'thread/fork',
+      buildThreadForkParams(sourceThreadId, options)
+    );
+    const forkName = options.name ?? this.name;
+    const forkRelay = options.relay ?? new Relay(forkName);
+
+    return new CodexRelayHandle(
+      forkName,
+      {
+        ...this.options,
+        ...options,
+        clientFactory: undefined,
+        framework: 'codex',
+      },
+      forkRelay,
+      {
+        client: this.client,
+        ownsClient: false,
+        threadId: response.thread.id,
+        autoStart: false,
+      }
+    );
+  }
+
+  onNotification(listener: (notification: CodexJsonRpcNotification) => void | Promise<void>): () => void {
+    this.notificationListeners.add(listener);
+    return () => {
+      this.notificationListeners.delete(listener);
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.unsubscribeClientNotifications();
+    await this.ready.catch(() => undefined);
+
+    if (this.currentThreadId) {
+      await this.client
+        .request('thread/unsubscribe', { threadId: this.currentThreadId })
+        .catch(() => undefined);
+    }
+
+    if (this.ownsClient) {
+      await this.client.close();
+    }
+  }
+
+  private async start(): Promise<void> {
+    const initializeResponse = await this.client.initialize({
+      clientInfo: this.options.clientInfo,
+      capabilities: {
+        experimentalApi: this.options.experimentalApi ?? false,
+        optOutNotificationMethods: this.options.notificationOptOutMethods ?? null,
+      },
+      timeoutMs: this.options.initializeTimeoutMs,
+    });
+    assertMinimumCodexVersion(
+      initializeResponse.userAgent,
+      this.options.minimumCodexVersion ?? MINIMUM_CODEX_APP_SERVER_VERSION
+    );
+
+    if (this.options.ensureRelaycastMcp !== false) {
+      await this.ensureRelaycastMcp();
+    }
+
+    const response =
+      this.options.resumeThreadId || this.options.resumePath
+        ? await this.client.request<CodexThreadResponse>(
+            'thread/resume',
+            buildThreadResumeParams(this.options)
+          )
+        : await this.client.request<CodexThreadStartResponse>(
+            'thread/start',
+            buildThreadStartParams(this.options)
+          );
+
+    this.currentThreadId = response.thread.id;
+  }
+
+  private async requireThreadId(): Promise<string> {
+    await this.ready;
+    if (!this.currentThreadId) {
+      throw new Error('Codex thread is not ready.');
+    }
+    return this.currentThreadId;
+  }
+
+  private consumeNextTurnPrefix(text: string): string {
+    if (!this.nextTurnPrefix) {
+      return text;
+    }
+
+    const prefix = this.nextTurnPrefix;
+    this.nextTurnPrefix = undefined;
+    return `${prefix}\n\n${text}`;
+  }
+
+  private appendNextTurnPrefix(text: string): void {
+    this.nextTurnPrefix = this.nextTurnPrefix ? `${this.nextTurnPrefix}\n\n${text}` : text;
+  }
+
+  private async ensureRelaycastMcp(): Promise<void> {
+    let cursor: string | undefined;
+    do {
+      const response = await this.client.request<ListMcpServerStatusResponse>('mcpServerStatus/list', {
+        cursor,
+        detail: 'toolsAndAuthOnly',
+      });
+      if (response.data.some((server) => server.name === 'relaycast')) {
+        return;
+      }
+      cursor = response.nextCursor ?? undefined;
+    } while (cursor);
+
+    await this.client.request('config/value/write', {
+      keyPath: 'mcp_servers.relaycast',
+      value: this.options.relaycastMcpServer ?? DEFAULT_RELAYCAST_MCP_SERVER,
+      mergeStrategy: 'upsert',
+    });
+    await this.client.request('config/mcpServer/reload');
+  }
+
+  private enqueueInboxTask(task: () => Promise<void>): Promise<void> {
+    this.inboxQueue = this.inboxQueue.then(task, task);
+    return this.inboxQueue;
+  }
+
+  private async flushInboxToActiveTurn(): Promise<void> {
+    await this.enqueueInboxTask(async () => {
+      if (!this.currentThreadId || !this.activeTurnId) {
+        return;
+      }
+
+      const prompt = await drainInbox(this.relay);
+      if (!prompt) {
+        return;
+      }
+
+      const expectedTurnId = this.activeTurnId;
+      try {
+        await this.client.request('turn/steer', {
+          threadId: this.currentThreadId,
+          input: [textInput(prompt)],
+          expectedTurnId,
+        });
+      } catch (error) {
+        this.appendNextTurnPrefix(prompt);
+        process.emitWarning(
+          `Could not steer Codex turn with relay messages: ${error instanceof Error ? error.message : String(error)}`,
+          'CodexRelayWarning'
+        );
+      }
+    });
+  }
+
+  private async flushInboxToNextTurn(): Promise<void> {
+    await this.enqueueInboxTask(async () => {
+      const prompt = await drainInbox(this.relay);
+      if (prompt) {
+        this.appendNextTurnPrefix(prompt);
+      }
+    });
+  }
+
+  private async handleNotification(notification: CodexJsonRpcNotification): Promise<void> {
+    await Promise.resolve(this.options.onNotification?.(notification)).catch((error) => {
+      process.emitWarning(
+        `Codex onNotification callback failed: ${error instanceof Error ? error.message : String(error)}`,
+        'CodexRelayWarning'
+      );
+    });
+    for (const listener of [...this.notificationListeners]) {
+      await Promise.resolve(listener(notification)).catch((error) => {
+        process.emitWarning(
+          `Codex notification listener failed: ${error instanceof Error ? error.message : String(error)}`,
+          'CodexRelayWarning'
+        );
+      });
+    }
+
+    const params = notification.params as CodexNotificationParams | undefined;
+    if (!params?.threadId || params.threadId !== this.currentThreadId) {
+      return;
+    }
+
+    if (notification.method === 'turn/started') {
+      this.activeTurnId = params.turn?.id ?? params.turnId ?? this.activeTurnId;
+      return;
+    }
+
+    if (notification.method === 'item/completed') {
+      await this.flushInboxToActiveTurn();
+      return;
+    }
+
+    if (notification.method === 'turn/completed') {
+      if (!params.turn?.id || params.turn.id === this.activeTurnId) {
+        this.activeTurnId = undefined;
+      }
+      await this.flushInboxToNextTurn();
+    }
+  }
+}
+
+/**
+ * Attach relay communication to Codex through `codex app-server` JSON-RPC.
+ * @param name - Agent name for relay registration.
+ * @param options - Codex app-server thread and transport options.
+ * @param relay - Optional pre-configured Relay instance.
+ * @returns A Codex handle with ready/send/steer/interrupt/fork/close methods.
+ */
+export function onRelay(
+  name: string,
+  options: CodexAdapterOptions = {},
+  relay: RelayLike = new Relay(name)
+): CodexHandle {
+  return new CodexRelayHandle(name, options, relay);
+}

--- a/packages/sdk/src/communicate/adapters/codex.ts
+++ b/packages/sdk/src/communicate/adapters/codex.ts
@@ -138,11 +138,18 @@ type CodexNotificationParams = {
 };
 
 type CodexHandleState = {
+  sharedClient?: SharedCodexJsonRpcClient;
   client?: CodexJsonRpcClientLike;
   ownsClient?: boolean;
   threadId?: string;
   ready?: Promise<void>;
   autoStart?: boolean;
+};
+
+type SharedCodexJsonRpcClient = {
+  client: CodexJsonRpcClientLike;
+  ownsClient: boolean;
+  references: number;
 };
 
 const DEFAULT_RELAYCAST_MCP_SERVER: CodexMcpServerConfig = {
@@ -192,7 +199,7 @@ function buildThreadStartParams(options: CodexAdapterOptions): Record<string, un
 function buildThreadResumeParams(options: CodexAdapterOptions): Record<string, unknown> {
   return pruneUndefined({
     ...threadOverrides(options),
-    threadId: options.resumeThreadId ?? '',
+    threadId: options.resumeThreadId,
     path: options.resumePath,
     excludeTurns: options.excludeTurns ?? true,
     persistExtendedHistory: options.persistExtendedHistory ?? true,
@@ -274,7 +281,7 @@ export class CodexRelayHandle implements CodexHandle {
   readonly ready: Promise<void>;
 
   private readonly client: CodexJsonRpcClientLike;
-  private readonly ownsClient: boolean;
+  private readonly sharedClient: SharedCodexJsonRpcClient;
   private readonly unsubscribeClientNotifications: () => void;
   private readonly notificationListeners = new Set<
     (notification: CodexJsonRpcNotification) => void | Promise<void>
@@ -292,8 +299,19 @@ export class CodexRelayHandle implements CodexHandle {
     private readonly relay: RelayLike,
     state: CodexHandleState = {}
   ) {
-    this.client = state.client ?? options.clientFactory?.() ?? createDefaultClient(options);
-    this.ownsClient = state.ownsClient ?? !state.client;
+    if (state.sharedClient) {
+      this.sharedClient = state.sharedClient;
+      this.sharedClient.references += 1;
+    } else {
+      const client = state.client ?? options.clientFactory?.() ?? createDefaultClient(options);
+      this.sharedClient = {
+        client,
+        ownsClient: state.ownsClient ?? !state.client,
+        references: 1,
+      };
+    }
+
+    this.client = this.sharedClient.client;
     this.currentThreadId = state.threadId;
     this.unsubscribeClientNotifications = this.client.onNotification((notification) =>
       this.handleNotification(notification)
@@ -374,8 +392,7 @@ export class CodexRelayHandle implements CodexHandle {
       },
       forkRelay,
       {
-        client: this.client,
-        ownsClient: false,
+        sharedClient: this.sharedClient,
         threadId: response.thread.id,
         autoStart: false,
       }
@@ -404,7 +421,8 @@ export class CodexRelayHandle implements CodexHandle {
         .catch(() => undefined);
     }
 
-    if (this.ownsClient) {
+    this.sharedClient.references -= 1;
+    if (this.sharedClient.ownsClient && this.sharedClient.references === 0) {
       await this.client.close();
     }
   }

--- a/packages/sdk/src/communicate/adapters/codex.ts
+++ b/packages/sdk/src/communicate/adapters/codex.ts
@@ -577,7 +577,8 @@ export class CodexRelayHandle implements CodexHandle {
     }
 
     if (notification.method === 'turn/completed') {
-      if (!params.turn?.id || params.turn.id === this.activeTurnId) {
+      const completedTurnId = params.turn?.id ?? params.turnId;
+      if (!completedTurnId || completedTurnId === this.activeTurnId) {
         this.activeTurnId = undefined;
       }
       await this.flushInboxToNextTurn();

--- a/packages/sdk/src/communicate/adapters/codex.ts
+++ b/packages/sdk/src/communicate/adapters/codex.ts
@@ -366,11 +366,12 @@ export class CodexRelayHandle implements CodexHandle {
     }
 
     const turnId = this.activeTurnId;
-    this.activeTurnId = undefined;
-    return this.client.request<CodexTurnInterruptResponse>('turn/interrupt', {
+    const response = await this.client.request<CodexTurnInterruptResponse>('turn/interrupt', {
       threadId,
       turnId,
     });
+    this.activeTurnId = undefined;
+    return response;
   }
 
   async fork(options: CodexForkOptions = {}): Promise<CodexHandle> {

--- a/packages/sdk/src/communicate/adapters/index.ts
+++ b/packages/sdk/src/communicate/adapters/index.ts
@@ -1,2 +1,3 @@
 export { onRelay as onPiRelay } from './pi.js';
 export { onRelay as onClaudeRelay } from './claude-sdk.js';
+export { onRelay as onCodexRelay } from './codex.js';

--- a/packages/sdk/src/communicate/index.ts
+++ b/packages/sdk/src/communicate/index.ts
@@ -1,9 +1,10 @@
 export * from './types.js';
 export { Relay } from './core.js';
-export { onPiRelay, onClaudeRelay } from './adapters/index.js';
+export { onPiRelay, onClaudeRelay, onCodexRelay } from './adapters/index.js';
 
 import { onRelay as onPiRelay } from './adapters/pi.js';
 import { onRelay as onClaudeRelay } from './adapters/claude-sdk.js';
+import { onRelay as onCodexRelay, type CodexAdapterOptions, type CodexHandle } from './adapters/codex.js';
 import { Relay } from './core.js';
 
 /**
@@ -11,7 +12,7 @@ import { Relay } from './core.js';
  *
  * Requires a `framework` discriminator to avoid ambiguous detection.
  * If you know which framework you're using, prefer importing the
- * adapter directly: `onPiRelay` or `onClaudeRelay`.
+ * adapter directly: `onPiRelay`, `onClaudeRelay`, or `onCodexRelay`.
  *
  * @param nameOrAgent - Agent name (string) or the agent/config object directly.
  * @param configOrOptions - Config/options object when first arg is a name.
@@ -19,12 +20,24 @@ import { Relay } from './core.js';
  * @returns The augmented agent config or options.
  */
 export function onRelay(
+  nameOrAgent: string,
+  configOrOptions: CodexAdapterOptions & { framework: 'codex' },
+  maybeRelay?: Relay
+): CodexHandle;
+export function onRelay(
   nameOrAgent: string | Record<string, unknown>,
   configOrOptions?: Record<string, unknown>,
   maybeRelay?: Relay
-): Record<string, unknown> {
+): Record<string, unknown>;
+export function onRelay(
+  nameOrAgent: string | Record<string, unknown>,
+  configOrOptions?: Record<string, unknown> | CodexAdapterOptions | Relay,
+  maybeRelay?: Relay
+): Record<string, unknown> | CodexHandle {
   const isStringName = typeof nameOrAgent === 'string';
-  const name = isStringName ? nameOrAgent : ((nameOrAgent as Record<string, unknown>).name as string) || 'Agent';
+  const name = isStringName
+    ? nameOrAgent
+    : ((nameOrAgent as Record<string, unknown>).name as string) || 'Agent';
   const target: unknown = isStringName ? configOrOptions : nameOrAgent;
   const relay = (isStringName ? maybeRelay : configOrOptions) as Relay | undefined;
 
@@ -33,11 +46,16 @@ export function onRelay(
   if (typeof target !== 'object' || target === null) {
     throw new Error(
       `onRelay() received a non-object target for ${name}. ` +
-      'Pass the framework config/options object, or use onPiRelay / onClaudeRelay directly.'
+        'Pass the framework config/options object, or use onPiRelay / onClaudeRelay directly.'
     );
   }
 
   const obj = target as Record<string, unknown>;
+
+  // Detect Codex app-server adapter via explicit discriminator.
+  if (obj.framework === 'codex') {
+    return onCodexRelay(name, target as Parameters<typeof onCodexRelay>[1], relayInstance);
+  }
 
   // Detect Pi: has customTools or Agent constructor
   if ('customTools' in obj || obj.constructor?.name === 'Agent') {
@@ -51,7 +69,7 @@ export function onRelay(
 
   throw new Error(
     `onRelay() could not auto-detect framework for ${name}. ` +
-    'Use the framework-specific adapter instead: onPiRelay or onClaudeRelay.'
+      'Use the framework-specific adapter instead: onPiRelay, onClaudeRelay, or onCodexRelay.'
   );
 }
 

--- a/packages/sdk/src/communicate/index.ts
+++ b/packages/sdk/src/communicate/index.ts
@@ -25,12 +25,16 @@ export function onRelay(
   maybeRelay?: Relay
 ): CodexHandle;
 export function onRelay(
+  nameOrAgent: CodexAdapterOptions & { framework: 'codex'; name?: string },
+  configOrOptions?: Relay
+): CodexHandle;
+export function onRelay(
   nameOrAgent: string | Record<string, unknown>,
-  configOrOptions?: Record<string, unknown>,
+  configOrOptions?: Record<string, unknown> | Relay,
   maybeRelay?: Relay
 ): Record<string, unknown>;
 export function onRelay(
-  nameOrAgent: string | Record<string, unknown>,
+  nameOrAgent: string | Record<string, unknown> | CodexAdapterOptions,
   configOrOptions?: Record<string, unknown> | CodexAdapterOptions | Relay,
   maybeRelay?: Relay
 ): Record<string, unknown> | CodexHandle {
@@ -46,7 +50,7 @@ export function onRelay(
   if (typeof target !== 'object' || target === null) {
     throw new Error(
       `onRelay() received a non-object target for ${name}. ` +
-        'Pass the framework config/options object, or use onPiRelay / onClaudeRelay directly.'
+        'Pass the framework config/options object, or use onPiRelay, onClaudeRelay, or onCodexRelay directly.'
     );
   }
 

--- a/packages/sdk/src/communicate/index.ts
+++ b/packages/sdk/src/communicate/index.ts
@@ -29,9 +29,13 @@ export function onRelay(
   configOrOptions?: Relay
 ): CodexHandle;
 export function onRelay(
-  nameOrAgent: string | Record<string, unknown>,
-  configOrOptions?: Record<string, unknown> | Relay,
+  nameOrAgent: string,
+  configOrOptions?: Record<string, unknown>,
   maybeRelay?: Relay
+): Record<string, unknown>;
+export function onRelay(
+  nameOrAgent: Record<string, unknown>,
+  configOrOptions?: Relay
 ): Record<string, unknown>;
 export function onRelay(
   nameOrAgent: string | Record<string, unknown> | CodexAdapterOptions,


### PR DESCRIPTION
## Summary

- Add a Codex communicate adapter backed by `codex app-server` stdio JSON-RPC.
- Add a reusable JSON-RPC client, Codex handle APIs (`ready`, `send`, `steer`, `interrupt`, `fork`, `close`), relay inbox injection on `item/completed` / `turn/completed`, relaycast MCP registration, and a minimum Codex version probe.
- Export `onCodexRelay`, add the `framework: 'codex'` discriminator in `onRelay()`, add the package subpath export, and document the PTY-vs-app-server tradeoff.

Fixes #803

## Testing

- `npm --prefix packages/sdk run check`
- `npx tsc -p packages/sdk/tsconfig.build.json --noEmit`
- `npx tsc -p packages/sdk/tsconfig.build.json`
- `npx vitest run src/__tests__/communicate/adapters/codex.test.ts src/__tests__/communicate/adapters/codex-jsonrpc.test.ts --config vitest.config.ts`
- `npx vitest run src/__tests__/communicate --config vitest.config.ts`
- Real Codex app-server initialize probe against installed `codex-cli 0.125.0`

Note: `npm --prefix packages/sdk run build` is currently blocked before SDK compilation in the existing prebuild chain: `packages/github-primitive` cannot resolve `@agent-relay/workflow-types` because the workspace package is not linked in `node_modules`. The direct SDK build-config compile and declaration emit pass.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
