### PR TITLE
fix(relaycast-mcp): trust at_live_* agent tokens, drop probe-then-rotate

### DIFF
--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -245,8 +245,13 @@ export interface SpawnOptions extends SpawnLifecycleHooks {
   shadowMode?: string;
   idleThresholdSecs?: number;
   restartPolicy?: RestartPolicy;
-  /** JWT token for relayauth/relayfile permissions. When set, the broker
-   *  injects RELAY_AGENT_TOKEN into the agent's environment. */
+  /** Optional pre-minted relaycast agent token (`at_live_<hex>`, from
+   *  `registerAgent(workspaceKey, name)` in `@agent-relay/sdk/http`). The
+   *  broker plumbs this as `RELAY_AGENT_TOKEN`, which the relaycast MCP
+   *  authenticates with. When omitted, the relaycast MCP auto-mints a token
+   *  using `RELAY_API_KEY` + the spawn name; that is the recommended path.
+   *  Note: this is a relaycast credential, NOT a relayfile/relayauth token —
+   *  override `env.RELAYFILE_TOKEN` on the constructor for relayfile auth. */
   agentToken?: string;
   /** When true, skip injecting the relay MCP configuration and protocol prompt into the spawned agent.
    *  Useful for minor tasks where relay messaging is not needed, saving tokens. */
@@ -355,8 +360,13 @@ export interface SpawnerSpawnOptions extends SpawnLifecycleHooks {
   model?: string;
   cwd?: string;
   idleThresholdSecs?: number;
-  /** JWT token for relayauth/relayfile permissions. When set, the broker
-   *  injects RELAY_AGENT_TOKEN into the agent's environment. */
+  /** Optional pre-minted relaycast agent token (`at_live_<hex>`, from
+   *  `registerAgent(workspaceKey, name)` in `@agent-relay/sdk/http`). The
+   *  broker plumbs this as `RELAY_AGENT_TOKEN`, which the relaycast MCP
+   *  authenticates with. When omitted, the relaycast MCP auto-mints a token
+   *  using `RELAY_API_KEY` + the spawn name; that is the recommended path.
+   *  Note: this is a relaycast credential, NOT a relayfile/relayauth token —
+   *  override `env.RELAYFILE_TOKEN` on the constructor for relayfile auth. */
   agentToken?: string;
   /** When true, skip injecting the relay MCP configuration and protocol prompt into the spawned agent.
    *  Useful for minor tasks where relay messaging is not needed, saving tokens. */
@@ -764,9 +774,8 @@ export class AgentRelay {
     }
 
     const spawnCwd = options.cwd ?? process.cwd();
-    const writes = spec.configFiles.length > 0
-      ? materializePersonaConfigFiles(spawnCwd, spec.configFiles)
-      : [];
+    const writes =
+      spec.configFiles.length > 0 ? materializePersonaConfigFiles(spawnCwd, spec.configFiles) : [];
 
     const baseArgs = options.args ?? [];
     const mergedArgs = [...spec.args, ...baseArgs];

--- a/src/cli/relaycast-mcp.startup.test.ts
+++ b/src/cli/relaycast-mcp.startup.test.ts
@@ -74,7 +74,10 @@ async function loadRelaycastMcpModule(options: LoadOptions = {}) {
       }
     });
     readonly server: {
-      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<{ tools?: Array<Record<string, unknown>> }>>;
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra: unknown) => Promise<{ tools?: Array<Record<string, unknown>> }>
+      >;
       setRequestHandler: ReturnType<typeof vi.fn>;
       sendResourceUpdated: ReturnType<typeof vi.fn>;
     };
@@ -99,9 +102,11 @@ async function loadRelaycastMcpModule(options: LoadOptions = {}) {
             })),
           ],
         ]),
-        setRequestHandler: vi.fn((_schema: unknown, handler: (req: unknown, extra: unknown) => Promise<any>) => {
-          this.listToolsHandler = handler;
-        }),
+        setRequestHandler: vi.fn(
+          (_schema: unknown, handler: (req: unknown, extra: unknown) => Promise<any>) => {
+            this.listToolsHandler = handler;
+          }
+        ),
         sendResourceUpdated: vi.fn(async (_payload: unknown) => undefined),
       };
       serverInstances.push(this);
