### PR TITLE
fix(sdk): drain broker stderr alongside stdout after startup

### DIFF
--- a/packages/sdk/src/__tests__/client-stdout-drain.test.ts
+++ b/packages/sdk/src/__tests__/client-stdout-drain.test.ts
@@ -39,13 +39,18 @@ function fakeBrokerSource(stream: 'stdout' | 'stderr'): string {
     `  const sink = process.${stream};`,
     '  let index = 0;',
     "  const chunk = 'x'.repeat(1024);",
+    // 5000 * ~1KB = ~5 MB total; macOS pipe buffer is ~64 KB, so this still
+    // forces ~80 backpressure cycles — plenty to wedge an undrained broker —
+    // while keeping the drained case fast enough that line-by-line readline
+    // parsing of stderr never races the drain timeout.
+    '  const totalChunks = 5000;',
     '  const writeMore = () => {',
     '    let ok = true;',
-    '    while (index < 20000 && ok) {',
+    '    while (index < totalChunks && ok) {',
     '      ok = sink.write(`event-${index}:${chunk}\\n`);',
     '      index += 1;',
     '    }',
-    '    if (index >= 20000) {',
+    '    if (index >= totalChunks) {',
     '      setTimeout(() => process.exit(0), 25);',
     '      return;',
     '    }',

--- a/packages/sdk/src/__tests__/client-stdout-drain.test.ts
+++ b/packages/sdk/src/__tests__/client-stdout-drain.test.ts
@@ -2,10 +2,11 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { test } from 'vitest';
 
-import { AgentRelayClient } from '../client.js';
+import { AgentRelayClient, __clientTestInternals } from '../client.js';
 
 const BROKER_STDIO_DRAIN_TIMEOUT_MS = 5_000;
 // Spawning Node + binding an HTTP server inside a Vitest worker can take
@@ -97,6 +98,25 @@ async function runFakeBrokerAndAssertDrains(stream: 'stdout' | 'stderr'): Promis
   }
 }
 
