### PR TITLE
Fix publish smoke install for cloud SDK dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -640,6 +640,7 @@ jobs:
           # workflow — so pack them locally and install them alongside the
           # SDK. Keep this list in sync with packages/sdk/package.json's
           # `dependencies` whenever a new internal dep is added.
+          (cd packages/cloud && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd packages/config && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd packages/github-primitive && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd packages/slack-primitive && npm pack --ignore-scripts --pack-destination "$TARBALLS")
@@ -657,13 +658,14 @@ jobs:
           npm init -y --silent >/dev/null
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
           BROKER_TGZ=$(ls "$TARBALLS"/agent-relay-broker-${{ matrix.platform }}-*.tgz | head -n1)
+          CLOUD_TGZ=$(ls "$TARBALLS"/agent-relay-cloud-*.tgz | head -n1)
           CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
           GITHUB_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-github-primitive-*.tgz | head -n1)
           SLACK_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-slack-primitive-*.tgz | head -n1)
           WORKFLOW_TYPES_TGZ=$(ls "$TARBALLS"/agent-relay-workflow-types-*.tgz | head -n1)
-          echo "Installing $SDK_TGZ + $BROKER_TGZ + $CONFIG_TGZ + $GITHUB_PRIMITIVE_TGZ + $SLACK_PRIMITIVE_TGZ + $WORKFLOW_TYPES_TGZ"
+          echo "Installing $SDK_TGZ + $BROKER_TGZ + $CLOUD_TGZ + $CONFIG_TGZ + $GITHUB_PRIMITIVE_TGZ + $SLACK_PRIMITIVE_TGZ + $WORKFLOW_TYPES_TGZ"
           npm install --ignore-scripts --no-audit --no-fund \
-            "$SDK_TGZ" "$BROKER_TGZ" "$CONFIG_TGZ" \
+            "$SDK_TGZ" "$BROKER_TGZ" "$CLOUD_TGZ" "$CONFIG_TGZ" \
             "$GITHUB_PRIMITIVE_TGZ" "$SLACK_PRIMITIVE_TGZ" "$WORKFLOW_TYPES_TGZ"
           ls node_modules/@agent-relay/
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -716,6 +716,7 @@ jobs:
           cd "$NEGATIVE"
           npm init -y --silent >/dev/null
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
+          CLOUD_TGZ=$(ls "$TARBALLS"/agent-relay-cloud-*.tgz | head -n1)
           CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
           GITHUB_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-github-primitive-*.tgz | head -n1)
           SLACK_PRIMITIVE_TGZ=$(ls "$TARBALLS"/agent-relay-slack-primitive-*.tgz | head -n1)
@@ -725,7 +726,7 @@ jobs:
           # entirely. The resolver should return null and spawn() should
           # throw the clear error.
           npm install --ignore-scripts --no-audit --no-fund --no-optional \
