### PR TITLE
fix(ci): publish SDK workflow types before SDK

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
           - main
           - cli-prerelease
           - sdk
+          - workflow-types
           - sdk-py
           - brand
         default: 'all'
@@ -738,6 +739,108 @@ jobs:
             }
           "
 
+  # Publish the SDK's exact-version internal runtime dependencies before the
+  # SDK. @agent-relay/sdk imports these packages at runtime and pins them to
+  # the release version, so they must exist on the registry before the SDK can
+  # be installed from npm. This also gives us one repair path for a partial
+  # publish: run package=workflow-types with custom_version=<broken-sdk-version>.
+  publish-sdk-internal-deps:
+    name: Publish SDK internal dep ${{ matrix.package }}
+    needs: [build, smoke-broker-packages]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'all' || github.event.inputs.package == 'sdk'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        package:
+          - config
+          - github-primitive
+          - workflow-types
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: .
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish to NPM
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
+            exit 0
+          fi
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+  # Publish workflow-types only. This is intentionally narrow: it repairs
+  # already-published SDK versions whose exact-version workflow-types package
+  # was missing, without attempting to republish @agent-relay/sdk.
+  publish-workflow-types-only:
+    name: Publish Workflow Types to NPM
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'workflow-types'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: .
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/workflow-types
+        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish Workflow Types to NPM
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/workflow-types
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
+            exit 0
+          fi
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
   # Publish the per-platform broker packages first. @agent-relay/sdk declares
   # these as exact-version optionalDependencies, so they must exist on the
   # registry at the matching version before the SDK is published — otherwise
@@ -874,10 +977,12 @@ jobs:
           steps.publish_3.outcome == 'failure'
         run: exit 1
 
-  # Publish all packages in parallel (npm publish doesn't need deps published first)
+  # Publish remaining packages in parallel. SDK runtime deps that are pinned by
+  # exact version are published by publish-sdk-internal-deps before this matrix
+  # can publish @agent-relay/sdk.
   publish-packages:
     name: Publish ${{ matrix.package }}
-    needs: [build, build-broker, publish-broker-packages]
+    needs: [build, build-broker, publish-broker-packages, publish-sdk-internal-deps]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'all'
     strategy:
@@ -892,7 +997,6 @@ jobs:
           - trajectory
           - hooks
           - user-directory
-          - config
           - cloud
           - sdk
           - telemetry
@@ -901,9 +1005,7 @@ jobs:
           - brand
           - gateway
           - credential-proxy
-          - github-primitive
           - browser-primitive
-          - workflow-types
 
     steps:
       - name: Checkout code
@@ -1000,7 +1102,7 @@ jobs:
   # Publish SDK only (when selected)
   publish-sdk-only:
     name: Publish SDK to NPM
-    needs: [build, build-broker, publish-broker-packages]
+    needs: [build, build-broker, publish-broker-packages, publish-sdk-internal-deps]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'sdk'
 
@@ -1945,6 +2047,8 @@ jobs:
         verify-acp-linux,
         verify-acp-macos,
         smoke-broker-packages,
+        publish-sdk-internal-deps,
+        publish-workflow-types-only,
         publish-broker-packages,
         publish-packages,
         publish-brand-only,
@@ -1989,6 +2093,8 @@ jobs:
           echo "| Verify relay-acp (Linux) | ${{ needs.verify-acp-linux.result == 'success' && '✅' || (needs.verify-acp-linux.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.verify-acp-linux.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Verify relay-acp (macOS) | ${{ needs.verify-acp-macos.result == 'success' && '✅' || (needs.verify-acp-macos.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.verify-acp-macos.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Smoke Broker Packages | ${{ needs.smoke-broker-packages.result == 'success' && '✅' || (needs.smoke-broker-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.smoke-broker-packages.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish SDK Internal Deps | ${{ needs.publish-sdk-internal-deps.result == 'success' && '✅' || (needs.publish-sdk-internal-deps.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-internal-deps.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish Workflow Types Only | ${{ needs.publish-workflow-types-only.result == 'success' && '✅' || (needs.publish-workflow-types-only.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-workflow-types-only.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Broker Packages | ${{ needs.publish-broker-packages.result == 'success' && '✅' || (needs.publish-broker-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-broker-packages.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Packages | ${{ needs.publish-packages.result == 'success' && '✅' || (needs.publish-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-packages.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Brand | ${{ needs.publish-brand-only.result == 'success' && '✅' || (needs.publish-brand-only.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-brand-only.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -82,7 +82,10 @@ jobs:
 
       # Registry/CDN propagation can lag the publish by up to a minute. Retry
       # with exponential backoff so the first run after publish doesn't miss.
