### PR TITLE
ci: add stale preview environment cleanup

### DIFF
--- a/.github/workflows/remove-stale-previews.yml
+++ b/.github/workflows/remove-stale-previews.yml
@@ -1,0 +1,67 @@
+name: Remove stale preview environments
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only — do not actually remove stages'
+        type: boolean
+        default: true
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: read
+
+concurrency:
+  group: remove-stale-previews
+  cancel-in-progress: false
+
+jobs:
+  remove-stale:
+    name: Remove stale preview stages
+    runs-on: ubuntu-latest
+    environment: preview
+    timeout-minutes: 30
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: gha-remove-stale-${{ github.run_id }}
+
+      - name: Assert AWS account
+        run: bash .github/scripts/assert-aws-account.sh "$AWS_ACCOUNT_ID" stale-cleanup remove
+
+      - name: Remove stale stages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+        run: |
+          # Scheduled runs always remove; manual runs honor the dry_run input.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            web/scripts/list-stale-stages.sh
+          else
+            web/scripts/list-stale-stages.sh --remove --yes
+          fi

--- a/web/scripts/list-stale-stages.sh
+++ b/web/scripts/list-stale-stages.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# List SST preview stages and identify ones whose GitHub PR is closed/merged.
+# Optionally remove them with --remove.
+#
+# Usage:
+#   web/scripts/list-stale-stages.sh                # report only
+#   web/scripts/list-stale-stages.sh --remove       # also run `sst remove` for stale stages
+#   web/scripts/list-stale-stages.sh --remove --yes # skip confirmation
+#
+# Uses AWS_PROFILE=ar_preview by default; override by exporting AWS_PROFILE.
+# Requires: aws cli, gh cli, jq, and (for --remove) node_modules/.bin/sst.
+
+set -euo pipefail
+
+REMOVE=0
+ASSUME_YES=0
+APP_NAME="relay-web"
+
+for arg in "$@"; do
+  case "$arg" in
+    --remove) REMOVE=1 ;;
+    --yes|-y) ASSUME_YES=1 ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+for bin in aws gh jq; do
+  command -v "$bin" >/dev/null || { echo "missing dependency: $bin" >&2; exit 1; }
+done
+
+# In CI, OIDC sets AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN directly. Only default
+# the profile for local dev so the CLI doesn't try to look up a missing ~/.aws/credentials entry.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  export AWS_PROFILE="${AWS_PROFILE:-ar_preview}"
+fi
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
+echo "==> AWS_PROFILE=${AWS_PROFILE:-<unset; using ambient creds>} AWS_REGION=$AWS_REGION"
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "AWS credentials invalid or missing." >&2
+  if [ -n "${AWS_PROFILE:-}" ]; then
+    echo "Try: aws sso login --profile $AWS_PROFILE" >&2
+  fi
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+web_dir="$repo_root/web"
+sst_bin="$repo_root/node_modules/.bin/sst"
+
+if [ "$REMOVE" = "1" ] && [ ! -x "$sst_bin" ]; then
+  echo "sst CLI not found at $sst_bin — run 'npm ci' at repo root" >&2
+  exit 1
+fi
+
+# 1. Resolve SST state bucket (SST writes /sst/bootstrap on first deploy per region/account).
+echo "==> Resolving SST state bucket via SSM /sst/bootstrap..."
+bootstrap_json="$(aws ssm get-parameter --name /sst/bootstrap --query 'Parameter.Value' --output text)"
+state_bucket="$(echo "$bootstrap_json" | jq -r '.bucket // .state // empty')"
+if [ -z "$state_bucket" ]; then
+  echo "could not read state bucket from /sst/bootstrap; raw value: $bootstrap_json" >&2
+  exit 1
+fi
+echo "    state bucket: $state_bucket"
+
+# 2. List every stage for this app from S3. Layout is app/<app>/<stage>.json
+state_prefix="app/$APP_NAME/"
+echo "==> Listing stages under s3://$state_bucket/$state_prefix ..."
+stages=()
+while IFS= read -r line; do
+  [ -n "$line" ] && stages+=("$line")
+done < <(
+  aws s3 ls "s3://$state_bucket/$state_prefix" 2>/dev/null \
+    | awk '$NF ~ /\.json$/ { sub(/\.json$/, "", $NF); print $NF }' | sort -u
+)
+
+if [ "${#stages[@]}" -eq 0 ]; then
+  echo "    no stages found"
+  exit 0
+fi
+echo "    found ${#stages[@]} stage(s)"
+
+# 3. Classify each stage. pr-N stages are checked against GitHub PR state.
+declare -a stale_stages=()
+declare -a active_stages=()
+declare -a unknown_stages=()
+
+printf "\n%-30s %-10s %s\n" "STAGE" "STATE" "DETAIL"
+printf -- "---------------------------------------------------------------\n"
+for stage in "${stages[@]}"; do
+  if [[ "$stage" =~ ^pr-([0-9]+)$ ]]; then
+    pr_num="${BASH_REMATCH[1]}"
+    pr_state="$(gh pr view "$pr_num" --json state --jq .state 2>/dev/null || echo "NOTFOUND")"
+    if [ "$pr_state" = "OPEN" ]; then
+      active_stages+=("$stage")
+      printf "%-30s %-10s PR #%s open — keep\n" "$stage" "active" "$pr_num"
+    else
+      stale_stages+=("$stage")
+      printf "%-30s %-10s PR #%s %s — stale\n" "$stage" "STALE" "$pr_num" "$pr_state"
+    fi
+  else
+    case "$stage" in
+      production|staging|main)
+        active_stages+=("$stage")
+        printf "%-30s %-10s reserved name — keep\n" "$stage" "active"
+        ;;
+      *)
+        unknown_stages+=("$stage")
+        printf "%-30s %-10s not a pr-N stage — manual review\n" "$stage" "unknown"
+        ;;
+    esac
+  fi
+done
+
+echo
+echo "Summary: ${#stale_stages[@]} stale, ${#active_stages[@]} active, ${#unknown_stages[@]} unknown"
+
+if [ "${#stale_stages[@]}" -eq 0 ]; then
+  echo "nothing to remove"
+  exit 0
+fi
+
+if [ "$REMOVE" != "1" ]; then
+  echo
+  echo "Rerun with --remove to tear down the stale stages."
+  exit 0
+fi
+
+if [ "$ASSUME_YES" != "1" ]; then
+  echo
+  read -r -p "Run 'sst remove' against ${#stale_stages[@]} stale stage(s)? [y/N] " ans
+  case "$ans" in
+    y|Y|yes|YES) ;;
+    *) echo "aborted"; exit 0 ;;
+  esac
+fi
+
+# 4. Remove each stale stage. Try unlock first in case a prior cleanup left a lock.
+cd "$web_dir"
+failed=()
+for stage in "${stale_stages[@]}"; do
+  echo
+  echo "==> Removing $stage"
+  "$sst_bin" unlock --stage "$stage" >/dev/null 2>&1 || true
+  if "$sst_bin" remove --stage "$stage"; then
+    echo "    removed $stage"
+  else
+    echo "    FAILED to remove $stage" >&2
+    failed+=("$stage")
+  fi
+done
+
+echo
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "completed with ${#failed[@]} failure(s): ${failed[*]}"
+  exit 1
+fi
+echo "done — removed ${#stale_stages[@]} stage(s)"