@@ -116,19 +121,23 @@ async function loadRelaycastMcpModule(options: LoadOptions = {}) {
     }
   }
 
-  const createInternalRelayCast = vi.fn((config: Record<string, unknown>, origin: Record<string, unknown>) => {
-    const inbox = vi.fn(async (token?: string) => behavior.inboxImpl(String(token ?? '')));
-    const registerOrRotate = vi.fn(async (input: { name: string; type?: string }) => behavior.registerImpl(input));
-    const as = vi.fn((token: string) => ({
-      inbox: vi.fn(async () => behavior.inboxImpl(token)),
-      token,
-    }));
-    relayInstances.push({ config, origin, inbox, registerOrRotate, as });
-    return {
-      agents: { registerOrRotate },
-      as,
-    };
-  });
+  const createInternalRelayCast = vi.fn(
+    (config: Record<string, unknown>, origin: Record<string, unknown>) => {
+      const inbox = vi.fn(async (token?: string) => behavior.inboxImpl(String(token ?? '')));
+      const registerOrRotate = vi.fn(async (input: { name: string; type?: string }) =>
+        behavior.registerImpl(input)
+      );
+      const as = vi.fn((token: string) => ({
+        inbox: vi.fn(async () => behavior.inboxImpl(token)),
+        token,
+      }));
+      relayInstances.push({ config, origin, inbox, registerOrRotate, as });
+      return {
+        agents: { registerOrRotate },
+        as,
+      };
+    }
+  );
 
   const createInternalWsClient = vi.fn((config: Record<string, unknown>, origin: Record<string, unknown>) => {
     if (options.wsClientThrows) {
@@ -164,7 +173,9 @@ async function loadRelaycastMcpModule(options: LoadOptions = {}) {
   vi.doMock('@relaycast/mcp', () => ({ MCP_VERSION: 'test-mcp-version' }));
   vi.doMock('@relaycast/mcp/dist/piggyback.js', () => ({ enablePiggyback }));
   vi.doMock('@relaycast/mcp/dist/resources/definitions.js', () => ({ registerResourceDefinitions }));
-  vi.doMock('@relaycast/mcp/dist/resources/subscriptions.js', () => ({ SubscriptionManager: FakeSubscriptionManager }));
+  vi.doMock('@relaycast/mcp/dist/resources/subscriptions.js', () => ({
+    SubscriptionManager: FakeSubscriptionManager,
+  }));
   vi.doMock('@relaycast/mcp/dist/tools/channels.js', () => ({ registerChannelTools }));
   vi.doMock('@relaycast/mcp/dist/tools/features.js', () => ({ registerFeatureTools }));
   vi.doMock('@relaycast/mcp/dist/tools/messaging.js', () => ({ registerMessagingTools }));
@@ -290,7 +301,9 @@ describe('createPatchedRelayMcpServer', () => {
       persona: 'Coverage tester',
       metadata: { model: 'gpt-5' },
     });
-    const workspaceRelay = mocks.relayInstances.find((instance) => instance.config.apiKey === 'rk_live_created');
+    const workspaceRelay = mocks.relayInstances.find(
+      (instance) => instance.config.apiKey === 'rk_live_created'
+    );
     expect(workspaceRelay?.registerOrRotate).toHaveBeenCalledWith({
       name: 'WorkerA',
       type: 'human',
@@ -414,7 +427,7 @@ describe('resolvePatchedStdioBootstrapOptions', () => {
     });
   });
 
-  it('reuses an existing agent token when inbox auth succeeds', async () => {
+  it('trusts an at_live_* agent token without probing or rotating', async () => {
     const { mod, mocks } = await loadRelaycastMcpModule();
     const options = {
       apiKey: 'rk_live_workspace',
@@ -427,53 +440,59 @@ describe('resolvePatchedStdioBootstrapOptions', () => {
     const result = await mod.resolvePatchedStdioBootstrapOptions(options);
 
     expect(result).toEqual(options);
-    expect(mocks.behavior.inboxImpl).toHaveBeenCalledWith('at_live_existing');
+    // No probe — D1 read-replica lag can spuriously 401 a fresh token, and
+    // rotating UPDATEs the tokenHash, permanently killing the original.
+    expect(mocks.behavior.inboxImpl).not.toHaveBeenCalled();
     expect(mocks.behavior.registerImpl).not.toHaveBeenCalled();
   });
 
-  it('rotates the agent token when the previous token is unauthorized', async () => {
+  it('mints a relaycast token when the caller provides a non-relaycast token (e.g. JWT)', async () => {
     const { mod, mocks } = await loadRelaycastMcpModule();
-    mocks.behavior.inboxImpl = vi.fn(async () => {
-      throw { statusCode: 401 };
-    });
     mocks.behavior.registerImpl = vi.fn(async () => ({
-      name: 'WorkerA-rebound',
-      token: 'at_live_rebound',
+      name: 'WorkerA',
+      token: 'at_live_minted',
     }));
 
     const result = await mod.resolvePatchedStdioBootstrapOptions({
       apiKey: 'rk_live_workspace',
       agentName: 'WorkerA',
-      agentToken: 'at_live_stale',
+      // A relayauth RS256 JWT, as `relay on start` plumbs into RELAY_AGENT_TOKEN.
+      agentToken: 'eyJhbGciOiJSUzI1NiJ9.payload.sig',
       agentType: 'human',
     });
 
+    expect(mocks.behavior.inboxImpl).not.toHaveBeenCalled();
     expect(mocks.behavior.registerImpl).toHaveBeenCalledWith({
       name: 'WorkerA',
       type: 'human',
     });
     expect(result).toEqual({
       apiKey: 'rk_live_workspace',
-      agentName: 'WorkerA-rebound',
-      agentToken: 'at_live_rebound',
+      agentName: 'WorkerA',
+      agentToken: 'at_live_minted',
       agentType: 'human',
     });
   });
 
-  it('rethrows non-auth inbox failures instead of silently rebinding', async () => {
+  it('mints a relaycast token when no agentToken is provided', async () => {
     const { mod, mocks } = await loadRelaycastMcpModule();
-    const failure = new Error('relay unavailable');
-    mocks.behavior.inboxImpl = vi.fn(async () => {
-      throw failure;
+    mocks.behavior.registerImpl = vi.fn(async () => ({
+      name: 'WorkerA',
+      token: 'at_live_minted',
+    }));
+
+    const result = await mod.resolvePatchedStdioBootstrapOptions({
+      apiKey: 'rk_live_workspace',
+      agentName: 'WorkerA',
+      agentType: 'agent',
     });
 
-    await expect(
-      mod.resolvePatchedStdioBootstrapOptions({
-        apiKey: 'rk_live_workspace',
-        agentName: 'WorkerA',
-        agentToken: 'at_live_existing',
-      })
-    ).rejects.toBe(failure);
+    expect(mocks.behavior.inboxImpl).not.toHaveBeenCalled();
+    expect(mocks.behavior.registerImpl).toHaveBeenCalledWith({
+      name: 'WorkerA',
+      type: 'agent',
+    });
+    expect(result.agentToken).toBe('at_live_minted');
   });
 });
 

--- a/src/cli/relaycast-mcp.ts
+++ b/src/cli/relaycast-mcp.ts
@@ -529,9 +529,28 @@ export function createPatchedRelayMcpServer(options: PatchedMcpServerOptions): M
   return mcpServer;
 }
 
+/** Relaycast agent tokens are opaque `at_live_<hex>` literals — see
+ * relaycast/packages/server/src/engine/agent.ts:38. Anything else (e.g. a
+ * relayauth RS256 JWT carried in RELAY_AGENT_TOKEN by `relay on start`) is not
+ * a valid relaycast credential and must be replaced. */
+function isRelaycastAgentToken(token: string | undefined): token is string {
+  return typeof token === 'string' && token.startsWith('at_live_');
+}
+
 export async function resolvePatchedStdioBootstrapOptions(
   options: PatchedMcpServerOptions
 ): Promise<PatchedMcpServerOptions> {
+  // Caller already minted a relaycast agent token — trust it. We must not
+  // probe-then-rotate here: rotation UPDATEs the agent's tokenHash, which
+  // permanently kills the original token, and on D1 read-replica lag a
+  // freshly-minted token can transiently fail an auth probe even though it is
+  // valid. The first real call will surface a 401 if the token is actually
+  // bad; that's a clearer failure mode than silently swapping the agent's
+  // identity behind the caller's back.
+  if (isRelaycastAgentToken(options.agentToken)) {
+    return options;
+  }
+
   if (!options.apiKey || !options.agentName) {
     return options;
   }
@@ -547,20 +566,6 @@ export async function resolvePatchedStdioBootstrapOptions(
       version: MCP_VERSION,
     }
   );
-
-  if (options.agentToken) {
-    try {
-      await relay.as(options.agentToken).inbox();
-      return options;
-    } catch (err) {
-      const relayErr = err as { code?: string; statusCode?: number } | undefined;
-      const unauthorized =
-        relayErr?.code === 'unauthorized' || relayErr?.statusCode === 401 || relayErr?.statusCode === 403;
-      if (!unauthorized) {
-        throw err;
-      }
-    }
-  }
 
   const registered = await relay.agents.registerOrRotate({
     name: options.agentName,


### PR DESCRIPTION
## Summary

- Bootstrap path no longer probes-then-rotates: a relaycast-shaped (`at_live_*`) token is now trusted as-is. We only mint via `registerOrRotate` when the caller passed no token or a non-relaycast format (e.g. a relayauth JWT, as `relay on start` plumbs into `RELAY_AGENT_TOKEN`).
- Updates the SDK JSDoc on `agentToken` so callers stop confusing it with a relayfile/relayauth token.

## Why

Reproducing the cortical-demo end-to-end surfaced "Invalid agent token" on the first `message.post` with a freshly-minted token. Tracing the failure to `resolvePatchedStdioBootstrapOptions`:

1. Orchestrator pre-mints `T1` via `registerAgent`.
2. Broker spawns the agent with `RELAY_AGENT_TOKEN=T1`.
3. MCP probes `inbox()` with `T1`. On D1 read-replica lag, this transiently 401s for a token that is genuinely valid.
4. The 401 path falls through to `registerOrRotate`, which **UPDATEs** the agent's `tokenHash` — `T1` is now permanently dead.
5. `session.agentToken = T2`. Subsequent `message.post` calls land on a replica that still has `hash(T1)` (or hasn't yet propagated `hash(T2)`) and surface "Invalid agent token".

The rotation isn't recoverable; the original token has been silently invalidated behind the caller's back. The fix is to trust the relaycast-shaped token. If the passed token is actually invalid, the first real call surfaces a clean 401 — same observable, without the destructive identity swap.

## Behavior matrix

| Caller passes | Old behavior | New behavior |
|---|---|---|
| `at_live_*` (SDK orchestrator, MCP register tool, etc.) | probe → on lag-401 → rotate → kill original | trust as-is |
| RS256 JWT (`relay on start` -> `RELAY_AGENT_TOKEN`) | probe → 401 → rotate → at_live_X | mint at_live_X (no probe) |
| nothing | mint at_live_X | mint at_live_X (no change) |

## Test plan

- [x] `npx vitest run src/cli/relaycast-mcp.startup.test.ts src/cli/relaycast-mcp.test.ts` — 14/14 green
- [x] Tests cover: trust at_live_*, mint on JWT, mint when absent, the registerAgentWithRebind tool path
- [ ] cortical-demo: `npm run demo`, edit Notion page, observe `[#general] notion-summarizer-…: <summary>` within 60s and the Slack handoff (companion change in `demos` repo drops the now-unnecessary pre-mint)
- [ ] `relay on start` smoke: run a session, confirm the JWT-shaped `RELAY_AGENT_TOKEN` still mints a fresh `at_live_*` and messaging works end-to-end

## Follow-ups (separate PRs)

- Spec Fix 2: `applyWorkspaceEnv` in `packages/sdk/src/relay.ts` writes the relaycast workspace id into `RELAYFILE_WORKSPACE`, causing `403 workspace mismatch` when the relayfile workspace differs.
- Spec Fix 5: `@relayfile/sdk` `agentInvite({scopes})` is metadata-only; either remove the parameter or wire to a relayauth child-token mint.
- Cut `@relayfile/sdk > 0.6.12` to surface the stale-token-shadow fix already on `relayfile@d6a9439`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)