### PR TITLE
fix(sdk): stop stamping relaycast workspace id into RELAYFILE_WORKSPACE

### DIFF
--- a/packages/sdk/src/__tests__/unit.test.ts
+++ b/packages/sdk/src/__tests__/unit.test.ts
@@ -456,13 +456,15 @@ test('ensureRelaycastApiKey: workspaceId reuses stored mapping and injects unifi
     const opts = (relay as unknown as { clientOptions: { env?: Record<string, string> } }).clientOptions;
     assert.equal(relay.workspaceKey, 'rk_live_cached');
     assert.equal(opts.env?.RELAY_API_KEY, 'rk_live_cached');
-    assert.equal(opts.env?.RELAYFILE_WORKSPACE, 'rw_cached123');
     assert.equal(opts.env?.RELAY_DEFAULT_WORKSPACE, 'rw_cached123');
     assert.equal(opts.env?.RELAY_WORKSPACE_ID, 'rw_cached123');
     assert.equal(
       opts.env?.RELAY_WORKSPACES_JSON,
       JSON.stringify([{ workspace_id: 'rw_cached123', api_key: 'rk_live_cached' }])
     );
+    // applyWorkspaceEnv must not override RELAYFILE_WORKSPACE — relaycast
+    // and relayfile workspace ids are independent.
+    assert.equal(opts.env?.RELAYFILE_WORKSPACE, undefined);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
@@ -515,14 +517,62 @@ test('ensureRelaycastApiKey: auto-generates a unified workspaceId for env-provid
     await (relay as unknown as { ensureRelaycastApiKey: () => Promise<void> }).ensureRelaycastApiKey();
 
     const opts = (relay as unknown as { clientOptions: { env?: Record<string, string> } }).clientOptions;
-    const workspaceId = opts.env?.RELAYFILE_WORKSPACE;
+    const workspaceId = opts.env?.RELAY_WORKSPACE_ID;
     assert.match(workspaceId ?? '', /^rw_[a-z0-9]{8}$/);
+    // Auto-generated relaycast id must not leak into RELAYFILE_WORKSPACE.
+    assert.equal(opts.env?.RELAYFILE_WORKSPACE, undefined);
 
     const registry = JSON.parse(await readFile(join(cwd, '.relay', 'workspaces.json'), 'utf8')) as Record<
       string,
       any
     >;
     assert.equal(registry[workspaceId!].relaycastApiKey, 'rk_live_env');
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test('ensureRelaycastApiKey: preserves caller-provided RELAYFILE_WORKSPACE', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'agent-relay-sdk-'));
+  try {
+    await mkdir(join(cwd, '.relay'), { recursive: true });
+    await writeFile(
+      join(cwd, '.relay', 'workspaces.json'),
+      `${JSON.stringify(
+        {
+          rw_relaycast: {
+            relaycastApiKey: 'rk_live_cached',
+            relayfileUrl: 'http://127.0.0.1:8080',
+            createdAt: '2026-03-27T00:00:00Z',
+            agents: ['codex'],
+          },
+        },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    );
+
+    const relay = new AgentRelay({
+      channels: ['general'],
+      cwd,
+      workspaceId: 'rw_relaycast',
+      env: {
+        RELAYFILE_WORKSPACE: 'rw_relayfile_caller_set',
+        RELAYFILE_TOKEN: 'eyJ.caller.jwt',
+        PATH: '/usr/bin',
+      },
+    });
+    await (relay as unknown as { ensureRelaycastApiKey: () => Promise<void> }).ensureRelaycastApiKey();
+
+    const opts = (relay as unknown as { clientOptions: { env?: Record<string, string> } }).clientOptions;
+    // Caller's RELAYFILE_WORKSPACE survives — relaycast and relayfile
+    // workspaces are independent ids.
+    assert.equal(opts.env?.RELAYFILE_WORKSPACE, 'rw_relayfile_caller_set');
+    assert.equal(opts.env?.RELAYFILE_TOKEN, 'eyJ.caller.jwt');
+    // Relaycast routing vars still reflect the relaycast workspace.
+    assert.equal(opts.env?.RELAY_WORKSPACE_ID, 'rw_relaycast');
+    assert.equal(opts.env?.RELAY_DEFAULT_WORKSPACE, 'rw_relaycast');
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -374,8 +374,13 @@ export interface AgentRelayOptions {
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
   /**
-   * Unified workspace ID shared across relayfile, relayauth claims, and
-   * relaycast key lookup.
+   * Relaycast workspace ID. Auto-generated when omitted. This is the id used
+   * for relaycast key lookup and surfaced via `RELAY_WORKSPACE_ID` /
+   * `RELAY_DEFAULT_WORKSPACE` to spawned agents.
+   *
+   * NOTE: this is a relaycast id, not a relayfile workspace id. They are
+   * independent. If the caller wants spawned agents to talk to a specific
+   * relayfile workspace, set `env.RELAYFILE_WORKSPACE` on the constructor.
    */
   workspaceId?: string;
   /**
@@ -597,10 +602,16 @@ export class AgentRelay {
   }
 
   private applyWorkspaceEnv(workspaceId: string, apiKey: string): void {
+    // `workspaceId` here is the **relaycast** workspace id resolved by this
+    // SDK (auto-created or caller-supplied via `new AgentRelay({ workspaceId })`).
+    // Do NOT write it into `RELAYFILE_WORKSPACE` — relayfile and relaycast
+    // workspaces are independent ids and a relayfile JWT scoped to a
+    // different workspace will 403 with "workspace mismatch". Callers that
+    // share an id across both services (e.g. the canonical `relay on start`
+    // flow) set `RELAYFILE_WORKSPACE` themselves.
     const env: NodeJS.ProcessEnv = {
       ...(this.clientOptions.env ?? process.env),
       RELAY_API_KEY: apiKey,
-      RELAYFILE_WORKSPACE: workspaceId,
       RELAY_DEFAULT_WORKSPACE: workspaceId,
       RELAY_WORKSPACE_ID: workspaceId,
       RELAY_WORKSPACES_JSON: JSON.stringify([{ workspace_id: workspaceId, api_key: apiKey }]),
@@ -764,9 +775,8 @@ export class AgentRelay {
     }
 
     const spawnCwd = options.cwd ?? process.cwd();
-    const writes = spec.configFiles.length > 0
-      ? materializePersonaConfigFiles(spawnCwd, spec.configFiles)
-      : [];
+    const writes =
+      spec.configFiles.length > 0 ? materializePersonaConfigFiles(spawnCwd, spec.configFiles) : [];
 
     const baseArgs = options.args ?? [];
     const mergedArgs = [...spec.args, ...baseArgs];


### PR DESCRIPTION
## Summary

- `applyWorkspaceEnv()` no longer writes `RELAYFILE_WORKSPACE`. The resolved id is a relaycast workspace id and has no claim to a relayfile env var.
- Caller-provided `env.RELAYFILE_WORKSPACE` is now preserved through workspace resolution.
- New unit test asserts the preservation.
- Updates `AgentRelayOptions.workspaceId` JSDoc to document the relaycast-vs-relayfile distinction.

## Why

The previous behavior stamped the resolved relaycast workspace id into `RELAYFILE_WORKSPACE` alongside the relaycast routing vars:

```ts
const env: NodeJS.ProcessEnv = {
  ...(this.clientOptions.env ?? process.env),
  RELAY_API_KEY: apiKey,
  RELAYFILE_WORKSPACE: workspaceId,    // ← clobbered relayfile workspace
  RELAY_DEFAULT_WORKSPACE: workspaceId,
  RELAY_WORKSPACE_ID: workspaceId,
  ...
};
```

Any caller using a pre-existing relayfile workspace (e.g. `relayfile login` already set up `rw_517d60b6`) and a freshly-created relaycast workspace (auto-generated `rw_rnmjyboo`) would see the relayfile id silently overwritten. The relayfile MCP then sent the wrong id to the relayfile API → `403 forbidden: workspace mismatch`.

The cortical-demo orchestrator was working around this by passing `workspaceId: workspace.workspaceId` so AgentRelay reused the relayfile id as its relaycast id — fragile, only worked because relaycast happens to accept arbitrary client-supplied ids. The proper fix is to stop conflating them.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Caller passes `env.RELAYFILE_WORKSPACE = 'rw_X'`, AgentRelay resolves relaycast id `rw_Y` | `RELAYFILE_WORKSPACE='rw_Y'` (overwritten) → 403 | `RELAYFILE_WORKSPACE='rw_X'` (preserved) ✓ |
| Caller passes nothing, AgentRelay resolves relaycast id `rw_Y` | `RELAYFILE_WORKSPACE='rw_Y'` (wrong namespace) | `RELAYFILE_WORKSPACE` unset; caller sets it explicitly when needed |
| `relay on start` (canonical flow) | `RELAYFILE_WORKSPACE` set in `buildAgentEnv` to the unified id, unaffected by SDK | Same — `start.ts` sets it directly, never via `applyWorkspaceEnv` |

## Test plan

- [x] `node --test packages/sdk/src/__tests__/unit.test.ts` — 27/28 pass; the one fail is a pre-existing flake (hardcoded `createdAt` date assertion at line 502, untouched by this PR)
- [x] New test `ensureRelaycastApiKey: preserves caller-provided RELAYFILE_WORKSPACE` covers the acceptance criterion
- [x] `tsc --noEmit -p .` clean
- [ ] cortical-demo: after this lands + #819, drop the `workspaceId: workspace.workspaceId` workaround from `scripts/orchestrator.ts` and confirm the demo still runs

## Companion to

- AgentWorkforce/relay#819 — the relaycast MCP probe-then-rotate root-cause fix.

## Out of scope

- Spec Fix 5 (`@relayfile/sdk` `agentInvite({scopes})` is metadata-only) — separate PR in the relayfile repo.
- Cutting `@relayfile/sdk > 0.6.12` for the stale-token-shadow fix already on `relayfile@d6a9439`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)