### PR TITLE
Fix workflow-types provenance metadata

### DIFF
--- a/packages/workflow-types/package.json
+++ b/packages/workflow-types/package.json
@@ -20,5 +20,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentWorkforce/relay.git",
+    "directory": "packages/workflow-types"
   }
 }


### PR DESCRIPTION
## Summary
- add repository metadata to @agent-relay/workflow-types so npm provenance validation sees the GitHub repository instead of an empty repository URL
- verified the packed tarball includes the repository object

## Verification
- publishable package repository metadata scan
- npm pack --ignore-scripts for packages/workflow-types and inspected package/package.json from the tarball
- git diff --check origin/main...HEAD