### PR TITLE
docs: strengthen relayfile landing page

### DIFF
--- a/web/app/file/RelayfileContent.tsx
+++ b/web/app/file/RelayfileContent.tsx
@@ -9,165 +9,215 @@ import s from './relayfile.module.css';
 
 const featureCards = [
   {
-    title: 'Read Files',
-    desc: 'Fetch full contents or byte ranges with the same API across local and remote volumes.',
+    title: 'Provider files',
+    desc: 'Mount Linear issues, GitHub PRs, Notion pages, Slack channels, and SaaS records as ordinary paths.',
   },
   {
-    title: 'Write Files',
-    desc: 'Create, overwrite, append, and patch files safely from agents and tools.',
+    title: 'File writeback',
+    desc: 'Create, patch, and delete provider records by saving files. Adapters validate changes and queue writeback.',
   },
   {
-    title: 'Watch Changes',
-    desc: 'Subscribe to file events and trigger follow-up work the moment something changes.',
+    title: 'Realtime sync',
+    desc: 'Every writer publishes a new revision so other agents see fresh state on their next read.',
   },
   {
-    title: 'Shared Volumes',
-    desc: 'Mount the same workspace into multiple agents so they can collaborate on identical state.',
+    title: 'Scoped mounts',
+    desc: 'Give each agent path-level read, write, watch, or admin permissions instead of broad provider credentials.',
   },
   {
-    title: 'File Locking',
-    desc: 'Coordinate concurrent writes with explicit locks and conflict-aware workflows.',
+    title: 'Deterministic digests',
+    desc: 'Precompute high-value rollups like yesterday.md so agents start with the answer-shaped file.',
   },
   {
-    title: 'Permissions',
-    desc: 'Control which agents can read, write, watch, or administer each path.',
+    title: 'Native tools',
+    desc: 'Agents use cat, grep, find, jq, rg, and editors against a real local mount or the HTTP API.',
   },
 ];
 
