### PR TITLE
Bump skills packages

### DIFF
--- a/.agents/skills/choosing-swarm-patterns/SKILL.md
+++ b/.agents/skills/choosing-swarm-patterns/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: choosing-swarm-patterns
-description: Use when coordinating multiple AI agents and need to pick the right orchestration pattern - covers 10 patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) with decision framework and reflection protocol
+description: Use when coordinating multiple AI agents with Agent Relay's workflow engine and need to pick the right orchestration pattern - covers the 10 core patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) plus 14 specialized ones, with decision framework and accurate SDK/YAML examples.
 ---
 
 ### Overview
 
-10 orchestration patterns for multi-agent workflows. Pick the simplest pattern that solves the problem — add complexity only when the system proves it's insufficient.
+The Agent Relay SDK (`@agent-relay/sdk`) supports 24 swarm patterns via a single `swarm.pattern` field. Patterns are configured declaratively in YAML or programmatically via the `workflow()` fluent builder — there are no standalone `fanOut(...)` / `hubAndSpoke(...)` helpers. Pick the simplest pattern that solves the problem; add complexity only when the system proves it's insufficient.
+
+### Two ways to run a pattern
+
+#### **1. YAML (portable):**
+
+```ts
+import { runWorkflow } from '@agent-relay/sdk/workflows';
+
+const run = await runWorkflow('workflows/feature-dev.yaml', {
+  vars: { task: 'Add OAuth login' },
+});
+```
 
 ### Quick Decision Framework
 
@@ -13,249 +25,383 @@ description: Use when coordinating multiple AI agents and need to pick the right
 
 ```
 Is the task independent per agent?
-  YES → fan-out (parallel workers)
+  YES → fan-out (parallel workers, hub collects)
 
 Does each step need the previous step's output?
   YES → Is it strictly linear?
     YES → pipeline
-    NO  → dag (parallel where possible)
+    NO  → dag (parallel where possible, `dependsOn` edges)
 
 Does a coordinator need to stay alive and adapt?
-  YES → Is there one level of management?
-    YES → hub-spoke
-    NO  → hierarchical (multi-level)
+  YES → hub-spoke (single-level hub + workers)
+        hierarchical (structurally identical in current impl; use for naming/intent)
 
 Is the task about making a decision?
   YES → Do agents need to argue opposing sides?
-    YES → debate (adversarial)
-    NO  → consensus (cooperative voting)
+    YES → debate (adversarial, full mesh)
+    NO  → consensus (cooperative, full mesh + coordination.consensusStrategy)
 
 Does the right specialist emerge during processing?
-  YES → handoff (dynamic routing)
+  YES → handoff (sequential chain, one active at a time)
 
 Do all agents need to freely collaborate?
-  YES → mesh (peer-to-peer)
+  YES → mesh (full peer-to-peer edges)
 
 Is cost the primary concern?
-  YES → cascade (cheap model first, escalate if needed)
+  YES → cascade (chain of increasingly capable agents; each step's prompt
+        decides whether to pass through or redo the prior output)
 ```
 
+### Pattern Reference (Core 10)
 
-### Pattern Reference
+| #   | Pattern          | Topology (actual edges)                                                                                             | Best For                                                                    |
+| --- | ---------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1   | **fan-out**      | Hub broadcasts to N workers; workers reply to hub only                                                              | Independent subtasks (reviews, research, tests)                             |
+| 2   | **pipeline**     | Linear chain (agent*i → agent*{i+1})                                                                                | Ordered stages (design → implement → test)                                  |
+| 3   | **hub-spoke**    | Hub ↔ spokes (bidirectional); no spoke-to-spoke                                                                     | Dynamic coordination, lead reviews/adjusts                                  |
+| 4   | **consensus**    | Full mesh; decision via `coordination.consensusStrategy`                                                            | Architecture decisions, approval gates                                      |
+| 5   | **mesh**         | Full mesh (every agent ↔ every other)                                                                               | Brainstorming, collaborative debugging                                      |
+| 6   | **handoff**      | Chain; passes control forward                                                                                       | Triage, specialist routing                                                  |
+| 7   | **cascade**      | Chain of `dependsOn` steps; all run on success, downstream skipped on upstream failure (no built-in "fall through") | Cost optimization: cheap first, each step's prompt passes through or redoes |
+| 8   | **dag**          | Edges from step `dependsOn`                                                                                         | Mixed dependencies, parallel where possible                                 |
+| 9   | **debate**       | Full mesh (same topology as mesh; roles drive behavior)                                                             | Rigorous adversarial examination                                            |
+| 10  | **hierarchical** | Hub + subordinates (single-level in current impl)                                                                   | Large teams; semantic distinction from hub-spoke                            |
 
-| # | Pattern | Topology | Agents | Best For |
-|---|---------|----------|--------|----------|
-| 1 | **fan-out** | Star (SDK center) | N parallel | Independent subtasks (reviews, research, tests) |
-| 2 | **pipeline** | Linear chain | Sequential | Ordered stages (design → implement → test) |
-| 3 | **hub-spoke** | Star (live hub) | 1 lead + N workers | Dynamic coordination, lead reviews/adjusts |
-| 4 | **consensus** | Broadcast + vote | N voters | Architecture decisions, approval gates |
-| 5 | **mesh** | Fully connected | N peers | Brainstorming, collaborative debugging |
-| 6 | **handoff** | Routing chain | 1 active at a time | Triage, specialist routing, support flows |
-| 7 | **cascade** | Tiered escalation | Cheapest → most capable | Cost optimization, production workloads |
-| 8 | **dag** | Dependency graph | Parallel + joins | Complex projects with mixed dependencies |
-| 9 | **debate** | Adversarial rounds | 2+ debaters + judge | Rigorous evaluation, architecture trade-offs |
-| 10 | **hierarchical** | Tree (multi-level) | Lead → coordinators → workers | Large teams, domain separation |
+> **Heads up:** `hierarchical` resolves to the same edge structure as `hub-spoke` in `coordinator.ts:313-319`. Multi-level tree topology is not currently implemented — use pattern name for intent, but expect the same runtime graph.
+
+### Additional Patterns (role-driven)
+
+These 14 additional patterns exist in `SwarmPattern` (types.ts:114-139). The coordinator has role-based auto-selection heuristics (`coordinator.ts:51-165`), but they only fire when `swarm.pattern` is **omitted** — YAML validation requires it (`runner.ts:2105-2117`), so auto-selection is effectively a programmatic-API feature. In YAML, set `swarm.pattern` explicitly.
+
+Topology is still resolved per-pattern once selected; the "Triggering roles" column reflects what the coordinator looks for to shape edges (per `coordinator.ts:250-450`):
+
+| Pattern           | Roles the topology keys off                             | Topology                                       |
+| ----------------- | ------------------------------------------------------- | ---------------------------------------------- |
+| `map-reduce`      | `mapper` + `reducer`                                    | coordinator → mappers → reducers → coordinator |
+| `scatter-gather`  | —                                                       | hub → workers → hub                            |
+| `supervisor`      | `supervisor`                                            | supervisor ↔ workers                           |
+| `reflection`      | `critic` or `reviewer` (auto-select uses `critic` only) | producers → critic → producers (loop)          |
+| `red-team`        | `attacker`/`red-team` + `defender`/`blue-team`          | adversarial mesh with optional judges          |
+| `verifier`        | `verifier`                                              | producers → verifiers → back to producers      |
+| `auction`         | `auctioneer`                                            | auctioneer → bidders → auctioneer              |
+| `escalation`      | `tier-*`                                                | tiered chain, escalate up / report down        |
+| `saga`            | `saga-orchestrator`, `compensate-handler`               | orchestrator ↔ participants                    |
+| `circuit-breaker` | `primary` + `fallback`/`backup`                         | try primary, fallback on failure               |
+| `blackboard`      | `blackboard` / `shared-workspace`                       | shared state hub                               |
+| `swarm`           | `hive-mind` / `swarm-agent`                             | stigmergy-style                                |
+| `competitive`     | — (declared explicitly)                                 | independent parallel implementations + judge   |
+| `review-loop`     | `implement*` + 2+ `reviewer*`                           | implementer ↔ reviewers                        |
 
 ### Pattern Details
 
 #### 1. fan-out — Parallel Workers
 
 ```ts
-fanOut([
-  { task: "Review auth.ts", name: "AuthReviewer" },
-  { task: "Review db.ts", name: "DbReviewer" },
-], { cli: "claude" });
+await workflow('review')
+  .pattern('fan-out')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('auth-rev', { cli: 'claude', role: 'worker', interactive: false })
+  .agent('db-rev', { cli: 'claude', role: 'worker', interactive: false })
+  .step('review-auth', { agent: 'auth-rev', task: 'Review auth.ts' })
+  .step('review-db', { agent: 'db-rev', task: 'Review db.ts' })
+  .run();
 ```
 
 #### 2. pipeline — Sequential Stages
 
-```ts
-pipeline([
-  { task: "Design the API schema", name: "Designer" },
-  { task: "Implement the endpoints", name: "Implementer" },
-  { task: "Write integration tests", name: "Tester" },
-]);
+```yaml
+swarm: { pattern: pipeline }
+agents:
+  - { name: designer, cli: claude }
+  - { name: implementer, cli: codex, interactive: false }
+  - { name: tester, cli: codex, interactive: false }
+workflows:
+  - name: build
+    steps:
+      - {
+          name: design,
+          agent: designer,
+          task: 'Design the API schema',
+          verification: { type: output_contains, value: DONE },
+        }
+      - {
+          name: implement,
+          agent: implementer,
+          dependsOn: [design],
+          task: 'Implement: {{steps.design.output}}',
+        }
+      - { name: test, agent: tester, dependsOn: [implement], task: 'Write integration tests' }
 ```
 
 #### 3. hub-spoke — Persistent Coordinator
 
 ```ts
-hubAndSpoke({
-  hub: { task: "Coordinate building a REST API", name: "Lead" },
-  workers: [
-    { task: "Build database models", name: "DbWorker" },
-    { task: "Build route handlers", name: "ApiWorker" },
-  ],
-});
+await workflow('api-build')
+  .pattern('hub-spoke')
+  .channel('swarm-api')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('db-worker', { cli: 'claude', role: 'worker' }) // interactive by default — hub DMs it
+  .agent('api-worker', { cli: 'claude', role: 'worker' }) // interactive by default — hub DMs it
+  .step('models', { agent: 'db-worker', task: 'Build database models' })
+  .step('routes', { agent: 'api-worker', task: 'Build route handlers', dependsOn: ['models'] })
+  .step('review', { agent: 'lead', task: 'Review everything', dependsOn: ['routes'] })
+  .run();
 ```
 
 #### 4. consensus — Cooperative Voting
 
-```ts
-consensus({
-  proposal: "Should we migrate to Fastify?",
-  voters: [
-    { task: "Evaluate performance", name: "PerfExpert" },
-    { task: "Evaluate DX", name: "DxExpert" },
-  ],
-  consensusType: "majority",
-});
+```yaml
+swarm: { pattern: consensus }
+agents:
+  - { name: perf, cli: claude, role: reviewer }
+  - { name: dx, cli: claude, role: reviewer }
+  - { name: sec, cli: claude, role: reviewer }
+coordination:
+  consensusStrategy: majority # declarative marker: majority | unanimous | quorum
+  votingThreshold: 0.66
+workflows:
+  - name: decide
+    steps:
+      - { name: evaluate-perf, agent: perf, task: 'Evaluate perf of Fastify migration' }
+      - { name: evaluate-dx, agent: dx, task: 'Evaluate DX of Fastify migration' }
+      - { name: evaluate-sec, agent: sec, task: 'Evaluate security of Fastify migration' }
 ```
 
 #### 5. mesh — Peer Collaboration
 
 ```ts
-mesh({
-  goal: "Debug the auth flow returning 500",
-  agents: [
-    { task: "Check server logs", name: "LogAnalyst" },
-    { task: "Review auth code", name: "CodeReviewer" },
-    { task: "Write repro test", name: "Tester" },
-  ],
-});
+await workflow('debug-auth')
+  .pattern('mesh')
+  .channel('swarm-debug')
+  .agent('logs', { cli: 'claude' })
+  .agent('code', { cli: 'claude' })
+  .agent('repro', { cli: 'claude' })
+  .step('logs', { agent: 'logs', task: 'Check server logs' })
+  .step('code', { agent: 'code', task: 'Review auth code' })
+  .step('repro', { agent: 'repro', task: 'Write repro test' })
+  .run();
 ```
 
 #### 6. handoff — Dynamic Routing
 
-```ts
-handoff({
-  entryPoint: { task: "Triage the request", name: "Triage" },
-  routes: [
-    { agent: { task: "Handle billing", name: "Billing" }, condition: "billing, payment" },
-    { agent: { task: "Handle tech issues", name: "TechSupport" }, condition: "error, bug" },
-  ],
-  maxHandoffs: 3,
-});
+```yaml
+swarm: { pattern: handoff }
+agents:
+  - { name: triage, cli: claude }
+  - { name: billing, cli: claude }
+  - { name: tech, cli: claude }
+workflows:
+  - name: support
+    steps:
+      - { name: triage, agent: triage, task: 'Triage: {{request}}' }
+      - { name: billing, agent: billing, dependsOn: [triage], task: 'Handle billing' }
+      - { name: tech, agent: tech, dependsOn: [triage], task: 'Handle tech issues' }
 ```
 
-#### 7. cascade — Cost-Aware Escalation
+#### 7. cascade — Cost-Aware Fallthrough
 
 ```ts
-cascade({
-  tiers: [
-    { agent: { task: "Answer this", cli: "claude" }, confidenceThreshold: 0.7, costWeight: 1 },
-    { agent: { task: "Answer this", cli: "claude" }, confidenceThreshold: 0.85, costWeight: 5 },
-    { agent: { task: "Answer this", cli: "claude" }, costWeight: 20 },
-  ],
-});
+await workflow('answer')
+  .pattern('cascade')
+  .agent('haiku', { cli: 'claude', model: 'claude-haiku-4-5-20251001' })
+  .agent('sonnet', { cli: 'claude', model: 'claude-sonnet-4-6' })
+  .agent('opus', { cli: 'claude', model: 'claude-opus-4-7' })
+  .step('try-haiku', { agent: 'haiku', task: '{{question}}' })
+  .step('try-sonnet', {
+    agent: 'sonnet',
+    task: 'If this is a complete answer, echo it verbatim. Otherwise answer anew:\n{{steps.try-haiku.output}}',
+    dependsOn: ['try-haiku'],
+  })
+  .step('try-opus', {
+    agent: 'opus',
+    task: 'Final-tier answer, using prior attempts for context:\n{{steps.try-sonnet.output}}',
+    dependsOn: ['try-sonnet'],
+  })
+  .run();
 ```
 
 #### 8. dag — Directed Acyclic Graph
 
 ```ts
