### PR TITLE
fix(sdk): finish agentToken doc cleanup in types.ts

### DIFF
--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -19,8 +19,13 @@ export interface SpawnPtyInput {
   restartPolicy?: RestartPolicy;
   continueFrom?: string;
   skipRelayPrompt?: boolean;
-  /** JWT token for relayauth/relayfile permissions. When set, the broker
-   *  injects RELAY_AGENT_TOKEN into the agent's environment. */
+  /** Optional pre-minted relaycast agent token (`at_live_<hex>`, from
+   *  `registerAgent(workspaceKey, name)` in `@agent-relay/sdk/http`). The
+   *  broker plumbs this as `RELAY_AGENT_TOKEN`, which the relaycast MCP
+   *  authenticates with. When omitted, the relaycast MCP auto-mints a token
+   *  using `RELAY_API_KEY` + the spawn name; that is the recommended path.
+   *  Note: this is a relaycast credential, NOT a relayfile/relayauth token —
+   *  override `env.RELAYFILE_TOKEN` on the constructor for relayfile auth. */
   agentToken?: string;
 }
 
@@ -31,8 +36,13 @@ export interface SpawnHeadlessInput {
   channels?: string[];
   task?: string;
   skipRelayPrompt?: boolean;
-  /** JWT token for relayauth/relayfile permissions. When set, the broker
-   *  injects RELAY_AGENT_TOKEN into the agent's environment. */
+  /** Optional pre-minted relaycast agent token (`at_live_<hex>`, from
+   *  `registerAgent(workspaceKey, name)` in `@agent-relay/sdk/http`). The
+   *  broker plumbs this as `RELAY_AGENT_TOKEN`, which the relaycast MCP
+   *  authenticates with. When omitted, the relaycast MCP auto-mints a token
+   *  using `RELAY_API_KEY` + the spawn name; that is the recommended path.
+   *  Note: this is a relaycast credential, NOT a relayfile/relayauth token —
+   *  override `env.RELAYFILE_TOKEN` on the constructor for relayfile auth. */
   agentToken?: string;
 }
 
@@ -54,8 +64,13 @@ export interface SpawnProviderInput {
   restartPolicy?: RestartPolicy;
   continueFrom?: string;
   skipRelayPrompt?: boolean;
-  /** JWT token for relayauth/relayfile permissions. When set, the broker
-   *  injects RELAY_AGENT_TOKEN into the agent's environment. */
+  /** Optional pre-minted relaycast agent token (`at_live_<hex>`, from
+   *  `registerAgent(workspaceKey, name)` in `@agent-relay/sdk/http`). The
+   *  broker plumbs this as `RELAY_AGENT_TOKEN`, which the relaycast MCP
+   *  authenticates with. When omitted, the relaycast MCP auto-mints a token
+   *  using `RELAY_API_KEY` + the spawn name; that is the recommended path.
+   *  Note: this is a relaycast credential, NOT a relayfile/relayauth token —
+   *  override `env.RELAYFILE_TOKEN` on the constructor for relayfile auth. */
   agentToken?: string;
 }
 


### PR DESCRIPTION
## Summary

Apply the corrected `agentToken` JSDoc to the three remaining interfaces in `packages/sdk/src/types.ts` that #819 missed: `SpawnPtyInput`, `SpawnHeadlessInput`, and `SpawnProviderInput`.

## Why

#819 updated the doc string on `agentToken` in `relay.ts` (`SpawnOptions`, `SpawnerSpawnOptions`), but the same field is declared on three more interfaces in `types.ts`. Because `dist/types.d.ts` is generated from `types.ts`, the published `@agent-relay/sdk@6.0.11` still ships the old comment ("JWT token for relayauth/relayfile permissions") on the public `SpawnPtyInput` / `SpawnHeadlessInput` / `SpawnProviderInput` types — defeating the documentation fix.

Verified post-fix: `grep -c "JWT token for relayauth/relayfile permissions" packages/sdk/src/**/*.ts` returns no matches.

## Test plan

- [x] `tsc --noEmit -p .` clean
- [ ] After publish: `grep "agentToken" node_modules/@agent-relay/sdk/dist/types.d.ts` shows the new wording on every occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)