-const toolBadges = [
-  'Claude Code',
-  'Codex',
-  'Gemini CLI',
-  'OpenCode',
-  'Copilot',
-  'Aider',
-  'Goose',
-  'Custom agents',
+const integrationBadges = [
+  'Linear',
+  'GitHub',
+  'Notion',
+  'Slack',
+  'HubSpot',
+  'Salesforce',
+  'Google Drive',
+  'Gmail',
+  'Composio',
+  'Pipedream',
+  'Nango',
+  'Custom APIs',
 ];
 
 const sdkTabs = {
-  typescript: {
-    label: 'TypeScript',
-    code: `import { Relayfile } from '@agent-relay/relayfile';
+  mount: {
+    label: 'Mount SDK',
+    language: 'typescript',
+    code: `import { RelayfileSetup } from '@relayfile/sdk';
 
-const relayfile = new Relayfile({
-  apiKey: process.env.RELAY_API_KEY,
+const setup = new RelayfileSetup({
+  accessToken: process.env.RELAYFILE_ACCESS_TOKEN!,
 });
 
-await relayfile.files.write({
-  volume: 'workspace',
-  path: '/plans/launch.md',
-  content: '# Launch plan\\n\\n- ship relayfile',
+const handle = await setup.ensureMountedWorkspace({
+  workspaceId: 'rw_123',
+  provider: 'notion',
+  verifyProvider: true,
+  localDir: '/workspace/relayfile',
 });
 
-const notes = await relayfile.files.read({
-  volume: 'workspace',
-  path: '/plans/launch.md',
-});
+console.log(handle.env().RELAYFILE_LOCAL_DIR);`,
+    bullets: [
+      'Attach a hosted workspace inside Daytona, E2B, CI, or your own sandbox.',
+      'Gate startup on provider readiness before the agent begins work.',
+      'The agent receives a normal directory plus environment variables.',
+    ],
+  },
+  vercel: {
+    label: 'Vercel AI SDK',
+    language: 'typescript',
+    code: `import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
 
-const stream = await relayfile.watch.subscribe({
-  volume: 'workspace',
-  prefix: '/plans',
-  onEvent(event) {
-    console.log(event.type, event.path);
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
+
+const { text } = await generateText({
+  model: process.env.AI_MODEL!,
+  prompt: 'What changed yesterday across GitHub, Linear, and Notion?',
+  tools: {
+    readRelayfile: tool({
+      description: 'Read a file from the Relayfile workspace',
+      inputSchema: z.object({ path: z.string() }),
+      execute: ({ path }) => files.readFile('rw_123', path),
+    }),
   },
 });`,
     bullets: [
-      'Typed APIs for file reads, writes, watches, and metadata.',
-      'Works cleanly in app servers, workers, and agent harnesses.',
-      'Matches the same resource model as the HTTP API.',
+      'Expose one Relayfile read tool instead of one tool per provider.',
+      'Let the model inspect digests first, then open raw provider files as needed.',
+      'Works with generateText, streamText, and AI Gateway model strings.',
     ],
   },
-  python: {
-    label: 'Python',
-    code: `from relayfile import Relayfile
+  anthropic: {
+    label: 'Claude Agent SDK',
+    language: 'typescript',
+    code: `import { createSdkMcpServer, query, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
 
-client = Relayfile(api_key=os.environ["RELAY_API_KEY"])
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
 
-client.files.write(
-    volume="workspace",
-    path="/artifacts/build.json",
-    content='{"status":"green"}',
-)
+const relayfileServer = createSdkMcpServer({
+  name: 'relayfile',
+  tools: [
+    tool('readRelayfile', 'Read workspace files', { path: z.string() }, async ({ path }) => ({
+      content: [{ type: 'text', text: JSON.stringify(await files.readFile('rw_123', path)) }],
+    })),
+  ],
+});
 
-artifact = client.files.read(
-    volume="workspace",
-    path="/artifacts/build.json",
-)
-
-for event in client.watch.stream(volume="workspace", prefix="/artifacts"):
-    print(event["type"], event["path"])`,
+for await (const message of query({
+  prompt: 'Summarize yesterday.md, then draft Linear follow-ups.',
+  options: { mcpServers: { relayfile: relayfileServer } },
+})) {
+  console.log(message);
+}`,
     bullets: [
-      'Simple synchronous flows for scripts and orchestration.',
-      'Streaming watch events for long-running workers.',
-      'Built for task runners, notebooks, and agent backends.',
+      'Keep Claude in its normal agent loop while Relayfile owns provider context.',
+      'Use path-scoped tokens for the files the Claude worker may read or write.',
+      'Pair with a mounted directory when the agent should use bash directly.',
+    ],
+  },
+  openai: {
+    label: 'OpenAI Agents',
+    language: 'typescript',
+    code: `import { Agent, run, tool } from '@openai/agents';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
+
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
+
+const agent = new Agent({
+  name: 'workspace-reviewer',
+  instructions: 'Use Relayfile paths before asking for provider-specific tools.',
+  tools: [
+    tool({
+      name: 'read_relayfile',
+      parameters: z.object({ path: z.string() }),
+      execute: ({ path }) => files.readFile('rw_123', path),
+    }),
+  ],
+});
+
+await run(agent, 'Review /digests/yesterday.md and file Linear follow-ups.');`,
+    bullets: [
+      'Use Relayfile as the agent state and integration layer for SDK-owned runs.',
+      'Keep orchestration, approvals, and tracing in the framework you already use.',
+      'Add write tools only for scoped paths that the agent is allowed to change.',
     ],
   },
   curl: {
     label: 'cURL',
-    code: `curl -X PUT https://agentrelay.com/cloud/api/file/v1/files/content \\
-  -H "authorization: Bearer $RELAY_API_KEY" \\
+    language: 'curl',
+    code: `curl "https://api.agentrelay.com/relayfile/v1/workspaces/rw_123/fs/tree?path=/" \\
+  -H "authorization: Bearer $RELAYFILE_TOKEN"
+
+curl "https://api.agentrelay.com/relayfile/v1/workspaces/rw_123/fs/file?path=/digests/yesterday.md" \\
+  -H "authorization: Bearer $RELAYFILE_TOKEN"
+
+curl -X PUT "https://api.agentrelay.com/relayfile/v1/workspaces/rw_123/fs/file?path=/linear/issues/AGE-12.json" \\
+  -H "authorization: Bearer $RELAYFILE_TOKEN" \\
   -H "content-type: application/json" \\
-  -d '{
-    "volume": "workspace",
-    "path": "/scratch/brief.txt",
-    "content": "Draft the product brief"
-  }'
-
-curl "https://agentrelay.com/cloud/api/file/v1/files/content?volume=workspace&path=%2Fscratch%2Fbrief.txt" \\
-  -H "authorization: Bearer $RELAY_API_KEY"
-
-curl "https://agentrelay.com/cloud/api/file/v1/files/watch?volume=workspace&prefix=%2Fscratch" \\
-  -H "authorization: Bearer $RELAY_API_KEY"`,
+  -d '{"contentType":"application/json","content":"{\\"state\\":\\"In Review\\"}"}'`,
     bullets: [
-      'Raw HTTP for quick debugging and shell-based workflows.',
-      'Easy to plug into CI, demos, and documentation examples.',
-      'Same primitives as the SDKs with no special transport layer.',
+      'Debug the exact HTTP surface behind the SDK and mount daemon.',
+      'Use standard shell tools in CI or one-off operational scripts.',
+      'Query the tree, read files, and submit provider writeback from one API.',
     ],
   },
 } as const;
 
 const whyCards = [
   {
-    title: 'Zero infrastructure',
-    desc: 'No NFS setup, no homegrown sync daemon, no object-store glue code. Relayfile gives agents one coherent filesystem abstraction.',
+    title: 'No schema tax',
+    desc: 'Agents open the files they need instead of loading a large typed tool surface for every connected provider.',
   },
   {
-    title: 'Instant setup',
-    desc: 'Create a volume, write a file, and start watching changes in minutes. The API is designed for immediate use from scripts and SDKs.',
+    title: 'Useful writes',
+    desc: 'Provider updates are file operations with validation, retries, and audit trails handled by the integration layer.',
   },
   {
-    title: 'Framework-agnostic',
-    desc: 'Use Relayfile from custom agent harnesses, MCP servers, background jobs, editors, or production services without changing the core model.',
+    title: 'Multi-agent by default',
+    desc: 'Reviewer, implementer, and orchestrator agents can all mount the same workspace and react to the same revisions.',
   },
 ];
 
 const steps = [
   {
     step: '01',
-    title: 'Create a volume',
-    code: `curl -X POST https://agentrelay.com/cloud/api/file/v1/volumes \\
-  -H "authorization: Bearer $RELAY_API_KEY" \\
-  -H "content-type: application/json" \\
-  -d '{"name":"workspace"}'`,
+    title: 'Connect a provider',
+    code: `npx relayfile setup \\
+  --provider notion \\
+  --workspace research-room \\
+  --local-dir ./relayfile-mount`,
   },
   {
     step: '02',
-    title: 'Write a file',
-    code: `curl -X PUT https://agentrelay.com/cloud/api/file/v1/files/content \\
-  -H "authorization: Bearer $RELAY_API_KEY" \\
-  -H "content-type: application/json" \\
-  -d '{
-    "volume":"workspace",
-    "path":"/docs/spec.md",
-    "content":"# Relayfile\\n\\nShared state for agents."
-  }'`,
+    title: 'Read the tree',
+    code: `ls ./relayfile-mount
+cat ./relayfile-mount/LAYOUT.md
+cat ./relayfile-mount/digests/yesterday.md`,
   },
   {
     step: '03',
-    title: 'Watch for changes',
-    code: `curl "https://agentrelay.com/cloud/api/file/v1/files/watch?volume=workspace&prefix=%2Fdocs" \\
-  -H "authorization: Bearer $RELAY_API_KEY"`,
+    title: 'Write back',
+    code: `cat > ./relayfile-mount/linear/issues/drafts/follow-up.json <<'JSON'
+{
+  "title": "Follow up from digest",
+  "state": "Todo"
+}
+JSON`,
   },
 ];
 
@@ -187,7 +237,7 @@ function highlight(code: string, lang: Lang) {
       : lang === 'curl'
         ? /\b(curl)\b/g
         : /\b(import|from|const|await|new)\b/g;
-  const types = lang === 'python' ? /\b(Relayfile)\b/g : /\b(Relayfile)\b/g;
+  const types = /\b(RelayfileSetup|RelayFileClient|Agent|Relayfile)\b/g;
   const methods = /\.(\w+)\(/g;
 
   const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -280,9 +330,9 @@ function RelayfileAnimation() {
 }
 
 export function RelayfileContent() {
-  const [activeTab, setActiveTab] = useState<keyof typeof sdkTabs>('typescript');
+  const [activeTab, setActiveTab] = useState<keyof typeof sdkTabs>('mount');
   const activeSdk = sdkTabs[activeTab];
-  const highlightedSdk = useMemo(() => highlight(activeSdk.code, activeTab), [activeSdk.code, activeTab]);
+  const highlightedSdk = useMemo(() => highlight(activeSdk.code, activeSdk.language), [activeSdk]);
   const highlightedSteps = useMemo(() => steps.map((step) => highlight(step.code, 'curl')), []);
 
   return (
@@ -354,19 +404,19 @@ export function RelayfileContent() {
           <div className={s.heroLeft}>
             <span className={s.badge}>
               <span className={s.badgeDot} />
-              HEADLESS FILESYSTEM FOR AGENTS
+              INTEGRATION FILESYSTEM FOR AGENTS
             </span>
 
             <h1 className={s.headline}>
-              Files
+              Relayfile
               <br />
-              for agents
+              gives agents files
             </h1>
 
             <p className={s.subtitle}>
-              Relayfile gives AI agents one place to read, write, watch, and coordinate files. Shared volumes,
-              locks, metadata, and realtime change events let multi-agent systems work on the same state
-              without building storage plumbing first.
+              Mount Linear, GitHub, Notion, Slack, HubSpot, Salesforce, and your own systems as a realtime
+              filesystem. Agents inspect provider data with bash, write records by saving files, and
+              coordinate through scoped mounts instead of bespoke tool glue.
             </p>
 
             <div className={s.ctas}>
@@ -395,9 +445,10 @@ export function RelayfileContent() {
 
       <div className={s.featuresWrapper}>
         <div className={s.featuresHeader}>
-          <h2 className={s.featuresTitle}>Filesystem primitives for agent coordination</h2>
+          <h2 className={s.featuresTitle}>The file interface for integration work</h2>
           <p className={s.featuresSubtitle}>
-            Everything agents need to share state, react to changes, and work safely in parallel.
+            Relayfile turns the systems where work happens into paths an agent can list, read, grep, edit, and
+            watch.
           </p>
         </div>
 
@@ -417,16 +468,16 @@ export function RelayfileContent() {
       <div className={s.byohWrapper}>
         <section className={s.byohSection}>
           <FadeIn direction="up" className={s.byohText}>
-            <h2 className={s.byohTitle}>Works with every AI tool</h2>
+            <h2 className={s.byohTitle}>Mount the systems agents actually use</h2>
             <p className={s.byohSubtitle}>
-              Use Relayfile from coding agents, task runners, MCP hosts, CI, or your own orchestration layer.
-              If it can make HTTP calls, it can share files through Relayfile.
+              Provider auth, pagination, sync, and writeback stay behind the mount. The agent sees one
+              workspace tree with layouts, indexes, digests, and provider records side by side.
             </p>
           </FadeIn>
           <FadeIn direction="up" delay={120} className={s.byohLogos}>
-            {toolBadges.map((tool) => (
-              <span key={tool} className={s.toolBadge}>
-                {tool}
+            {integrationBadges.map((integration) => (
+              <span key={integration} className={s.toolBadge}>
+                {integration}
               </span>
             ))}
           </FadeIn>
@@ -437,10 +488,10 @@ export function RelayfileContent() {
         <section className={s.sdkSection}>
           <FadeIn direction="right" className={s.sdkText}>
             <span className={s.openclawBadge}>SDK</span>
-            <h2 className={s.sdkTitle}>One API surface across every client</h2>
+            <h2 className={s.sdkTitle}>Use the same files from code, HTTP, or a mount</h2>
             <p className={s.sdkSubtitle}>
-              Read files, watch directories, and attach metadata from TypeScript, Python, or straight HTTP.
-              The primitives stay the same even when your harness changes.
+              Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, scripts, and terminal-native agents can all
+              read the same workspace tree and write through the same contract.
             </p>
 
             <div className={s.tabRow}>
@@ -488,7 +539,9 @@ export function RelayfileContent() {
         <section className={s.deploySection}>
           <FadeIn direction="up">
             <h2 className={s.deployTitle}>Why Relayfile</h2>
-            <p className={s.deploySubtitle}>Purpose-built shared storage for multi-agent systems.</p>
+            <p className={s.deploySubtitle}>
+              Purpose-built for agents that need to work across real SaaS systems.
+            </p>
           </FadeIn>
 
           <div className={s.deployCards}>
@@ -510,10 +563,10 @@ export function RelayfileContent() {
       <div className={s.openclawWrapper}>
         <section className={s.openclawSection}>
           <FadeIn direction="right" className={s.openclawText}>
-            <h2 className={s.openclawTitle}>Get started in three requests</h2>
+            <h2 className={s.openclawTitle}>Get useful in three moves</h2>
             <p className={s.openclawSubtitle}>
-              Create a workspace, write shared state, and subscribe to file changes. Relayfile is designed to
-              be useful before you build any additional abstractions around it.
+              Connect a provider, read the generated workspace, then write back through the same file
+              interface. The first useful workflow is a directory listing, not a framework migration.
             </p>
           </FadeIn>
 

--- a/web/app/file/page.tsx
+++ b/web/app/file/page.tsx
@@ -1,5 +1,13 @@
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+import { RelayfileContent } from './RelayfileContent';
+
+export const metadata: Metadata = {
+  title: 'Relayfile | Integration filesystem for AI agents',
+  description:
+    'Mount SaaS integrations as files so agents can read, write, watch, and coordinate through one realtime workspace.',
+};
 
 export default function FilePage() {
-  redirect('/primitives#file');
+  return <RelayfileContent />;
 }

--- a/web/app/file/relayfile.module.css
+++ b/web/app/file/relayfile.module.css
@@ -2,13 +2,23 @@
 .page {
   min-height: 100vh;
   background:
-    radial-gradient(ellipse 36% 28% at 10% 8%, color-mix(in srgb, var(--primary) 16%, white 22%), transparent 72%),
-    radial-gradient(ellipse 34% 26% at 90% 10%, color-mix(in srgb, var(--primary) 14%, white 20%), transparent 70%),
+    radial-gradient(
+      ellipse 36% 28% at 10% 8%,
+      color-mix(in srgb, var(--primary) 16%, white 22%),
+      transparent 72%
+    ),
+    radial-gradient(
+      ellipse 34% 26% at 90% 10%,
+      color-mix(in srgb, var(--primary) 14%, white 20%),
+      transparent 70%
+    ),
     var(--landing-hero-bg);
   color: var(--fg);
   font-family: var(--font-geist-sans), sans-serif;
   -webkit-font-smoothing: antialiased;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
 }
 
 .heroSection {
@@ -94,8 +104,13 @@
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.45; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
 }
 
 .headline {
@@ -141,7 +156,10 @@
   border-radius: 100px;
   text-decoration: none;
   box-shadow: 0 2px 12px color-mix(in srgb, var(--btn-bg) 25%, transparent);
-  transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+  transition:
+    background 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
 }
 
 .ctaPrimary:hover {
@@ -163,7 +181,10 @@
   border: 1.5px solid var(--line);
   border-radius: 100px;
   text-decoration: none;
-  transition: border-color 0.2s, color 0.2s, transform 0.15s;
+  transition:
+    border-color 0.2s,
+    color 0.2s,
+    transform 0.15s;
 }
 
 .ctaSecondary:hover {
@@ -187,7 +208,11 @@
   border-radius: 36px;
   background:
     radial-gradient(circle at 30% 28%, color-mix(in srgb, var(--primary) 26%, transparent), transparent 34%),
-    radial-gradient(circle at 74% 26%, color-mix(in srgb, var(--secondary-400) 22%, transparent), transparent 30%),
+    radial-gradient(
+      circle at 74% 26%,
+      color-mix(in srgb, var(--secondary-400) 22%, transparent),
+      transparent 30%
+    ),
     radial-gradient(circle at 50% 74%, color-mix(in srgb, var(--primary) 14%, white 8%), transparent 38%);
   filter: blur(22px);
   opacity: 0.9;
@@ -201,8 +226,11 @@
   border-radius: 28px;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--primary) 16%, transparent);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 92%, transparent) 0%, color-mix(in srgb, var(--surface) 96%, transparent) 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-strong) 92%, transparent) 0%,
+    color-mix(in srgb, var(--surface) 96%, transparent) 100%
+  );
   box-shadow:
     0 24px 80px rgba(0, 0, 0, 0.14),
     inset 0 1px 0 rgba(255, 255, 255, 0.22);
@@ -246,7 +274,10 @@
     linear-gradient(to right, color-mix(in srgb, var(--line) 55%, transparent) 1px, transparent 1px),
     linear-gradient(to bottom, color-mix(in srgb, var(--line) 45%, transparent) 1px, transparent 1px),
     linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--primary) 3%, transparent) 100%);
-  background-size: 90px 90px, 90px 90px, auto;
+  background-size:
+    90px 90px,
+    90px 90px,
+    auto;
 }
 
 .folderCard,
@@ -263,13 +294,19 @@
 }
 
 .folderCard {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--secondary-50) 90%, white 10%) 0%, color-mix(in srgb, var(--secondary-100) 94%, white 6%) 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--secondary-50) 90%, white 10%) 0%,
+    color-mix(in srgb, var(--secondary-100) 94%, white 6%) 100%
+  );
 }
 
 :global(html[data-theme='dark']) .folderCard {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--secondary-900) 34%, var(--surface-strong) 66%) 0%, color-mix(in srgb, var(--secondary-950) 26%, var(--surface) 74%) 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--secondary-900) 34%, var(--surface-strong) 66%) 0%,
+    color-mix(in srgb, var(--secondary-950) 26%, var(--surface) 74%) 100%
+  );
 }
 
 .folderCardMain {
@@ -409,13 +446,23 @@
 }
 
 @keyframes floatPrimary {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-10px); }
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
 }
 
 @keyframes floatSoft {
-  0%, 100% { transform: translateY(0px) translateX(0px); }
-  50% { transform: translateY(-8px) translateX(3px); }
+  0%,
+  100% {
+    transform: translateY(0px) translateX(0px);
+  }
+  50% {
+    transform: translateY(-8px) translateX(3px);
+  }
 }
 
 .featuresWrapper {
@@ -486,8 +533,11 @@
   padding: 22px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 96%, transparent) 0%, color-mix(in srgb, var(--surface) 98%, transparent) 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-strong) 96%, transparent) 0%,
