### PR TITLE
fix(cli): persist spawned agents across cwd

### DIFF
--- a/.trajectories/completed/2026-05/traj_whd40oxptlhn.json
+++ b/.trajectories/completed/2026-05/traj_whd40oxptlhn.json
@@ -1,0 +1,55 @@
+{
+  "id": "traj_whd40oxptlhn",
+  "version": 1,
+  "task": {
+    "title": "Review spawn persistence fix and open PR"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-13T10:57:02.796Z",
+  "completedAt": "2026-05-13T11:00:43.100Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-13T11:00:29.230Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_iitqy5b02jfd",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-13T11:00:29.230Z",
+      "endedAt": "2026-05-13T11:00:43.100Z",
+      "events": [
+        {
+          "ts": 1778670029232,
+          "type": "decision",
+          "content": "Move spawn persistence fix onto clean main-based branch: Move spawn persistence fix onto clean main-based branch",
+          "raw": {
+            "question": "Move spawn persistence fix onto clean main-based branch",
+            "chosen": "Move spawn persistence fix onto clean main-based branch",
+            "alternatives": [],
+            "reasoning": "The original working branch had unrelated proactive-runtime commits; a PR from it would have included unrelated history. The fix branch now tracks origin/main and carries only the spawn persistence change plus trajectory records."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reviewed the spawn persistence fix on a clean origin/main-based branch, confirmed the CLI lifecycle behavior, reran focused Vitest and ESLint checks, and prepared the branch for PR.",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  },
+  "commits": [],
+  "filesChanged": [
+    "src/cli/commands/agent-management.ts",
+    "src/cli/commands/agent-management.test.ts",
+    ".trajectories/index.json",
+    ".trajectories/completed/2026-05/traj_wx00tjvpptvg.json",
+    ".trajectories/completed/2026-05/traj_whd40oxptlhn.json"
+  ],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_whd40oxptlhn.md
+++ b/.trajectories/completed/2026-05/traj_whd40oxptlhn.md
@@ -1,0 +1,40 @@
+# Trajectory: Review spawn persistence fix and open PR
+
+> **Status:** ✅ Completed
+> **Confidence:** 88%
+> **Started:** May 13, 2026 at 12:57 PM
+> **Completed:** May 13, 2026 at 01:00 PM
+
+---
+
+## Summary
+
+Reviewed the spawn persistence fix on a clean origin/main-based branch, confirmed the CLI lifecycle behavior, reran focused Vitest and ESLint checks, and prepared the branch for PR.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Move spawn persistence fix onto clean main-based branch
+
+- **Chose:** Move spawn persistence fix onto clean main-based branch
+- **Reasoning:** The original working branch had unrelated proactive-runtime commits; a PR from it would have included unrelated history. The fix branch now tracks origin/main and carries only the spawn persistence change plus trajectory records.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Move spawn persistence fix onto clean main-based branch: Move spawn persistence fix onto clean main-based branch
+
+---
+
+## Artifacts
+
+**Commits:** none yet
+**Files changed:** src/cli/commands/agent-management.ts, src/cli/commands/agent-management.test.ts, .trajectories/index.json, .trajectories/completed/2026-05/traj_wx00tjvpptvg.json, .trajectories/completed/2026-05/traj_whd40oxptlhn.json

--- a/.trajectories/completed/2026-05/traj_wx00tjvpptvg.json
+++ b/.trajectories/completed/2026-05/traj_wx00tjvpptvg.json
@@ -1,0 +1,63 @@
+{
+  "id": "traj_wx00tjvpptvg",
+  "version": 1,
+  "task": {
+    "title": "Investigate agent-relay spawn persistence"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-13T10:49:12.464Z",
+  "completedAt": "2026-05-13T10:53:03.748Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-13T10:52:06.811Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_b2u14i704jjm",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-13T10:52:06.811Z",
+      "endedAt": "2026-05-13T10:53:03.748Z",
+      "events": [
+        {
+          "ts": 1778669526813,
+          "type": "decision",
+          "content": "Keep spawn broker scoped to invoking project: Keep spawn broker scoped to invoking project",
+          "raw": {
+            "question": "Keep spawn broker scoped to invoking project",
+            "chosen": "Keep spawn broker scoped to invoking project",
+            "alternatives": [],
+            "reasoning": "The CLI --cwd option describes the spawned worker working directory; using it to choose the broker made agent-relay who connect to a different project scope and hide the spawned agent."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778669554293,
+          "type": "reflection",
+          "content": "Found spawn persistence failure caused by two CLI-layer issues: autostart used owned SDK brokers that shutdown in finally, and --cwd selected the broker scope instead of only the worker cwd. Patched spawn to autostart a background broker and preserve current project broker scope.",
+          "raw": {
+            "confidence": 0.84
+          },
+          "significance": "high",
+          "tags": ["confidence:0.84"]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed agent-relay spawn persistence by autostarting a detached background broker for one-shot spawn commands and by treating --cwd as the spawned agent cwd rather than the broker project scope. Added a regression test for --cwd broker-scope behavior and verified with Vitest plus ESLint.",
+    "approach": "Standard approach",
+    "confidence": 0.86
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "a5dd2166d3e4ddbdf6a9005e592ba8777552b471",
+    "endRef": "a5dd2166d3e4ddbdf6a9005e592ba8777552b471"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_wx00tjvpptvg.md
+++ b/.trajectories/completed/2026-05/traj_wx00tjvpptvg.md
@@ -1,0 +1,34 @@
+# Trajectory: Investigate agent-relay spawn persistence
+
+> **Status:** ✅ Completed
+> **Confidence:** 86%
+> **Started:** May 13, 2026 at 12:49 PM
+> **Completed:** May 13, 2026 at 12:53 PM
+
+---
+
+## Summary
+
+Fixed agent-relay spawn persistence by autostarting a detached background broker for one-shot spawn commands and by treating --cwd as the spawned agent cwd rather than the broker project scope. Added a regression test for --cwd broker-scope behavior and verified with Vitest plus ESLint.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Keep spawn broker scoped to invoking project
+
+- **Chose:** Keep spawn broker scoped to invoking project
+- **Reasoning:** The CLI --cwd option describes the spawned worker working directory; using it to choose the broker made agent-relay who connect to a different project scope and hide the spawned agent.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Keep spawn broker scoped to invoking project: Keep spawn broker scoped to invoking project
+- Found spawn persistence failure caused by two CLI-layer issues: autostart used owned SDK brokers that shutdown in finally, and --cwd selected the broker scope instead of only the worker cwd. Patched spawn to autostart a background broker and preserve current project broker scope.

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-12T21:46:30.219Z",
+  "lastUpdated": "2026-05-13T11:00:43.267Z",
   "trajectories": {
     "traj_1775914133873_35667beb": {
       "title": "fix-sdk-build-resolution-workflow",
@@ -388,6 +388,20 @@
       "startedAt": "2026-05-11T18:25:24.626Z",
       "completedAt": "2026-05-11T18:37:05.318Z",
       "path": "/home/runner/work/relay/relay/.trajectories/completed/2026-05/traj_mi9eqd4rjfea.json"
+    },
+    "traj_wx00tjvpptvg": {
+      "title": "Investigate agent-relay spawn persistence",
+      "status": "completed",
+      "startedAt": "2026-05-13T10:49:12.464Z",
+      "completedAt": "2026-05-13T10:53:03.748Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/completed/2026-05/traj_wx00tjvpptvg.json"
+    },
+    "traj_whd40oxptlhn": {
+      "title": "Review spawn persistence fix and open PR",
+      "status": "completed",
+      "startedAt": "2026-05-13T10:57:02.796Z",
+      "completedAt": "2026-05-13T11:00:43.100Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relay/.trajectories/completed/2026-05/traj_whd40oxptlhn.json"
     }
   }
 }

--- a/src/cli/commands/agent-management.test.ts
+++ b/src/cli/commands/agent-management.test.ts
@@ -120,10 +120,38 @@ describe('registerAgentManagementCommands', () => {
       cwd: undefined,
       shadowOf: undefined,
       shadowMode: undefined,
+      continueFrom: undefined,
     });
     expect(client.listAgents).toHaveBeenCalledTimes(1);
     expect(client.shutdown).toHaveBeenCalledTimes(1);
     expect(deps.log).toHaveBeenCalledWith('Spawned agent: WorkerA (pid: 4321)');
+  });
+
+  it('uses --cwd for the spawned agent without changing broker project scope', async () => {
+    const client = createClientMock({
+      listAgents: vi.fn(async () => [{ name: 'WorkerCwd', pid: 4322 }]),
+    });
+    const { program, deps } = createHarness({ client, projectRoot: '/tmp/control-project' });
+
+    const exitCode = await runCommand(program, [
+      'spawn',
+      'WorkerCwd',
+      'codex',
+      '--cwd',
+      '/tmp/worker-project',
+      'Ship tests',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(deps.createAutostartClient).toHaveBeenCalledWith('/tmp/control-project');
+    expect(client.spawnPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'WorkerCwd',
+        cli: 'codex',
+        cwd: '/tmp/worker-project',
+        task: 'Ship tests',
+      })
+    );
   });
 
   it('uses stdin task for spawn when task argument is omitted', async () => {

--- a/src/cli/commands/agent-management.ts
+++ b/src/cli/commands/agent-management.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { spawn as spawnProcess } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -93,9 +94,51 @@ async function createSdkClient(cwd: string, autoStart: boolean): Promise<AgentMa
     if (!autoStart) {
       throw new Error('No running broker found. Start one with: agent-relay up');
     }
-    const client = await AgentRelayClient.spawn({ cwd });
-    return client as unknown as AgentManagementClient;
   }
+
+  await startBackgroundBroker(cwd);
+  const client = await waitForBrokerClient(cwd);
+  return client as unknown as AgentManagementClient;
+}
+
+function startBackgroundBroker(cwd: string): void {
+  const cliScript = process.argv[1];
+  if (!cliScript) {
+    throw new Error('Unable to locate agent-relay CLI script for broker autostart');
+  }
+
+  const child = spawnProcess(
+    process.execPath,
+    [cliScript, 'up', '--background', '--no-dashboard', '--no-spawn'],
+    {
+      cwd,
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    }
+  );
+  child.unref();
+}
+
+async function waitForBrokerClient(
+  cwd: string,
+  timeoutMs = 15_000,
+  intervalMs = 250
+): Promise<AgentRelayClient> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      return AgentRelayClient.connect({ cwd });
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`Broker did not become ready after autostart: ${detail}`);
 }
 
 function withDefaults(overrides: Partial<AgentManagementDependencies> = {}): AgentManagementDependencies {
@@ -209,7 +252,7 @@ export function registerAgentManagementCommands(
 
         let client: AgentManagementClient;
         try {
-          client = await deps.createAutostartClient(options.cwd || deps.getProjectRoot());
+          client = await deps.createAutostartClient(deps.getProjectRoot());
         } catch (err: any) {
           deps.error(`Failed to connect to broker: ${err?.message || String(err)}`);
           deps.exit(1);


### PR DESCRIPTION
## Summary
- autostart a detached background broker for one-shot `agent-relay spawn` instead of using an SDK-owned broker that shuts down immediately
- keep broker lookup scoped to the invoking project while passing `--cwd` only to the spawned worker
- add a regression test covering `spawn --cwd` broker-scope behavior

## Fresh review
- Re-reviewed the lifecycle path on a clean `origin/main` branch. No blocking findings found.
- Main residual risk is that the autostart path depends on the regular `agent-relay up --background` CLI entrypoint becoming ready within the wait window.

## Tests
- `npm exec -- vitest run src/cli/commands/agent-management.test.ts`
- `npm exec -- eslint src/cli/commands/agent-management.ts src/cli/commands/agent-management.test.ts`