### PR TITLE
Bump relaycast Rust SDK to 1.0.2

### DIFF
--- a/.github/workflows/build-broker-binary.yml
+++ b/.github/workflows/build-broker-binary.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          cache-bin: false
 
       - name: Install musl tools (x86_64)
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,6 +130,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: broker-${{ matrix.target }}
+          cache-bin: false
 
       - name: Build broker binary (unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -57,6 +57,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - run: cargo test
 
   rust-cross-compile:
@@ -82,6 +84,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          cache-bin: false
       - name: Install cross-compilation tools
         if: matrix.packages
         run: |
@@ -103,6 +106,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - run: cargo clippy -- -D warnings
 
   rust-fmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,8 @@ jobs:
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Run Rust tests
         run: cargo test --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7eb6ecfa6b2b3599f4367c50e511575111a69ebe61556b472ad107802a32aa"
+checksum = "d887af9016823e94bf5efd35c4855f3ff96b415e595fc62833c66229567e8170"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=1.0.0"
+relaycast = "=1.0.2"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"


### PR DESCRIPTION
## Summary
- Bump the broker's exact relaycast Rust SDK pin from 1.0.0 to 1.0.2
- Refresh Cargo.lock to pick up the published crate checksum

## Why
relaycast 1.0.2 includes the channel response decoding fix needed by the broker default-channel startup path.

## Testing
- cargo test