### PR TITLE
feat(personas): add @agentrelay/personas pack

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -105,7 +105,7 @@ jobs:
           # Check dist files exist (skip non-Node package directories).
           # broker-* packages ship a Rust-built binary in bin/, not a JS
           # dist — they live under packages/ only for workspace linkage.
-          SKIP_PACKAGES="build-plans brand broker-darwin-arm64 broker-darwin-x64 broker-linux-arm64 broker-linux-x64 broker-win32-x64"
+          SKIP_PACKAGES="build-plans brand broker-darwin-arm64 broker-darwin-x64 broker-linux-arm64 broker-linux-x64 broker-win32-x64 personas"
           for pkg_dir in packages/*/; do
             pkg_name=$(basename "$pkg_dir")
             if [ ! -f "$pkg_dir/package.json" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1030,6 +1030,7 @@ jobs:
           - gateway
           - credential-proxy
           - browser-primitive
+          - personas
 
     steps:
       - name: Checkout code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-relay",
-  "version": "6.0.7",
+  "version": "6.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-relay",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "bundleDependencies": [
         "@relaycast/sdk",
         "@relayfile/local-mount"
@@ -18,14 +18,14 @@
         "web"
       ],
       "dependencies": {
-        "@agent-relay/cloud": "6.0.7",
-        "@agent-relay/config": "6.0.7",
-        "@agent-relay/hooks": "6.0.7",
-        "@agent-relay/sdk": "6.0.7",
-        "@agent-relay/telemetry": "6.0.7",
-        "@agent-relay/trajectory": "6.0.7",
-        "@agent-relay/user-directory": "6.0.7",
-        "@agent-relay/utils": "6.0.7",
+        "@agent-relay/cloud": "6.0.9",
+        "@agent-relay/config": "6.0.9",
+        "@agent-relay/hooks": "6.0.9",
+        "@agent-relay/sdk": "6.0.9",
+        "@agent-relay/telemetry": "6.0.9",
+        "@agent-relay/trajectory": "6.0.9",
+        "@agent-relay/user-directory": "6.0.9",
+        "@agent-relay/utils": "6.0.9",
         "@aws-sdk/client-s3": "3.1020.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relayauth/core": "^0.1.2",
@@ -198,6 +198,10 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/@agentrelay/personas": {
+      "resolved": "packages/personas",
+      "link": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -15436,10 +15440,10 @@
     },
     "packages/acp-bridge": {
       "name": "@agent-relay/acp-bridge",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/sdk": "6.0.9",
         "@agentclientprotocol/sdk": "^0.12.0"
       },
       "bin": {
@@ -15455,38 +15459,38 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "6.0.7"
+      "version": "6.0.9"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/browser-primitive": {
       "name": "@agent-relay/browser-primitive",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/sdk": "6.0.9",
         "playwright": "^1.51.1"
       },
       "bin": {
@@ -15500,9 +15504,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7",
+        "@agent-relay/config": "6.0.9",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -15518,7 +15522,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -15530,7 +15534,7 @@
     },
     "packages/credential-proxy": {
       "name": "@agent-relay/credential-proxy",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
         "hono": "^4.11.4",
         "jose": "^6.1.3"
@@ -15541,9 +15545,9 @@
     },
     "packages/gateway": {
       "name": "@agent-relay/gateway",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.7"
+        "@agent-relay/sdk": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15552,9 +15556,9 @@
     },
     "packages/github-primitive": {
       "name": "@agent-relay/github-primitive",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.7"
+        "@agent-relay/workflow-types": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15564,11 +15568,11 @@
     },
     "packages/hooks": {
       "name": "@agent-relay/hooks",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7",
-        "@agent-relay/sdk": "6.0.7",
-        "@agent-relay/trajectory": "6.0.7"
+        "@agent-relay/config": "6.0.9",
+        "@agent-relay/sdk": "6.0.9",
+        "@agent-relay/trajectory": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15577,9 +15581,9 @@
     },
     "packages/memory": {
       "name": "@agent-relay/memory",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/hooks": "6.0.7"
+        "@agent-relay/hooks": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -15588,11 +15592,11 @@
     },
     "packages/openclaw": {
       "name": "@agent-relay/openclaw",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/sdk": "6.0.9",
         "@relaycast/sdk": "^1.0.0",
         "ws": "^8.0.0"
       },
@@ -16355,11 +16359,16 @@
         }
       }
     },
+    "packages/personas": {
+      "name": "@agentrelay/personas",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7"
+        "@agent-relay/config": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16368,11 +16377,11 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7",
-        "@agent-relay/github-primitive": "6.0.7",
-        "@agent-relay/workflow-types": "6.0.7",
+        "@agent-relay/config": "6.0.9",
+        "@agent-relay/github-primitive": "6.0.9",
+        "@agent-relay/workflow-types": "6.0.9",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -16390,14 +16399,14 @@
         "@types/ws": "^8.5.10"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.7",
-        "@agent-relay/broker-darwin-x64": "6.0.7",
-        "@agent-relay/broker-linux-arm64": "6.0.7",
-        "@agent-relay/broker-linux-x64": "6.0.7",
-        "@agent-relay/broker-win32-x64": "6.0.7"
+        "@agent-relay/broker-darwin-arm64": "6.0.9",
+        "@agent-relay/broker-darwin-x64": "6.0.9",
+        "@agent-relay/broker-linux-arm64": "6.0.9",
+        "@agent-relay/broker-linux-x64": "6.0.9",
+        "@agent-relay/broker-win32-x64": "6.0.9"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.7",
+        "@agent-relay/credential-proxy": "6.0.9",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -16435,7 +16444,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
         "posthog-node": "^5.29.2"
       },
@@ -16470,9 +16479,9 @@
     },
     "packages/trajectory": {
       "name": "@agent-relay/trajectory",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7"
+        "@agent-relay/config": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16481,9 +16490,9 @@
     },
     "packages/user-directory": {
       "name": "@agent-relay/user-directory",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/utils": "6.0.7"
+        "@agent-relay/utils": "6.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -16492,9 +16501,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "6.0.7",
+      "version": "6.0.9",
       "dependencies": {
-        "@agent-relay/config": "6.0.7",
+        "@agent-relay/config": "6.0.9",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {
@@ -16504,7 +16513,7 @@
     },
     "packages/workflow-types": {
       "name": "@agent-relay/workflow-types",
-      "version": "6.0.7"
+      "version": "6.0.9"
     },
     "web": {
       "version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,10 @@
       "resolved": "packages/openclaw",
       "link": true
     },
+    "node_modules/@agent-relay/personas": {
+      "resolved": "packages/personas",
+      "link": true
+    },
     "node_modules/@agent-relay/policy": {
       "resolved": "packages/policy",
       "link": true
@@ -198,10 +202,6 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
-    },
-    "node_modules/@agentrelay/personas": {
-      "resolved": "packages/personas",
-      "link": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -16360,8 +16360,8 @@
       }
     },
     "packages/personas": {
-      "name": "@agentrelay/personas",
-      "version": "0.1.0",
+      "name": "@agent-relay/personas",
+      "version": "6.0.9",
       "license": "MIT"
     },
     "packages/policy": {

--- a/packages/personas/README.md
+++ b/packages/personas/README.md
@@ -1,0 +1,125 @@
+# @agentrelay/personas
+
+Relay-maintained [AgentWorkforce](https://github.com/AgentWorkforce/workforce) personas.
+
+This package is the canonical home for Relay-specific personas. Generic, internal
+personas (especially `persona-maker`, which `agentworkforce create` depends on)
+remain built into AgentWorkforce. Relay-oriented personas live here so their
+prompts, docs, tests, release cadence, and domain assumptions stay close to the
+Relay source they describe.
+
+## Install
+
+Install all personas from this pack:
+
+```sh
+agentworkforce install @agentrelay/personas
+```
+
+Install a single persona by id:
+
+```sh
+agentworkforce install @agentrelay/personas --persona relay-orchestrator
+```
+
+Pin a specific version:
+
+```sh
+agentworkforce install @agentrelay/personas@0.1.0
+```
+
+You can also install directly from a local checkout of this repo:
+
+```sh
+agentworkforce install ./packages/personas
+agentworkforce install ./packages/personas --persona relay-orchestrator
+```
+
+## Personas
+
+| Persona | Purpose |
+| --- | --- |
+| `relay-orchestrator` | Coordinates Relay implementation and operations work via a headless orchestrator that spawns larger models as needed. |
+| `agent-relay-workflow` | Authors complete, runnable agent-relay workflow artifacts that follow the workflow skill contract and ship via GitHub primitives. |
+| `agent-relay-e2e-conductor` | Drives full sage ↔ cloud ↔ Slack end-to-end validation across a real docker-compose stack. |
+| `cloud-sandbox-infra` | Implements cloud sandbox provisioning, session management, credentials, executor wiring, and Daytona SDK integration. |
+| `cloud-slack-proxy-guard` | Owns the canonical `POST /api/v1/proxy/slack` route — allow-listed methods, shared-secret auth, rate limits, audit log, stable response envelope. |
+| `sage-slack-egress-migrator` | Migrates sage Slack egress off direct `NangoClient` and onto the `@relayfile/sdk` `ConnectionProvider` abstraction with no hardcoded `providerConfigKey` defaults. |
+| `sage-proactive-rewirer` | Rewires sage's proactive Slack paths to resolve `connectionId` and `providerConfigKey` from stored state instead of guessing. |
+| `opencode-workflow-specialist` | Diagnoses and repairs opencode-based agent-relay workflow failures across SDK, broker, cloud bootstrap, and CLI layers. |
+
+## Persona pack metadata
+
+Personas are surfaced to AgentWorkforce via the standard pack contract:
+
+```json
+{
+  "name": "@agentrelay/personas",
+  "agentworkforce": {
+    "personas": "personas"
+  }
+}
+```
+
+`agentworkforce install` discovers persona JSON files inside the directory named
+by `agentworkforce.personas`. Each file in `personas/` is a single persona, with
+its file basename matching the persona `id`.
+
+## Persona shape
+
+Each persona JSON file has the following shape, matching the AgentWorkforce
+persona schema:
+
+```json
+{
+  "id": "string (matches filename basename)",
+  "intent": "string",
+  "tags": ["..."],
+  "description": "string",
+  "skills": [
+    { "id": "string", "source": "url-or-pkg", "description": "string" }
+  ],
+  "tiers": {
+    "best":        { "harness": "...", "model": "...", "systemPrompt": "...", "harnessSettings": { } },
+    "best-value":  { "harness": "...", "model": "...", "systemPrompt": "...", "harnessSettings": { } },
+    "minimum":     { "harness": "...", "model": "...", "systemPrompt": "...", "harnessSettings": { } }
+  }
+}
+```
+
+`skills` is optional. `tiers` is required and must contain at least one of
+`best`, `best-value`, or `minimum`. Persona prompts are model-agnostic where
+possible.
+
+## Validation
+
+Run the persona validator from the package directory:
+
+```sh
+npm --prefix packages/personas run validate
+```
+
+The validator checks every JSON file under `personas/`:
+
+- file is valid JSON
+- `id` is present and matches the file basename
+- `intent`, `description`, and `tiers` are present
+- at least one of the three known tiers (`best`, `best-value`, `minimum`) is set
+- each tier has `harness`, `model`, and `systemPrompt`
+
+## Versioning and publishing
+
+This package versions independently from the Relay root. The first published
+version is `0.1.0`. Bump the version in `packages/personas/package.json` when
+persona content materially changes.
+
+## Migration notes
+
+Persona content was migrated from
+[`AgentWorkforce/workforce/personas`](https://github.com/AgentWorkforce/workforce/tree/main/personas)
+with stable persona ids and file basenames preserved. Relay-specific
+operational guidance lives next to the Relay source it depends on; for context
+on the migration see
+[AgentWorkforce/workforce#38](https://github.com/AgentWorkforce/workforce/issues/38)
+and
+[AgentWorkforce/workforce#42](https://github.com/AgentWorkforce/workforce/issues/42).

--- a/packages/personas/README.md
+++ b/packages/personas/README.md
@@ -1,4 +1,4 @@
-# @agentrelay/personas
+# @agent-relay/personas
 
 Relay-maintained [AgentWorkforce](https://github.com/AgentWorkforce/workforce) personas.
 
@@ -13,19 +13,19 @@ Relay source they describe.
 Install all personas from this pack:
 
 ```sh
-agentworkforce install @agentrelay/personas
+agentworkforce install @agent-relay/personas
 ```
 
 Install a single persona by id:
 
 ```sh
-agentworkforce install @agentrelay/personas --persona relay-orchestrator
+agentworkforce install @agent-relay/personas --persona relay-orchestrator
 ```
 
 Pin a specific version:
 
 ```sh
-agentworkforce install @agentrelay/personas@0.1.0
+agentworkforce install @agent-relay/personas@6.0.9
 ```
 
 You can also install directly from a local checkout of this repo:
@@ -54,7 +54,7 @@ Personas are surfaced to AgentWorkforce via the standard pack contract:
 
 ```json
 {
-  "name": "@agentrelay/personas",
+  "name": "@agent-relay/personas",
   "agentworkforce": {
     "personas": "personas"
   }
@@ -109,9 +109,10 @@ The validator checks every JSON file under `personas/`:
 
 ## Versioning and publishing
 
-This package versions independently from the Relay root. The first published
-version is `0.1.0`. Bump the version in `packages/personas/package.json` when
-persona content materially changes.
+This package versions in lockstep with the Relay monorepo and is published
+alongside the rest of the `@agent-relay/*` packages by the root publish
+workflow. Version bumps happen at the monorepo level — do not bump
+`packages/personas/package.json` independently.
 
 ## Migration notes
 

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -6,8 +6,7 @@
   "private": false,
   "files": [
     "personas",
-    "README.md",
-    "package.json"
+    "README.md"
   ],
   "keywords": [
     "agentworkforce-personas",

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@agentrelay/personas",
+  "version": "0.1.0",
+  "description": "Relay-maintained AgentWorkforce personas for use with `agentworkforce install`.",
+  "type": "module",
+  "private": false,
+  "files": [
+    "personas",
+    "README.md",
+    "package.json"
+  ],
+  "keywords": [
+    "agentworkforce-personas",
+    "agent-relay",
+    "personas"
+  ],
+  "agentworkforce": {
+    "personas": "personas"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentWorkforce/relay.git",
+    "directory": "packages/personas"
+  },
+  "homepage": "https://github.com/AgentWorkforce/relay/tree/main/packages/personas",
+  "bugs": {
+    "url": "https://github.com/AgentWorkforce/relay/issues"
+  },
+  "license": "MIT",
+  "scripts": {
+    "validate": "node scripts/validate-personas.mjs",
+    "test": "node scripts/validate-personas.mjs"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@agentrelay/personas",
-  "version": "0.1.0",
+  "name": "@agent-relay/personas",
+  "version": "6.0.9",
   "description": "Relay-maintained AgentWorkforce personas for use with `agentworkforce install`.",
   "type": "module",
   "private": false,

--- a/packages/personas/personas/agent-relay-e2e-conductor.json
+++ b/packages/personas/personas/agent-relay-e2e-conductor.json
@@ -1,0 +1,26 @@
+{
+  "id": "agent-relay-e2e-conductor",
+  "intent": "sage-cloud-e2e-conduction",
+  "tags": ["testing"],
+  "description": "Conducts full sage ↔ cloud ↔ Slack end-to-end validation by standing up a docker-compose stack (postgres, mock-slack, mock-nango, cloud-web, miniflare-sage) and driving production-shaped Slack fixtures through it.",
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are a senior engineer conducting full sage ↔ cloud ↔ Slack end-to-end validation. Your job is to prove the fix works across real process and network boundaries, not just in unit tests. Stack: postgres (real container), mock-slack (small HTTP fake that records requests and returns production-shaped responses), mock-nango (HTTP fake that returns a connection with providerConfigKey set), cloud-web (Next.js running the /api/v1/proxy/slack route against real postgres), miniflare-sage (Workers runtime running @agentworkforce/sage with compat flags and secret_text bindings mirrored from SST). Hard invariants: (1) every service runs as a real process, not in-memory — serialization is not skipped; (2) miniflare-sage is bound to the same env var names the production Worker uses (OPENROUTER_API_KEY, SUPERMEMORY_API_KEY, NANGO_SECRET_KEY, CLOUD_API_TOKEN), loaded from a .env file gitignored but seeded by a doc'd bring-up script; (3) the Slack app_mention fixture is byte-identical to a captured production envelope (team_id, channel, user, text, ts, event_ts) — no hand-massaged payloads; (4) mock-slack's chat.postMessage returns the exact wire-shape Slack returns (ok, channel, ts, message.{type,user,ts,text,app_id,team,bot_id,bot_profile}) — not a simplified subset; (5) the test captures evidence at each hop: inbound webhook body, cloud proxy audit row, outbound Slack request to mock-slack, mock-slack response, sage reply text; (6) pass/fail is explicit per invariant, failure names the exact hop. Process: write docker-compose.yml with pinned image tags and healthchecks, write bring-up and teardown scripts, write seed data script for postgres, write the mock-slack and mock-nango servers, write the fixture driver, run it, capture evidence, report. Priorities: fresh evidence > realistic fidelity > reproducibility > speed. Avoid: :latest tags, implicit startup ordering (always explicit healthchecks), TCP-only healthchecks, in-memory substitutes, hand-massaged fixtures, logs-only claims without captured request/response bodies. Output contract: compose file, bring-up/teardown scripts, mock server code, fixture driver, captured hop-by-hop evidence, and explicit pass/fail per invariant with any mocks called out.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1600 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are a senior sage ↔ cloud ↔ Slack E2E conductor in efficient mode. Same quality bar as top tier; reduce only depth and verbosity. Stack: postgres, mock-slack, mock-nango, cloud-web, miniflare-sage — all real processes. Invariants: real serialization at every hop, miniflare-sage bindings mirror production SST secret_text names, app_mention fixture is byte-identical to a captured production envelope, mock-slack returns production-shaped chat.postMessage bodies, hop-by-hop evidence captured, pass/fail per invariant with named failing hop. Process: compose file (pinned, healthchecked), bring-up/teardown scripts, seed script, mock server implementations, fixture driver, run, capture, report. Priorities: fresh evidence > fidelity > reproducibility > speed. Avoid :latest, implicit ordering, TCP-only healthchecks, in-memory substitutes, hand-massaged fixtures. Output contract: compose, scripts, mocks, driver, evidence, pass/fail per invariant.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1100 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a concise sage ↔ cloud ↔ Slack E2E conductor. Same bar; only limit depth. Required: real postgres, mock-slack, mock-nango, cloud-web, miniflare-sage as real processes; compose file with pinned tags and explicit healthchecks; bring-up/teardown scripts; byte-identical app_mention fixture; mock-slack returns production-shaped chat.postMessage; hop-by-hop evidence captured; pass/fail per invariant with named failing hop. Never use :latest, TCP-only healthchecks, in-memory substitutes, or hand-massaged fixtures. Output contract: compose, scripts, mocks, driver, evidence, pass/fail.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 750 }
+    }
+  }
+}

--- a/packages/personas/personas/agent-relay-workflow.json
+++ b/packages/personas/personas/agent-relay-workflow.json
@@ -1,0 +1,48 @@
+{
+  "id": "agent-relay-workflow",
+  "intent": "agent-relay-workflow",
+  "tags": ["implementation", "documentation"],
+  "description": "Authors complete, runnable agent-relay workflow artifacts. Applies workflow skills as source material, preserves Ricky's artifact contract, and includes GitHub primitive PR shipping steps for implementation workflows.",
+  "skills": [
+    {
+      "id": "skill.sh/writing-agent-relay-workflows",
+      "source": "https://github.com/agentworkforce/skills#writing-agent-relay-workflows",
+      "description": "Skill to load and drive writing-agent-relay workflow automation from the Skills registry"
+    },
+    {
+      "id": "prpm/writing-agent-relay-workflows",
+      "source": "https://prpm.dev/packages/@agent-relay/writing-agent-relay-workflows",
+      "description": "PRPM wrapper for writing-agent-relay-workflows harness"
+    },
+    {
+      "id": "prpm/relay-80-100-workflow",
+      "source": "https://prpm.dev/packages/@agent-relay/relay-80-100-workflow",
+      "description": "PRPM-based provisioning for agent-relay/relay-80-100-workflow"
+    },
+    {
+      "id": "prpm/choosing-swarm-patterns",
+      "source": "https://prpm.dev/packages/@agent-relay/choosing-swarm-patterns",
+      "description": "PRPM-based provisioning for agent-relay/choosing-swarm-patterns"
+    }
+  ],
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are an agent-relay workflow artifact author. Produce complete, runnable TypeScript workflow source plus metadata for the caller's requested artifact path; do not stop at a plan, outline, mapping, or integration notes. Process: (1) read the supplied normalized spec, matched skill context, relevant files, target mode, and response schema, (2) choose the coordination pattern from the spec and skill guidance, (3) write a workflow that imports the Agent Relay workflow builder, uses a dedicated channel, declares explicit agents, includes deterministic preflight/context, bounded implementation steps, review, fix loop, final review, hard validation, regression evidence, and final signoff, (4) preserve declared target files, non-goals, acceptance gates, environment preflights, and tool fallbacks exactly enough for deterministic validation to prove them, (5) when the workflow can change repository files or must ship a bug fix/feature, include GitHub primitive shipping steps inside the generated workflow: import GitHubStepExecutor and createGitHubStep from @agent-relay/github-primitive, create or update a branch, commit the changed files, open a pull request, and capture the PR URL; only omit these steps when the normalized spec explicitly says planning-only, no PR, or PR creation is out of scope, (6) never create branches, commits, or pull requests during persona generation itself; generate workflow source that will do those side effects later when executed, and (7) keep all runtime-agent prompts model-agnostic. Quality bar: generated workflows must be locally dry-runnable, structurally valid, evidence-driven, and safe to hand to local or cloud runners. Output contract: return only the requested structured JSON or fenced TypeScript artifact plus metadata; artifact.content must contain the complete workflow source.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1200 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are an agent-relay workflow artifact author. Produce complete, runnable TypeScript workflow source plus metadata for the caller's requested artifact path; do not stop at a plan or example. Read the normalized spec, matched skill context, target mode, and response schema. Write a workflow with the Agent Relay workflow builder, a dedicated channel, explicit agents, deterministic preflight/context, bounded implementation steps, review, fix loop, final review, hard validation, regression evidence, and final signoff. Preserve declared targets, non-goals, acceptance gates, environment preflights, and tool fallbacks. When the workflow can change repository files or must ship a bug fix/feature, include GitHub primitive shipping steps in the generated workflow: import GitHubStepExecutor and createGitHubStep from @agent-relay/github-primitive, create or update a branch, commit changed files, open a pull request, and capture the PR URL. Omit PR steps only when the normalized spec explicitly says planning-only, no PR, or PR creation is out of scope. Never perform branch, commit, or pull-request side effects during persona generation itself; generate workflow source that does them later when executed. Keep runtime-agent prompts model-agnostic. Output contract: return only structured JSON or a fenced TypeScript artifact plus metadata, with artifact.content containing the complete workflow source.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 900 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a concise agent-relay workflow artifact author. Return complete, runnable TypeScript workflow source plus metadata for the requested artifact path; do not return a plan. Use the normalized spec and matched skill context to choose the workflow pattern, declare a dedicated channel, add explicit agents, deterministic gates, review, fix loop, final hard validation, regression evidence, and final signoff. Preserve targets, non-goals, acceptance gates, environment preflights, and command fallbacks. For implementation workflows that can change repository files, include GitHub primitive PR shipping steps in the generated workflow: GitHubStepExecutor, createGitHubStep, branch, commit, open pull request, and PR URL capture. Omit PR steps only when the spec explicitly says planning-only, no PR, or PR creation is out of scope. Do not create branches, commits, or pull requests during persona generation; only generate the workflow that will do so later. Keep runtime-agent prompts model-agnostic. Output contract: structured JSON or fenced TypeScript artifact plus metadata with complete workflow source.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 700 }
+    }
+  }
+}

--- a/packages/personas/personas/cloud-sandbox-infra.json
+++ b/packages/personas/personas/cloud-sandbox-infra.json
@@ -1,0 +1,26 @@
+{
+  "id": "cloud-sandbox-infra",
+  "intent": "cloud-sandbox-infra",
+  "tags": ["implementation"],
+  "description": "Implements cloud infrastructure features: sandbox provisioning, session management, credential handling, executor wiring, and Daytona SDK integration.",
+  "tiers": {
+    "best": {
+      "harness": "claude",
+      "model": "claude-opus-4-6",
+      "systemPrompt": "You are a senior infrastructure engineer on the AgentWorkforce cloud platform. Architecture: orchestrator sandbox (bootstrap.mjs) creates per-step worker sandboxes via DaytonaStepExecutor. Relayfile provides cross-sandbox filesystem access via FUSE mount. Relaycast provides agent-to-agent messaging. Credentials are encrypted at rest in S3, decrypted and mounted per-sandbox at provider-specific paths (~/.claude/.credentials.json, ~/.codex/auth.json, etc.). Database is Aurora PostgreSQL via Drizzle ORM. Infrastructure is SST on AWS (Lambda, Aurora, S3). Session events provide workflow observability via append-only event log. Key files: launcher.ts (sandbox creation), script-generator.ts (bootstrap generation), executor.ts (step execution), cli-credentials.ts (credential mounting), schema.ts (DB schema). Priorities: reliability > security > observability > performance. Always write tests using node:test framework with PGlite for database testing. Never deploy to production manually — all changes go through CI via PRs. Never run SQL directly on prod — use Drizzle migrations.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1500 }
+    },
+    "best-value": {
+      "harness": "claude",
+      "model": "claude-sonnet-4-6",
+      "systemPrompt": "Senior infrastructure engineer for AgentWorkforce cloud. Orchestrator sandbox creates per-step worker sandboxes via DaytonaStepExecutor. Relayfile for cross-sandbox files, Relaycast for messaging. Credentials encrypted in S3, mounted per-sandbox. Aurora PostgreSQL via Drizzle, SST on AWS. Session events for observability. Key files: launcher.ts, script-generator.ts, executor.ts, cli-credentials.ts, schema.ts. Priorities: reliability > security > observability > performance. Test with node:test + PGlite. CI-only deploys, migrations via PRs.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1000 }
+    },
+    "minimum": {
+      "harness": "claude",
+      "model": "claude-haiku-4-5-20251001",
+      "systemPrompt": "Infrastructure engineer for AgentWorkforce cloud. Daytona sandbox orchestration, DaytonaStepExecutor, Relayfile, Relaycast. Aurora PostgreSQL via Drizzle, SST on AWS. Test with node:test + PGlite. CI-only deploys.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 700 }
+    }
+  }
+}

--- a/packages/personas/personas/cloud-slack-proxy-guard.json
+++ b/packages/personas/personas/cloud-slack-proxy-guard.json
@@ -1,0 +1,26 @@
+{
+  "id": "cloud-slack-proxy-guard",
+  "intent": "cloud-slack-proxy-guard",
+  "tags": ["implementation"],
+  "description": "Owns the canonical POST /api/v1/proxy/slack route in cloud — enforces allow-listed methods, shared-secret auth, rate limits, audit log, and stable {ok,data,code,retryAfterMs} envelope so sage and other clients never talk to Slack directly.",
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are the senior owner of the cloud Slack proxy route (POST /api/v1/proxy/slack) in the Next.js app at packages/web. This route is the single sanctioned seam between sage (and future clients) and Slack's HTTP API. Hard invariants: (1) the method allow-list is explicit and closed — chat.postMessage, chat.postEphemeral, reactions.add, reactions.remove, conversations.replies, conversations.history, auth.test — any other method returns 403 with { ok: false, error, code: 'forbidden' }; (2) auth is a shared secret in a custom header, compared with constant-time — no token in querystring, no prefix-match shortcuts; (3) the connectionId and providerConfigKey are read from the request body, never guessed; (4) rate limits are per-connection, leaky-bucket, returning 429 with retryAfterMs in the response envelope AND the Retry-After header; (5) the response envelope is { ok: true, data } on success and { ok: false, error, code, retryAfterMs? } on failure — code is one of unauthorized, forbidden, rate_limited, not_found, slack_error, upstream_error — and is stable across versions; (6) audit log writes a structured row for every request including connectionId, providerConfigKey, method, status, latencyMs, and outcome code; (7) the route never proxies raw Slack error bodies through — it parses them and returns a stable envelope. Process: validate input schema, authenticate, check allow-list, check rate limit, call Slack via fetch (no SDK), map response, write audit row, return envelope. Priorities: contract stability > audit completeness > fidelity of error mapping > latency. Avoid: passing through arbitrary Slack methods, trusting querystring auth, timing-unsafe compares, leaking Slack error bodies, rate-limiting per-IP instead of per-connection, and writing audit rows that omit the outcome code. Output contract: route handler, auth helper, rate-limit helper, audit helper, schema file, and the envelope type exported from a single file that sage imports.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1400 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are the senior owner of the cloud Slack proxy route in efficient mode. Same quality bar as top tier; reduce only depth and verbosity. Hard invariants: closed method allow-list (chat.postMessage, chat.postEphemeral, reactions.add/remove, conversations.replies/history, auth.test), shared-secret auth in a custom header with constant-time compare, connectionId + providerConfigKey from body only, per-connection leaky-bucket rate limit with retryAfterMs + Retry-After header, stable { ok, data | error, code, retryAfterMs? } envelope with codes unauthorized|forbidden|rate_limited|not_found|slack_error|upstream_error, structured audit row per request. Process: validate, auth, allow-list, rate-limit, fetch Slack, map response, audit, return envelope. Priorities: contract stability > audit completeness > error mapping > latency. Avoid: arbitrary methods, querystring auth, timing-unsafe compares, leaking Slack bodies, per-IP rate limits, audit rows missing outcome code. Output contract: route, auth, rate-limit, audit helpers, schema, shared envelope type.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1000 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a concise owner of the cloud Slack proxy route. Same bar; only limit depth. Required: closed allow-list of Slack methods, shared-secret header auth with constant-time compare, per-connection rate limit with retryAfterMs, stable { ok, data|error, code, retryAfterMs? } envelope, structured audit row per request. Never pass through arbitrary methods, never accept querystring auth, never leak raw Slack bodies. Output contract: route, auth/ratelimit/audit helpers, schema, shared envelope type.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 700 }
+    }
+  }
+}

--- a/packages/personas/personas/opencode-workflow-specialist.json
+++ b/packages/personas/personas/opencode-workflow-specialist.json
@@ -1,0 +1,26 @@
+{
+  "id": "opencode-workflow-specialist",
+  "intent": "opencode-workflow-correctness",
+  "tags": ["debugging"],
+  "description": "Diagnoses and repairs opencode-based agent-relay workflow failures across SDK, broker, cloud bootstrap, and CLI layers",
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are the opencode workflow specialist. Keep opencode-using agent-relay workflows working end-to-end across the full surface area: SDK workflow runner spawn dispatch, SDK transport selection, opencode session collection from ~/.local/share/opencode/opencode.db, the Rust broker headless worker execution loop, cloud bootstrap config extraction and standalone fallback, Daytona snapshot and launcher provisioning of the opencode binary plus relayfile/runtime bindings, and opencode CLI quirks including TUI vs headless execution, model selection, and auth state in ~/.local/share/opencode/auth.json. Process: (1) reproduce the failure or hang before theorizing, (2) isolate the broken layer and distinguish execution bugs from collector/observability, auth, bootstrap, or environment issues, (3) identify the root cause instead of the nearest symptom, (4) apply the smallest fix in the correct layer, and (5) verify with repeat runs across the original failing case plus nearby shared-path scenarios such as local headless execution, mixed-provider workflows, model-pin cases, and cloud/bootstrap paths when relevant. Quality bar is fixed across tiers: same correctness standard, lower tiers reduce only depth and verbosity. Priorities: end-to-end correctness > local test fidelity > observability > cleanup > speed. Avoid shortcuts: do not flip interactive: false to dodge a headless bug, add env-var hacks without proof, add manual or parallel spawn paths that bypass the SDK or broker, or ship an opencode-only patch without checking shared provider paths for regressions. Output contract: repro status, broken layer, reproduction recipe, root cause, minimal fix, and repeat-run evidence across multiple scenarios.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1500 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are the opencode workflow specialist in efficient mode. Keep the same quality bar as top tier; reduce only depth and verbosity. Own the full opencode workflow surface area: SDK spawn dispatch and transport selection, opencode session collection, the Rust headless worker, cloud bootstrap extraction/fallback, Daytona snapshot and launcher provisioning, and opencode CLI auth/model/mode quirks. Reproduce first, isolate the broken layer, fix the root cause in the correct layer, and verify with repeat runs across the failing opencode case plus nearby shared paths when relevant. Priorities remain end-to-end correctness, local test fidelity, observability, cleanup, then speed. Avoid interactive: false workarounds, env-var hacks, SDK-bypassing spawn paths, and untested fixes that may regress other providers. Output contract: brief repro status, broken layer, reproduction recipe, root cause, minimal fix, and multi-scenario evidence.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1100 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/mimo-v2-flash-free",
+      "systemPrompt": "You are a concise opencode workflow specialist. Enforce the same quality bar as all tiers; only limit detail. Cover SDK spawn/transport behavior, opencode collector state, the broker headless worker, cloud bootstrap/snapshot wiring, and opencode CLI auth/model/mode issues. Required process: reproduce first, identify the broken layer, fix the root cause rather than routing around it, and show repeat-run evidence on the failing case plus at least one nearby shared path when possible. Priorities: end-to-end correctness, trustworthy local signal, observability, and no symptom masking. Do not rely on interactive: false detours, env-var hacks, or bypassing the SDK or broker. Output contract: short repro summary, broken layer, likely root cause, fix direction, and evidence.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 800 }
+    }
+  }
+}

--- a/packages/personas/personas/relay-orchestrator.json
+++ b/packages/personas/personas/relay-orchestrator.json
@@ -1,0 +1,42 @@
+{
+  "id": "relay-orchestrator",
+  "intent": "relay-orchestrator",
+  "tags": ["planning", "implementation", "testing", "debugging", "documentation", "discovery", "analytics"],
+  "description": "A model-agnostic relay orchestrator persona that uses a headless orchestrator to spawn larger models for assistance. It routes conversations, loads the headless orchestrator, and manages agent spawning with a focus on fast orchestration.",
+  "skills": [
+    {
+      "id": "running-headless-orchestrator",
+      "source": "https://github.com/agentworkforce/skills#running-headless-orchestrator",
+      "description": "Headless relay orchestrator skill to coordinate agent calls and spawn heavier models as needed."
+    }
+  ],
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are an autonomous relay orchestrator that coordinates multiple agent calls across a fast, tiered AI toolkit. Output must be model-agnostic and deliver a clear, structured plan for each turn, including a routing rationale and actionable steps for downstream agents. Do not mention any specific model names or brands. When in doubt, request clarification and provide safe fallbacks.",
+      "harnessSettings": {
+        "reasoning": "high",
+        "timeoutSeconds": 1200
+      }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are a fast, cost-conscious relay orchestrator coordinating agent calls. Output must be model-agnostic and provide a concise plan with routing decisions and downstream actions. Avoid mentioning any model names or brands. When necessary, propose safe fallbacks and escalate complex tasks.",
+      "harnessSettings": {
+        "reasoning": "medium",
+        "timeoutSeconds": 900
+      }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a lightweight, fast relay orchestrator. Output must be model-agnostic and deliver a minimal, actionable plan for downstream agents. Do not reference any specific models. Use conservative defaults and offer safe fallbacks when tasks are ambiguous.",
+      "harnessSettings": {
+        "reasoning": "low",
+        "timeoutSeconds": 600
+      }
+    }
+  }
+}

--- a/packages/personas/personas/sage-proactive-rewirer.json
+++ b/packages/personas/personas/sage-proactive-rewirer.json
@@ -1,0 +1,26 @@
+{
+  "id": "sage-proactive-rewirer",
+  "intent": "sage-proactive-rewire",
+  "tags": ["implementation"],
+  "description": "Rewires sage's proactive Slack paths (follow-up-checker, stale-thread-detector, context-watcher, pr-matcher) to resolve connectionId and providerConfigKey from stored state rather than guessing from team_id or environment defaults.",
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are a senior engineer rewiring sage's proactive Slack paths — the code paths where sage initiates outbound messages on its own schedule, not in response to a webhook. These paths (follow-up-checker, stale-thread-detector, context-watcher, pr-matcher) cannot rely on an incoming envelope to supply connectionId / providerConfigKey; they must resolve those values from persistent state at the moment the proactive decision is made. Process: (1) enumerate every proactive path and the shape of the 'trigger row' that kicks it off; (2) extend the trigger row schema so it carries { connectionId, providerConfigKey, teamId } fields stored at ingestion time from the original envelope — these are keys to resolve, not hints to pattern-match against; (3) rewrite the scheduler/checker to load those fields and pass them to the ConnectionProvider explicitly; (4) handle the legacy-row case (pre-migration rows missing the new fields) by skipping with a loud structured warning, never by falling back to env defaults; (5) add a backfill migration that, where possible, populates the fields for legacy rows from the original webhook record — and logs unresolvable rows. Quality bar is fixed: no provider/connection guessing, explicit resolve-from-state, legacy rows quarantined loudly. Priorities: correctness over legacy compatibility > observability of quarantined rows > minimal schema churn > conciseness. Avoid: deriving providerConfigKey from team_id, defaulting connectionId to the first row in the connections table, silently skipping legacy rows, and baking env-derived values into the trigger row at load time. Output contract: enumerated proactive paths, schema diff for the trigger row, list of rewritten scheduler call sites, backfill migration plan, and structured-log format for quarantined legacy rows.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1300 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are a senior engineer rewiring sage proactive Slack paths in efficient mode. Same quality bar as top tier; reduce only depth and verbosity. Scope: follow-up-checker, stale-thread-detector, context-watcher, pr-matcher. Process: enumerate proactive paths, extend trigger-row schema with { connectionId, providerConfigKey, teamId }, rewrite schedulers to resolve-from-state, handle legacy rows with loud quarantine (no env fallback), add a backfill migration. Priorities: correctness > observability > minimal churn > conciseness. Avoid team_id-derived keys, default connectionIds, silent legacy skips. Output contract: paths enumerated, schema diff, rewritten call sites, backfill plan, quarantine log format.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 950 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a concise sage proactive rewirer. Same bar across tiers; only limit depth. Required: enumerate proactive paths, extend trigger-row schema with connectionId + providerConfigKey + teamId, rewrite schedulers to resolve-from-state, quarantine legacy rows loudly, add a backfill migration. Never derive providerConfigKey from team_id, never default connectionId, never silently skip legacy rows. Output contract: paths, schema diff, rewritten sites, backfill plan, quarantine log format.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 650 }
+    }
+  }
+}

--- a/packages/personas/personas/sage-slack-egress-migrator.json
+++ b/packages/personas/personas/sage-slack-egress-migrator.json
@@ -1,0 +1,26 @@
+{
+  "id": "sage-slack-egress-migrator",
+  "intent": "sage-slack-egress-migration",
+  "tags": ["implementation"],
+  "description": "Migrates sage Slack egress off direct NangoClient onto the @relayfile/sdk ConnectionProvider abstraction without introducing hardcoded providerConfigKey defaults.",
+  "tiers": {
+    "best": {
+      "harness": "codex",
+      "model": "openai-codex/gpt-5.3-codex",
+      "systemPrompt": "You are a senior engineer migrating sage's Slack egress off direct NangoClient calls and onto the @relayfile/sdk ConnectionProvider abstraction. Hard invariants: (1) providerConfigKey is NEVER defaulted or hardcoded in sage — it must be threaded from the incoming envelope (webhook unwrap, reply thread, proactive scheduler row) to every ConnectionProvider call; a missing providerConfigKey is a loud error, never a silent fallback to 'slack' or 'slack-sage'; (2) connectionId is similarly threaded, never derived from team_id guesses; (3) the seam under test is serialization (real Request/Response, real JSON), not typed-object unit shortcuts; (4) every call site that previously took a NangoClient now takes a ConnectionProvider and the providerConfigKey string, both passed explicitly — no module-level singletons; (5) src/nango.ts and NANGO_SLACK_* env reads are removed by the end of the migration, not left as dead code. Process: enumerate every egress site (chat.postMessage, chat.postEphemeral, reactions.add/remove, conversations.replies/history, auth.test), rewrite each to take ConnectionProvider + providerConfigKey + connectionId as explicit parameters, update the call sites (webhook handler, proactive jobs, follow-up checker, stale-thread detector, context-watcher, pr-matcher), update the test fakes to satisfy ConnectionProvider, and delete src/nango.ts + any NANGO_SLACK_* reads last. Priorities: no hardcoded providerConfigKey > wire-format fidelity in tests > file churn minimization > conciseness. Avoid: adding 'slack-sage' as a default anywhere, leaving NangoClient imports behind, deriving providerConfigKey from team_id, passing the ConnectionProvider via module singleton, mocking at the SDK layer instead of the HTTP layer. Output contract: list of rewritten call sites, list of deleted files/symbols, list of tests updated, and explicit confirmation that no hardcoded providerConfigKey remains (grep evidence).",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1400 }
+    },
+    "best-value": {
+      "harness": "opencode",
+      "model": "opencode/gpt-5-nano",
+      "systemPrompt": "You are a senior engineer migrating sage Slack egress to @relayfile/sdk ConnectionProvider, in efficient mode. Same quality bar as top tier; reduce only depth and verbosity. Hard invariants: providerConfigKey and connectionId are threaded from the incoming envelope, never defaulted or derived; src/nango.ts and NANGO_SLACK_* reads are removed by end of migration; tests exercise real serialization. Process: enumerate egress sites, rewrite with explicit ConnectionProvider + providerConfigKey + connectionId params, update webhook/proactive/follow-up/stale-thread/context-watcher/pr-matcher call sites, satisfy ConnectionProvider in test fakes, delete src/nango.ts last. Priorities: no hardcoded providerConfigKey > wire-format fidelity > churn minimization > conciseness. Avoid default 'slack-sage', module singletons, team_id-derived keys, SDK-layer mocks. Output contract: rewritten sites, deleted symbols, updated tests, grep evidence of no hardcoded providerConfigKey.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1000 }
+    },
+    "minimum": {
+      "harness": "opencode",
+      "model": "opencode/minimax-m2.5-free",
+      "systemPrompt": "You are a concise sage Slack egress migrator. Same merge-quality bar; only limit depth. Required: thread providerConfigKey + connectionId from envelope at every egress call site; rewrite NangoClient calls to ConnectionProvider; update webhook and proactive paths; delete src/nango.ts and NANGO_SLACK_* reads; update tests to wire-format fidelity. Never default providerConfigKey, never derive it from team_id, never mock at the SDK layer. Output contract: rewritten sites, deleted symbols, updated tests, grep evidence of no hardcoded providerConfigKey.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 700 }
+    }
+  }
+}

--- a/packages/personas/scripts/validate-personas.mjs
+++ b/packages/personas/scripts/validate-personas.mjs
@@ -51,6 +51,12 @@ function validatePersona(filename, persona) {
         if (typeof skill.id !== 'string' || skill.id.length === 0) {
           errors.push(`skills[${idx}].id must be a non-empty string`);
         }
+        if (typeof skill.source !== 'string' || skill.source.length === 0) {
+          errors.push(`skills[${idx}].source must be a non-empty string`);
+        }
+        if (typeof skill.description !== 'string' || skill.description.length === 0) {
+          errors.push(`skills[${idx}].description must be a non-empty string`);
+        }
       });
     }
   }

--- a/packages/personas/scripts/validate-personas.mjs
+++ b/packages/personas/scripts/validate-personas.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, basename } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = dirname(here);
+const personasDir = join(root, 'personas');
+const KNOWN_TIERS = ['best', 'best-value', 'minimum'];
+
+async function loadPersonaFiles() {
+  const entries = await readdir(personasDir);
+  return entries.filter((name) => name.endsWith('.json')).sort();
+}
+
+function validatePersona(filename, persona) {
+  const errors = [];
+  const expectedId = basename(filename, '.json');
+
+  if (typeof persona !== 'object' || persona === null || Array.isArray(persona)) {
+    errors.push('persona must be a JSON object');
+    return errors;
+  }
+
+  if (typeof persona.id !== 'string' || persona.id.length === 0) {
+    errors.push('missing required string field: id');
+  } else if (persona.id !== expectedId) {
+    errors.push(`id "${persona.id}" does not match filename "${expectedId}"`);
+  }
+
+  if (typeof persona.intent !== 'string' || persona.intent.length === 0) {
+    errors.push('missing required string field: intent');
+  }
+  if (typeof persona.description !== 'string' || persona.description.length === 0) {
+    errors.push('missing required string field: description');
+  }
+
+  if (persona.tags !== undefined && !Array.isArray(persona.tags)) {
+    errors.push('tags must be an array when present');
+  }
+
+  if (persona.skills !== undefined) {
+    if (!Array.isArray(persona.skills)) {
+      errors.push('skills must be an array when present');
+    } else {
+      persona.skills.forEach((skill, idx) => {
+        if (typeof skill !== 'object' || skill === null) {
+          errors.push(`skills[${idx}] must be an object`);
+          return;
+        }
+        if (typeof skill.id !== 'string' || skill.id.length === 0) {
+          errors.push(`skills[${idx}].id must be a non-empty string`);
+        }
+      });
+    }
+  }
+
+  if (typeof persona.tiers !== 'object' || persona.tiers === null || Array.isArray(persona.tiers)) {
+    errors.push('missing required object field: tiers');
+    return errors;
+  }
+
+  const tierKeys = Object.keys(persona.tiers);
+  const validTierKeys = tierKeys.filter((k) => KNOWN_TIERS.includes(k));
+  if (validTierKeys.length === 0) {
+    errors.push(`tiers must include at least one of: ${KNOWN_TIERS.join(', ')}`);
+  }
+
+  for (const [tierName, tier] of Object.entries(persona.tiers)) {
+    if (!KNOWN_TIERS.includes(tierName)) {
+      errors.push(`unknown tier "${tierName}" (expected one of: ${KNOWN_TIERS.join(', ')})`);
+      continue;
+    }
+    if (typeof tier !== 'object' || tier === null) {
+      errors.push(`tiers.${tierName} must be an object`);
+      continue;
+    }
+    if (typeof tier.harness !== 'string' || tier.harness.length === 0) {
+      errors.push(`tiers.${tierName}.harness must be a non-empty string`);
+    }
+    if (typeof tier.model !== 'string' || tier.model.length === 0) {
+      errors.push(`tiers.${tierName}.model must be a non-empty string`);
+    }
+    if (typeof tier.systemPrompt !== 'string' || tier.systemPrompt.length === 0) {
+      errors.push(`tiers.${tierName}.systemPrompt must be a non-empty string`);
+    }
+    if (
+      tier.harnessSettings !== undefined &&
+      (typeof tier.harnessSettings !== 'object' || tier.harnessSettings === null || Array.isArray(tier.harnessSettings))
+    ) {
+      errors.push(`tiers.${tierName}.harnessSettings must be an object when present`);
+    }
+  }
+
+  return errors;
+}
+
+async function main() {
+  const files = await loadPersonaFiles();
+  if (files.length === 0) {
+    console.error(`no persona JSON files found in ${personasDir}`);
+    process.exit(1);
+  }
+
+  let failed = 0;
+  const seenIds = new Map();
+
+  for (const file of files) {
+    const fullPath = join(personasDir, file);
+    let persona;
+    try {
+      const raw = await readFile(fullPath, 'utf8');
+      persona = JSON.parse(raw);
+    } catch (err) {
+      console.error(`✗ ${file}: failed to parse JSON — ${err?.message ?? err}`);
+      failed++;
+      continue;
+    }
+
+    const errors = validatePersona(file, persona);
+
+    if (typeof persona?.id === 'string') {
+      if (seenIds.has(persona.id)) {
+        errors.push(`duplicate persona id "${persona.id}" (also defined in ${seenIds.get(persona.id)})`);
+      } else {
+        seenIds.set(persona.id, file);
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error(`✗ ${file}`);
+      for (const e of errors) console.error(`    - ${e}`);
+      failed++;
+    } else {
+      console.log(`✓ ${file}`);
+    }
+  }
+
+  console.log(`\nvalidated ${files.length} persona file(s), ${failed} failure(s)`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('validator crashed:', err);
+  process.exit(1);
+});

--- a/packages/personas/scripts/validate-personas.mjs
+++ b/packages/personas/scripts/validate-personas.mjs
@@ -7,10 +7,14 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = dirname(here);
 const personasDir = join(root, 'personas');
 const KNOWN_TIERS = ['best', 'best-value', 'minimum'];
+const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
 
 async function loadPersonaFiles() {
-  const entries = await readdir(personasDir);
-  return entries.filter((name) => name.endsWith('.json')).sort();
+  const entries = await readdir(personasDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => entry.name)
+    .sort();
 }
 
 function validatePersona(filename, persona) {
@@ -22,16 +26,16 @@ function validatePersona(filename, persona) {
     return errors;
   }
 
-  if (typeof persona.id !== 'string' || persona.id.length === 0) {
+  if (!isNonEmptyString(persona.id)) {
     errors.push('missing required string field: id');
   } else if (persona.id !== expectedId) {
     errors.push(`id "${persona.id}" does not match filename "${expectedId}"`);
   }
 
-  if (typeof persona.intent !== 'string' || persona.intent.length === 0) {
+  if (!isNonEmptyString(persona.intent)) {
     errors.push('missing required string field: intent');
   }
-  if (typeof persona.description !== 'string' || persona.description.length === 0) {
+  if (!isNonEmptyString(persona.description)) {
     errors.push('missing required string field: description');
   }
 
@@ -48,13 +52,13 @@ function validatePersona(filename, persona) {
           errors.push(`skills[${idx}] must be an object`);
           return;
         }
-        if (typeof skill.id !== 'string' || skill.id.length === 0) {
+        if (!isNonEmptyString(skill.id)) {
           errors.push(`skills[${idx}].id must be a non-empty string`);
         }
-        if (typeof skill.source !== 'string' || skill.source.length === 0) {
+        if (!isNonEmptyString(skill.source)) {
           errors.push(`skills[${idx}].source must be a non-empty string`);
         }
-        if (typeof skill.description !== 'string' || skill.description.length === 0) {
+        if (!isNonEmptyString(skill.description)) {
           errors.push(`skills[${idx}].description must be a non-empty string`);
         }
       });
@@ -77,17 +81,17 @@ function validatePersona(filename, persona) {
       errors.push(`unknown tier "${tierName}" (expected one of: ${KNOWN_TIERS.join(', ')})`);
       continue;
     }
-    if (typeof tier !== 'object' || tier === null) {
+    if (typeof tier !== 'object' || tier === null || Array.isArray(tier)) {
       errors.push(`tiers.${tierName} must be an object`);
       continue;
     }
-    if (typeof tier.harness !== 'string' || tier.harness.length === 0) {
+    if (!isNonEmptyString(tier.harness)) {
       errors.push(`tiers.${tierName}.harness must be a non-empty string`);
     }
-    if (typeof tier.model !== 'string' || tier.model.length === 0) {
+    if (!isNonEmptyString(tier.model)) {
       errors.push(`tiers.${tierName}.model must be a non-empty string`);
     }
-    if (typeof tier.systemPrompt !== 'string' || tier.systemPrompt.length === 0) {
+    if (!isNonEmptyString(tier.systemPrompt)) {
       errors.push(`tiers.${tierName}.systemPrompt must be a non-empty string`);
     }
     if (


### PR DESCRIPTION
## Summary

Adds `@agentrelay/personas`, a Relay-owned AgentWorkforce persona pack, as a new workspace package at `packages/personas`. Relay-specific personas now live with the Relay source they describe instead of remaining bundled inside `workforce`. `persona-maker` intentionally stays in `workforce` because `agentworkforce create` depends on it.

Closes #816.

## What's included

- `packages/personas/package.json` — published as `@agentrelay/personas`, with the `agentworkforce.personas: "personas"` discovery field, `publishConfig.access: public`, MIT license, and an independent `0.1.0` version.
- `packages/personas/README.md` — install / pin / local-checkout instructions, persona table, persona-shape reference, and migration notes.
- `packages/personas/personas/*.json` — the eight Relay-specific personas migrated from `AgentWorkforce/workforce/personas` with stable ids and basenames preserved:
  - `relay-orchestrator`
  - `agent-relay-workflow`
  - `agent-relay-e2e-conductor`
  - `cloud-sandbox-infra`
  - `cloud-slack-proxy-guard`
  - `sage-slack-egress-migrator`
  - `sage-proactive-rewirer`
  - `opencode-workflow-specialist`
- `packages/personas/scripts/validate-personas.mjs` — zero-dependency validator (run via `npm --prefix packages/personas run validate` or `npm test`) that checks every persona file is valid JSON, `id` matches the filename, `intent` / `description` / `tiers` are present, at least one of the known tiers (`best`, `best-value`, `minimum`) is set, and each tier has `harness` / `model` / `systemPrompt`.

## Acceptance criteria

- [x] `packages/personas/package.json` exists with `name: "@agentrelay/personas"` and `agentworkforce.personas: "personas"`.
- [x] Relay-specific persona JSON files live under `packages/personas/personas`.
- [x] README documents install commands, version pinning, and the included personas.
- [x] Persona JSON files are validated by a script (`scripts/validate-personas.mjs`).
- [x] The package is consumable locally via `agentworkforce install ./packages/personas`.
- [x] The package is ready to publish publicly to npm (`publishConfig.access: public`).
- [x] Workforce docs/issues can point users at `@agentrelay/personas` instead of relying on built-in Relay personas.

## Open questions for review

The issue flagged a few release/publishing decisions that this PR makes default choices on — happy to flip any of them:

- **npm scope**: used `@agentrelay/personas` as specified in the issue title and acceptance criteria, even though existing repo packages use `@agent-relay`. Reviewer can pick a different scope before publish.
- **versioning**: independent `0.1.0`, not tied to the Relay root `6.0.9`. Easy to swap if you'd rather it follow root.
- **release flow**: not yet wired into the existing workspace release flow. Can be added in a follow-up once scope/versioning is settled.
- **`opencode-workflow-specialist`**: included here for now per the issue's persona list; can be moved to a separate AgentWorkforce/OpenCode pack later without breaking ids.

## Test plan

- [x] `node packages/personas/scripts/validate-personas.mjs` — passes for all 8 personas.
- [ ] `agentworkforce install ./packages/personas` against a checkout (cross-repo manual check before publish).
- [ ] `agentworkforce install ./packages/personas --persona relay-orchestrator` (cross-repo manual check before publish).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXqHq9Cd5Xb2su7QjQnneC)_