### PR TITLE
blog: neutral Mirage credit (drop chronology claim)

### DIFF
--- a/web/content/blog/just-give-the-agent-files.mdx
+++ b/web/content/blog/just-give-the-agent-files.mdx
@@ -94,7 +94,7 @@ $ jq -r '.id' $MOUNT/notion/pages/by-title/just-give-the-agent-files__c24642bb.j
 $ cat $MOUNT/notion/pages/3566800c-1c90-8035-a491-cdc3c24642bb/content.md
 ```
 
-Linear issues use `<identifier>__<uuid>` — ticket number first so the listing is immediately scannable. We picked up the filename shape after seeing it in [Mirage](https://github.com/strukto-ai/mirage)'s mount, and Mirage's broader "mount everything as one tree" framing is the closest prior art to relayfile:
+Linear issues use `<identifier>__<uuid>` — ticket number first so the listing is immediately scannable. [Mirage](https://github.com/strukto-ai/mirage) converged on a similar filename shape in their mount, and their broader "mount everything as one tree" framing is the closest thing in this space to what we're doing:
 
 ```bash
 $ ls $MOUNT/linear/issues/


### PR DESCRIPTION
## Summary

One-line tweak to the Mirage credit in `web/content/blog/just-give-the-agent-files.mdx`.

**Before:**
> We picked up the filename shape after seeing it in [Mirage]'s mount, and Mirage's broader \"mount everything as one tree\" framing is the closest prior art to relayfile:

**After:**
> [Mirage] converged on a similar filename shape in their mount, and their broader \"mount everything as one tree\" framing is the closest thing in this space to what we're doing:

## Why

\"Prior art\" implies Mirage came first. \"We picked up the filename shape after seeing it in their mount\" implies we borrowed it from them. Neither is established — relayfile predates the moment we first saw Mirage's repo. The neutral framing credits them for working in the same space without making a chronology claim either direction.

## Test plan

- [ ] Skim the post on staging; sentence still reads cleanly in context
- [ ] No surrounding paragraphs changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)