### PR TITLE
Bump Relayfile SDK dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "6.0.2",
+  "version": "6.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "bundleDependencies": [
         "@relaycast/sdk",
         "@relayfile/local-mount"
@@ -18,14 +18,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "6.1.0",
-        "@agent-relay/config": "6.0.2",
-        "@agent-relay/hooks": "6.0.2",
-        "@agent-relay/sdk": "6.1.0",
-        "@agent-relay/telemetry": "6.0.2",
-        "@agent-relay/trajectory": "6.0.2",
-        "@agent-relay/user-directory": "6.0.2",
-        "@agent-relay/utils": "6.0.2",
+        "@agent-relay/cloud": "6.0.6",
+        "@agent-relay/config": "6.0.6",
+        "@agent-relay/hooks": "6.0.6",
+        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/telemetry": "6.0.6",
+        "@agent-relay/trajectory": "6.0.6",
+        "@agent-relay/user-directory": "6.0.6",
+        "@agent-relay/utils": "6.0.6",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -33,7 +33,7 @@
         "@relaycast/mcp": "1.0.0",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/local-mount": "^0.2.2",
-        "@relayfile/sdk": "^0.1.2",
+        "@relayfile/sdk": "^0.6.0",
         "@sinclair/typebox": "^0.34.14",
         "agent-trajectories": "^0.5.4",
         "chalk": "^4.1.2",
@@ -1277,7 +1277,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3824,6 +3823,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@relayfile/core": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-fnrTei5KhuwGHgPEIzyqr9D53xo+Bwkusv8N2QPgbrTiWIH3kQY8K7HgyfplGu7pex1+JVh0+iNbe5Jc5aVbSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@relayfile/local-mount": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@relayfile/local-mount/-/local-mount-0.2.2.tgz",
@@ -3869,10 +3877,13 @@
       }
     },
     "node_modules/@relayfile/sdk": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.1.13.tgz",
-      "integrity": "sha512-vsy4pPNknSxA1RS/FB8KjMJCjqhDKctiBYC/4bTne49ZzzGixjL1GGPt41WWQjDdR3EO1ASyELtmiGspwLWarw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-k2SgtYzSojWpD1zfL1J6savQ4jSM2UmQfwkYJPavOJ1AVb7L9fCd4BC4+RYM316fgVn4oRBLSfzzFe3h6zRulg==",
       "license": "MIT",
+      "dependencies": {
+        "@relayfile/core": "0.6.1"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -15425,10 +15436,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.1.0",
+        "@agent-relay/sdk": "6.0.6",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15444,38 +15455,38 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "6.0.2"
+      "version": "6.0.6"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "license": "MIT"
     },
     "packages/browser-primitive": {
       "name": "@agent-relay/browser-primitive",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/sdk": "6.1.0",
+        "@agent-relay/sdk": "6.0.6",
         "playwright": "^1.51.1"
       },
       "bin": {
@@ -15489,9 +15500,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "6.1.0",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2",
+        "@agent-relay/config": "6.0.6",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15507,7 +15518,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15519,7 +15530,7 @@
     },
     "packages/credential-proxy": {
       "name": "@agent-relay/credential-proxy",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
         "hono": "^4.11.4",
         "jose": "^6.1.3"
@@ -15530,9 +15541,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/sdk": "6.1.0"
+        "@agent-relay/sdk": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15541,9 +15552,9 @@
     },
     "packages/github-primitive": {
       "name": "@agent-relay/github-primitive",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.2"
+        "@agent-relay/workflow-types": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15553,11 +15564,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@agent-relay/sdk": "6.1.0",
-        "@agent-relay/trajectory": "6.0.2"
+        "@agent-relay/config": "6.0.6",
+        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/trajectory": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15566,9 +15577,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/hooks": "6.0.2"
+        "@agent-relay/hooks": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15577,11 +15588,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.1.0",
+        "@agent-relay/sdk": "6.0.6",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16346,9 +16357,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2"
+        "@agent-relay/config": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16357,11 +16368,11 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "6.1.0",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2",
-        "@agent-relay/github-primitive": "6.0.2",
-        "@agent-relay/workflow-types": "6.0.2",
+        "@agent-relay/config": "6.0.6",
+        "@agent-relay/github-primitive": "6.0.6",
+        "@agent-relay/workflow-types": "6.0.6",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -16379,14 +16390,14 @@
         "@types/ws": "^8.5.10"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.2",
-        "@agent-relay/broker-darwin-x64": "6.0.2",
-        "@agent-relay/broker-linux-arm64": "6.0.2",
-        "@agent-relay/broker-linux-x64": "6.0.2",
-        "@agent-relay/broker-win32-x64": "6.0.2"
+        "@agent-relay/broker-darwin-arm64": "6.0.6",
+        "@agent-relay/broker-darwin-x64": "6.0.6",
+        "@agent-relay/broker-linux-arm64": "6.0.6",
+        "@agent-relay/broker-linux-x64": "6.0.6",
+        "@agent-relay/broker-win32-x64": "6.0.6"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.2",
+        "@agent-relay/credential-proxy": "6.0.6",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -16424,7 +16435,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
         "posthog-node": "^5.29.2"
       },
@@ -16459,9 +16470,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2"
+        "@agent-relay/config": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16470,9 +16481,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/utils": "6.0.2"
+        "@agent-relay/utils": "6.0.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16481,9 +16492,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dependencies": {
-        "@agent-relay/config": "6.0.2",
+        "@agent-relay/config": "6.0.6",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {
@@ -16493,7 +16504,7 @@
     },
     "packages/workflow-types": {
       "name": "@agent-relay/workflow-types",
-      "version": "6.0.2"
+      "version": "6.0.6"
     },
     "web": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@relaycast/mcp": "1.0.0",
     "@relaycast/sdk": "^1.1.0",
     "@relayfile/local-mount": "^0.2.2",
-    "@relayfile/sdk": "^0.1.2",
+    "@relayfile/sdk": "^0.6.0",
     "@sinclair/typebox": "^0.34.14",
     "agent-trajectories": "^0.5.4",
     "chalk": "^4.1.2",


### PR DESCRIPTION
## Summary
- bump the root agent-relay dependency on @relayfile/sdk to the 0.6 line
- refresh the lockfile so agent-relay installs @relayfile/sdk/@relayfile/core 0.6.1

## Verification
- npm run build:packages
- npm run build:sdk
- npm ls @relayfile/sdk --userconfig=/dev/null