### PR TITLE
docs(web): add icons for CLI/broker API reference nav items

### DIFF
--- a/web/components/docs/DocsNav.tsx
+++ b/web/components/docs/DocsNav.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import {
   Activity,
+  BookOpen,
   Bot,
   Cloud,
   Clock3,
@@ -12,6 +13,7 @@ import {
   FolderOpen,
   Hash,
   Mail,
+  Network,
   Plug,
   PlayCircle,
   Power,
@@ -61,6 +63,8 @@ const navIcons: Record<string, NavIcon> = {
   'cli-workflows': Workflow,
   'cli-cloud-commands': Cloud,
   'cli-on-the-relay': Plug,
+  'reference-cli': BookOpen,
+  'reference-broker-api': Network,
   'typescript-sdk': SiTypescript,
   'react-sdk': FaReact,
   'python-sdk': SiPython,


### PR DESCRIPTION
## Summary
- The docs sidebar (`web/components/docs/DocsNav.tsx`) was rendering two nav items without icons because `navIcons` had no entries for their slugs:
  - **CLI reference** (`reference-cli`)
  - **Broker HTTP / WS API** (`reference-broker-api`)
- Added `BookOpen` for the CLI reference and `Network` for the broker HTTP/WS API (both from `lucide-react`, matching the existing icon style).

## Test plan
- [ ] Visit `/docs/*` and confirm every item under the **CLI** group renders with a leading icon.
- [ ] Confirm "CLI reference" shows a book icon and "Broker HTTP / WS API" shows a network icon.
- [ ] No icon spacing/alignment regressions elsewhere in the sidebar.


---
_Generated by [Claude Code](https://claude.ai/code/session_014YmGpaCafbg9k7eZhNujju)_