### PR TITLE
fix: resolve #825 — slack-primitive: persist askQuestion exchanges to workflow run record

### DIFF
--- a/packages/runner/src/execution/slack-ask-question-handler.ts
+++ b/packages/runner/src/execution/slack-ask-question-handler.ts
@@ -1,0 +1,21 @@
+import { Step } from '../../types';
+import { updateRunAskQuestionExchanges } from '../persistence/runs';
+
+export async function handleSlackAskQuestion(
+  step: Step,
+  runId: string,
+  timeoutMs: number
+): Promise<void> {
+  try {
+    const result = await step.waitForReply(timeoutMs);
+    const exchange = {
+      question: step.input.question,
+      timestamp: new Date(),
+      reply: result.reply,
+      timeout: result.timeout === true
+    };
+    await updateRunAskQuestionExchanges(runId, exchange);
+  } catch (error) {
+    throw error;
+  }
+}

--- a/packages/runner/src/types/workflow-run-record.ts
+++ b/packages/runner/src/types/workflow-run-record.ts
@@ -1,0 +1,20 @@
+export interface WorkflowRunRecord {
+  id: string;
+  workflowId: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+  createdAt: Date;
+  updatedAt: Date;
+  askQuestionExchanges?: AskQuestionExchange[];
+}
+
+export interface AskQuestionExchange {
+  channel: string;
+  questionTimestamp: string;
+  questionText: string;
+  replierUserId?: string;
+  replyText?: string;
+  replyTimestamp?: string;
+  matchedChoices?: string[];
+  matchedRegexGroups?: Record<string, string>;
+  timeoutOutcome?: 'timeout' | 'cancelled' | null;
+}


### PR DESCRIPTION
## Summary

fix: resolve #825 — slack-primitive: persist askQuestion exchanges to workflow run record

## Problem

**Severity**: `High` | **File**: `packages/runner/src/types/workflow-run-record.ts`

Add an optional `askQuestionExchanges` array field to the workflow run record. Each element corresponds to one askQuestion step execution, storing channel, question timestamp, question text, replier user ID, reply text, reply timestamp, matched choices/regex groups, and timeout outcome. This enables post-mortem inspection without relying on Slack's message retention.

## Solution



## Changes

- `packages/runner/src/types/workflow-run-record.ts` (new)
- `packages/runner/src/execution/slack-ask-question-handler.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"