### PR TITLE
feat(workflow-sdk): add pr_url verification check

### DIFF
--- a/packages/sdk/src/workflows/__tests__/verification.test.ts
+++ b/packages/sdk/src/workflows/__tests__/verification.test.ts
@@ -11,6 +11,7 @@ import {
   checkFileExists,
   checkCustom,
   execCustomVerification,
+  findPrUrl,
   type VerificationCheck,
   type VerificationResult,
   type VerificationOptions,
@@ -311,6 +312,70 @@ describe('verification logic', () => {
       const file = path.join(tmpDir, 'ok.txt');
       fs.writeFileSync(file, 'ok');
       expect(checkFileExists('ok.txt', tmpDir)).toBe(true);
+    });
+  });
+
+  describe('pr_url verification', () => {
+    it('passes when a github PR URL appears in the worker output', () => {
+      const result = run(
+        { type: 'pr_url', value: '' },
+        'shipped: https://github.com/AgentWorkforce/cloud/pull/606 ready for review'
+      );
+      expect(result.passed).toBe(true);
+      expect(result.completionReason).toBe('completed_verified');
+    });
+
+    it('fails with a WorkflowCompletionError when no PR URL is present', () => {
+      expect(() =>
+        run(
+          { type: 'pr_url', value: '' },
+          'All tests pass and the build is clean.\nfiles modified: foo.ts, bar.ts'
+        )
+      ).toThrow(WorkflowCompletionError);
+    });
+
+    it('rejects PR URLs for a different repository when a qualifier is provided', () => {
+      expect(() =>
+        run(
+          { type: 'pr_url', value: 'AgentWorkforce/relaycast' },
+          'Migration done: https://github.com/AgentWorkforce/cloud/pull/606'
+        )
+      ).toThrow(WorkflowCompletionError);
+    });
+
+    it('accepts a PR URL whose repo matches the qualifier case-insensitively', () => {
+      const result = run(
+        { type: 'pr_url', value: 'agentworkforce/relaycast' },
+        'See https://github.com/AgentWorkforce/relaycast/pull/128 for the SDK change.'
+      );
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe('findPrUrl', () => {
+    it('returns the first matching URL when no qualifier is given', () => {
+      const url = findPrUrl(
+        'first https://github.com/foo/bar/pull/1 second https://github.com/foo/bar/pull/2'
+      );
+      expect(url).toBe('https://github.com/foo/bar/pull/1');
+    });
+
+    it('filters by repository qualifier', () => {
+      const url = findPrUrl(
+        'wrong https://github.com/foo/bar/pull/1 right https://github.com/baz/qux/pull/9',
+        'baz/qux'
+      );
+      expect(url).toBe('https://github.com/baz/qux/pull/9');
+    });
+
+    it('returns null when no PR URL is present', () => {
+      expect(findPrUrl('OWNER_DECISION: COMPLETE\nfiles modified: foo.ts')).toBeNull();
+    });
+
+    it('ignores PR URLs echoed inside the injected task text', () => {
+      const injected = 'Reference: https://github.com/foo/bar/pull/42';
+      const output = injected + '\nWorker said: tests pass, no PR opened, all good';
+      expect(findPrUrl(output, undefined, injected)).toBeNull();
     });
   });
 });

--- a/packages/sdk/src/workflows/verification.ts
+++ b/packages/sdk/src/workflows/verification.ts
@@ -122,6 +122,18 @@ export function runVerification(
       break;
     }
 
+    case 'pr_url': {
+      const found = findPrUrl(output, check.value, injectedTaskText);
+      if (!found) {
+        const repoQualifier = check.value ? ` for repository "${check.value}"` : '';
+        return fail(
+          `Verification failed for "${stepName}": step output does not contain a GitHub PR URL${repoQualifier}. ` +
+            `Workers must open a pull request and include the URL in their output before reporting completion.`
+        );
+      }
+      break;
+    }
+
     default:
       break;
   }
@@ -189,6 +201,36 @@ export function checkOutputContains(output: string, token: string, injectedTaskT
     return false;
   }
   return stripInjectedTaskEcho(output, injectedTaskText).includes(token);
+}
+
+const PR_URL_PATTERN = /https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)\b/gi;
+
+/**
+ * Returns the first GitHub PR URL found in {@link output}. When
+ * {@link repoQualifier} is non-empty (format: `<owner>/<repo>`, case
+ * insensitive), only URLs belonging to that repository are accepted.
+ *
+ * Use via `verification: { type: 'pr_url', value: 'owner/repo' }` to require
+ * a step to publish a pull request before completing. The check exists so
+ * workflow runners can refuse `OWNER_DECISION: COMPLETE` from workers that
+ * shipped code locally but never opened a PR.
+ */
+export function findPrUrl(output: string, repoQualifier?: string, injectedTaskText?: string): string | null {
+  const sanitized = stripInjectedTaskEcho(output, injectedTaskText);
+  const qualifier = repoQualifier?.trim().toLowerCase();
+  PR_URL_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PR_URL_PATTERN.exec(sanitized))) {
+    if (!qualifier) {
+      return match[0];
+    }
+    const owner = match[1]?.toLowerCase();
+    const repo = match[2]?.toLowerCase();
+    if (`${owner}/${repo}` === qualifier) {
+      return match[0];
+    }
+  }
+  return null;
 }
 
 const DEFAULT_CUSTOM_VERIFY_TIMEOUT_MS = parseInt(process.env.CUSTOM_VERIFY_TIMEOUT_MS ?? '30000', 10);

