### PR TITLE
feat(sdk): add WorkflowBuilder.paths() for multi-repo cloud workflows

### DIFF
--- a/packages/sdk/src/workflows/__tests__/builder-paths.test.ts
+++ b/packages/sdk/src/workflows/__tests__/builder-paths.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+
+import { WorkflowBuilder } from '../builder.js';
+
+describe('WorkflowBuilder.paths()', () => {
+  it('records the declared paths on toConfig() output', () => {
+    const config = new WorkflowBuilder('multi-repo')
+      .paths([
+        { name: 'alpha', path: 'alpha', description: 'Demo repo A' },
+        { name: 'beta', path: 'beta', description: 'Demo repo B' },
+      ])
+      .agent('worker', { cli: 'codex' })
+      .step('noop', { type: 'deterministic', command: 'true' })
+      .toConfig();
+
+    expect(config.paths).toEqual([
+      { name: 'alpha', path: 'alpha', description: 'Demo repo A' },
+      { name: 'beta', path: 'beta', description: 'Demo repo B' },
+    ]);
+  });
+
+  it('omits the paths field entirely when none are declared', () => {
+    const config = new WorkflowBuilder('single-repo')
+      .agent('worker', { cli: 'codex' })
+      .step('noop', { type: 'deterministic', command: 'true' })
+      .toConfig();
+
+    expect(config.paths).toBeUndefined();
+  });
+
+  it('does not allow downstream callers to mutate the recorded paths via the input array', () => {
+    const original = [{ name: 'alpha', path: 'alpha' }];
+    const builder = new WorkflowBuilder('mutation-guard')
+      .paths(original)
+      .agent('w', { cli: 'codex' })
+      .step('s', { type: 'deterministic', command: 'true' });
+
+    // Mutating the original array AFTER passing it in should not change
+    // the config the builder emits.
+    original.push({ name: 'beta', path: 'beta' });
+    original[0].name = 'mutated';
+
+    const config = builder.toConfig();
+    expect(config.paths).toEqual([{ name: 'alpha', path: 'alpha' }]);
+  });
+
+  it('rejects non-array inputs', () => {
+    const builder = new WorkflowBuilder('bad-input');
+    // @ts-expect-error — runtime guard, not a type-level test
+    expect(() => builder.paths('not-an-array')).toThrow(/expects an array/);
+  });
+
+  it('rejects entries missing name or path', () => {
+    const builder = new WorkflowBuilder('bad-entry');
+    // @ts-expect-error — runtime guard
+    expect(() => builder.paths([{ name: 'alpha' }])).toThrow(/string `name` and `path`/);
+    // @ts-expect-error — runtime guard
+    expect(() => builder.paths([{ path: 'beta' }])).toThrow(/string `name` and `path`/);
+  });
+
+  it('rejects duplicate path names', () => {
+    const builder = new WorkflowBuilder('dup');
+    expect(() =>
+      builder.paths([
+        { name: 'alpha', path: 'alpha' },
+        { name: 'alpha', path: 'alpha-also' },
+      ])
+    ).toThrow(/duplicate entry name "alpha"/);
+  });
+
+  it('returns the builder so the call chains', () => {
+    const builder = new WorkflowBuilder('chain');
+    const returned = builder.paths([{ name: 'alpha', path: 'alpha' }]);
+    expect(returned).toBe(builder);
+  });
+});