-            "$SDK_TGZ" "$CONFIG_TGZ" "$GITHUB_PRIMITIVE_TGZ" "$SLACK_PRIMITIVE_TGZ" "$WORKFLOW_TYPES_TGZ"
+            "$SDK_TGZ" "$CLOUD_TGZ" "$CONFIG_TGZ" "$GITHUB_PRIMITIVE_TGZ" "$SLACK_PRIMITIVE_TGZ" "$WORKFLOW_TYPES_TGZ"
           node --input-type=module -e "
             import { AgentRelayClient } from '@agent-relay/sdk';
             try {
@@ -759,6 +760,7 @@ jobs:
       max-parallel: 3
       matrix:
         package:
+          - cloud
           - config
           - github-primitive
           - slack-primitive

--- a/.trajectories/completed/2026-05/traj_aw7stgf4qau0.json
+++ b/.trajectories/completed/2026-05/traj_aw7stgf4qau0.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_aw7stgf4qau0",
+  "version": 1,
+  "task": {
+    "title": "Fix publish smoke cloud tarball dependency"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-11T07:49:42.778Z",
+  "completedAt": "2026-05-11T07:50:37.848Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-11T07:50:37.764Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_a8gmxh7ko84g",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-11T07:50:37.764Z",
+      "endedAt": "2026-05-11T07:50:37.848Z",
+      "events": [
+        {
+          "ts": 1778485837765,
+          "type": "decision",
+          "content": "Added cloud to publish smoke local tarballs: Added cloud to publish smoke local tarballs",
+          "raw": {
+            "question": "Added cloud to publish smoke local tarballs",
+            "chosen": "Added cloud to publish smoke local tarballs",
+            "alternatives": [],
+            "reasoning": "@agent-relay/cloud is an exact-version SDK dependency after release version bump, so the pre-publish scratch install must use the locally packed cloud tarball just like config/github/slack/workflow-types."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Updated publish.yml smoke packaging to pack packages/cloud, locate agent-relay-cloud-*.tgz, and include it in the scratch npm install. Verified YAML parses and added a static Node check that the smoke workflow covers all @agent-relay/* SDK dependencies.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay-fix-publish-cloud-tarball",
+  "tags": [],
+  "_trace": {
+    "startRef": "b57a1114d23903af4a1fc7d76e70d045cc2e78b0",
+    "endRef": "b57a1114d23903af4a1fc7d76e70d045cc2e78b0"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_aw7stgf4qau0.json
+++ b/.trajectories/completed/2026-05/traj_aw7stgf4qau0.json
@@ -44,7 +44,7 @@
   },
   "commits": [],
   "filesChanged": [],
-  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay-fix-publish-cloud-tarball",
+  "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "b57a1114d23903af4a1fc7d76e70d045cc2e78b0",

--- a/.trajectories/completed/2026-05/traj_aw7stgf4qau0.md
+++ b/.trajectories/completed/2026-05/traj_aw7stgf4qau0.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Updated publish.yml smoke packaging to pack packages/cloud, locate agent-relay-cloud-_.tgz, and include it in the scratch npm install. Verified YAML parses and added a static Node check that the smoke workflow covers all @agent-relay/_ SDK dependencies.
+Updated publish.yml smoke packaging to pack packages/cloud, locate `agent-relay-cloud-*.tgz`, and include it in the scratch npm install. Verified YAML parses and added a static Node check that the smoke workflow covers all `@agent-relay/*` SDK dependencies.
 
 **Approach:** Standard approach
 

--- a/.trajectories/completed/2026-05/traj_aw7stgf4qau0.md
+++ b/.trajectories/completed/2026-05/traj_aw7stgf4qau0.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix publish smoke cloud tarball dependency
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** May 11, 2026 at 09:49 AM
+> **Completed:** May 11, 2026 at 09:50 AM
+
+---
+
+## Summary
+
+Updated publish.yml smoke packaging to pack packages/cloud, locate agent-relay-cloud-_.tgz, and include it in the scratch npm install. Verified YAML parses and added a static Node check that the smoke workflow covers all @agent-relay/_ SDK dependencies.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added cloud to publish smoke local tarballs
+
+- **Chose:** Added cloud to publish smoke local tarballs
+- **Reasoning:** @agent-relay/cloud is an exact-version SDK dependency after release version bump, so the pre-publish scratch install must use the locally packed cloud tarball just like config/github/slack/workflow-types.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Added cloud to publish smoke local tarballs: Added cloud to publish smoke local tarballs

--- a/.trajectories/completed/2026-05/traj_z171lng2fbbi.json
+++ b/.trajectories/completed/2026-05/traj_z171lng2fbbi.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_z171lng2fbbi",
+  "version": 1,
+  "task": {
+    "title": "Address PR 840 review feedback"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-11T08:06:37.977Z",
+  "completedAt": "2026-05-11T08:07:48.097Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-11T08:07:47.976Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_jdknonibobpa",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-11T08:07:47.976Z",
+      "endedAt": "2026-05-11T08:07:48.097Z",
+      "events": [
+        {
+          "ts": 1778486867976,
+          "type": "decision",
+          "content": "Included cloud in all SDK publish dependency paths: Included cloud in all SDK publish dependency paths",
+          "raw": {
+            "question": "Included cloud in all SDK publish dependency paths",
+            "chosen": "Included cloud in all SDK publish dependency paths",
+            "alternatives": [],
+            "reasoning": "Review feedback showed the negative smoke and SDK-only internal publish matrix must mirror the positive smoke path because @agent-relay/cloud is an exact-version runtime dependency of @agent-relay/sdk."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR 840 feedback by adding the cloud tarball to the negative optional-dep smoke install, adding cloud to the publish-sdk-internal-deps matrix, replacing the first trajectory projectId absolute path with AgentWorkforce/relay, and fixing wildcard text in the trajectory Markdown. Revalidated workflow YAML, trajectory JSON, and static internal-dependency coverage across pack, positive smoke, negative smoke, and publish matrix.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "fa2c7dcbd01bbc35b7ceb7a1b9cff032f73d624b",
+    "endRef": "fa2c7dcbd01bbc35b7ceb7a1b9cff032f73d624b"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_z171lng2fbbi.md
+++ b/.trajectories/completed/2026-05/traj_z171lng2fbbi.md
@@ -1,0 +1,33 @@
+# Trajectory: Address PR 840 review feedback
+
+> **Status:** ✅ Completed
+> **Confidence:** 96%
+> **Started:** May 11, 2026 at 10:06 AM
+> **Completed:** May 11, 2026 at 10:07 AM
+
+---
+
+## Summary
+
+Addressed PR 840 feedback by adding the cloud tarball to the negative optional-dep smoke install, adding cloud to the publish-sdk-internal-deps matrix, replacing the first trajectory projectId absolute path with AgentWorkforce/relay, and fixing wildcard text in the trajectory Markdown. Revalidated workflow YAML, trajectory JSON, and static internal-dependency coverage across pack, positive smoke, negative smoke, and publish matrix.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Included cloud in all SDK publish dependency paths
+
+- **Chose:** Included cloud in all SDK publish dependency paths
+- **Reasoning:** Review feedback showed the negative smoke and SDK-only internal publish matrix must mirror the positive smoke path because @agent-relay/cloud is an exact-version runtime dependency of @agent-relay/sdk.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Included cloud in all SDK publish dependency paths: Included cloud in all SDK publish dependency paths

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-11T07:50:37.967Z",
+  "lastUpdated": "2026-05-11T08:07:48.291Z",
   "trajectories": {
     "traj_1775914133873_35667beb": {
       "title": "fix-sdk-build-resolution-workflow",
@@ -352,7 +352,7 @@
       "status": "completed",
       "startedAt": "2026-05-10T15:18:12.326Z",
       "completedAt": "2026-05-10T15:29:41.840Z",
-      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay-pr831-ci-fix/.trajectories/completed/2026-05/traj_iole5zdt9orr.json"
+      "path": ".trajectories/completed/2026-05/traj_iole5zdt9orr.json"
     },
     "traj_mz5m5ysjj31e": {
       "title": "Fix Relay SDK broker stdout drain",
@@ -367,6 +367,13 @@
       "startedAt": "2026-05-11T07:49:42.778Z",
       "completedAt": "2026-05-11T07:50:37.848Z",
       "path": ".trajectories/completed/2026-05/traj_aw7stgf4qau0.json"
+    },
+    "traj_z171lng2fbbi": {
+      "title": "Address PR 840 review feedback",
+      "status": "completed",
+      "startedAt": "2026-05-11T08:06:37.977Z",
+      "completedAt": "2026-05-11T08:07:48.097Z",
+      "path": ".trajectories/completed/2026-05/traj_z171lng2fbbi.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-10T20:35:47.482Z",
+  "lastUpdated": "2026-05-11T07:50:37.967Z",
   "trajectories": {
     "traj_1775914133873_35667beb": {
       "title": "fix-sdk-build-resolution-workflow",
@@ -360,6 +360,13 @@
       "startedAt": "2026-05-10T20:24:43.831Z",
       "completedAt": "2026-05-10T20:35:47.359Z",
       "path": ".trajectories/completed/2026-05/traj_mz5m5ysjj31e.json"
+    },
+    "traj_aw7stgf4qau0": {
+      "title": "Fix publish smoke cloud tarball dependency",
+      "status": "completed",
+      "startedAt": "2026-05-11T07:49:42.778Z",
+      "completedAt": "2026-05-11T07:50:37.848Z",
+      "path": ".trajectories/completed/2026-05/traj_aw7stgf4qau0.json"
     }
   }
 }


### PR DESCRIPTION
## Summary
- pack `packages/cloud` with the SDK smoke-test internal dependency tarballs
- include the cloud tarball in the scratch-project `npm install`
- record the fix trajectory for future release-workflow context

## Why
The publish smoke job version-bumps the SDK to the new release version before publishing. Since `@agent-relay/sdk` depends on exact-version `@agent-relay/cloud`, the scratch install tried to resolve unpublished `@agent-relay/cloud@6.0.15` from npm and failed with `ETARGET`.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish.yml parses"'`
- static Node check confirmed the smoke workflow covers all internal `@agent-relay/*` SDK dependencies: cloud, config, github-primitive, slack-primitive, workflow-types