### PR TITLE
fix(broker): stop stamping default_workspace_id into RELAYFILE_WORKSPACE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1094,10 +1094,13 @@ async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Result<()> {
         ),
     ];
     if let Some(default_workspace_id) = default_workspace_id.clone() {
-        worker_env.push((
-            "RELAYFILE_WORKSPACE".to_string(),
-            default_workspace_id.clone(),
-        ));
+        // Do NOT stamp RELAYFILE_WORKSPACE from default_workspace_id. The
+        // relaycast workspace id and the relayfile workspace id are
+        // independent — a relayfile JWT scoped to a different workspace will
+        // 403 with "workspace mismatch" when the relayfile MCP sends the
+        // wrong id. Callers that share an id across both services (e.g. the
+        // canonical `relay on start` flow) set RELAYFILE_WORKSPACE
+        // themselves through per-spawn env_vars.
         worker_env.push((
             "RELAY_DEFAULT_WORKSPACE".to_string(),
             default_workspace_id.clone(),

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -243,10 +243,11 @@ pub fn spawn_env_vars(
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        env.push((
-            "RELAYFILE_WORKSPACE".to_string(),
-            default_workspace.to_string(),
-        ));
+        // `default_workspace` is the relaycast workspace id; do NOT stamp it
+        // as RELAYFILE_WORKSPACE. Relaycast and relayfile workspace ids are
+        // independent — callers set RELAYFILE_WORKSPACE explicitly through
+        // their own spawn env when they want spawned agents to talk to a
+        // specific relayfile workspace.
         env.push((
             "RELAY_DEFAULT_WORKSPACE".to_string(),
             default_workspace.to_string(),


### PR DESCRIPTION
## Summary

Drop the `RELAYFILE_WORKSPACE` push from both `worker_env` (`src/main.rs`) and `spawn_env_vars` (`src/spawner.rs`). The relaycast workspace id has no claim to that env var.

## Why

Follow-up to #820. The Codex review caught that the SDK-side fix was incomplete:

> When a caller supplies `env.RELAYFILE_WORKSPACE` with a separate relayfile id and then spawns an agent, this still passes the relaycast id as `RELAY_DEFAULT_WORKSPACE`. The broker builds `worker_env` by copying `default_workspace_id` into `RELAYFILE_WORKSPACE` (`src/main.rs:1096-1105`), and `WorkerRegistry::spawn` applies that env over the inherited process env (`src/worker.rs:330-331`), so the actual agent process still gets the relaycast id and the relayfile MCP can continue to hit the workspace-mismatch 403.

Verified the chain in code: SDK's `applyWorkspaceEnv` writes `RELAY_DEFAULT_WORKSPACE` (relaycast id) → broker reads it via `auth.rs:504` into `default_workspace_id` → broker stamps that into `RELAYFILE_WORKSPACE` in `worker_env` (`main.rs:1096-1106`) → `WorkerRegistry::spawn` overrides the inherited env (`worker.rs:330`). End result: spawned agent's relayfile MCP still gets the wrong id, 403s as before.

This PR removes those two stamps. `RELAY_DEFAULT_WORKSPACE` and `RELAY_WORKSPACE_ID` remain — those are relaycast routing vars and correctly carry the relaycast id.

## Verified safe for `relay on start`

The canonical flow sets `RELAYFILE_WORKSPACE` explicitly through `buildAgentEnv` per-spawn env_vars (`src/cli/commands/on/start.ts:1309`). Those go through a different code path (`spawner.rs:104` `cmd.env` loop, applied AFTER `worker_env`), so the explicit value still wins. No regression for `relay on start`.

## Test plan

- [x] `cargo test --lib` — 232/232 green, 2 ignored
- [x] `cargo build` clean
- [ ] Smoke: `relay on start` flow — verify spawned agent's `RELAYFILE_WORKSPACE` matches `workspaceSession.workspaceId`
- [ ] Smoke: SDK `AgentRelay` with caller-provided `env.RELAYFILE_WORKSPACE` — verify spawned agent inherits that id and not the relaycast id

## Companion to

- #819 — relaycast MCP probe-then-rotate fix (merged)
- #820 — SDK-side `applyWorkspaceEnv` fix (merged)
- AgentWorkforce/relayfile#100 — `agentInviteScoped` (in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)