-      - name: Wait for package on registry
+      # The SDK pins internal runtime deps to the exact same release version;
+      # wait for those too so npm/Bun installs cannot resolve a half-published
+      # SDK that later fails at runtime inside @agent-relay/sdk/workflows.
+      - name: Wait for SDK and internal deps on registry
         shell: bash
         run: |
           set -euo pipefail
@@ -92,16 +95,33 @@ jobs:
             echo "version=latest — no wait needed"
             exit 0
           fi
+
+          PACKAGES=(
+            "$SPEC"
+            "@agent-relay/config@$VERSION"
+            "@agent-relay/github-primitive@$VERSION"
+            "@agent-relay/workflow-types@$VERSION"
+          )
+
           for i in 1 2 3 4 5 6; do
-            if npm view "$SPEC" version >/dev/null 2>&1; then
-              echo "registry has $SPEC"
+            missing=()
+            for pkg in "${PACKAGES[@]}"; do
+              if ! npm view "$pkg" version >/dev/null 2>&1; then
+                missing+=("$pkg")
+              fi
+            done
+
+            if [ "${#missing[@]}" -eq 0 ]; then
+              echo "registry has SDK and internal deps for $VERSION"
               exit 0
             fi
+
             WAIT=$((2 ** i))
-            echo "attempt $i: registry not ready, sleeping ${WAIT}s"
+            echo "attempt $i: registry missing ${missing[*]}, sleeping ${WAIT}s"
             sleep "$WAIT"
           done
-          echo "FAIL: registry never surfaced $SPEC"
+
+          echo "FAIL: registry never surfaced all SDK packages for $VERSION"
           exit 1
 
       - name: Install @agent-relay/sdk into scratch project
@@ -118,6 +138,19 @@ jobs:
           echo ""
           echo "=== installed @agent-relay/ packages ==="
           ls node_modules/@agent-relay/
+
+      - name: Verify workflow module imports
+        shell: bash
+        run: |
+          cd "$SCRATCH"
+          node --input-type=module -e "
+            const workflows = await import('@agent-relay/sdk/workflows');
+            if (!workflows.WorkflowRunner || !workflows.workflow) {
+              console.error('FAIL: @agent-relay/sdk/workflows missing expected exports');
+              process.exit(1);
+            }
+            console.log('OK: @agent-relay/sdk/workflows imports with workflow-types installed');
+          "
 
       - name: Verify only the matching broker package was installed
         shell: bash


### PR DESCRIPTION
## Summary
- publish @agent-relay/config, @agent-relay/github-primitive, and @agent-relay/workflow-types before @agent-relay/sdk for all/sdk release flows
- add a workflow-types-only publish option to repair partial releases such as sdk@6.0.4 requiring workflow-types@6.0.4
- harden published SDK verification to wait for exact-version internal deps and import @agent-relay/sdk/workflows

## Context
The Daytona/Bun bootstrap failed with: Cannot find module @agent-relay/workflow-types from @agent-relay/sdk@6.0.4. Registry checks confirmed sdk@6.0.4 declares @agent-relay/workflow-types@6.0.4, but npm only has workflow-types@6.0.3.

## Verification
- npm --prefix packages/workflow-types run build
- npm --prefix packages/sdk run check
- ruby YAML parse for publish.yml and verify-publish-sdk.yml
- actionlint -shellcheck= .github/workflows/publish.yml .github/workflows/verify-publish-sdk.yml
- git diff --check -- .github/workflows/publish.yml .github/workflows/verify-publish-sdk.yml

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
