### PR TITLE
fix(ci): publish SDK internal deps before sdk

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1040,10 +1040,41 @@ jobs:
       - name: Update npm for OIDC support
         run: npm install -g npm@latest
 
+      - name: Dry run SDK internal deps
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          set -euo pipefail
+          for package in config github-primitive workflow-types; do
+            echo "Dry run - would publish @agent-relay/${package}"
+            (cd "packages/${package}" && npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts)
+          done
+
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/sdk
         run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish SDK internal deps to NPM
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.build.outputs.new_version }}"
+
+          publish_if_missing() {
+            local package="$1"
+            local name="@agent-relay/${package}"
+            if npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
+              echo "✓ ${name}@${VERSION} is already published"
+              return
+            fi
+
+            echo "Publishing ${name}@${VERSION}"
+            (cd "packages/${package}" && npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts)
+          }
+
+          publish_if_missing config
+          publish_if_missing github-primitive
+          publish_if_missing workflow-types
 
       - name: Publish SDK to NPM
         if: github.event.inputs.dry_run != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1073,8 +1073,8 @@ jobs:
           }
 
           publish_if_missing config
-          publish_if_missing github-primitive
           publish_if_missing workflow-types
+          publish_if_missing github-primitive
 
       - name: Publish SDK to NPM
         if: github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Summary
- publish required SDK internal packages (`config`, `github-primitive`, `workflow-types`) during `package=sdk` releases before publishing `@agent-relay/sdk`
- skip already-published internal package versions so reruns can repair a missing package without failing on existing ones
- include the same internal deps in sdk dry-run validation

## Why
`@agent-relay/sdk@6.0.4` depends on `@agent-relay/workflow-types@6.0.4`, but that package was not published, so runtime imports of `@agent-relay/sdk/workflows` fail with `Cannot find module @agent-relay/workflow-types`. PR #804 fixed the `package=all` path; this covers the `package=sdk` path and lets reruns publish a missing internal dep idempotently.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'YAML_OK'"`\n- `npm --prefix packages/workflow-types run build`\n- `(cd packages/workflow-types && npm pack --ignore-scripts --pack-destination "$tmp")` verified tarball contains `dist/index.js`, `dist/index.d.ts`, source maps, and `package.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
