### PR TITLE
feat(agent): export createContextFactory + its option/return interfaces

### DIFF
--- a/packages/agent/src/context.ts
+++ b/packages/agent/src/context.ts
@@ -16,7 +16,7 @@ import type {
 import { tagWithCurrentBurnTags } from './burn.js';
 import { createPolicyGate } from './policy.js';
 
-interface CreateContextFactoryOptions {
+export interface CreateContextFactoryOptions {
   workspace: string;
   agentId: string;
   logger?: Logger;
@@ -35,7 +35,7 @@ interface CreateContextFactoryOptions {
   trackSchedule(id: string): void;
 }
 
-interface ContextFactory {
+export interface ContextFactory {
   base: Context;
   withEvent(signal: AbortSignal, event: AgentEvent): Context;
   withSignal(signal: AbortSignal): Context;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -208,6 +208,9 @@ export function agent(definition: AgentDefinition): AgentHandle {
  */
 export { NoRetry, relayfileTools, deployAgent };
 
+export { createContextFactory } from './context.js';
+export type { CreateContextFactoryOptions, ContextFactory } from './context.js';
+
 export type {
   AgentDefinition,
   AgentHandle,


### PR DESCRIPTION
## Summary

- Re-export `createContextFactory` from `@agent-relay/agent`'s package index
- Add `export` keyword to `CreateContextFactoryOptions` and `ContextFactory` interfaces in `context.ts`

## Why

`createContextFactory` was defined and exported from `packages/agent/src/context.ts`, but the package index (`packages/agent/src/index.ts`) only re-exported `agent`, `NoRetry`, `relayfileTools`, and `deployAgent`. Downstream callers that wanted to build a `Context` outside of the `agent()` factory had no public way to do so.

This surfaced during the cloud#548 (M1-M4 proactive-runtime chain) dedupe: a cloud-side test (`tests/proactive-runtime/inbox-policy-e2e.test.ts`) was reaching in via a deep `packages/agent-relay-agent/src/context.js` import. When that in-tree fork was deleted in favor of consuming `@agent-relay/agent@^6.0.18` from npm, the test broke because the public package didn't expose the symbol.

The two interfaces (`CreateContextFactoryOptions`, `ContextFactory`) were also missing the `export` keyword, so callers couldn't even type the arguments / return value if they did manage to import the function.

## Scope

- Purely additive (no signature or behavior change to existing exports).
- No new runtime code; the function is unchanged.
- Typecheck clean on `packages/agent`.

## Test plan

- [x] `tsc --noEmit` on `packages/agent` — green
- [x] No-op for existing consumers (no removed/renamed exports)
- [ ] Once published, cloud#548's `inbox-policy-e2e.test.ts` can import via the public package surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)