--- a/packages/workflow-types/src/index.ts
+++ b/packages/workflow-types/src/index.ts
@@ -330,7 +330,17 @@ export type DeterministicWorkflowStep = WorkflowStep;
 
 /** Verification check to validate a step's output. */
 export interface VerificationCheck {
-  type: 'output_contains' | 'exit_code' | 'file_exists' | 'custom';
+  type: 'output_contains' | 'exit_code' | 'file_exists' | 'custom' | 'pr_url';
+  /**
+   * Type-specific value:
+   *  - output_contains: token that must appear in the step's output
+   *  - exit_code: expected exit code (currently informational)
+   *  - file_exists: path that must exist (relative to cwd or absolute)
+   *  - custom: shell command to execute, or `regex:<pattern>` against output
+   *  - pr_url: optional `<owner>/<repo>` qualifier to require the discovered
+   *    PR URL belongs to a specific repository; leave empty to accept any
+   *    GitHub PR URL in the step output
+   */
   value: string;
   description?: string;
   timeoutMs?: number;


### PR DESCRIPTION
## Summary
Adds a new \`'pr_url'\` value to the \`VerificationCheck\` type union. Workflow authors can now gate step completion on the worker leaving behind a GitHub PR URL — closing the loophole that let multiple Track A–F workers of the proactive-runtime M3 swarm post \`OWNER_DECISION: COMPLETE\` with green tests and a clean process exit but no PR.

## Motivation
\`resolveOwnerCompletionDecision\` already runs \`step.verification\` before honoring \`OWNER_DECISION: COMPLETE\` (a failing check throws \`failed_verification\`). The gap was that no built-in check expressed "this step must publish a PR." Workflow authors could compose it with \`type: 'custom'\` and a shell command, but the friction is high enough that nobody did — including the M3 workflow, which relied on a free-text brief instructing workers to \`gh pr create\`. None of the workers did, and evidence-based completion (positive-conclusion text + process-exit=0) waved them through.

## API
\`\`\`ts
// any GitHub PR URL in step output counts
verification: { type: 'pr_url', value: '' }

// require the PR belong to a specific repo
verification: { type: 'pr_url', value: 'AgentWorkforce/relaycast' }
\`\`\`

Repo qualifier is case-insensitive. PR URLs echoed inside the injected task brief are stripped before scanning (via the existing \`stripInjectedTaskEcho\` path), so reference URLs in the brief don't satisfy the gate.

## Test plan
- [x] \`npx vitest run packages/sdk/src/workflows/__tests__/verification.test.ts\` — 44 tests pass (36 existing + 8 new)
- [x] Pre-existing failures in \`verification-traceback.test.ts\` and \`verification-custom.test.ts\` (5 total) are unchanged on this branch — verified by stashing my diff and re-running

## Follow-ups
- Update the proactive-runtime M3 workflow (and any others whose steps ship PRs) to declare \`verification: { type: 'pr_url', value: '<owner>/<repo>' }\` on the implementation steps. The runtime change here is additive — no existing workflow regresses.
- Consider tightening \`judgeOwnerCompletionByEvidence\` so file-modification + clean exit alone never imply completion when a workflow declares an artifact expectation. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)