### PR DESCRIPTION
## Summary

- Adds **`web/scripts/list-stale-stages.sh`** — lists every `relay-web` stage from the SST state bucket, classifies each `pr-N` against GitHub's PR state, and (with `--remove`) runs `sst unlock` + `sst remove` for stages whose PR is closed/merged.
- Adds **`.github/workflows/remove-stale-previews.yml`** — "Remove stale preview environments". Runs daily at 06:00 UTC and is manually dispatchable with a `dry_run` boolean (defaults to `true` for safe inspection).

## Why

Deploy Preview has been failing on `web/**` PRs with `TooManyCachePolicies` / `EntityLimitExceeded` once the per-account CloudFront quota fills. The existing per-PR cleanup only fires on PR-close events and can silently skip (path filter, stale stage locks, >30 day rerun window), leaving stages orphaned. This workflow drains the leak.

## Behavior

- Local: `web/scripts/list-stale-stages.sh` (dry-run) / `--remove [--yes]`. Defaults to `AWS_PROFILE=ar_preview`, region `us-east-1`; override by exporting your own.
- CI: skips the profile default when OIDC has set `AWS_ACCESS_KEY_ID`, then uses the same `preview` environment and IAM role as `preview-web.yml`.
- Reserved stage names (`production`, `staging`, `main`) are kept.
- Non-`pr-N` stages are listed as "unknown — manual review" and never auto-removed.

## Test plan

- [ ] Run "Remove stale preview environments" workflow manually with `dry_run=true` from the Actions tab — confirm it lists current stages and flags non-OPEN PRs as stale.
- [ ] Re-run with `dry_run=false` — confirm leaked stages are torn down and the next `web/**` Deploy Preview succeeds.
- [ ] Locally: `web/scripts/list-stale-stages.sh` after `aws sso login --profile ar_preview` — confirm same output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)