-dag({
-  nodes: [
-    { id: "scaffold", task: "Create project scaffold" },
-    { id: "frontend", task: "Build React UI", dependsOn: ["scaffold"] },
-    { id: "backend", task: "Build API", dependsOn: ["scaffold"] },
-    { id: "integrate", task: "Wire together", dependsOn: ["frontend", "backend"] },
-  ],
-  maxConcurrency: 3,
-});
+await workflow('fullstack')
+  .pattern('dag')
+  .maxConcurrency(3)
+  .agent('dev', { cli: 'codex', role: 'worker' })
+  .step('scaffold', { agent: 'dev', task: 'Create project scaffold' })
+  .step('frontend', { agent: 'dev', task: 'Build React UI', dependsOn: ['scaffold'] })
+  .step('backend', { agent: 'dev', task: 'Build API', dependsOn: ['scaffold'] })
+  .step('integrate', { agent: 'dev', task: 'Wire together', dependsOn: ['frontend', 'backend'] })
+  .run();
 ```
 
 #### 9. debate — Adversarial Refinement
 
-```ts
-debate({
-  topic: "Monorepo vs polyrepo for the new platform?",
-  debaters: [
-    { task: "Argue for monorepo", position: "monorepo" },
-    { task: "Argue for polyrepo", position: "polyrepo" },
-  ],
-  judge: { task: "Judge and decide", name: "ArchJudge" },
-  maxRounds: 3,
-});
+```yaml
+swarm: { pattern: debate }
+agents:
+  - { name: pro, cli: claude, role: debater, task: 'Argue FOR monorepo' }
+  - { name: con, cli: claude, role: debater, task: 'Argue FOR polyrepo' }
+  - { name: judge, cli: claude, role: judge, task: 'Decide after 3 rounds' }
+coordination:
+  barriers:
+    - { name: debate-done, waitFor: [pro-round-3, con-round-3] }
 ```
 
-#### 10. hierarchical — Multi-Level Delegation
+#### 10. hierarchical — Multi-Level (structurally hub-spoke today)
 
 ```ts
-hierarchical({
-  agents: [
-    { id: "lead", task: "Coordinate full-stack app", role: "lead" },
-    { id: "fe-coord", task: "Manage frontend", role: "coordinator", reportsTo: "lead" },
-    { id: "be-coord", task: "Manage backend", role: "coordinator", reportsTo: "lead" },
-    { id: "fe-dev", task: "Build components", role: "worker", reportsTo: "fe-coord" },
-    { id: "be-dev", task: "Build API", role: "worker", reportsTo: "be-coord" },
-  ],
-});
+await workflow('large-team')
+  .pattern('hierarchical')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('fe-coord', { cli: 'claude', role: 'coordinator' })
+  .agent('be-coord', { cli: 'claude', role: 'coordinator' })
+  .agent('fe-dev', { cli: 'codex', role: 'worker', interactive: false })
+  .agent('be-dev', { cli: 'codex', role: 'worker', interactive: false })
+  .step('plan', { agent: 'lead', task: 'Coordinate full-stack app' })
+  .step('fe-plan', { agent: 'fe-coord', task: 'Manage frontend', dependsOn: ['plan'] })
+  .step('be-plan', { agent: 'be-coord', task: 'Manage backend', dependsOn: ['plan'] })
+  .step('fe-impl', { agent: 'fe-dev', task: 'Build components', dependsOn: ['fe-plan'] })
+  .step('be-impl', { agent: 'be-dev', task: 'Build API', dependsOn: ['be-plan'] })
+  .run();
 ```
 
+### Verification & Completion Signals
 
-### Reflection Protocol
+#### An agent step can complete in several ways (`runner.ts:5353-5395`, `runner.ts:4527-4538`):
 
-#### All patterns support reflection — periodic synthesis that enables course correction. Enabled via `reflectionThreshold` on WorkflowOptions.
-
-```ts
-{
-  reflectionThreshold: 10, // trigger after 10 agent messages
-  onReflect: async (ctx) => {
-    // Examine ctx.recentMessages, ctx.agentStatuses
-    // Return adjustments or null
-  },
-}
+```yaml
+verification:
+  type: output_contains # or: exit_code | file_exists | custom
+  value: DONE # or: PLAN_COMPLETE, IMPLEMENTATION_COMPLETE, REVIEW_COMPLETE
 ```
 
+### Relaycast MCP — Correct Tool Names
+
+The skill previously referenced `mcp__relaycast__send` / `mcp__relaycast__dm` — those names are wrong. The real tools (the first three are cited in the workflow convention-injection at `relay-adapter.ts:31-35`; the rest are exposed by the live `relaycast` MCP server):
+
+| Purpose                  | Tool                                  | Source                |
+| ------------------------ | ------------------------------------- | --------------------- |
+| Send DM to another agent | `mcp__relaycast__message_dm_send`     | `relay-adapter.ts:31` |
+| Check inbox              | `mcp__relaycast__message_inbox_check` | `relay-adapter.ts:35` |
+| List agents              | `mcp__relaycast__agent_list`          | `relay-adapter.ts:35` |
+| Post to a channel        | `mcp__relaycast__message_post`        | relaycast MCP server  |
+| Reply in a thread        | `mcp__relaycast__message_reply`       | relaycast MCP server  |
+| Spawn sub-agent          | `mcp__relaycast__agent_add`           | relaycast MCP server  |
+| Remove sub-agent         | `mcp__relaycast__agent_remove`        | relaycast MCP server  |
+
+> `interactive: false` agents run as non-interactive subprocesses with no relay connection — they must NOT call any `mcp__relaycast__*` tool (validator warns on this at `validator.ts:138-150`, check `NONINTERACTIVE_RELAY`).
+
+### Reflection (Trajectories)
+
+#### Reflection is **not** a `reflectionThreshold` callback. It's configured via the `trajectories:` block:
+
+```yaml
+trajectories:
+  enabled: true
+  reflectOnBarriers: true # config flag exists but runner does NOT currently invoke this path
+  reflectOnConverge: true # fires at parallel convergence points (runner.ts:2762-2779)
+  autoDecisions: true # record retry/skip/fail decisions
+```
 
 ### Common Mistakes
 
-| Mistake | Why It Fails | Fix |
-|---------|-------------|-----|
-| Using mesh for everything | O(n^2) communication, debugging nightmare | Use hub-spoke for most tasks |
-| Pipeline for independent work | Sequential bottleneck | Use fan-out or dag |
-| Hub-spoke for simple parallel tasks | Hub is unnecessary overhead | Use fan-out |
-| Consensus for non-decisions | Voting on implementation tasks wastes time | Use hub-spoke, let lead decide |
-| No circuit breaker on handoff | Infinite routing loops | Always set maxHandoffs |
-| Cascade without confidence parsing | Agents don't report confidence | Convention injection handles this |
-| Hierarchical for 3 agents | Management overhead exceeds benefit | Use hub-spoke for small teams |
+| Mistake                                      | Why It Fails                                                                  | Fix                                                                                           |
+| -------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                           |
+| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                            |
+| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                       |
+| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                          |
+| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match   |
+| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`         |
+| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops |
+| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                    |
+| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                    |
+| Writing `mcp__relaycast__send(...)`          | Wrong tool name                                                               | Use `mcp__relaycast__message_post` or `message_dm_send`                                       |
 
-### DAG Executor — Proven Pattern
+### Resume & Re-run
 
-#### Agent Completion: Detect → Release → Collect
-
-```
-Agent writes summary file → Orchestrator polls (5s) → Detects new mtime →
-  Reads summary → Calls client.release(agent) → agent_exited fires → Node marked complete
-```
-
-#### State & Resume
+#### ```ts
 
 ```ts
-saveState(completed, depsOutput, results, startTime);
-// Restart with --resume to skip completed nodes
+// Resume a failed run:
+await runWorkflow('feature-dev.yaml', { resume: '<runId>' });
+
+// Skip ahead, re-using cached outputs from an earlier run:
+await runWorkflow('feature-dev.yaml', {
+  startFrom: 'review',
+  previousRunId: '<runId>',
+});
 ```
 
+### Complete YAML Example
 
-### YAML Workflow Definition
-
-#### Any pattern can be defined in YAML for portability:
+#### ```yaml
 
 ```yaml
-version: "1.0"
+version: '1.0'
 name: feature-dev
-pattern: hub-spoke
+description: 'Blueprint-style feature development with quality gates.'
+swarm:
+  pattern: hub-spoke
+  maxConcurrency: 2
+  timeoutMs: 3600000
+  channel: swarm-feature-dev
+  idleNudge: { nudgeAfterMs: 120000, escalateAfterMs: 120000, maxNudges: 1 }
 agents:
-  - id: lead
-    role: lead
-    cli: claude
-  - id: developer
-    role: worker
-    cli: codex
-    reportsTo: lead
-steps:
-  - id: plan
-    agent: lead
-    prompt: "Create a development plan for: {{task}}"
-    expects: "PLAN_COMPLETE"
-  - id: implement
-    agent: developer
-    dependsOn: [plan]
-    prompt: "Implement: {{steps.plan.output}}"
-    expects: "DONE"
-reflection:
+  - { name: lead, cli: claude, role: lead, permissions: { access: full } }
+  - { name: planner, cli: codex, role: planner, interactive: false, permissions: { access: readonly } }
+  - { name: developer, cli: codex, role: worker, interactive: false, permissions: { access: readwrite } }
+  - { name: reviewer, cli: claude, role: reviewer, permissions: { access: readonly } }
+workflows:
+  - name: feature-delivery
+    onError: retry
+    preflight:
+      - { command: 'git status --porcelain', failIf: non-empty, description: 'Clean worktree' }
+    steps:
+      - name: plan
+        agent: planner
+        task: 'Plan: {{task}}'
+        verification: { type: output_contains, value: PLAN_COMPLETE }
+      - name: implement
+        agent: developer
+        dependsOn: [plan]
+        task: 'Implement: {{steps.plan.output}}'
+        verification: { type: output_contains, value: IMPLEMENTATION_COMPLETE }
+      - name: test
+        type: deterministic
+        dependsOn: [implement]
+        command: npm test
+      - name: review
+        agent: reviewer
+        dependsOn: [test]
+        task: 'Review implementation'
+        verification: { type: output_contains, value: REVIEW_COMPLETE }
+coordination:
+  barriers:
+    - { name: delivery-ready, waitFor: [plan, implement, review], timeoutMs: 900000 }
+trajectories:
   enabled: true
-  threshold: 10
-trajectory:
-  enabled: true
+  reflectOnBarriers: true
+  reflectOnConverge: true
+errorHandling:
+  strategy: retry
+  maxRetries: 2
+  retryDelayMs: 5000
 ```
+
+### Source of Truth
+
+| Claim                                                             | File                                                                         |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Pattern enum (24 patterns)                                        | `packages/sdk/src/workflows/types.ts:114-139`                                |
+| Topology resolution per pattern                                   | `packages/sdk/src/workflows/coordinator.ts:240-450`                          |
+| Interactive-only topology edges                                   | `packages/sdk/src/workflows/coordinator.ts:218-237`                          |
+| Pattern auto-selection heuristics (programmatic API only)         | `packages/sdk/src/workflows/coordinator.ts:51-165`                           |
+| `WorkflowBuilder` fluent API                                      | `packages/sdk/src/workflows/builder.ts`                                      |
+| `runWorkflow(yamlPath, options)`                                  | `packages/sdk/src/workflows/run.ts`                                          |
+| YAML validation requires `version` + `name` + `swarm.pattern`     | `packages/sdk/src/workflows/runner.ts:2105-2117`                             |
+| MCP tool names cited in convention-injection                      | `packages/sdk/src/relay-adapter.ts:29-36`                                    |
+| Completion modes (verification / evidence / owner / process-exit) | `packages/sdk/src/workflows/runner.ts:5353-5395`, `4527-4538`                |
+| Completion via PTY + summary fallback                             | `packages/sdk/src/workflows/runner.ts:6600-6615`                             |
+| Downstream skip on upstream failure (not success)                 | `packages/sdk/src/workflows/runner.ts:7057-7088`, `step-executor.ts:329-334` |
+| Trajectory reflection (only `reflectOnConverge` wired)            | `packages/sdk/src/workflows/runner.ts:2762-2779`, `trajectory.ts:173-190`    |

--- a/.agents/skills/running-headless-orchestrator/SKILL.md
+++ b/.agents/skills/running-headless-orchestrator/SKILL.md
@@ -30,7 +30,10 @@ A headless orchestrator is an agent that:
 | Spawn worker                      | `agent-relay spawn Worker1 claude "task"`               |
 | List workers                      | `agent-relay who`                                       |
 | View worker logs                  | `agent-relay agents:logs Worker1`                       |
-| Send message                      | `agent-relay send Worker1 "message"`                    |
+| Send DM to worker                 | `agent-relay send Worker1 "message"`                    |
+| Post to channel                   | `agent-relay send '#general' "message"`                 |
+| Read worker's unread DM replies   | `agent-relay inbox --agent Worker1`                     |
+| Read full DM conversation history | `agent-relay history --to Worker1`                      |
 | Release worker                    | `agent-relay release Worker1`                           |
 | Stop infrastructure               | `agent-relay down`                                      |
 
