### PR TITLE
fix(broker): replace blocking stdout writer task with tokio::io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
@@ -585,6 +586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +647,15 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1534,6 +1553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1717,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2393,6 +2424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2551,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2672,6 +2740,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2.0"
 relaycast = "=1.0.0"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tempfile = "3.19"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3816,13 +3816,18 @@ async fn run_headless_worker(cmd: HeadlessCommand) -> Result<()> {
 
     let (out_tx, mut out_rx) = mpsc::channel::<ProtocolEnvelope<Value>>(512);
     tokio::spawn(async move {
+        // Mirror the cooperative-stdout fix in pty_worker.rs:
+        // `std::io::stdout().lock().write_all` from inside `tokio::spawn`
+        // blocks the OS thread when the parent stalls reading, which costs
+        // a tokio worker and loses the select-loop wakeup. Use the async
+        // sink so backpressure becomes a `Pending` future.
+        let mut stdout = tokio::io::stdout();
         while let Some(frame) = out_rx.recv().await {
-            if let Ok(line) = serde_json::to_string(&frame) {
-                use std::io::Write;
-                let mut stdout = std::io::stdout().lock();
-                let _ = stdout.write_all(line.as_bytes());
-                let _ = stdout.write_all(b"\n");
-                let _ = stdout.flush();
+            if let Ok(mut line) = serde_json::to_string(&frame) {
+                line.push('\n');
+                if stdout.write_all(line.as_bytes()).await.is_err() {
+                    break;
+                }
             }
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     process::Stdio,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -72,6 +72,7 @@ const THREAD_HISTORY_LIMIT: usize = 1_000;
 const DEFAULT_HTTP_API_LOCAL_DELIVERY_TIMEOUT_MS: u64 = 3_000;
 const DEFAULT_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: u64 = 20_000;
 const DEFAULT_HTTP_API_EVENT_EMIT_TIMEOUT_MS: u64 = 200;
+static TRACING_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 
 fn startup_debug_enabled() -> bool {
     std::env::var("AGENT_RELAY_STARTUP_DEBUG")
@@ -3815,17 +3816,16 @@ async fn run_headless_worker(cmd: HeadlessCommand) -> Result<()> {
     let provider_args = cmd.args.clone();
 
     let (out_tx, mut out_rx) = mpsc::channel::<ProtocolEnvelope<Value>>(512);
-    tokio::spawn(async move {
-        // Mirror the cooperative-stdout fix in pty_worker.rs:
-        // `std::io::stdout().lock().write_all` from inside `tokio::spawn`
-        // blocks the OS thread when the parent stalls reading, which costs
-        // a tokio worker and loses the select-loop wakeup. Use the async
-        // sink so backpressure becomes a `Pending` future.
+    let writer_task = tokio::spawn(async move {
+        // Keep one async stdout handle for this process. Tokio's `write_all`
+        // is not cancel-safe if the task is aborted mid-write, so shutdown
+        // below drops `out_tx` and awaits this task before returning.
         let mut stdout = tokio::io::stdout();
         while let Some(frame) = out_rx.recv().await {
             if let Ok(mut line) = serde_json::to_string(&frame) {
                 line.push('\n');
-                if stdout.write_all(line.as_bytes()).await.is_err() {
+                if stdout.write_all(line.as_bytes()).await.is_err() || stdout.flush().await.is_err()
+                {
                     break;
                 }
             }
@@ -4151,6 +4151,8 @@ async fn run_headless_worker(cmd: HeadlessCommand) -> Result<()> {
         json!({"code": final_exit_code, "signal": final_exit_signal}),
     )
     .await;
+    drop(out_tx);
+    let _ = writer_task.await;
 
     Ok(())
 }
@@ -4222,14 +4224,18 @@ async fn send_frame(
 }
 
 fn init_tracing() {
+    let (writer, guard) = tracing_appender::non_blocking(std::io::stderr());
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .with_target(true)
+        .with_writer(writer)
         .finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    if tracing::subscriber::set_global_default(subscriber).is_ok() {
+        let _ = TRACING_GUARD.set(guard);
+    }
 }
 
 fn channels_from_csv(raw: &str) -> Vec<String> {

--- a/src/pty_worker.rs
+++ b/src/pty_worker.rs
@@ -181,13 +181,23 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
 
     let (out_tx, mut out_rx) = mpsc::channel::<ProtocolEnvelope<Value>>(1024);
     let writer_task = tokio::spawn(async move {
+        // Use tokio's async stdout so pipe backpressure surfaces as `Pending`
+        // and never parks the OS thread inside a blocking write() syscall.
+        // The previous implementation used `std::io::stdout().lock().write_all`
+        // from inside `tokio::spawn`; when the parent SDK reader stalled, the
+        // 64 KB macOS pipe buffer filled and the syscall blocked, taking the
+        // tokio worker thread with it. On resumption, the select-loop wakeup
+        // for `pty_rx` was lost — the broker stayed parked in
+        // `_pthread_cond_wait` and the workflow deadlocked at fanout.
+        use tokio::io::AsyncWriteExt;
+        let mut stdout = tokio::io::stdout();
         while let Some(frame) = out_rx.recv().await {
-            if let Ok(line) = serde_json::to_string(&frame) {
-                use std::io::Write;
-                let mut stdout = std::io::stdout().lock();
-                let _ = stdout.write_all(line.as_bytes());
-                let _ = stdout.write_all(b"\n");
-                let _ = stdout.flush();
+            if let Ok(mut line) = serde_json::to_string(&frame) {
+                line.push('\n');
+                if stdout.write_all(line.as_bytes()).await.is_err() {
+                    // Parent closed the pipe; nothing further to do.
+                    break;
+                }
             }
         }
     });

--- a/src/pty_worker.rs
+++ b/src/pty_worker.rs
@@ -181,21 +181,17 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
 
     let (out_tx, mut out_rx) = mpsc::channel::<ProtocolEnvelope<Value>>(1024);
     let writer_task = tokio::spawn(async move {
-        // Use tokio's async stdout so pipe backpressure surfaces as `Pending`
-        // and never parks the OS thread inside a blocking write() syscall.
-        // The previous implementation used `std::io::stdout().lock().write_all`
-        // from inside `tokio::spawn`; when the parent SDK reader stalled, the
-        // 64 KB macOS pipe buffer filled and the syscall blocked, taking the
-        // tokio worker thread with it. On resumption, the select-loop wakeup
-        // for `pty_rx` was lost — the broker stayed parked in
-        // `_pthread_cond_wait` and the workflow deadlocked at fanout.
+        // Keep one async stdout handle for this process. Tokio's `write_all`
+        // is not cancel-safe if the task is aborted mid-write, but this task is
+        // normally shut down by dropping `out_tx` and awaiting it below, so the
+        // frame stream is drained instead of cancelled.
         use tokio::io::AsyncWriteExt;
         let mut stdout = tokio::io::stdout();
         while let Some(frame) = out_rx.recv().await {
             if let Ok(mut line) = serde_json::to_string(&frame) {
                 line.push('\n');
-                if stdout.write_all(line.as_bytes()).await.is_err() {
-                    // Parent closed the pipe; nothing further to do.
+                if stdout.write_all(line.as_bytes()).await.is_err() || stdout.flush().await.is_err()
+                {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
Two writer tasks in the broker spawn-loop body used `std::io::stdout().lock().write_all()` from inside `tokio::spawn`:

- \`src/pty_worker.rs:182-193\` (PTY worker → SDK frame stream)
- \`src/main.rs::run_headless_worker\` ~ \`:3817-3828\` (headless worker → SDK frame stream)

Synchronous I/O from an async task **blocks the OS worker thread** when the parent reader stalls. On macOS the kernel pipe buffer is 64KB; once it fills, the \`write_all()\` syscall blocks, taking the tokio thread with it. On resumption, the \`tokio::select!\` wakeup that drives \`pty_rx\` is lost — the broker stays parked in \`_pthread_cond_wait\` and downstream PTY workers freeze.

This is the **upstream root-cause fix** corresponding to relay#838 (SDK-side drain — necessary but not sufficient) and ricky#98 (Node-side spawn monkeypatch — backstop). After both of those landed, multi-agent workflows still wedged at fanout because the broker writer task itself remained the trap.

## Reproducer
Any workflow that fans out to ≥9 PTY workers with sustained \`worker_stream\` traffic. We reproduced via \`proactive-runtime-m1\` four times across two days — every wedge had the same shape:

| Wedge bundle | broker-init main thread | broker-pty thread |
|---|---|---|
| 92b45d3e (pre-drain) | \`write()\` blocked (2 frames) + 4 mutex-wait frames | \`write()\` blocked |
| c9600674 (pre-drain) | \`_pthread_mutex_firstfit_lock_wait\` (4 frames) | \`write()\` blocked |
| 75e5064d (post-SDK-6.0.15 + post-ricky#98 loader unblocker) | All 9 tokio workers in \`_pthread_cond_wait\`; zero \`write\`; zero mutex-wait | n/a |

The 75e5064d shape is the same blocking-writer design in cancel-unsafe steady state: workers had drained their kernel pipes by the time we sampled, but the wakeup chain into \`tokio::select!\` had been lost when one of them temporarily stalled in \`write_all\` earlier. All 9 workers' logs froze within 4 seconds of each other.

## What changed
- \`src/pty_worker.rs\` — writer task uses \`tokio::io::stdout()\` + \`AsyncWriteExt::write_all().await\`. Imports \`AsyncWriteExt\` inside the task to scope the trait. Parent-closes-pipe now breaks the loop instead of silently dropping writes.
- \`src/main.rs::run_headless_worker\` — same change to the headless writer task. Uses the already-imported \`AsyncWriteExt\` from line 37.

Backpressure now surfaces as \`Pending\`. The OS thread never blocks. No wakeups are lost.

## Verification
- \`cargo build --release\` — clean
- \`cargo test --release --lib\` — **232/232 pass** (including all \`pty::tests\`)
- \`cargo test --release --test '*'\` — **8/8 pass**

Suggested follow-on tests (next PR, not in scope here):
- \`tokio\` test that spawns \`agent-relay-broker pty\` in a child, **never reads its stdout**, feeds 1MB of stdin frames, and asserts the broker stays responsive for ≥60s. Pre-fix wedges within 1-2s on macOS (64KB pipe). Post-fix should run indefinitely.
- Vitest harness with 9 mock workers emitting 200KB/4s + a deliberately-slow WS subscriber.
- CI lint: \`grep "std::io::stdout" src/\` returns 0 under any \`tokio::spawn\` block.

## Related
- relay#838 — SDK 6.0.15 stdout drain
- ricky#94 — Node-side loader unblocker (introduced)
- ricky#98 — Node-side loader unblocker fix (use \`data\` event, not \`pause\`)