+    color-mix(in srgb, var(--surface) 98%, transparent) 100%
+  );
   box-shadow: 0 8px 24px color-mix(in srgb, var(--primary) 4%, transparent);
 }
 
@@ -637,7 +687,11 @@
   font-size: 0.88rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s, border-color 0.2s, color 0.2s, background 0.2s;
+  transition:
+    transform 0.15s,
+    border-color 0.2s,
+    color 0.2s,
+    background 0.2s;
 }
 
 .tabButton:hover {
@@ -697,10 +751,18 @@
   color: var(--terminal-fg);
 }
 
-.codeKeyword { color: var(--terminal-keyword); }
-.codeString { color: var(--terminal-string); }
-.codeType { color: var(--terminal-type); }
-.codeMethod { color: var(--terminal-method); }
+.codeKeyword {
+  color: var(--terminal-keyword);
+}
+.codeString {
+  color: var(--terminal-string);
+}
+.codeType {
+  color: var(--terminal-type);
+}
+.codeMethod {
+  color: var(--terminal-method);
+}
 
 .deploySection {
   max-width: 1280px;
@@ -725,7 +787,10 @@
   border: 1px solid var(--line);
   background: var(--card-bg);
   text-align: left;
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
 }
 
 .deployCard:hover {
@@ -904,6 +969,7 @@
   .folderCardMain {
     left: 50%;
     transform: translateX(-50%);
+    animation: none;
   }
 
   .folderCardTop {
@@ -924,6 +990,7 @@
     left: 50%;
     bottom: 72px;
     transform: translateX(-50%);
+    animation: none;
   }
 
   .activityRail {

--- a/web/app/primitives/PrimitivesContent.tsx
+++ b/web/app/primitives/PrimitivesContent.tsx
@@ -14,12 +14,30 @@ const primitives = [
     description:
       'Tokens, scopes, RBAC, policies, and audit trails for multi-agent systems. Give every agent a real identity, a human sponsor, and access that can be verified, revoked, and explained.',
     features: [
-      { title: 'JWT Tokens', desc: 'Issue short-lived access tokens with sponsor chains, workspace context, and edge-verifiable claims.' },
-      { title: 'Scope-Based Access', desc: 'Grant exact permissions with plane, resource, action, and optional path constraints.' },
-      { title: 'RBAC Policies', desc: 'Bundle scopes into named roles and layer deny-first policies from org to workspace to agent.' },
-      { title: 'Audit Trails', desc: 'Track every token use, scope decision, and admin action back to a responsible human.' },
-      { title: 'Token Revocation', desc: 'Invalidate credentials globally in under a second with edge-aware revocation checks.' },
-      { title: 'Budget Enforcement', desc: 'Cap spend, rate, and risky actions before an agent runs away with production access.' },
+      {
+        title: 'JWT Tokens',
+        desc: 'Issue short-lived access tokens with sponsor chains, workspace context, and edge-verifiable claims.',
+      },
+      {
+        title: 'Scope-Based Access',
+        desc: 'Grant exact permissions with plane, resource, action, and optional path constraints.',
+      },
+      {
+        title: 'RBAC Policies',
+        desc: 'Bundle scopes into named roles and layer deny-first policies from org to workspace to agent.',
+      },
+      {
+        title: 'Audit Trails',
+        desc: 'Track every token use, scope decision, and admin action back to a responsible human.',
+      },
+      {
+        title: 'Token Revocation',
+        desc: 'Invalidate credentials globally in under a second with edge-aware revocation checks.',
+      },
+      {
+        title: 'Budget Enforcement',
+        desc: 'Cap spend, rate, and risky actions before an agent runs away with production access.',
+      },
     ],
     docsHref: '/docs',
     githubHref: 'https://github.com/agentworkforce/relayauth',
@@ -28,18 +46,36 @@ const primitives = [
     id: 'file',
     badge: 'RELAYFILE',
     title: 'File',
-    subtitle: 'Headless filesystem for AI agents',
+    subtitle: 'Integration filesystem for AI agents',
     description:
-      'One place to read, write, watch, and coordinate files. Shared volumes, locks, metadata, and realtime change events let multi-agent systems work on the same state without building storage plumbing first.',
+      'Mount Linear, GitHub, Notion, Slack, and custom systems as a realtime file tree. Agents read provider context with normal file tools and write records by saving files.',
     features: [
-      { title: 'Read Files', desc: 'Fetch full contents or byte ranges with the same API across local and remote volumes.' },
-      { title: 'Write Files', desc: 'Create, overwrite, append, and patch files safely from agents and tools.' },
-      { title: 'Watch Changes', desc: 'Subscribe to file events and trigger follow-up work the moment something changes.' },
-      { title: 'Shared Volumes', desc: 'Mount the same workspace into multiple agents so they can collaborate on identical state.' },
-      { title: 'File Locking', desc: 'Coordinate concurrent writes with explicit locks and conflict-aware workflows.' },
-      { title: 'Permissions', desc: 'Control which agents can read, write, watch, or administer each path.' },
+      {
+        title: 'Provider Files',
+        desc: 'Project SaaS records, generated digests, indexes, and local artifacts into one workspace tree.',
+      },
+      {
+        title: 'Writeback',
+        desc: 'Create or patch provider records through canonical JSON and Markdown paths.',
+      },
+      {
+        title: 'Realtime Sync',
+        desc: 'Propagate new revisions between reviewer, implementer, and orchestrator agents.',
+      },
+      {
+        title: 'Scoped Mounts',
+        desc: 'Grant each agent exact path-level read, write, watch, or admin permissions.',
+      },
+      {
+        title: 'Framework Tools',
+        desc: 'Expose Relayfile to Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, and custom harnesses.',
+      },
+      {
+        title: 'Native Shell',
+        desc: 'Use cat, grep, find, jq, rg, editors, and ordinary scripts against the same files.',
+      },
     ],
-    docsHref: '/docs',
+    docsHref: '/docs/file-sharing',
     githubHref: 'https://github.com/agentworkforce/relayfile',
   },
   {
@@ -50,12 +86,30 @@ const primitives = [
     description:
       'Channels, threads, DMs, and real-time events for multi-agent systems. Two API calls to start, zero infrastructure to manage.',
     features: [
-      { title: 'Channels', desc: 'Organize agent communication into named channels. Public, private, or ephemeral.' },
-      { title: 'Threads', desc: 'Reply to any message to create a focused thread without cluttering the main channel.' },
-      { title: 'Direct Messages', desc: 'Send private messages between agents for side conversations and coordination.' },
-      { title: 'Reactions', desc: 'React to messages with emoji to signal approval, completion, or attention.' },
-      { title: 'Real-Time Events', desc: 'Stream channel events via WebSocket or SSE for instant message delivery.' },
-      { title: 'Inbox', desc: 'Each agent gets a unified inbox of unread mentions, DMs, and thread replies.' },
+      {
+        title: 'Channels',
+        desc: 'Organize agent communication into named channels. Public, private, or ephemeral.',
+      },
+      {
+        title: 'Threads',
+        desc: 'Reply to any message to create a focused thread without cluttering the main channel.',
+      },
+      {
+        title: 'Direct Messages',
+        desc: 'Send private messages between agents for side conversations and coordination.',
+      },
+      {
+        title: 'Reactions',
+        desc: 'React to messages with emoji to signal approval, completion, or attention.',
+      },
+      {
+        title: 'Real-Time Events',
+        desc: 'Stream channel events via WebSocket or SSE for instant message delivery.',
+      },
+      {
+        title: 'Inbox',
+        desc: 'Each agent gets a unified inbox of unread mentions, DMs, and thread replies.',
+      },
     ],
     docsHref: '/docs',
     githubHref: 'https://github.com/agentworkforce/relaycast',
@@ -68,12 +122,30 @@ const primitives = [
     description:
       'Cron expressions, webhook delivery, WebSocket real-time events, and execution logs — all built on Cloudflare Durable Objects.',
     features: [
-      { title: 'Cron Expressions', desc: 'Full cron expression support with second-level precision. Timezone-aware scheduling out of the box.' },
-      { title: 'Webhook Delivery', desc: 'HTTP POST deliveries with automatic retries, exponential backoff, and configurable timeout.' },
-      { title: 'WebSocket Events', desc: 'Subscribe to schedule lifecycle events in real-time — fired, success, failure, and retry.' },
-      { title: 'Execution Logs', desc: 'Every job execution logged with request/response payloads, status codes, and latency.' },
-      { title: 'Durable Object Alarms', desc: 'Automatic failover across 300+ data centers. Your jobs fire even if individual PoPs go down.' },
-      { title: 'TypeScript & Python SDKs', desc: 'First-party SDKs with full type safety, auto-completion, and chainable methods.' },
+      {
+        title: 'Cron Expressions',
+        desc: 'Full cron expression support with second-level precision. Timezone-aware scheduling out of the box.',
+      },
+      {
+        title: 'Webhook Delivery',
+        desc: 'HTTP POST deliveries with automatic retries, exponential backoff, and configurable timeout.',
+      },
+      {
+        title: 'WebSocket Events',
+        desc: 'Subscribe to schedule lifecycle events in real-time — fired, success, failure, and retry.',
+      },
+      {
+        title: 'Execution Logs',
+        desc: 'Every job execution logged with request/response payloads, status codes, and latency.',
+      },
+      {
+        title: 'Durable Object Alarms',
+        desc: 'Automatic failover across 300+ data centers. Your jobs fire even if individual PoPs go down.',
+      },
+      {
+        title: 'TypeScript & Python SDKs',
+        desc: 'First-party SDKs with full type safety, auto-completion, and chainable methods.',
+      },
     ],
     docsHref: '/docs',
     githubHref: 'https://app.agentcron.dev',
@@ -104,9 +176,8 @@ export function PrimitivesContent() {
 
           <FadeIn direction="up" delay={120}>
             <p className={s.subtitle}>
-              Four primitives that give AI agents identity, shared files,
-              real-time messaging, and scheduled execution — without building
-              infrastructure from scratch.
+              Four primitives that give AI agents identity, shared files, real-time messaging, and scheduled
+              execution — without building infrastructure from scratch.
             </p>
           </FadeIn>
 
@@ -138,12 +209,7 @@ export function PrimitivesContent() {
 
             <div className={s.featuresGrid}>
               {primitive.features.map((feature, fi) => (
-                <FadeIn
-                  key={feature.title}
-                  direction="up"
-                  delay={fi * 50}
-                  className={s.featureCol}
-                >
+                <FadeIn key={feature.title} direction="up" delay={fi * 50} className={s.featureCol}>
                   <div className={s.featureCard}>
                     <h3 className={s.featureTitle}>{feature.title}</h3>
                     <p className={s.featureDesc}>{feature.desc}</p>
@@ -176,8 +242,8 @@ export function PrimitivesContent() {
           <div className={s.poweredCard}>
             <span className={s.poweredEyebrow}>Powered by Agent Relay</span>
             <p className={s.poweredText}>
-              All four primitives run on the same platform. One workspace, one
-              API key, and one SDK across auth, files, messaging, and scheduling.
+              All four primitives run on the same platform. One workspace, one API key, and one SDK across
+              auth, files, messaging, and scheduling.
             </p>
             <Link href="/docs" className={s.ctaPrimary}>
               Get started

--- a/web/content/docs/file-sharing.mdx
+++ b/web/content/docs/file-sharing.mdx
@@ -14,12 +14,141 @@ coordinate the same files, Relayfile gives them one coherent filesystem abstract
 
 ## Relayfile at a glance
 
-- Read files and byte ranges through one API
-- Write, append, and patch files from agents or services
+- Mount provider-backed data as files: Linear, GitHub, Notion, Slack, HubSpot, Salesforce, and custom APIs
+- Read, grep, and summarize through normal file tools instead of loading a provider-specific tool surface
+- Write provider records by saving JSON or Markdown files to canonical paths
 - Watch paths for realtime changes and trigger follow-up work
-- Share the same volume across several agents
-- Coordinate concurrent writes with explicit locks
+- Share the same workspace across several agents, sandboxes, and humans
 - Control read, write, watch, and admin access per path
+
+## Quick start
+
+Use hosted setup when you want Agent Relay to handle OAuth, initial sync, writeback workers, and the local mount daemon.
+
+```bash
+npx relayfile setup \
+  --provider notion \
+  --workspace research-room \
+  --local-dir ./relayfile-mount
+```
+
+The mounted directory is intentionally boring:
+
+```bash
+ls ./relayfile-mount
+cat ./relayfile-mount/LAYOUT.md
+cat ./relayfile-mount/digests/yesterday.md
+find ./relayfile-mount/notion/pages/by-edited/2026-05-12 -maxdepth 1 -type f
+```
+
+To write back to a provider, save a file in the provider tree. The adapter validates the payload, queues writeback, and records the operation.
+
+```bash
+cat > ./relayfile-mount/linear/issues/drafts/follow-up-from-digest.json <<'JSON'
+{
+  "title": "Follow up from yesterday's digest",
+  "description": "Check the customer note linked from /digests/yesterday.md.",
+  "state": "Todo"
+}
+JSON
+```
+
+## Programmatic usage
+
+Relayfile can be a mounted directory for terminal-native agents, or a small tool inside an SDK-owned agent loop.
+
+### Mount from a sandbox
+
+```ts
+import { RelayfileSetup } from '@relayfile/sdk';
+
+const setup = new RelayfileSetup({
+  accessToken: process.env.RELAYFILE_ACCESS_TOKEN!,
+});
+
+const handle = await setup.ensureMountedWorkspace({
+  workspaceId: 'rw_123',
+  provider: 'notion',
+  verifyProvider: true,
+  localDir: '/workspace/relayfile',
+});
+
+console.log(handle.env().RELAYFILE_LOCAL_DIR);
+```
+
+### Vercel AI SDK
+
+```ts
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
+
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
+
+const { text } = await generateText({
+  model: process.env.AI_MODEL!,
+  prompt: 'What changed yesterday across GitHub, Linear, and Notion?',
+  tools: {
+    readRelayfile: tool({
+      description: 'Read a file from the Relayfile workspace',
+      inputSchema: z.object({ path: z.string() }),
+      execute: ({ path }) => files.readFile('rw_123', path),
+    }),
+  },
+});
+```
+
+### Claude Agent SDK
+
+```ts
+import { createSdkMcpServer, query, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
+
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
+
+const relayfileServer = createSdkMcpServer({
+  name: 'relayfile',
+  tools: [
+    tool('readRelayfile', 'Read workspace files', { path: z.string() }, async ({ path }) => ({
+      content: [{ type: 'text', text: JSON.stringify(await files.readFile('rw_123', path)) }],
+    })),
+  ],
+});
+
+for await (const message of query({
+  prompt: 'Summarize /digests/yesterday.md, then draft Linear follow-ups.',
+  options: { mcpServers: { relayfile: relayfileServer } },
+})) {
+  console.log(message);
+}
+```
+
+### OpenAI Agents SDK
+
+```ts
+import { Agent, run, tool } from '@openai/agents';
+import { z } from 'zod';
+import { RelayFileClient } from '@relayfile/sdk';
+
+const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
+
+const reviewer = new Agent({
+  name: 'workspace-reviewer',
+  instructions: 'Use Relayfile paths before asking for provider-specific tools.',
+  tools: [
+    tool({
+      name: 'read_relayfile',
+      parameters: z.object({ path: z.string() }),
+      execute: ({ path }) => files.readFile('rw_123', path),
+    }),
+  ],
+});
+
+await run(reviewer, 'Review /digests/yesterday.md and file Linear follow-ups.');
+```
+
+For write access, add a separate `writeRelayfile` tool and mint a token scoped to the exact paths that agent owns, such as `relayfile:fs:write:/linear/issues/*`.
 
 ## Where to go next
 


### PR DESCRIPTION
## Summary
- Serve the dedicated /file landing page instead of redirecting to /primitives#file
- Reposition Relayfile around provider files, writeback, realtime sync, scoped mounts, deterministic digests, and native tools
- Add Mount SDK, Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, and cURL examples to the landing page
- Expand /docs/file-sharing with quickstart and programmatic usage examples
- Align the /primitives#file tile with the updated positioning

## Validation
- npx prettier --write web/app/file/RelayfileContent.tsx web/app/file/page.tsx web/app/file/relayfile.module.css web/app/primitives/PrimitivesContent.tsx web/content/docs/file-sharing.mdx
- git diff --check
- npm run build (using a temporary node_modules symlink in the clean worktree; build exits 0, with the existing isolated-worktree ESLint plugin resolution warning)
- Browser checked /file at desktop and mobile widths