@@ -73,11 +76,17 @@ mcp__relaycast__agent_add(
 #### Step 3: Monitor and Coordinate
 
 ```
-# Check for worker messages
+# Check if workers have replied (returns unread counts — not the content)
 mcp__relaycast__message_inbox_check()
 
-# Send follow-up instructions
+# List Worker1's DM conversations (use `as` to specify the agent)
+mcp__relaycast__message_dm_list(as: "Worker1")
+
+# Send a targeted DM to a specific worker
 mcp__relaycast__message_dm_send(to: "Worker1", text: "Also add unit tests")
+
+# Broadcast to all agents on a channel
+mcp__relaycast__message_post(channel: "general", text: "All workers: wrap up current task")
 
 # List active workers
 mcp__relaycast__agent_list()
@@ -97,14 +106,36 @@ agent-relay down
 
 ### CLI Commands for Orchestration
 
+#### Channel vs DM — When to Use Each
+
+```bash
+# WRONG — history (no flags) will not show DM replies from workers
+agent-relay history
+
+# Read a worker's UNREAD DM replies (clears after reading)
+agent-relay inbox --agent Worker1
+
+# Read the full DM conversation history with a worker (read + unread)
+agent-relay history --to Worker1
+
+# Read only the thread between two specific agents
+agent-relay history --to Worker1 --from Orchestrator
+```
+
 #### Spawning and Messaging
 
 ```bash
 # Spawn a worker
 agent-relay spawn Worker1 claude "Implement auth module"
 
-# Send message to worker
+# Send a DM to a specific worker (replies readable via inbox --agent)
 agent-relay send Worker1 "Add unit tests too"
+
+# Broadcast to all workers via channel
+agent-relay send '#general' "Team: wrap up and report status"
+
+# Read Worker1's DM reply
+agent-relay inbox --agent Worker1
 
 # Release when done
 agent-relay release Worker1
@@ -119,8 +150,11 @@ agent-relay who
 # View real-time output from a worker (critical for debugging)
 agent-relay agents:logs Worker1
 
-# View recent message history
-agent-relay history
+# Read DM replies from a specific worker
+agent-relay inbox --agent Worker1
+
+# View channel message history (channel posts only — not DMs)
+agent-relay history --to '#general'
 
 # Check overall system status
 agent-relay status
@@ -164,8 +198,14 @@ Monitor workers (do this frequently):
   agent-relay who              # List active workers
   agent-relay agents:logs Worker1  # View worker output/progress
 
-Send instructions:
+Send targeted DM instructions:
   agent-relay send Worker1 "Additional instructions"
+
+Broadcast to all workers:
+  agent-relay send '#general' "All workers: prioritize the auth module"
+
+Read worker replies (DMs are not visible in history):
+  agent-relay inbox --agent Worker1
 
 Release when done:
   agent-relay release Worker1
@@ -174,7 +214,10 @@ Release when done:
 - Workers will ACK when they receive tasks
 - Workers will send DONE when complete
 - Use `agent-relay agents:logs <name>` to monitor progress
-- Use `agent-relay history` to see message flow
+- Use `agent-relay inbox --agent <name>` to read **unread** DM replies from a worker (clears after reading)
+- Use `agent-relay history --to <name>` to re-read the full DM conversation (read + unread)
+- Use `agent-relay history --to '#general'` to see channel message flow
+- Do NOT use `agent-relay history` alone to check worker replies — it only shows channel posts, DM replies are invisible there
 ```
 
 ### Lifecycle Events
@@ -191,17 +234,21 @@ The broker emits these events (available via SDK subscriptions):
 
 ### Common Mistakes
 
-| Mistake                                                  | Fix                                                                                                                             |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `agent-relay: command not found` or mise/asdf shim error | Ensure Node is available first (`node --version`); if a shim is broken, fix the runtime manager, then install/use `agent-relay` |
-| "Nested session" error                                   | Broker handles this automatically; if running manually, unset `CLAUDECODE` env var                                              |
-| Broker not starting                                      | Try `agent-relay down` first, then use foreground `agent-relay up --no-dashboard --verbose` to see readiness logs               |
-| Background broker says started but status is STOPPED     | Prefer foreground mode for that project/session; background mode may have detached incorrectly                                  |
-| Spawn fails with `internal reply dropped`                | Broker likely is not fully ready yet; wait for readiness, then spawn one worker first                                           |
-| Workers not connecting                                   | Ensure broker started; check `agent-relay who` and worker logs                                                                  |
-| Not monitoring workers                                   | Use `agent-relay agents:logs <name>` frequently to track progress                                                               |
-| Workers seem stuck                                       | Check logs with `agent-relay agents:logs <name>` for errors                                                                     |
-| Messages not delivered                                   | Check `agent-relay history` to verify message flow                                                                              |
+| Mistake                                                    | Fix                                                                                                                                                                       |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent-relay: command not found` or mise/asdf shim error   | Ensure Node is available first (`node --version`); if a shim is broken, fix the runtime manager, then install/use `agent-relay`                                           |
+| "Nested session" error                                     | Broker handles this automatically; if running manually, unset `CLAUDECODE` env var                                                                                        |
+| Broker not starting                                        | Try `agent-relay down` first, then use foreground `agent-relay up --no-dashboard --verbose` to see readiness logs                                                         |
+| Background broker says started but status is STOPPED       | Prefer foreground mode for that project/session; background mode may have detached incorrectly                                                                            |
+| Spawn fails with `internal reply dropped`                  | Broker likely is not fully ready yet; wait for readiness, then spawn one worker first                                                                                     |
+| Workers not connecting                                     | Ensure broker started; check `agent-relay who` and worker logs                                                                                                            |
+| Not monitoring workers                                     | Use `agent-relay agents:logs <name>` frequently to track progress                                                                                                         |
+| Workers seem stuck                                         | Check logs with `agent-relay agents:logs <name>` for errors                                                                                                               |
+| Messages not delivered                                     | Check `agent-relay history --to '#general'` for channel messages; use `agent-relay inbox --agent <name>` for DMs                                                          |
+| Worker replies not showing in history                      | Expected — `history` only shows channel posts. Use `agent-relay inbox --agent <name>` (unread only) or `agent-relay history --to <name>` (full thread) to read DM replies |
+| `inbox_check` shows unread but can't see content           | `inbox_check` only returns counts. Use `mcp__relaycast__message_dm_list(as: "<name>")` to list conversations, or `agent-relay inbox --agent <name>` via CLI               |
+| `inbox --agent` showed messages once but now shows nothing | `inbox` only shows **unread** — already-read messages won't reappear. Use `agent-relay history --to <name>` to re-read the full conversation                              |
+| Sent to wrong destination                                  | `agent-relay send Worker1 "..."` = DM; `agent-relay send '#general' "..."` = channel broadcast. The `#` prefix is required for channels                                   |
 
 ### Overview
 

--- a/.agents/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.agents/skills/writing-agent-relay-workflows/SKILL.md
@@ -21,7 +21,7 @@ The relay broker-sdk workflow system orchestrates multiple AI agents (Claude, Co
 
 ### Quick Reference
 
-#### ```typescript
+#### > **Note:** this Quick Reference assumes an **ESM** workflow file (the host `package.json` has `"type": "module"`). For CJS repos, see rule #1 in **Critical TypeScript rules** below — convert `import { workflow } from '@agent-relay/sdk/workflows'` to `const { workflow } = require('@agent-relay/sdk/workflows')` and wrap the workflow in `async function main() { ... } main().catch(console.error)` since CJS does not support top-level `await`. **Always check `package.json` before copy-pasting the snippet.**
 
 ```typescript
 import { workflow } from '@agent-relay/sdk/workflows';
@@ -124,6 +124,45 @@ runWorkflow().catch((error) => {
 });
 ```
 
+#### 2b. Standard preflight template for resumable workflows
+
+```ts
+.step('preflight', {
+  type: 'deterministic',
+  command: [
+    'set -e',
+    'BRANCH=$(git rev-parse --abbrev-ref HEAD)',
+    'echo "branch: $BRANCH"',
+    'if [ "$BRANCH" != "fix/your-branch-name" ]; then echo "ERROR: wrong branch"; exit 1; fi',
+    // Files the workflow is allowed to find dirty on entry:
+    //   - package-lock.json: npm install is idempotent and often touches it
+    //   - every file the workflow's edit steps will rewrite: a prior partial
+    //     run may have left them dirty, and the edit step will rewrite
+    //     them cleanly before commit
+    // Everything else is unexpected drift and must fail preflight.
+    'ALLOWED_DIRTY="package-lock.json|path/to/file1\\\\.ts|path/to/file2\\\\.ts"',
+    'DIRTY=$(git diff --name-only | grep -vE "^(${ALLOWED_DIRTY})$" || true)',
+    'if [ -n "$DIRTY" ]; then echo "ERROR: unexpected tracked drift:"; echo "$DIRTY"; exit 1; fi',
+    'if ! git diff --cached --quiet; then echo "ERROR: staging area is dirty"; git diff --cached --stat; exit 1; fi',
+    'gh auth status >/dev/null 2>&1 || (echo "ERROR: gh CLI not authenticated"; exit 1)',
+    'echo PREFLIGHT_OK',
+  ].join(' && '),
+  captureOutput: true,
+  failOnError: true,
+}),
+```
+
+#### 2c. Picking the right `.join()` for multi-line shell commands
+
+```ts
+command: [
+  'set -e',
+  'HITS=$(grep -c diag src/cli/commands/setup.ts || true)',
+  'if [ "$HITS" -lt 6 ]; then echo "FAIL"; exit 1; fi',
+  'echo OK',
+].join(' && '),
+```
+
 #### 3. Keep final verification boring and deterministic
 
 ```bash
@@ -134,6 +173,24 @@ grep -Eq "foo|bar|baz" file.ts
 
 ```bash
 /opt/homebrew/bin/bash workflows/your-workflow/execute.sh --wave 2
+```
+
+#### 9. Factor repo-specific setup into a shared helper
+
+```ts
+// workflows/lib/cloud-repo-setup.ts
+export interface CloudRepoSetupOptions {
+  branch: string;
+  committerName?: string;
+  extraSetupCommands?: string[];
+  skipWorkspaceBuild?: boolean;
+}
+
+export function applyCloudRepoSetup<T>(wf: T, opts: CloudRepoSetupOptions): T {
+  // adds two steps: setup-branch, install-deps
+  // install-deps runs: npm install + workspace prebuilds (build:platform, build:core, etc.)
+  // ...
+}
 ```
 
 ### End-to-End Bug Fix Workflows

--- a/.claude/skills/choosing-swarm-patterns/SKILL.md
+++ b/.claude/skills/choosing-swarm-patterns/SKILL.md
@@ -1,338 +1,478 @@
 ---
 name: choosing-swarm-patterns
-description: Use when coordinating multiple AI agents and need to pick the right orchestration pattern - covers 10 patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) with decision framework and reflection protocol
+description: Use when coordinating multiple AI agents with Agent Relay's workflow engine and need to pick the right orchestration pattern - covers the 10 core patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) plus 14 specialized ones, with decision framework and accurate SDK/YAML examples.
 ---
 
 # Choosing Swarm Patterns
 
 ## Overview
 
-10 orchestration patterns for multi-agent workflows. Pick the simplest pattern that solves the problem — add complexity only when the system proves it's insufficient.
+The Agent Relay SDK (`@agent-relay/sdk`) supports 24 swarm patterns via a single `swarm.pattern` field. Patterns are configured declaratively in YAML or programmatically via the `workflow()` fluent builder — there are no standalone `fanOut(...)` / `hubAndSpoke(...)` helpers. Pick the simplest pattern that solves the problem; add complexity only when the system proves it's insufficient.
+
+## Two ways to run a pattern
+
+**1. YAML (portable):**
+
+```ts
+import { runWorkflow } from '@agent-relay/sdk/workflows';
+
+const run = await runWorkflow('workflows/feature-dev.yaml', {
+  vars: { task: 'Add OAuth login' },
+});
+```
+
+**2. Fluent builder (programmatic):**
+
+```ts
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const run = await workflow('feature-dev')
+  .pattern('hub-spoke')
+  .channel('swarm-feature-dev')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('developer', { cli: 'codex', role: 'worker', interactive: false })
+  .step('plan', { agent: 'lead', task: 'Plan {{task}}' })
+  .step('implement', { agent: 'developer', task: 'Implement: {{steps.plan.output}}', dependsOn: ['plan'] })
+  .run();
+```
+
+Both paths hit the same `WorkflowRunner`.
 
 ## Quick Decision Framework
 
 ```
 Is the task independent per agent?
-  YES → fan-out (parallel workers)
+  YES → fan-out (parallel workers, hub collects)
 
 Does each step need the previous step's output?
   YES → Is it strictly linear?
     YES → pipeline
-    NO  → dag (parallel where possible)
+    NO  → dag (parallel where possible, `dependsOn` edges)
 
 Does a coordinator need to stay alive and adapt?
-  YES → Is there one level of management?
-    YES → hub-spoke
-    NO  → hierarchical (multi-level)
+  YES → hub-spoke (single-level hub + workers)
+        hierarchical (structurally identical in current impl; use for naming/intent)
 
 Is the task about making a decision?
   YES → Do agents need to argue opposing sides?
-    YES → debate (adversarial)
-    NO  → consensus (cooperative voting)
+    YES → debate (adversarial, full mesh)
+    NO  → consensus (cooperative, full mesh + coordination.consensusStrategy)
 
 Does the right specialist emerge during processing?
-  YES → handoff (dynamic routing)
+  YES → handoff (sequential chain, one active at a time)
 
 Do all agents need to freely collaborate?
-  YES → mesh (peer-to-peer)
+  YES → mesh (full peer-to-peer edges)
 
 Is cost the primary concern?
-  YES → cascade (cheap model first, escalate if needed)
+  YES → cascade (chain of increasingly capable agents; each step's prompt
+        decides whether to pass through or redo the prior output)
 ```
 
-## Pattern Reference
+## Pattern Reference (Core 10)
 
-| # | Pattern | Topology | Agents | Best For |
-|---|---------|----------|--------|----------|
-| 1 | **fan-out** | Star (SDK center) | N parallel | Independent subtasks (reviews, research, tests) |
-| 2 | **pipeline** | Linear chain | Sequential | Ordered stages (design → implement → test) |
-| 3 | **hub-spoke** | Star (live hub) | 1 lead + N workers | Dynamic coordination, lead reviews/adjusts |
-| 4 | **consensus** | Broadcast + vote | N voters | Architecture decisions, approval gates |
-| 5 | **mesh** | Fully connected | N peers | Brainstorming, collaborative debugging |
-| 6 | **handoff** | Routing chain | 1 active at a time | Triage, specialist routing, support flows |
-| 7 | **cascade** | Tiered escalation | Cheapest → most capable | Cost optimization, production workloads |
-| 8 | **dag** | Dependency graph | Parallel + joins | Complex projects with mixed dependencies |
-| 9 | **debate** | Adversarial rounds | 2+ debaters + judge | Rigorous evaluation, architecture trade-offs |
-| 10 | **hierarchical** | Tree (multi-level) | Lead → coordinators → workers | Large teams, domain separation |
+| #   | Pattern          | Topology (actual edges)                                                                                             | Best For                                                                    |
+| --- | ---------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1   | **fan-out**      | Hub broadcasts to N workers; workers reply to hub only                                                              | Independent subtasks (reviews, research, tests)                             |
+| 2   | **pipeline**     | Linear chain (agent*i → agent*{i+1})                                                                                | Ordered stages (design → implement → test)                                  |
+| 3   | **hub-spoke**    | Hub ↔ spokes (bidirectional); no spoke-to-spoke                                                                     | Dynamic coordination, lead reviews/adjusts                                  |
+| 4   | **consensus**    | Full mesh; decision via `coordination.consensusStrategy`                                                            | Architecture decisions, approval gates                                      |
+| 5   | **mesh**         | Full mesh (every agent ↔ every other)                                                                               | Brainstorming, collaborative debugging                                      |
+| 6   | **handoff**      | Chain; passes control forward                                                                                       | Triage, specialist routing                                                  |
+| 7   | **cascade**      | Chain of `dependsOn` steps; all run on success, downstream skipped on upstream failure (no built-in "fall through") | Cost optimization: cheap first, each step's prompt passes through or redoes |
+| 8   | **dag**          | Edges from step `dependsOn`                                                                                         | Mixed dependencies, parallel where possible                                 |
+| 9   | **debate**       | Full mesh (same topology as mesh; roles drive behavior)                                                             | Rigorous adversarial examination                                            |
+| 10  | **hierarchical** | Hub + subordinates (single-level in current impl)                                                                   | Large teams; semantic distinction from hub-spoke                            |
+
+> **Heads up:** `hierarchical` resolves to the same edge structure as `hub-spoke` in `coordinator.ts:313-319`. Multi-level tree topology is not currently implemented — use pattern name for intent, but expect the same runtime graph.
+
+## Additional Patterns (role-driven)
+
+These 14 additional patterns exist in `SwarmPattern` (types.ts:114-139). The coordinator has role-based auto-selection heuristics (`coordinator.ts:51-165`), but they only fire when `swarm.pattern` is **omitted** — YAML validation requires it (`runner.ts:2105-2117`), so auto-selection is effectively a programmatic-API feature. In YAML, set `swarm.pattern` explicitly.
+
+Topology is still resolved per-pattern once selected; the "Triggering roles" column reflects what the coordinator looks for to shape edges (per `coordinator.ts:250-450`):
+
+| Pattern           | Roles the topology keys off                             | Topology                                       |
+| ----------------- | ------------------------------------------------------- | ---------------------------------------------- |
+| `map-reduce`      | `mapper` + `reducer`                                    | coordinator → mappers → reducers → coordinator |
+| `scatter-gather`  | —                                                       | hub → workers → hub                            |
+| `supervisor`      | `supervisor`                                            | supervisor ↔ workers                           |
+| `reflection`      | `critic` or `reviewer` (auto-select uses `critic` only) | producers → critic → producers (loop)          |
+| `red-team`        | `attacker`/`red-team` + `defender`/`blue-team`          | adversarial mesh with optional judges          |
+| `verifier`        | `verifier`                                              | producers → verifiers → back to producers      |
+| `auction`         | `auctioneer`                                            | auctioneer → bidders → auctioneer              |
+| `escalation`      | `tier-*`                                                | tiered chain, escalate up / report down        |
+| `saga`            | `saga-orchestrator`, `compensate-handler`               | orchestrator ↔ participants                    |
+| `circuit-breaker` | `primary` + `fallback`/`backup`                         | try primary, fallback on failure               |
+| `blackboard`      | `blackboard` / `shared-workspace`                       | shared state hub                               |
+| `swarm`           | `hive-mind` / `swarm-agent`                             | stigmergy-style                                |
+| `competitive`     | — (declared explicitly)                                 | independent parallel implementations + judge   |
+| `review-loop`     | `implement*` + 2+ `reviewer*`                           | implementer ↔ reviewers                        |
 
 ## Pattern Details
 
+All examples below use real API shapes (`WorkflowBuilder` / YAML), verified against `packages/sdk/src/workflows/builder.ts` and `packages/sdk/src/workflows/types.ts`.
+
+> **YAML fragments vs complete configs:** The per-pattern YAML snippets below are fragments that show only the pattern-relevant shape. A runnable YAML file also requires `version: "1.0"` and `name: <id>` at the top (`runner.ts:2105-2117`). See the [Complete YAML Example](#complete-yaml-example) for the full structure.
+>
+> **Topology edges exclude `interactive: false` agents.** `resolveTopology` (`coordinator.ts:218-237`) drops non-interactive agents from the message graph — they run as one-shot subprocesses with no relay connection. Topology claims like "hub ↔ spokes" describe the interactive-agent edges; workers marked `interactive: false` are spawned and collected via stdout, not via relay messages.
+
 ### 1. fan-out — Parallel Workers
+
 ```ts
-fanOut([
-  { task: "Review auth.ts", name: "AuthReviewer" },
-  { task: "Review db.ts", name: "DbReviewer" },
-], { cli: "claude" });
+await workflow('review')
+  .pattern('fan-out')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('auth-rev', { cli: 'claude', role: 'worker', interactive: false })
+  .agent('db-rev', { cli: 'claude', role: 'worker', interactive: false })
+  .step('review-auth', { agent: 'auth-rev', task: 'Review auth.ts' })
+  .step('review-db', { agent: 'db-rev', task: 'Review db.ts' })
+  .run();
 ```
-- Workers run independently, no inter-agent communication
-- SDK collects all DONE messages
-- Use when: tasks are embarrassingly parallel
+
+Workers run independently; hub aggregates. No inter-worker edges.
 
 ### 2. pipeline — Sequential Stages
-```ts
-pipeline([
-  { task: "Design the API schema", name: "Designer" },
-  { task: "Implement the endpoints", name: "Implementer" },
-  { task: "Write integration tests", name: "Tester" },
-]);
+
+```yaml
+swarm: { pattern: pipeline }
+agents:
+  - { name: designer, cli: claude }
+  - { name: implementer, cli: codex, interactive: false }
+  - { name: tester, cli: codex, interactive: false }
+workflows:
+  - name: build
+    steps:
+      - {
+          name: design,
+          agent: designer,
+          task: 'Design the API schema',
+          verification: { type: output_contains, value: DONE },
+        }
+      - {
+          name: implement,
+          agent: implementer,
+          dependsOn: [design],
+          task: 'Implement: {{steps.design.output}}',
+        }
+      - { name: test, agent: tester, dependsOn: [implement], task: 'Write integration tests' }
 ```
-- Stage N+1 receives Stage N's DONE summary as context
-- Pipeline halts on failure
-- Use when: clear linear dependency chain
+
+Each stage receives the previous stage's output via `{{steps.<name>.output}}`. Halts on step failure unless `onError: retry` / `continue`.
 
 ### 3. hub-spoke — Persistent Coordinator
+
 ```ts
-hubAndSpoke({
-  hub: { task: "Coordinate building a REST API", name: "Lead" },
-  workers: [
-    { task: "Build database models", name: "DbWorker" },
-    { task: "Build route handlers", name: "ApiWorker" },
-  ],
-});
+await workflow('api-build')
+  .pattern('hub-spoke')
+  .channel('swarm-api')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('db-worker', { cli: 'claude', role: 'worker' }) // interactive by default — hub DMs it
+  .agent('api-worker', { cli: 'claude', role: 'worker' }) // interactive by default — hub DMs it
+  .step('models', { agent: 'db-worker', task: 'Build database models' })
+  .step('routes', { agent: 'api-worker', task: 'Build route handlers', dependsOn: ['models'] })
+  .step('review', { agent: 'lead', task: 'Review everything', dependsOn: ['routes'] })
+  .run();
 ```
-- Hub stays alive, receives ACK/DONE from workers
-- Hub can spawn additional workers dynamically
-- Use when: lead needs to review, adjust, and make decisions
+
+Hub (picked via `role: lead` or first agent) stays on the channel and direct-messages interactive workers via `mcp__relaycast__message_dm_send`.
+
+> **Don't set `interactive: false` on a hub-spoke worker** if you want it to receive coordination DMs — `resolveTopology` strips non-interactive agents from the message graph (`coordinator.ts:218-237`). Use `interactive: false` only when the worker is a one-shot subprocess whose stdout you collect via `{{steps.X.output}}` without any mid-run coordination.
 
 ### 4. consensus — Cooperative Voting
-```ts
-consensus({
-  proposal: "Should we migrate to Fastify?",
-  voters: [
-    { task: "Evaluate performance", name: "PerfExpert" },
-    { task: "Evaluate DX", name: "DxExpert" },
-  ],
-  consensusType: "majority",
-});
+
+```yaml
+swarm: { pattern: consensus }
+agents:
+  - { name: perf, cli: claude, role: reviewer }
+  - { name: dx, cli: claude, role: reviewer }
+  - { name: sec, cli: claude, role: reviewer }
+coordination:
+  consensusStrategy: majority # declarative marker: majority | unanimous | quorum
+  votingThreshold: 0.66
+workflows:
+  - name: decide
+    steps:
+      - { name: evaluate-perf, agent: perf, task: 'Evaluate perf of Fastify migration' }
+      - { name: evaluate-dx, agent: dx, task: 'Evaluate DX of Fastify migration' }
+      - { name: evaluate-sec, agent: sec, task: 'Evaluate security of Fastify migration' }
 ```
-- Agents independently evaluate, then VOTE: approve/reject
-- Supports majority, supermajority, unanimous, weighted, quorum
-- Use when: need a decision with diverse perspectives
+
+Full-mesh topology. **Caveat:** `coordination.consensusStrategy` and `votingThreshold` are declared in `CoordinationConfig` (`types.ts:768-772`) but the runner has **no built-in vote-tallying logic** — the fields only influence coordinator auto-selection (`coordinator.ts:63-64`). To implement voting, aggregate the step outputs in a downstream lead/judge step that reads `{{steps.evaluate-*.output}}`.
 
 ### 5. mesh — Peer Collaboration
+
 ```ts
-mesh({
-  goal: "Debug the auth flow returning 500",
-  agents: [
-    { task: "Check server logs", name: "LogAnalyst" },
-    { task: "Review auth code", name: "CodeReviewer" },
-    { task: "Write repro test", name: "Tester" },
-  ],
-});
+await workflow('debug-auth')
+  .pattern('mesh')
+  .channel('swarm-debug')
+  .agent('logs', { cli: 'claude' })
+  .agent('code', { cli: 'claude' })
+  .agent('repro', { cli: 'claude' })
+  .step('logs', { agent: 'logs', task: 'Check server logs' })
+  .step('code', { agent: 'code', task: 'Review auth code' })
+  .step('repro', { agent: 'repro', task: 'Write repro test' })
+  .run();
 ```
-- All agents on same channel, free communication
-- Round tracking detects stalls
-- Use when: collaborative exploration without hierarchy
+
+Every agent ↔ every other agent. Use for collaborative exploration without hierarchy.
 
 ### 6. handoff — Dynamic Routing
-```ts
-handoff({
-  entryPoint: { task: "Triage the request", name: "Triage" },
-  routes: [
-    { agent: { task: "Handle billing", name: "Billing" }, condition: "billing, payment" },
-    { agent: { task: "Handle tech issues", name: "TechSupport" }, condition: "error, bug" },
-  ],
-  maxHandoffs: 3,
-});
-```
-- One active agent at a time; transfers control dynamically
-- Circuit breaker prevents infinite routing loops
-- Use when: right specialist isn't known upfront
 
-### 7. cascade — Cost-Aware Escalation
-```ts
-cascade({
-  tiers: [
-    { agent: { task: "Answer this", cli: "claude" }, confidenceThreshold: 0.7, costWeight: 1 },
-    { agent: { task: "Answer this", cli: "claude" }, confidenceThreshold: 0.85, costWeight: 5 },
-    { agent: { task: "Answer this", cli: "claude" }, costWeight: 20 },
-  ],
-});
+```yaml
+swarm: { pattern: handoff }
+agents:
+  - { name: triage, cli: claude }
+  - { name: billing, cli: claude }
+  - { name: tech, cli: claude }
+workflows:
+  - name: support
+    steps:
+      - { name: triage, agent: triage, task: 'Triage: {{request}}' }
+      - { name: billing, agent: billing, dependsOn: [triage], task: 'Handle billing' }
+      - { name: tech, agent: tech, dependsOn: [triage], task: 'Handle tech issues' }
 ```
-- Start cheap, escalate if confidence < threshold
-- Agent reports: `DONE [confidence=0.4]: <answer>`
-- Use when: most tasks are simple, some need heavy reasoning
+
+Chain passes control forward. **Note:** The runner doesn't support "route to one branch and skip the others" declaratively — `dependsOn` steps all run when their dependencies complete, and skipping is only triggered by upstream **failure** (`runner.ts:7057-7088`). For true pick-one routing, have the triage step emit a routing token in its output and let each downstream step's prompt check `{{steps.triage.output}}` and no-op if it doesn't match.
+
+### 7. cascade — Cost-Aware Fallthrough
+
+```ts
+await workflow('answer')
+  .pattern('cascade')
+  .agent('haiku', { cli: 'claude', model: 'claude-haiku-4-5-20251001' })
+  .agent('sonnet', { cli: 'claude', model: 'claude-sonnet-4-6' })
+  .agent('opus', { cli: 'claude', model: 'claude-opus-4-7' })
+  .step('try-haiku', { agent: 'haiku', task: '{{question}}' })
+  .step('try-sonnet', {
+    agent: 'sonnet',
+    task: 'If this is a complete answer, echo it verbatim. Otherwise answer anew:\n{{steps.try-haiku.output}}',
+    dependsOn: ['try-haiku'],
+  })
+  .step('try-opus', {
+    agent: 'opus',
+    task: 'Final-tier answer, using prior attempts for context:\n{{steps.try-sonnet.output}}',
+    dependsOn: ['try-sonnet'],
+  })
+  .run();
+```
+
+**Important:** `cascade` only sets edge topology. The runner has **no skip-on-success logic** for the cascade pattern — a chain of `dependsOn` steps all execute in order on success, and failed upstream steps mark their dependents as **skipped** (`step-executor.ts:329-334`, `runner.ts:7057-7088`). So a verification-gated first step won't "fall through" to later steps on failure, and won't skip them on success either. The idiom above delegates the escalation decision to the prompt of each downstream step (read the upstream answer and pass-through or redo). No confidence-score parsing exists in-engine.
 
 ### 8. dag — Directed Acyclic Graph
+
 ```ts
-dag({
-  nodes: [
-    { id: "scaffold", task: "Create project scaffold" },
-    { id: "frontend", task: "Build React UI", dependsOn: ["scaffold"] },
-    { id: "backend", task: "Build API", dependsOn: ["scaffold"] },
-    { id: "integrate", task: "Wire together", dependsOn: ["frontend", "backend"] },
-  ],
-  maxConcurrency: 3,
-});
+await workflow('fullstack')
+  .pattern('dag')
+  .maxConcurrency(3)
+  .agent('dev', { cli: 'codex', role: 'worker' })
+  .step('scaffold', { agent: 'dev', task: 'Create project scaffold' })
+  .step('frontend', { agent: 'dev', task: 'Build React UI', dependsOn: ['scaffold'] })
+  .step('backend', { agent: 'dev', task: 'Build API', dependsOn: ['scaffold'] })
+  .step('integrate', { agent: 'dev', task: 'Wire together', dependsOn: ['frontend', 'backend'] })
+  .run();
 ```
-- Topological sort determines execution order
-- Independent nodes run in parallel
-- Use when: pipeline is too linear, fan-out is too flat
+
+Runner derives execution waves from `dependsOn`; independent nodes run in parallel up to `swarm.maxConcurrency`. The `dag` pattern is auto-selected when any step has `dependsOn`.
 
 ### 9. debate — Adversarial Refinement
-```ts
-debate({
-  topic: "Monorepo vs polyrepo for the new platform?",
-  debaters: [
-    { task: "Argue for monorepo", position: "monorepo" },
-    { task: "Argue for polyrepo", position: "polyrepo" },
-  ],
-  judge: { task: "Judge and decide", name: "ArchJudge" },
-  maxRounds: 3,
-});
-```
-- Structured rounds: ARGUMENT → counterargument → VERDICT
-- Optional judge; without judge, agents self-converge or split
-- Use when: need rigorous adversarial examination
 
-### 10. hierarchical — Multi-Level Delegation
-```ts
-hierarchical({
-  agents: [
-    { id: "lead", task: "Coordinate full-stack app", role: "lead" },
-    { id: "fe-coord", task: "Manage frontend", role: "coordinator", reportsTo: "lead" },
-    { id: "be-coord", task: "Manage backend", role: "coordinator", reportsTo: "lead" },
-    { id: "fe-dev", task: "Build components", role: "worker", reportsTo: "fe-coord" },
-    { id: "be-dev", task: "Build API", role: "worker", reportsTo: "be-coord" },
-  ],
-});
-```
-- Workers → coordinators → lead (multi-level reporting)
-- Coordinators synthesize sub-team output
-- Use when: too many workers for one hub to manage
+Debate currently shares the **full-mesh** topology with `mesh` and `consensus`. Differentiate via roles + task prompts:
 
-## Reflection Protocol
-
-All patterns support reflection — periodic synthesis that enables course correction. Enabled via `reflectionThreshold` on WorkflowOptions.
-
-```ts
-{
-  reflectionThreshold: 10, // trigger after 10 agent messages
-  onReflect: async (ctx) => {
-    // Examine ctx.recentMessages, ctx.agentStatuses
-    // Return adjustments or null
-  },
-}
+```yaml
+swarm: { pattern: debate }
+agents:
+  - { name: pro, cli: claude, role: debater, task: 'Argue FOR monorepo' }
+  - { name: con, cli: claude, role: debater, task: 'Argue FOR polyrepo' }
+  - { name: judge, cli: claude, role: judge, task: 'Decide after 3 rounds' }
+coordination:
+  barriers:
+    - { name: debate-done, waitFor: [pro-round-3, con-round-3] }
 ```
 
-Reflection is event-driven (importance-weighted accumulation), not timer-based. See WORKFLOWS_SPEC.md for full details.
+Drive rounds and verdicts through the agent's system prompt/task, not a dedicated `maxRounds` knob — there isn't one at the pattern level.
+
+### 10. hierarchical — Multi-Level (structurally hub-spoke today)
+
+```ts
+await workflow('large-team')
+  .pattern('hierarchical')
+  .agent('lead', { cli: 'claude', role: 'lead' })
+  .agent('fe-coord', { cli: 'claude', role: 'coordinator' })
+  .agent('be-coord', { cli: 'claude', role: 'coordinator' })
+  .agent('fe-dev', { cli: 'codex', role: 'worker', interactive: false })
+  .agent('be-dev', { cli: 'codex', role: 'worker', interactive: false })
+  .step('plan', { agent: 'lead', task: 'Coordinate full-stack app' })
+  .step('fe-plan', { agent: 'fe-coord', task: 'Manage frontend', dependsOn: ['plan'] })
+  .step('be-plan', { agent: 'be-coord', task: 'Manage backend', dependsOn: ['plan'] })
+  .step('fe-impl', { agent: 'fe-dev', task: 'Build components', dependsOn: ['fe-plan'] })
+  .step('be-impl', { agent: 'be-dev', task: 'Build API', dependsOn: ['be-plan'] })
+  .run();
+```
+
+Coordinator/worker distinction is expressed in step `dependsOn` graph, not topology. Agent edges collapse to single-level hub-spoke.
+
+## Verification & Completion Signals
+
+An agent step can complete in several ways (`runner.ts:5353-5395`, `runner.ts:4527-4538`):
+
+- **Verification pass** — when the step declares a `verification` block and the output satisfies it.
+- **Clean process exit** — agent exits 0 with no verification configured.
+- **Evidence-based** — channel posts, file changes, or coordination signals trigger completion.
+- **Owner decision** — a `lead`-role agent posts `COMPLETE` / `INCOMPLETE_RETRY` / `INCOMPLETE_FAIL` for the step.
+
+Verification block shape:
+
+```yaml
+verification:
+  type: output_contains # or: exit_code | file_exists | custom
+  value: DONE # or: PLAN_COMPLETE, IMPLEMENTATION_COMPLETE, REVIEW_COMPLETE
+```
+
+Conventional signals baked into the adapter (`relay-adapter.ts:29-36`):
+
+- `ACK: ...` — received a task
+- `DONE: ...` — task complete
+
+The runner captures PTY chunks as step output and also records channel posts + file changes as `StepCompletionEvidence`. Legacy fallback: a file at `.relay/summaries/{stepName}.md` is read if PTY output is empty (`runner.ts:6607`).
+
+## Relaycast MCP — Correct Tool Names
+
+The skill previously referenced `mcp__relaycast__send` / `mcp__relaycast__dm` — those names are wrong. The real tools (the first three are cited in the workflow convention-injection at `relay-adapter.ts:31-35`; the rest are exposed by the live `relaycast` MCP server):
+
+| Purpose                  | Tool                                  | Source                |
+| ------------------------ | ------------------------------------- | --------------------- |
+| Send DM to another agent | `mcp__relaycast__message_dm_send`     | `relay-adapter.ts:31` |
+| Check inbox              | `mcp__relaycast__message_inbox_check` | `relay-adapter.ts:35` |
+| List agents              | `mcp__relaycast__agent_list`          | `relay-adapter.ts:35` |
+| Post to a channel        | `mcp__relaycast__message_post`        | relaycast MCP server  |
+| Reply in a thread        | `mcp__relaycast__message_reply`       | relaycast MCP server  |
+| Spawn sub-agent          | `mcp__relaycast__agent_add`           | relaycast MCP server  |
+| Remove sub-agent         | `mcp__relaycast__agent_remove`        | relaycast MCP server  |
+
+> `interactive: false` agents run as non-interactive subprocesses with no relay connection — they must NOT call any `mcp__relaycast__*` tool (validator warns on this at `validator.ts:138-150`, check `NONINTERACTIVE_RELAY`).
+
+## Reflection (Trajectories)
+
+Reflection is **not** a `reflectionThreshold` callback. It's configured via the `trajectories:` block:
+
+```yaml
+trajectories:
+  enabled: true
+  reflectOnBarriers: true # config flag exists but runner does NOT currently invoke this path
+  reflectOnConverge: true # fires at parallel convergence points (runner.ts:2762-2779)
+  autoDecisions: true # record retry/skip/fail decisions
+```
+
+**What actually runs today:** only `reflectOnConverge` is wired into the runner (`runner.ts:2762-2779`). `shouldReflectOnBarriers` is defined in `trajectory.ts:486-487` but not called — set the flag if you want forward compatibility, but don't depend on it.
+
+Programmatic equivalent:
+
+```ts
+workflow('x').trajectories({ enabled: true, reflectOnConverge: true });
+```
+
+For a first-class critic loop, use the `reflection` **pattern** (agents with `role: critic` get wired as reviewers in `coordinator.ts:363-378`).
 
 ## Common Mistakes
 
-| Mistake | Why It Fails | Fix |
-|---------|-------------|-----|
-| Using mesh for everything | O(n^2) communication, debugging nightmare | Use hub-spoke for most tasks |
-| Pipeline for independent work | Sequential bottleneck | Use fan-out or dag |
-| Hub-spoke for simple parallel tasks | Hub is unnecessary overhead | Use fan-out |
-| Consensus for non-decisions | Voting on implementation tasks wastes time | Use hub-spoke, let lead decide |
-| No circuit breaker on handoff | Infinite routing loops | Always set maxHandoffs |
-| Cascade without confidence parsing | Agents don't report confidence | Convention injection handles this |
-| Hierarchical for 3 agents | Management overhead exceeds benefit | Use hub-spoke for small teams |
+| Mistake                                      | Why It Fails                                                                  | Fix                                                                                           |
+| -------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                           |
+| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                            |
+| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                       |
+| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                          |
+| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match   |
+| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`         |
+| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops |
+| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                    |
+| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                    |
+| Writing `mcp__relaycast__send(...)`          | Wrong tool name                                                               | Use `mcp__relaycast__message_post` or `message_dm_send`                                       |
 
-## DAG Executor — Proven Pattern
+## Resume & Re-run
 
-The recommended architecture for DAG workflow execution, validated on a 9-node / 5-wave production run.
-
-### Agent Completion: Detect → Release → Collect
-
-**This is the critical pattern.** Claude Code agents don't auto-exit — the orchestrator must detect completion and release them.
-
-```
-Agent writes summary file → Orchestrator polls (5s) → Detects new mtime →
-  Reads summary → Calls client.release(agent) → agent_exited fires → Node marked complete
-```
-
-**Implementation:**
 ```ts
-// Track initial mtime to distinguish new writes from stale files
-let initialMtime = 0;
-try { initialMtime = statSync(summaryPath).mtimeMs; } catch {}
+// Resume a failed run:
+await runWorkflow('feature-dev.yaml', { resume: '<runId>' });
 
-// Poll for summary file every 5s
-const poll = setInterval(() => {
-  const stat = statSync(summaryPath);
-  if (stat.mtimeMs > initialMtime) {
-    const content = readFileSync(summaryPath, "utf-8").trim();
-    await client.release(agentName); // triggers agent_exited
-    finish("completed", content);
-  }
-}, 5_000);
+// Skip ahead, re-using cached outputs from an earlier run:
+await runWorkflow('feature-dev.yaml', {
+  startFrom: 'review',
+  previousRunId: '<runId>',
+});
 ```
 
-**Convention injection tells agents to:**
-1. Send summary via **Relaycast MCP** (`mcp__relaycast__send` to channel) for inter-agent communication
-2. Write summary to `.relay/summaries/{nodeId}.md` as the completion signal
-3. Include file paths, type names, method signatures — downstream agents depend on this
+Cached outputs live in `.agent-relay/step-outputs/`; runs in `.agent-relay/workflow-runs.jsonl`. Env vars `RESUME_RUN_ID`, `START_FROM`, `PREVIOUS_RUN_ID` are auto-detected.
 
-### Communication: Relaycast MCP
-
-Agents communicate through the Relaycast MCP, not file-based protocols:
-- **Channel messages:** `mcp__relaycast__send` with channel name
-- **Direct messages:** `mcp__relaycast__dm` with agent name
-- Claude Code agents inherit `.mcp.json` config and have full MCP access
-- Other CLIs (codex, aider) may not have MCP — use summary files as fallback
-
-### State & Resume
-
-Persist state after every node completion for crash recovery:
-```ts
-saveState(completed, depsOutput, results, startTime);
-// Restart with --resume to skip completed nodes
-```
-
-**Pitfall:** When resuming, only load `completed` nodes — never load `failed` entries, or downstream will be permanently blocked.
-
-### Pitfalls Reference
-
-| Category | Pitfall | Fix |
-|----------|---------|-----|
-| **Completion** | Waiting for `agent_exited` without releasing — agents idle until timeout | Poll for summary file, release agent when detected |
-| **Completion** | No resolved guard — poll interval and timeout both fire, double-resolve | `resolved` boolean flag checked before every resolve |
-| **Signals** | PTY prompt echo matches signal keywords (`DONE:`, `ERROR:`) causing false completion | Never put signal keywords in task prompts; use file-based signals |
-| **Summaries** | Thin summaries ("Created types") useless for downstream agents | Convention injection requires file paths, signatures, key exports |
-| **Execution** | `Promise.race` in batch — one success masks later failures | `Promise.allSettled` for each batch |
-| **Resilience** | No `--resume` — orchestrator crash loses all progress | Persist completed set + depsOutput after each node |
-| **Resilience** | No downstream failure propagation — dependents stuck in limbo | Mark all transitive dependents as "blocked" on failure |
-| **Convention** | Agents don't read existing code — output doesn't match project patterns | `readFirst` field per node, included in convention injection |
-| **Capabilities** | Assuming all CLIs have MCP tools — codex/aider may not | Check CLI capabilities; use summary files as fallback for non-Claude CLIs |
-| **Infrastructure** | Rust broker vs Node.js CLI binary confusion (same name, different behavior) | Always set explicit `binaryPath`; use unique broker names to avoid 409 conflicts |
-| **Infrastructure** | `getLogs()` assumes Node.js daemon log files — Rust broker doesn't write them | Use broker events or summary files, not log file polling |
-
-## YAML Workflow Definition
-
-Any pattern can be defined in YAML for portability:
+## Complete YAML Example
 
 ```yaml
-version: "1.0"
+version: '1.0'
 name: feature-dev
-pattern: hub-spoke
+description: 'Blueprint-style feature development with quality gates.'
+swarm:
+  pattern: hub-spoke
+  maxConcurrency: 2
+  timeoutMs: 3600000
+  channel: swarm-feature-dev
+  idleNudge: { nudgeAfterMs: 120000, escalateAfterMs: 120000, maxNudges: 1 }
 agents:
-  - id: lead
-    role: lead
-    cli: claude
-  - id: developer
-    role: worker
-    cli: codex
-    reportsTo: lead
-steps:
-  - id: plan
-    agent: lead
-    prompt: "Create a development plan for: {{task}}"
-    expects: "PLAN_COMPLETE"
-  - id: implement
-    agent: developer
-    dependsOn: [plan]
-    prompt: "Implement: {{steps.plan.output}}"
-    expects: "DONE"
-reflection:
+  - { name: lead, cli: claude, role: lead, permissions: { access: full } }
+  - { name: planner, cli: codex, role: planner, interactive: false, permissions: { access: readonly } }
+  - { name: developer, cli: codex, role: worker, interactive: false, permissions: { access: readwrite } }
+  - { name: reviewer, cli: claude, role: reviewer, permissions: { access: readonly } }
+workflows:
+  - name: feature-delivery
+    onError: retry
+    preflight:
+      - { command: 'git status --porcelain', failIf: non-empty, description: 'Clean worktree' }
+    steps:
+      - name: plan
+        agent: planner
+        task: 'Plan: {{task}}'
+        verification: { type: output_contains, value: PLAN_COMPLETE }
+      - name: implement
+        agent: developer
+        dependsOn: [plan]
+        task: 'Implement: {{steps.plan.output}}'
+        verification: { type: output_contains, value: IMPLEMENTATION_COMPLETE }
+      - name: test
+        type: deterministic
+        dependsOn: [implement]
+        command: npm test
+      - name: review
+        agent: reviewer
+        dependsOn: [test]
+        task: 'Review implementation'
+        verification: { type: output_contains, value: REVIEW_COMPLETE }
+coordination:
+  barriers:
+    - { name: delivery-ready, waitFor: [plan, implement, review], timeoutMs: 900000 }
+trajectories:
   enabled: true
-  threshold: 10
-trajectory:
-  enabled: true
+  reflectOnBarriers: true
+  reflectOnConverge: true
+errorHandling:
+  strategy: retry
+  maxRetries: 2
+  retryDelayMs: 5000
 ```
 
-Store in `.relay/workflows/` and run with:
-```ts
-const workflow = await loadWorkflow(".relay/workflows/feature-dev.yaml");
-const run = runWorkflow(workflow, "Add user authentication");
-```
+Built-in templates: `packages/sdk/src/workflows/builtin-templates/` (feature-dev, bug-fix, code-review, competitive, documentation, refactor, review-loop, security-audit).
+
+## Source of Truth
+
+| Claim                                                             | File                                                                         |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Pattern enum (24 patterns)                                        | `packages/sdk/src/workflows/types.ts:114-139`                                |
+| Topology resolution per pattern                                   | `packages/sdk/src/workflows/coordinator.ts:240-450`                          |
+| Interactive-only topology edges                                   | `packages/sdk/src/workflows/coordinator.ts:218-237`                          |
+| Pattern auto-selection heuristics (programmatic API only)         | `packages/sdk/src/workflows/coordinator.ts:51-165`                           |
+| `WorkflowBuilder` fluent API                                      | `packages/sdk/src/workflows/builder.ts`                                      |
+| `runWorkflow(yamlPath, options)`                                  | `packages/sdk/src/workflows/run.ts`                                          |
+| YAML validation requires `version` + `name` + `swarm.pattern`     | `packages/sdk/src/workflows/runner.ts:2105-2117`                             |
+| MCP tool names cited in convention-injection                      | `packages/sdk/src/relay-adapter.ts:29-36`                                    |
+| Completion modes (verification / evidence / owner / process-exit) | `packages/sdk/src/workflows/runner.ts:5353-5395`, `4527-4538`                |
+| Completion via PTY + summary fallback                             | `packages/sdk/src/workflows/runner.ts:6600-6615`                             |
+| Downstream skip on upstream failure (not success)                 | `packages/sdk/src/workflows/runner.ts:7057-7088`, `step-executor.ts:329-334` |
+| Trajectory reflection (only `reflectOnConverge` wired)            | `packages/sdk/src/workflows/runner.ts:2762-2779`, `trajectory.ts:173-190`    |

--- a/.claude/skills/running-headless-orchestrator/SKILL.md
+++ b/.claude/skills/running-headless-orchestrator/SKILL.md
@@ -34,7 +34,10 @@ A headless orchestrator is an agent that:
 | Spawn worker                      | `agent-relay spawn Worker1 claude "task"`               |
 | List workers                      | `agent-relay who`                                       |
 | View worker logs                  | `agent-relay agents:logs Worker1`                       |
-| Send message                      | `agent-relay send Worker1 "message"`                    |
+| Send DM to worker                 | `agent-relay send Worker1 "message"`                    |
+| Post to channel                   | `agent-relay send '#general' "message"`                 |
+| Read worker's unread DM replies   | `agent-relay inbox --agent Worker1`                     |
+| Read full DM conversation history | `agent-relay history --to Worker1`                      |
 | Release worker                    | `agent-relay release Worker1`                           |
 | Stop infrastructure               | `agent-relay down`                                      |
 
@@ -98,11 +101,17 @@ agent-relay spawn Worker1 claude "Implement the authentication module following 
 ### Step 3: Monitor and Coordinate
 
 ```
-# Check for worker messages
+# Check if workers have replied (returns unread counts — not the content)
 mcp__relaycast__message_inbox_check()
 
-# Send follow-up instructions
+# List Worker1's DM conversations (use `as` to specify the agent)
+mcp__relaycast__message_dm_list(as: "Worker1")
+
+# Send a targeted DM to a specific worker
 mcp__relaycast__message_dm_send(to: "Worker1", text: "Also add unit tests")
+
+# Broadcast to all agents on a channel
+mcp__relaycast__message_post(channel: "general", text: "All workers: wrap up current task")
 
 # List active workers
 mcp__relaycast__agent_list()
@@ -124,14 +133,63 @@ agent-relay down
 
 **Use the `agent-relay` CLI extensively for monitoring and managing workers.** The CLI provides essential visibility into agent activity.
 
+### Channel vs DM — When to Use Each
+
+**DM** — targeted, private, for responses you need to read back:
+
+- `agent-relay send Worker1 "message"` — sends a DM to Worker1
+- `mcp__relaycast__message_dm_send(to: "Worker1", text: "...")` — same via MCP
+- Worker replies arrive as DMs back to the sender
+
+**Channel post** — broadcast, visible to all agents on that channel:
+
+- `agent-relay send '#general' "message"` — posts to #general (`#` prefix required)
+- `mcp__relaycast__message_post(channel: "general", text: "...")` — same via MCP
+- Use for coordination messages, status updates, announcements
+
+**Critical: `history` only shows channel messages, not DMs.**
+After sending a DM to a worker, their reply will NOT appear in `agent-relay history`.
+Use `inbox --agent` or `message_dm_list` to read DM replies.
+
+`inbox --agent <name>` shows only **unread** notifications — once read, they disappear.
+For the **full conversation thread** (including already-read messages) use `history --to <agent>`.
+
+```bash
+# WRONG — history (no flags) will not show DM replies from workers
+agent-relay history
+
+# Read a worker's UNREAD DM replies (clears after reading)
+agent-relay inbox --agent Worker1
+
+# Read the full DM conversation history with a worker (read + unread)
+agent-relay history --to Worker1
+
+# Read only the thread between two specific agents
+agent-relay history --to Worker1 --from Orchestrator
+```
+
+```
+# WRONG — inbox_check only tells you there are unread messages, not what they say
+mcp__relaycast__message_inbox_check()
+
+# RIGHT — list Worker1's DM conversations and content (as = the agent to read as)
+mcp__relaycast__message_dm_list(as: "Worker1")
+```
+
 ### Spawning and Messaging
 
 ```bash
 # Spawn a worker
 agent-relay spawn Worker1 claude "Implement auth module"
 
-# Send message to worker
+# Send a DM to a specific worker (replies readable via inbox --agent)
 agent-relay send Worker1 "Add unit tests too"
+
+# Broadcast to all workers via channel
+agent-relay send '#general' "Team: wrap up and report status"
+
+# Read Worker1's DM reply
+agent-relay inbox --agent Worker1
 
 # Release when done
 agent-relay release Worker1
@@ -146,8 +204,11 @@ agent-relay who
 # View real-time output from a worker (critical for debugging)
 agent-relay agents:logs Worker1
 
-# View recent message history
-agent-relay history
+# Read DM replies from a specific worker
+agent-relay inbox --agent Worker1
+
+# View channel message history (channel posts only — not DMs)
+agent-relay history --to '#general'
 
 # Check overall system status
 agent-relay status
@@ -193,8 +254,14 @@ Monitor workers (do this frequently):
   agent-relay who              # List active workers
   agent-relay agents:logs Worker1  # View worker output/progress
 
-Send instructions:
+Send targeted DM instructions:
   agent-relay send Worker1 "Additional instructions"
+
+Broadcast to all workers:
+  agent-relay send '#general' "All workers: prioritize the auth module"
+
+Read worker replies (DMs are not visible in history):
+  agent-relay inbox --agent Worker1
 
 Release when done:
   agent-relay release Worker1
@@ -203,7 +270,10 @@ Release when done:
 - Workers will ACK when they receive tasks
 - Workers will send DONE when complete
 - Use `agent-relay agents:logs <name>` to monitor progress
-- Use `agent-relay history` to see message flow
+- Use `agent-relay inbox --agent <name>` to read **unread** DM replies from a worker (clears after reading)
+- Use `agent-relay history --to <name>` to re-read the full DM conversation (read + unread)
+- Use `agent-relay history --to '#general'` to see channel message flow
+- Do NOT use `agent-relay history` alone to check worker replies — it only shows channel posts, DM replies are invisible there
 ```
 
 ## Lifecycle Events
@@ -220,17 +290,21 @@ The broker emits these events (available via SDK subscriptions):
 
 ## Common Mistakes
 
-| Mistake                                                  | Fix                                                                                                                             |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `agent-relay: command not found` or mise/asdf shim error | Ensure Node is available first (`node --version`); if a shim is broken, fix the runtime manager, then install/use `agent-relay` |
-| "Nested session" error                                   | Broker handles this automatically; if running manually, unset `CLAUDECODE` env var                                              |
-| Broker not starting                                      | Try `agent-relay down` first, then use foreground `agent-relay up --no-dashboard --verbose` to see readiness logs               |
-| Background broker says started but status is STOPPED     | Prefer foreground mode for that project/session; background mode may have detached incorrectly                                  |
-| Spawn fails with `internal reply dropped`                | Broker likely is not fully ready yet; wait for readiness, then spawn one worker first                                           |
-| Workers not connecting                                   | Ensure broker started; check `agent-relay who` and worker logs                                                                  |
-| Not monitoring workers                                   | Use `agent-relay agents:logs <name>` frequently to track progress                                                               |
-| Workers seem stuck                                       | Check logs with `agent-relay agents:logs <name>` for errors                                                                     |
-| Messages not delivered                                   | Check `agent-relay history` to verify message flow                                                                              |
+| Mistake                                                    | Fix                                                                                                                                                                       |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent-relay: command not found` or mise/asdf shim error   | Ensure Node is available first (`node --version`); if a shim is broken, fix the runtime manager, then install/use `agent-relay`                                           |
+| "Nested session" error                                     | Broker handles this automatically; if running manually, unset `CLAUDECODE` env var                                                                                        |
+| Broker not starting                                        | Try `agent-relay down` first, then use foreground `agent-relay up --no-dashboard --verbose` to see readiness logs                                                         |
+| Background broker says started but status is STOPPED       | Prefer foreground mode for that project/session; background mode may have detached incorrectly                                                                            |
+| Spawn fails with `internal reply dropped`                  | Broker likely is not fully ready yet; wait for readiness, then spawn one worker first                                                                                     |
+| Workers not connecting                                     | Ensure broker started; check `agent-relay who` and worker logs                                                                                                            |
+| Not monitoring workers                                     | Use `agent-relay agents:logs <name>` frequently to track progress                                                                                                         |
+| Workers seem stuck                                         | Check logs with `agent-relay agents:logs <name>` for errors                                                                                                               |
+| Messages not delivered                                     | Check `agent-relay history --to '#general'` for channel messages; use `agent-relay inbox --agent <name>` for DMs                                                          |
+| Worker replies not showing in history                      | Expected — `history` only shows channel posts. Use `agent-relay inbox --agent <name>` (unread only) or `agent-relay history --to <name>` (full thread) to read DM replies |
+| `inbox_check` shows unread but can't see content           | `inbox_check` only returns counts. Use `mcp__relaycast__message_dm_list(as: "<name>")` to list conversations, or `agent-relay inbox --agent <name>` via CLI               |
+| `inbox --agent` showed messages once but now shows nothing | `inbox` only shows **unread** — already-read messages won't reappear. Use `agent-relay history --to <name>` to re-read the full conversation                              |
+| Sent to wrong destination                                  | `agent-relay send Worker1 "..."` = DM; `agent-relay send '#general' "..."` = channel broadcast. The `#` prefix is required for channels                                   |
 
 ## Prerequisites
 

--- a/.claude/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.claude/skills/writing-agent-relay-workflows/SKILL.md
@@ -23,6 +23,8 @@ The relay broker-sdk workflow system orchestrates multiple AI agents (Claude, Co
 
 ## Quick Reference
 
+> **Note:** this Quick Reference assumes an **ESM** workflow file (the host `package.json` has `"type": "module"`). For CJS repos, see rule #1 in **Critical TypeScript rules** below — convert `import { workflow } from '@agent-relay/sdk/workflows'` to `const { workflow } = require('@agent-relay/sdk/workflows')` and wrap the workflow in `async function main() { ... } main().catch(console.error)` since CJS does not support top-level `await`. **Always check `package.json` before copy-pasting the snippet.**
+
 ```typescript
 import { workflow } from '@agent-relay/sdk/workflows';
 
@@ -182,6 +184,125 @@ Preferred options, in order:
 3. Use plain indented examples instead of fenced blocks
 4. If fenced blocks must exist inside generated inner code, escape them consistently and syntax-check the outer workflow file afterward
 
+### 2b. Standard preflight template for resumable workflows
+
+Every non-trivial workflow should start with a deterministic `preflight` step that validates the environment before any agent runs. A workflow that fails mid-DAG and gets re-run (or resumed via `--start-from`) will re-execute preflight, so preflight must tolerate the partial state left behind by the previous run — specifically, dirty files that the workflow itself is expected to edit.
+
+The battle-tested template:
+
+```ts
+.step('preflight', {
+  type: 'deterministic',
+  command: [
+    'set -e',
+    'BRANCH=$(git rev-parse --abbrev-ref HEAD)',
+    'echo "branch: $BRANCH"',
+    'if [ "$BRANCH" != "fix/your-branch-name" ]; then echo "ERROR: wrong branch"; exit 1; fi',
+    // Files the workflow is allowed to find dirty on entry:
+    //   - package-lock.json: npm install is idempotent and often touches it
+    //   - every file the workflow's edit steps will rewrite: a prior partial
+    //     run may have left them dirty, and the edit step will rewrite
+    //     them cleanly before commit
+    // Everything else is unexpected drift and must fail preflight.
+    'ALLOWED_DIRTY="package-lock.json|path/to/file1\\\\.ts|path/to/file2\\\\.ts"',
+    'DIRTY=$(git diff --name-only | grep -vE "^(${ALLOWED_DIRTY})$" || true)',
+    'if [ -n "$DIRTY" ]; then echo "ERROR: unexpected tracked drift:"; echo "$DIRTY"; exit 1; fi',
+    'if ! git diff --cached --quiet; then echo "ERROR: staging area is dirty"; git diff --cached --stat; exit 1; fi',
+    'gh auth status >/dev/null 2>&1 || (echo "ERROR: gh CLI not authenticated"; exit 1)',
+    'echo PREFLIGHT_OK',
+  ].join(' && '),
+  captureOutput: true,
+  failOnError: true,
+}),
+```
+
+**Rules baked into this template:**
+
+- **Always include `package-lock.json`** in `ALLOWED_DIRTY`. Both `npm install` and `npm ci` can touch it idempotently.
+- **Include every file the workflow's edit steps will rewrite.** The commit step uses explicit `git add <path>` (never `git add -A`), so allowing these files to be dirty on entry is safe — unrelated drift in other files still fails preflight.
+- **Escape dots in regex paths:** `setup\.ts` not `setup.ts`. In a JS template literal this means four backslashes: `"setup\\\\.ts"`.
+- **Use `grep -vE "^(...)$"` for full-line match.** Substring matches bleed across unrelated files (e.g., `setup.ts` would also match `packages/core/src/bootstrap/setup.ts`).
+- **Append `|| true` to the grep.** Without it, an empty result triggers `set -e` and the whole preflight fails before the `if` can even run.
+- **Check the staging area separately.** A dirty index is different from a dirty working tree and both must be clean (modulo allow-list).
+- **Check `gh auth status` early** if any downstream step uses `gh pr create` or similar. Failing on auth at the end of a long DAG is painful.
+
+**Never use `git diff --quiet` alone as your "clean tree" check.** It fails on any dirty file, including the ones the workflow is expected to rewrite, which causes false failures on every resume / re-run.
+
+### 2c. Picking the right `.join()` for multi-line shell commands
+
+When a `command:` field is a JS array that gets joined into a shell command string, the join delimiter determines what kinds of content the array can contain.
+
+**`.join(' && ')`** — use when every element is a self-contained shell statement. Each element becomes independent and the next one runs only if the previous succeeded. Works for linear scripts with `set -e`.
+
+```ts
+command: [
+  'set -e',
+  'HITS=$(grep -c diag src/cli/commands/setup.ts || true)',
+  'if [ "$HITS" -lt 6 ]; then echo "FAIL"; exit 1; fi',
+  'echo OK',
+].join(' && '),
+```
+
+**`.join('\n')`** — use when array elements must be part of a larger compound statement that spans multiple physical lines:
+
+- heredocs (`cat <<EOF ... EOF`)
+- multi-line `if` / `while` / `for` bodies
+- shell functions defined inline
+
+`&&` is a command separator. It cannot appear between a heredoc's opening line and its body, between a `for` and its body, or inside an `if`'s consequent block. Joining such content with `&&` produces a shell syntax error.
+
+**Never mix heredocs with `&&` joining.** The most common failure mode:
+
+```ts
+// ❌ BROKEN — heredoc body gets && inserted between each line
+command: [
+  'set -e',
+  'cat > /tmp/f <<EOF',
+  'line 1',
+  'line 2',
+  'EOF',
+  'next-command',
+].join(' && '),
+```
+
+Results in `set -e && cat > /tmp/f <<EOF && line 1 && line 2 && EOF && next-command` — a shell syntax error because `&&` cannot appear inside a heredoc body. Use `.join('\n')` or (better) sidestep the heredoc entirely.
+
+**The `printf` + `mktemp` alternative — use this for commit messages, PR bodies, and any other multi-line file content.** It avoids heredocs altogether and composes with `.join(' && ')`:
+
+```ts
+command: [
+  'set -e',
+  'BODY=$(mktemp)',
+  // Each line of the file is a separate printf argument. No heredoc,
+  // no shell metacharacter hazards, no command-substitution nesting.
+  'printf "%s\\n" "## Summary" "" "body line 1" "body line 2" > "$BODY"',
+  'gh pr create --title "..." --body-file "$BODY"',
+  'rm -f "$BODY"',
+].join(' && '),
+```
+
+This pattern is specifically recommended over `git commit -m "$(cat <<'EOF' ... EOF)"` and `gh pr create --body "$(cat <<'BODY' ... BODY)"`. Nesting a heredoc inside `$(...)` forces the shell to match a closing paren across many lines of unparsed body text, and any stray parenthesis in the body text can silently break the match. `--body-file` + `mktemp` + `printf` is immune to that entire class of bug.
+
+### 2d. Template-literal escape sequences are processed once before the string is rendered
+
+If your file generates code as a giant template literal (the pattern used by `packages/core/src/bootstrap/script-generator.ts` in cloud), every backslash in that template gets processed by JavaScript before the string is returned. This silently breaks regexes and escape sequences that are meant to appear in the _generated_ output.
+
+Specifically:
+
+- `\s` is not a recognized string escape → the backslash is stripped → `\s` renders as a literal `s`
+- `\b` _is_ a recognized string escape (backspace, U+0008) → `\b` renders as a backspace character in the output
+- `\n`, `\t`, `\r`, `\\`, `\0`, `\uXXXX`, `\xXX` all get resolved at template time
+
+The footgun: the outer TypeScript compiles cleanly, the rendered code parses and runs, and the regex/escape just never matches what the author intended. See AgentWorkforce/cloud#113 for the exact incident (`hasConfigExport = /^export\s+.../m` silently became `/^exports+.../m` in the generated bootstrap, making every TS workflow fall through to the standalone-script fallback).
+
+Guidelines:
+
+1. If you want a regex pattern that survives the template-literal pass unchanged, double every backslash in the source: `\\s`, `\\b`, `\\n` (the `\\` renders to `\` in the output, producing a correct regex at runtime).
+2. If you want to write a long string-literal newline into the output, `'\\n'` in the template renders to `'\n'` in the output, which the runtime JS interprets as a newline. Using a literal `'\n'` would render an actual newline into the JS source — visually messy and sometimes surprising.
+3. If you add anything non-trivial to a generator file that returns a big template literal, add a unit test that calls the generator with canonical inputs and asserts something about the rendered output — either exact string matches or, for regexes, `eval`/construct the regex and test it against known samples. See `tests/orchestrator/script-generator.test.ts` in cloud for prior art.
+
+Task-prompt workaround: for agent-relay workflow _task prompts_ (where the contents go into a template literal but the inner content is plain text for an LLM), it's often cleaner to build the string as an array and `.join('\n')` at the boundary. That sidesteps the "does this backslash survive?" question entirely — no backslashes in the source, no processing to reason about. Several workflows in `cloud/workflows/` use this pattern (see the sage migration PRs).
+
 ### 3. Keep final verification boring and deterministic
 
 Final verification should validate real outputs with simple, portable shell commands. If checking for multiple symbols, use extended regex explicitly:
@@ -243,6 +364,26 @@ Document clearly whether the executor supports:
 
 Do not assume users will infer the behavior. In particular, `--wave N` should be understood as "run only this wave" unless the executor explicitly chains onward.
 
+### 7a. `--resume` vs `--start-from` when fixing a buggy step
+
+When a workflow fails at step X and you want to re-run it after editing the workflow file, the flag choice matters:
+
+| Flag                                         | Reads workflow file fresh?           | Uses cached step outputs?                |
+| -------------------------------------------- | ------------------------------------ | ---------------------------------------- |
+| `--resume <id>`                              | ❌ replays **stored config from DB** | ✅ from same run id                      |
+| `--start-from <step> --previous-run-id <id>` | ✅ reads fresh file                  | ✅ from previous run id's cached outputs |
+
+**Rule:** if you edited the workflow file to fix the failing step, use `--start-from <failing-step> --previous-run-id <id>`, **not** `--resume <id>`. `--resume` pulls the entire workflow config from the run's DB record and replays it — your edits to the workflow file are ignored, and the step re-runs with its original (broken) definition.
+
+This is counterintuitive because "resume" sounds like "pick up where you left off with whatever I just changed." It does not. It picks up where you left off with the **stored** config from when the run first started.
+
+**When to use each:**
+
+- Transient failure (network hiccup, rate limit, flaky agent), no code edits: `--resume <id>` is fine, fast, and correct.
+- You edited the workflow file (any step definition, any prompt, any verify gate): **always** `--start-from <failing-step> --previous-run-id <id>`. Everything upstream of the failing step loads from cache, the fresh file supplies the fixed definition, and downstream steps run as normal.
+
+If the runner complains that `--start-from` can't find cached outputs for the previous run id, fall back to a clean from-scratch run. The workflow's preflight should be forgiving enough (see §2b "Standard preflight template") that a from-scratch re-run succeeds even when a prior partial run left files dirty.
+
 ### 8. Syntax-check workflow files after editing
 
 After editing workflow `.ts` files, run a lightweight syntax check before launching a large batch run. This is especially important if the workflow contains:
@@ -251,6 +392,57 @@ After editing workflow `.ts` files, run a lightweight syntax check before launch
 - embedded code examples
 - escaped backticks
 - wrapper changes around workflow execution
+
+### 9. Factor repo-specific setup into a shared helper
+
+If multiple workflows in the same repo need the same boilerplate before any agent touches code (branch checkout, `npm install`, workspace-package prebuild, language toolchain init, etc.), do **not** copy-paste those steps into every workflow. Put them in `workflows/lib/<repo>-setup.ts` and import from there.
+
+**Why it matters:** without a shared helper, the first workflow that needs a new prerequisite step (e.g. `npm run build:platform` because a workspace package's `package.json` points `types` at `dist/`) adds it locally, and every other workflow silently misses it. In a fresh cloud sandbox that means agents hit `Cannot find module '@cloud/platform'` during typecheck and paper over it with ad-hoc `external-modules.d.ts` shims or `as GetObjectCommandOutput` casts scattered across unrelated files. Those workarounds sync back down with the patch and pollute the PR.
+
+**Pattern:**
+
+```ts
+// workflows/lib/cloud-repo-setup.ts
+export interface CloudRepoSetupOptions {
+  branch: string;
+  committerName?: string;
+  extraSetupCommands?: string[];
+  skipWorkspaceBuild?: boolean;
+}
+
+export function applyCloudRepoSetup<T>(wf: T, opts: CloudRepoSetupOptions): T {
+  // adds two steps: setup-branch, install-deps
+  // install-deps runs: npm install + workspace prebuilds (build:platform, build:core, etc.)
+  // ...
+}
+```
+
+Consumer workflows break the builder chain once and call through:
+
+```ts
+const baseWf = workflow(NAME)
+  .description(...)
+  .pattern('dag')
+  .agent(...)
+  .agent(...);
+
+const wf = applyCloudRepoSetup(baseWf, {
+  branch: BRANCH,
+  committerName: 'My Workflow Bot',
+});
+
+await wf
+  .step('read-spec', { dependsOn: ['install-deps'], ... })
+  ...
+  .run(...);
+```
+
+**Rules:**
+
+- The helper lives in the **consumer repo**, not in the SDK. Different customer repos have different languages, package managers, and build graphs — `@agent-relay/sdk` should stay agnostic.
+- Pre-build any workspace package whose `package.json` `main`/`types` point at a generated `dist/`. Fresh sandboxes don't have that `dist/` yet, and agents will invent workarounds rather than run the build. See the `@cloud/platform` case above.
+- Every install step includes `--legacy-peer-deps --no-audit --no-fund 2>&1 | tail -10` (or equivalent noise-trimming) because full install output blows past `captureOutput` size limits.
+- Document the helper in the repo's `CLAUDE.md` / `AGENTS.md` so new workflow authors (and agents writing workflows) discover it.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ This ensures the user maintains control over what goes into the main branch.
 
 The `.trajectories/` directory must remain tracked in git. It contains trajectory records from the `trail` tool that provide valuable context for future agents and humans about past decisions, reasoning, and work history.
 
-<!-- prpm:snippet:start @agent-workforce/trail-snippet@1.1.0 -->
+<!-- prpm:snippet:start @agent-workforce/trail-snippet@1.1.2 -->
+
 # Trail
 
 Record your work as a trajectory for future agents and humans to follow.
@@ -40,11 +41,13 @@ Record your work as a trajectory for future agents and humans to follow.
 ## Usage
 
 If `trail` is installed globally, run commands directly:
+
 ```bash
 trail start "Task description"
 ```
 
 If not globally installed, use npx to run from local installation:
+
 ```bash
 npx trail start "Task description"
 ```
@@ -58,6 +61,7 @@ trail start "Implement user authentication"
 ```
 
 With external task reference:
+
 ```bash
 trail start "Fix login bug" --task "ENG-123"
 ```
@@ -72,11 +76,13 @@ trail decision "Chose JWT over sessions" \
 ```
 
 For minor decisions, reasoning is optional:
+
 ```bash
 trail decision "Used existing auth middleware"
 ```
 
 **Record decisions when you:**
+
 - Choose between alternatives
 - Make architectural trade-offs
 - Decide on an approach after investigation
@@ -91,6 +97,7 @@ trail reflect "Workers aligned on auth approach, API layer progressing well" \
 ```
 
 With focal points and adjustments:
+
 ```bash
 trail reflect "Frontend and backend duplicating validation logic" \
   --focal-points "duplication,ownership" \
@@ -99,6 +106,7 @@ trail reflect "Frontend and backend duplicating validation logic" \
 ```
 
 **Record reflections when you:**
+
 - Have received several updates and need to synthesize the big picture
 - Notice workers or tasks diverging from the plan
 - Want to course-correct before continuing
@@ -116,7 +124,22 @@ When done, complete with a retrospective:
 trail complete --summary "Added JWT auth with refresh tokens" --confidence 0.85
 ```
 
+After completing work, compact the finished trajectory or merged PR into a
+durable summary. When the compacted summary is sufficient, discard the raw
+source trajectories so `.trajectories/index.json` and list output stay focused:
+
+```bash
+trail compact --discard-sources
+# or after a PR merge:
+trail compact --pr 42 --discard-sources
+```
+
+`--discard-sources` removes the source trajectory JSON/Markdown/trace files and
+updates the index. Use it after confirming the compacted artifact is the record
+you want to keep.
+
 **Confidence levels:**
+
 - 0.9+ : High confidence, well-tested
 - 0.7-0.9 : Good confidence, standard implementation
 - 0.5-0.7 : Some uncertainty, edge cases possible
@@ -133,6 +156,7 @@ trail abandon --reason "Blocked by missing API credentials"
 ## Checking Status
 
 View current trajectory:
+
 ```bash
 trail status
 ```
@@ -140,47 +164,57 @@ trail status
 ## Listing and Viewing Trajectories
 
 List all trajectories:
+
 ```bash
 trail list
 ```
 
 View a specific trajectory:
+
 ```bash
 trail show <trajectory-id>
 ```
 
-Export a trajectory (markdown, json, timeline, html, pr-summary):
+Export a trajectory (markdown, json, timeline, html):
+
 ```bash
 trail export <trajectory-id> --format markdown
 ```
 
 ## Compacting Trajectories
 
-After a PR merge, compact related trajectories into a single summary:
+After a PR merge, compact related trajectories into a single summary and prune
+raw source trajectories when the summary should replace them:
 
 ```bash
-trail compact --pr 42
+trail compact --pr 42 --discard-sources
 ```
 
-Compact by branch:
+Compact by branch (finds trajectories with commits not in the specified base branch):
+
 ```bash
-trail compact --branch feature/auth
+trail compact --branch main --discard-sources
 ```
 
-Compact by commit range:
+Compact by specific commits:
+
 ```bash
-trail compact --commits abc123..def456
+trail compact --commits abc123,def456 --discard-sources
 ```
 
-Compaction consolidates decisions and creates a grouped summary, reducing noise while preserving key decisions.
+Compaction consolidates decisions and creates a grouped summary. Adding
+`--discard-sources` makes the compacted artifact the durable record by removing
+the raw trajectories and their index entries.
 
 ## Why Trail?
 
 Your trajectory helps others understand:
+
 - **What** you built (commits show this)
 - **Why** you built it this way (trajectory shows this)
 - **What alternatives** you considered
 - **What challenges** you faced
 
 Future agents can query past trajectories to learn from your decisions.
-<!-- prpm:snippet:end @agent-workforce/trail-snippet@1.1.0 -->
+
+<!-- prpm:snippet:end @agent-workforce/trail-snippet@1.1.2 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "bundleDependencies": [
         "@relaycast/sdk",
         "@relayfile/local-mount"
@@ -18,14 +18,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "6.0.6",
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/hooks": "6.0.6",
-        "@agent-relay/sdk": "6.0.6",
-        "@agent-relay/telemetry": "6.0.6",
-        "@agent-relay/trajectory": "6.0.6",
-        "@agent-relay/user-directory": "6.0.6",
-        "@agent-relay/utils": "6.0.6",
+        "@agent-relay/cloud": "6.0.7",
+        "@agent-relay/config": "6.0.7",
+        "@agent-relay/hooks": "6.0.7",
+        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/telemetry": "6.0.7",
+        "@agent-relay/trajectory": "6.0.7",
+        "@agent-relay/user-directory": "6.0.7",
+        "@agent-relay/utils": "6.0.7",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -35,7 +35,7 @@
         "@relayfile/local-mount": "^0.2.2",
         "@relayfile/sdk": "^0.6.0",
         "@sinclair/typebox": "^0.34.14",
-        "agent-trajectories": "^0.5.4",
+        "agent-trajectories": "^0.5.7",
         "chalk": "^4.1.2",
         "chokidar": "^5.0.0",
         "commander": "^12.1.0",
@@ -15436,10 +15436,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/sdk": "6.0.7",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15455,38 +15455,38 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "6.0.6"
+      "version": "6.0.7"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT"
     },
     "packages/browser-primitive": {
       "name": "@agent-relay/browser-primitive",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/sdk": "6.0.7",
         "playwright": "^1.51.1"
       },
       "bin": {
@@ -15500,9 +15500,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
+        "@agent-relay/config": "6.0.7",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15518,7 +15518,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15530,7 +15530,7 @@
     },
     "packages/credential-proxy": {
       "name": "@agent-relay/credential-proxy",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
         "hono": "^4.11.4",
         "jose": "^6.1.3"
@@ -15541,9 +15541,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.6"
+        "@agent-relay/sdk": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15552,9 +15552,9 @@
     },
     "packages/github-primitive": {
       "name": "@agent-relay/github-primitive",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.6"
+        "@agent-relay/workflow-types": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15564,11 +15564,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/sdk": "6.0.6",
-        "@agent-relay/trajectory": "6.0.6"
+        "@agent-relay/config": "6.0.7",
+        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/trajectory": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15577,9 +15577,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/hooks": "6.0.6"
+        "@agent-relay/hooks": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15588,11 +15588,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/sdk": "6.0.7",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16357,9 +16357,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6"
+        "@agent-relay/config": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16368,11 +16368,11 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/github-primitive": "6.0.6",
-        "@agent-relay/workflow-types": "6.0.6",
+        "@agent-relay/config": "6.0.7",
+        "@agent-relay/github-primitive": "6.0.7",
+        "@agent-relay/workflow-types": "6.0.7",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -16390,14 +16390,14 @@
         "@types/ws": "^8.5.10"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.6",
-        "@agent-relay/broker-darwin-x64": "6.0.6",
-        "@agent-relay/broker-linux-arm64": "6.0.6",
-        "@agent-relay/broker-linux-x64": "6.0.6",
-        "@agent-relay/broker-win32-x64": "6.0.6"
+        "@agent-relay/broker-darwin-arm64": "6.0.7",
+        "@agent-relay/broker-darwin-x64": "6.0.7",
+        "@agent-relay/broker-linux-arm64": "6.0.7",
+        "@agent-relay/broker-linux-x64": "6.0.7",
+        "@agent-relay/broker-win32-x64": "6.0.7"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.6",
+        "@agent-relay/credential-proxy": "6.0.7",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -16435,7 +16435,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
         "posthog-node": "^5.29.2"
       },
@@ -16470,9 +16470,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6"
+        "@agent-relay/config": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16481,9 +16481,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/utils": "6.0.6"
+        "@agent-relay/utils": "6.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16492,9 +16492,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
+        "@agent-relay/config": "6.0.7",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {
@@ -16504,7 +16504,7 @@
     },
     "packages/workflow-types": {
       "name": "@agent-relay/workflow-types",
-      "version": "6.0.6"
+      "version": "6.0.7"
     },
     "web": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@relayfile/local-mount": "^0.2.2",
     "@relayfile/sdk": "^0.6.0",
     "@sinclair/typebox": "^0.34.14",
-    "agent-trajectories": "^0.5.4",
+    "agent-trajectories": "^0.5.7",
     "chalk": "^4.1.2",
     "chokidar": "^5.0.0",
     "commander": "^12.1.0",

--- a/prpm.lock
+++ b/prpm.lock
@@ -117,9 +117,9 @@
       "installedPath": ".claude/skills/browser-testing-with-screenshots/SKILL.md"
     },
     "@agent-workforce/trail-snippet#agents.md:AGENTS.md": {
-      "version": "1.1.0",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-workforce%2Ftrail-snippet/1.1.0.tar.gz",
-      "integrity": "sha256-8d8824b5236660e18c780b3574ee756737401d9a77e843411cdd509ceb9e0668",
+      "version": "1.1.2",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-workforce%2Ftrail-snippet/1.1.2.tar.gz",
+      "integrity": "sha256-36f0490e6afffb8e6793f06119d4dd2058d7b0e23d65ead2adce9a8010da0bf0",
       "format": "agents.md",
       "subtype": "snippet",
       "sourceFormat": "generic",
@@ -144,9 +144,9 @@
       "installedPath": ".agents/skills/creating-agent-skills-skill/SKILL.md"
     },
     "@agent-relay/choosing-swarm-patterns#claude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fchoosing-swarm-patterns/1.0.0.tar.gz",
-      "integrity": "sha256-2b28661abb540c56b46ad980b238589c6dcf59faaa3e66c80c72f72c01407f38",
+      "version": "1.1.2",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fchoosing-swarm-patterns/1.1.2.tar.gz",
+      "integrity": "sha256-1620ad2b76a65aabb522d8432592da191d4194b7e7539e06a6fb086a1690fbef",
       "format": "claude",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -154,9 +154,9 @@
       "installedPath": ".claude/skills/choosing-swarm-patterns/SKILL.md"
     },
     "@agent-relay/writing-agent-relay-workflows#claude": {
-      "version": "1.4.0",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.4.0.tar.gz",
-      "integrity": "sha256-9bbb0861f470beedde502569c7e8d665808a82bc3ca40029d864eb7f0420419d",
+      "version": "1.5.1",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.5.1.tar.gz",
+      "integrity": "sha256-745f43edd930c5f930065e8f92a3f2fae6ef902dd768576d574f9c3a50837042",
       "format": "claude",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -164,9 +164,9 @@
       "installedPath": ".claude/skills/writing-agent-relay-workflows/SKILL.md"
     },
     "@agent-relay/running-headless-orchestrator#claude": {
-      "version": "1.0.2",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Frunning-headless-orchestrator/1.0.2.tar.gz",
-      "integrity": "sha256-ee99ab71023fd2168143acc6c6bb4b1032181bbf16458d6537ad68d779ec0e7e",
+      "version": "1.0.4",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Frunning-headless-orchestrator/1.0.4.tar.gz",
+      "integrity": "sha256-9c7a5ec7aed3f974fb3607bb3c8d5b249daa2fed957d3beea8f219f06937605c",
       "format": "claude",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -184,9 +184,9 @@
       "installedPath": ".claude/skills/using-agent-relay/SKILL.md"
     },
     "@agent-relay/choosing-swarm-patterns#codex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fchoosing-swarm-patterns/1.0.0.tar.gz",
-      "integrity": "sha256-2b28661abb540c56b46ad980b238589c6dcf59faaa3e66c80c72f72c01407f38",
+      "version": "1.1.2",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fchoosing-swarm-patterns/1.1.2.tar.gz",
+      "integrity": "sha256-1620ad2b76a65aabb522d8432592da191d4194b7e7539e06a6fb086a1690fbef",
       "format": "codex",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -194,9 +194,9 @@
       "installedPath": ".agents/skills/choosing-swarm-patterns/SKILL.md"
     },
     "@agent-relay/writing-agent-relay-workflows#codex": {
-      "version": "1.4.0",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.4.0.tar.gz",
-      "integrity": "sha256-9bbb0861f470beedde502569c7e8d665808a82bc3ca40029d864eb7f0420419d",
+      "version": "1.5.1",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.5.1.tar.gz",
+      "integrity": "sha256-745f43edd930c5f930065e8f92a3f2fae6ef902dd768576d574f9c3a50837042",
       "format": "codex",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -214,9 +214,9 @@
       "installedPath": ".agents/skills/using-agent-relay/SKILL.md"
     },
     "@agent-relay/running-headless-orchestrator#codex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Frunning-headless-orchestrator/1.0.2.tar.gz",
-      "integrity": "sha256-ee99ab71023fd2168143acc6c6bb4b1032181bbf16458d6537ad68d779ec0e7e",
+      "version": "1.0.4",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Frunning-headless-orchestrator/1.0.4.tar.gz",
+      "integrity": "sha256-9c7a5ec7aed3f974fb3607bb3c8d5b249daa2fed957d3beea8f219f06937605c",
       "format": "codex",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -244,5 +244,5 @@
       "installedPath": ".agents/skills/relay-80-100-workflow/SKILL.md"
     }
   },
-  "generated": "2026-04-15T21:23:37.703Z"
+  "generated": "2026-05-04T08:36:28.666Z"
 }


### PR DESCRIPTION
## Summary
- Bump `agent-trajectories` to `^0.5.7` and refresh skill bundles (`choosing-swarm-patterns`, `running-headless-orchestrator`, `writing-agent-relay-workflows`) under both `.agents/` and `.claude/`.
- Sync `AGENTS.md`, `package-lock.json`, and `prpm.lock` to match the new skill versions.

## Test plan
- [ ] CI green on this branch
- [ ] Skills load correctly in a fresh `claude` session
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relay/pull/812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->