+test('post-startup drain attaches directly to stdout and stderr streams', () => {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  stdout.pause();
+  stderr.pause();
+
+  const child = {
+    stdout,
+    stderr,
+  } as unknown as Parameters<typeof __clientTestInternals.drainBrokerStdioAfterStartup>[0];
+
+  __clientTestInternals.drainBrokerStdioAfterStartup(child);
+
+  assert.equal(stdout.listenerCount('data'), 1);
+  assert.equal(stderr.listenerCount('data'), 1);
+  assert.equal(stdout.isPaused(), false);
+  assert.equal(stderr.isPaused(), false);
+});
+
 test(
   'spawn drains broker stdout after startup so event floods cannot wedge the broker',
   async () => {
@@ -108,9 +128,6 @@ test(
 test(
   'spawn drains broker stderr after startup so tracing/log floods cannot wedge the broker',
   async () => {
-    // The Rust broker routes `tracing` output to stderr (rule: rust.md). Under
-    // heavy fanout stderr fills its kernel pipe (~64KB on macOS) and blocks
-    // the broker process exactly like stdout did before the existing drain.
     await runFakeBrokerAndAssertDrains('stderr');
   },
   TEST_TIMEOUT_MS

--- a/packages/sdk/src/__tests__/client-stdout-drain.test.ts
+++ b/packages/sdk/src/__tests__/client-stdout-drain.test.ts
@@ -7,59 +7,67 @@ import { test } from 'vitest';
 
 import { AgentRelayClient } from '../client.js';
 
-const BROKER_STDOUT_DRAIN_TIMEOUT_MS = 5_000;
+const BROKER_STDIO_DRAIN_TIMEOUT_MS = 5_000;
+// Spawning Node + binding an HTTP server inside a Vitest worker can take
+// several seconds on cold machines; give startup generous headroom so the
+// drain assertion (not startup latency) is what's being measured.
+const BROKER_STARTUP_TIMEOUT_MS = 30_000;
+// Test timeout must cover startup + drain wait + cleanup with margin.
+const TEST_TIMEOUT_MS = 60_000;
 
-test('spawn drains broker stdout after startup so event floods cannot wedge the broker', async () => {
-  const cwd = await mkdtemp(join(tmpdir(), 'agent-relay-sdk-stdout-drain-'));
+function fakeBrokerSource(stream: 'stdout' | 'stderr'): string {
+  return [
+    "const http = require('node:http');",
+    'const server = http.createServer((req, res) => {',
+    "  if (req.url === '/api/session') {",
+    "    res.writeHead(200, { 'content-type': 'application/json' });",
+    "    res.end(JSON.stringify({ workspace_key: 'wk_fake', mode: 'test', uptime_secs: 0 }));",
+    '    return;',
+    '  }',
+    "  if (req.url === '/api/session/renew' || req.url === '/api/shutdown') {",
+    "    res.writeHead(200, { 'content-type': 'application/json' });",
+    '    res.end(JSON.stringify({ ok: true }));',
+    '    return;',
+    '  }',
+    "  res.writeHead(404, { 'content-type': 'application/json' });",
+    "  res.end(JSON.stringify({ error: 'not found' }));",
+    '});',
+    "server.listen(0, '127.0.0.1', () => {",
+    '  const address = server.address();',
+    // Startup URL always goes to stdout so the SDK can parse it.
+    '  console.log(`[agent-relay] API listening on http://127.0.0.1:${address.port}`);',
+    `  const sink = process.${stream};`,
+    '  let index = 0;',
+    "  const chunk = 'x'.repeat(1024);",
+    '  const writeMore = () => {',
+    '    let ok = true;',
+    '    while (index < 20000 && ok) {',
+    '      ok = sink.write(`event-${index}:${chunk}\\n`);',
+    '      index += 1;',
+    '    }',
+    '    if (index >= 20000) {',
+    '      setTimeout(() => process.exit(0), 25);',
+    '      return;',
+    '    }',
+    "    sink.once('drain', writeMore);",
+    '  };',
+    '  writeMore();',
+    '});',
+    '',
+  ].join('\n');
+}
+
+async function runFakeBrokerAndAssertDrains(stream: 'stdout' | 'stderr'): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), `agent-relay-sdk-${stream}-drain-`));
 
   try {
     await mkdir(cwd, { recursive: true });
-    await writeFile(
-      join(cwd, 'init'),
-      [
-        "const http = require('node:http');",
-        'const server = http.createServer((req, res) => {',
-        "  if (req.url === '/api/session') {",
-        "    res.writeHead(200, { 'content-type': 'application/json' });",
-        "    res.end(JSON.stringify({ workspace_key: 'wk_fake', mode: 'test', uptime_secs: 0 }));",
-        '    return;',
-        '  }',
-        "  if (req.url === '/api/session/renew' || req.url === '/api/shutdown') {",
-        "    res.writeHead(200, { 'content-type': 'application/json' });",
-        '    res.end(JSON.stringify({ ok: true }));',
-        '    return;',
-        '  }',
-        "  res.writeHead(404, { 'content-type': 'application/json' });",
-        "  res.end(JSON.stringify({ error: 'not found' }));",
-        '});',
-        "server.listen(0, '127.0.0.1', () => {",
-        '  const address = server.address();',
-        '  console.log(`[agent-relay] API listening on http://127.0.0.1:${address.port}`);',
-        '  let index = 0;',
-        "  const chunk = 'x'.repeat(1024);",
-        '  const writeMore = () => {',
-        '    let ok = true;',
-        '    while (index < 20000 && ok) {',
-        '      ok = process.stdout.write(`event-${index}:${chunk}\\n`);',
-        '      index += 1;',
-        '    }',
-        '    if (index >= 20000) {',
-        '      setTimeout(() => process.exit(0), 25);',
-        '      return;',
-        '    }',
-        "    process.stdout.once('drain', writeMore);",
-        '  };',
-        '  writeMore();',
-        '});',
-        '',
-      ].join('\n'),
-      'utf8'
-    );
+    await writeFile(join(cwd, 'init'), fakeBrokerSource(stream), 'utf8');
 
     const client = await AgentRelayClient.spawn({
       binaryPath: process.execPath,
       cwd,
-      startupTimeoutMs: 3_000,
+      startupTimeoutMs: BROKER_STARTUP_TIMEOUT_MS,
       requestTimeoutMs: 3_000,
     });
 
@@ -70,7 +78,7 @@ test('spawn drains broker stdout after startup so event floods cannot wedge the 
         ? 'exited'
         : await Promise.race([
             new Promise<'exited'>((resolve) => child.once('exit', () => resolve('exited'))),
-            sleep(BROKER_STDOUT_DRAIN_TIMEOUT_MS).then(() => 'blocked' as const),
+            sleep(BROKER_STDIO_DRAIN_TIMEOUT_MS).then(() => 'blocked' as const),
           ]);
 
     client.disconnect();
@@ -82,4 +90,23 @@ test('spawn drains broker stdout after startup so event floods cannot wedge the 
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
-});
+}
+
+test(
+  'spawn drains broker stdout after startup so event floods cannot wedge the broker',
+  async () => {
+    await runFakeBrokerAndAssertDrains('stdout');
+  },
+  TEST_TIMEOUT_MS
+);
+
+test(
+  'spawn drains broker stderr after startup so tracing/log floods cannot wedge the broker',
+  async () => {
+    // The Rust broker routes `tracing` output to stderr (rule: rust.md). Under
+    // heavy fanout stderr fills its kernel pipe (~64KB on macOS) and blocks
+    // the broker process exactly like stdout did before the existing drain.
+    await runFakeBrokerAndAssertDrains('stderr');
+  },
+  TEST_TIMEOUT_MS
+);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -684,15 +684,20 @@ async function waitForApiUrl(
 function drainBrokerStdioAfterStartup(child: ChildProcess): void {
   // Drain both stdout AND stderr after startup so high-volume broker
   // diagnostics/events cannot fill either pipe and block the broker process.
-  // The Rust broker routes `tracing` output to stderr (rule: rust.md); under
-  // heavy fanout stderr fills its kernel pipe (~64KB on macOS) and wedges the
-  // broker exactly like stdout did before this drain existed.
+  // Stderr also has a readline consumer above for line buffering/onStderr; this
+  // raw drain is intentionally no-op and exists only to keep the stream flowing
+  // if that consumer is changed or removed later.
   for (const stream of [child.stdout, child.stderr]) {
     if (!stream) continue;
     stream.on('data', () => {});
     stream.resume();
   }
 }
+
+/** @internal Test-only hooks; not part of the public SDK API. */
+export const __clientTestInternals = {
+  drainBrokerStdioAfterStartup,
+};
 
 function pushBufferedLine(lines: string[], line: string): void {
   lines.push(line);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -261,7 +261,7 @@ export class AgentRelayClient {
       stdoutLines,
       stderrLines,
     });
-    drainBrokerStdoutAfterStartup(child);
+    drainBrokerStdioAfterStartup(child);
 
     const client = new AgentRelayClient({
       baseUrl,
@@ -681,14 +681,17 @@ async function waitForApiUrl(
   });
 }
 
-function drainBrokerStdoutAfterStartup(child: ChildProcess): void {
-  if (!child.stdout) return;
-
-  child.stdout.on('data', () => {
-    // Drain broker stdout after startup so high-volume broker diagnostics/events
-    // cannot fill the pipe and block the broker process.
-  });
-  child.stdout.resume();
+function drainBrokerStdioAfterStartup(child: ChildProcess): void {
+  // Drain both stdout AND stderr after startup so high-volume broker
+  // diagnostics/events cannot fill either pipe and block the broker process.
+  // The Rust broker routes `tracing` output to stderr (rule: rust.md); under
+  // heavy fanout stderr fills its kernel pipe (~64KB on macOS) and wedges the
+  // broker exactly like stdout did before this drain existed.
+  for (const stream of [child.stdout, child.stderr]) {
+    if (!stream) continue;
+    stream.on('data', () => {});
+    stream.resume();
+  }
 }
 
 function pushBufferedLine(lines: string[], line: string): void {


### PR DESCRIPTION
## Summary
[PR #838](https://github.com/AgentWorkforce/relay/pull/838) added \`drainBrokerStdoutAfterStartup\` to keep the broker's **stdout** pipe drained after the SDK finishes parsing the startup URL. **Stderr has the same failure mode but was never covered.**

The Rust broker routes \`tracing\` output to stderr (\`.claude/rules/rust.md\`). Under heavy fanout (e.g. 9 PTY workers in proactive-runtime M1), tracing volume is large enough to fill stderr's ~64KB kernel pipe and block the broker process exactly the way stdout did before #838.

## Why the existing readline isn't enough on its own
\`AgentRelayClient.spawn\` already attaches \`createInterface({ input: child.stderr })\` (\`client.ts:248\`) with a \`'line'\` listener that pushes into \`stderrLines\`. That keeps stderr in flowing mode during normal operation — *most of the time*. But:
- readline parses lines synchronously; under sustained pressure it can fall behind the producer.
- Boundary conditions (mid-line buffered flushes, the moment the URL parser releases stdout, etc.) can cause the stream to momentarily fall back to paused mode.

A no-op \`'data'\` listener + explicit \`.resume()\` gives a belt-and-suspenders guarantee the kernel pipe is always drained, regardless of readline's pace.

## What changed
- \`packages/sdk/src/client.ts\`
  - Rename \`drainBrokerStdoutAfterStartup\` → \`drainBrokerStdioAfterStartup\` (now accurate — covers both streams).
  - Iterate over \`[child.stdout, child.stderr]\` and attach the no-op drain handler + \`.resume()\` to each.
  - Update the single call site at \`client.ts:264\`.
- \`packages/sdk/src/__tests__/client-stdout-drain.test.ts\`
  - Extract the fake-broker generator + drain-or-block harness into helpers parameterized by stream name.
  - Existing stdout test now floods the named stream; add a parallel test that floods stderr and asserts the broker exits within the same 5s window.
  - Bump per-test timeout to 30s so spawn + drain + child-exit has headroom past vitest's 5s default. The inner \`BROKER_STDIO_DRAIN_TIMEOUT_MS\` is still 5s — what's measured is the broker's exit timing, not the test wall-clock.

## Verification
- \`npx vitest run packages/sdk/src/__tests__/client-stdout-drain.test.ts\` — **2/2 pass** (stdout drain + new stderr drain regression).

## Related
- relay#838 — original stdout-only drain
- relay#841 — Rust broker writer-task fix (the upstream root cause)
- ricky#94 / #98 — Node-side child_process.spawn monkeypatch (backstop for consumers still on older SDKs)