--- a/packages/sdk/src/workflows/builder.ts
+++ b/packages/sdk/src/workflows/builder.ts
@@ -11,6 +11,7 @@ import type {
   DryRunReport,
   ErrorHandlingConfig,
   IdleNudgeConfig,
+  PathDefinition,
   RelayYamlConfig,
   StateConfig,
   SwarmPattern,
@@ -157,6 +158,7 @@ export class WorkflowBuilder {
   private _timeoutMs?: number;
   private _channel?: string;
   private _idleNudge?: IdleNudgeConfig;
+  private _paths?: PathDefinition[];
   private _agents: AgentDefinition[] = [];
   private _steps: WorkflowStep[] = [];
   private _errorHandling?: ErrorHandlingConfig;
@@ -240,6 +242,38 @@ export class WorkflowBuilder {
   /** Set the previous run ID whose cached step outputs should be used with startFrom. */
   previousRunId(id: string): this {
     this._previousRunId = id;
+    return this;
+  }
+
+  /**
+   * Declare named paths to additional directories the workflow needs.
+   *
+   * For multi-repo cloud workflows (relay#774, cloud#302), each entry is
+   * tarballed by the CLI at submit time and mounted at
+   * `/home/daytona/workspace/{name}/` in the sandbox. Locally, the runner
+   * resolves `path` relative to the workflow file's parent directory and
+   * agents reference each entry by its declared `name`.
+   *
+   * Calling this is a no-op for the runtime — the runner doesn't need
+   * `paths` to execute steps. The CLI and the cloud bootstrap consume
+   * it. Declaring via the builder keeps single-source-of-truth for tools
+   * that walk the built config (e.g. dashboards, dry-run reports).
+   */
+  paths(paths: PathDefinition[]): this {
+    if (!Array.isArray(paths)) {
+      throw new Error('.paths() expects an array of PathDefinition objects');
+    }
+    const seen = new Set<string>();
+    for (const p of paths) {
+      if (!p || typeof p.name !== 'string' || typeof p.path !== 'string') {
+        throw new Error('.paths() entries must each have string `name` and `path` fields');
+      }
+      if (seen.has(p.name)) {
+        throw new Error(`.paths() got duplicate entry name "${p.name}"`);
+      }
+      seen.add(p.name);
+    }
+    this._paths = paths.map((p) => ({ ...p }));
     return this;
   }
 
@@ -381,6 +415,9 @@ export class WorkflowBuilder {
     };
 
     if (this._description !== undefined) config.description = this._description;
+    if (this._paths !== undefined && this._paths.length > 0) {
+      config.paths = this._paths.map((p) => ({ ...p }));
+    }
     if (this._maxConcurrency !== undefined) config.swarm.maxConcurrency = this._maxConcurrency;
     if (this._timeoutMs !== undefined) config.swarm.timeoutMs = this._timeoutMs;
     if (this._channel !== undefined) config.swarm.channel = this._channel;


### PR DESCRIPTION
## Summary
- Phase B of the multi-repo cloud workflow rollout (relay#774, cloud#302) shipped the CLI-side regex parser for `paths` and the cloud bootstrap that mounts each declared path, but never added a fluent `.paths(...)` method on the SDK `WorkflowBuilder`. Workflows that wrote the natural form
  ```ts
  workflow('multi-repo').paths([{name:'alpha', path:'alpha'}, ...]).run()
  ```
  tarballed correctly at submit time (CLI parsed the literal via regex) but threw `TypeError: ... .paths is not a function` the moment the sandbox runtime evaluated the file, because the builder the sandbox imports from `@agent-relay/sdk/workflows` had no such method.
- This PR adds the missing builder method.

## What changes
- `packages/sdk/src/workflows/builder.ts`: import the existing `PathDefinition` type, add a `_paths` private field on `WorkflowBuilder`, add a `paths(paths: PathDefinition[]): this` method with up-front validation (non-array, missing `name`/`path`, duplicate names all throw at builder time), and thread `_paths` into `toConfig()` so the field lands on the built `RelayYamlConfig`.
- `packages/sdk/src/workflows/__tests__/builder-paths.test.ts`: 7 focused tests — recording, omission when unset, defensive copy-on-input, three validation paths, and the chain-return contract.

## What does NOT change
- The runner still does not consume `paths` to execute steps — that's a CLI/cloud concern. Adding the method is purely about being a no-op-at-runtime, single-source-of-truth setter for tools that walk the built config (dashboards, dry-run reports, cloud bootstrap).
- `PathDefinition` type already existed in `types.ts`; this PR only wires the fluent setter that callers expect to exist.

## Once published + snapshot rebuilt
Workflow authors can swap the current Phase-B workaround
```ts
export const config = { paths: [...] };  // CLI-only, regex-parsed
```
back to the natural fluent form
```ts
workflow('multi-repo').paths([...]).step(...).run();
```
without the runtime TypeError.

## Test plan
- [x] `vitest run packages/sdk/src/workflows/__tests__/builder-paths.test.ts` — 7/7 passing
- [x] Full SDK suite re-run: 956 passing, 1 pre-existing failure on `main` (`workflow-runner.test.ts` "record review completion in trajectory" — unrelated to this change, also fails on `origin/main` HEAD)
- [x] `tsc --noEmit` against `packages/sdk` — clean
- [ ] After release: cloud sandbox snapshot needs to be rebuilt against the bumped `@agent-relay/sdk` so existing relax + bootstrap PRs (cloud#423/#425/#431) close out the demo end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)