### PR TITLE
fix(web): use next/link for docs navigation (fixes ~700ms clicks)

### DIFF
--- a/web/components/docs/BannerLink.tsx
+++ b/web/components/docs/BannerLink.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { ArrowRight, BookOpen, PlayCircle, Rocket } from 'lucide-react';
 
 import styles from './docs.module.css';
+
+function isInternalHref(href: string): boolean {
+  return href.startsWith('/') && !href.startsWith('//');
+}
 
 type BannerIcon = 'play' | 'rocket' | 'docs';
 
@@ -20,13 +25,27 @@ const iconMap = {
 export function BannerLink({ href, children, icon = 'docs' }: BannerLinkProps) {
   const Icon = iconMap[icon];
 
-  return (
-    <a href={href} className={styles.bannerLink}>
+  const inner = (
+    <>
       <span className={styles.bannerLinkIconWrap}>
         <Icon className={styles.bannerLinkIcon} aria-hidden="true" />
       </span>
       <span className={styles.bannerLinkText}>{children}</span>
       <ArrowRight className={styles.bannerLinkArrow} aria-hidden="true" />
+    </>
+  );
+
+  if (isInternalHref(href)) {
+    return (
+      <Link href={href} className={styles.bannerLink}>
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <a href={href} className={styles.bannerLink}>
+      {inner}
     </a>
   );
 }

--- a/web/components/docs/Card.tsx
+++ b/web/components/docs/Card.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 
 import styles from './docs.module.css';
+
+function isInternalHref(href: string): boolean {
+  return href.startsWith('/') && !href.startsWith('//');
+}
 
 interface CardProps {
   title: string;
@@ -22,6 +27,13 @@ export function Card({ title, href, children }: CardProps) {
   );
 
   if (href) {
+    if (isInternalHref(href)) {
+      return (
+        <Link href={href} className={styles.card}>
+          {inner}
+        </Link>
+      );
+    }
     return (
       <a href={href} className={styles.card}>
         {inner}

--- a/web/components/docs/DocsNav.tsx
+++ b/web/components/docs/DocsNav.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentType } from 'react';
 import { useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
   Activity,
@@ -135,10 +136,10 @@ export function DocsNav({ variant = 'sidebar' }: { variant?: 'sidebar' | 'mobile
               const Icon = navIcons[item.slug];
               return (
                 <li key={item.slug}>
-                  <a href={href} className={`${styles.navLink} ${isActive ? styles.navLinkActive : ''}`}>
+                  <Link href={href} className={`${styles.navLink} ${isActive ? styles.navLinkActive : ''}`}>
                     {Icon && <Icon className={styles.navIcon} aria-hidden="true" />}
                     <span className={styles.navLabel}>{item.title}</span>
-                  </a>
+                  </Link>
                 </li>
               );
             })}

--- a/web/components/docs/DocsSearch.tsx
+++ b/web/components/docs/DocsSearch.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import type { SearchEntry } from '../../lib/docs';
@@ -124,18 +125,18 @@ export function DocsSearch({ index }: DocsSearchProps) {
                   <p className={s.empty}>No results for &ldquo;{query}&rdquo;</p>
                 ) : (
                   results.map((entry, i) => (
-                    <a
+                    <Link
                       key={entry.slug}
                       href={`/docs/${entry.slug}`}
                       className={`${s.result} ${i === activeIdx ? s.resultActive : ''}`}
-                      onClick={(e) => { e.preventDefault(); navigate(entry.slug); }}
+                      onClick={() => close()}
                       onMouseEnter={() => setActiveIdx(i)}
                     >
                       <span className={s.resultTitle}>{entry.title}</span>
                       {entry.description && (
                         <span className={s.resultDesc}>{entry.description}</span>
                       )}
-                    </a>
+                    </Link>
                   ))
                 )}
               </div>


### PR DESCRIPTION
## Summary

Docs navigation was taking ~700ms per click. The pages are statically generated (`generateStaticParams` in `app/docs/[slug]/page.tsx`), but the sidebar, in-page Cards, BannerLinks, and search results were all rendering plain `<a>` tags. That opts out of:

- **Link prefetching** — `<Link>` prefetches the RSC payload on hover / on viewport entry, so the next page is already in memory before the click. `<a>` does nothing.
- **Client-side navigation** — `<a>` does a full document navigation: re-downloads HTML/CSS/JS, re-hydrates `SiteNav`, `DocsLanguageProvider`, `DocsNav`, `SiteFooter`, rebuilds the search index, etc. `<Link>` swaps only the `<main>` slot.
- **Static cache hits on the edge** — even with `generateStaticParams`, OpenNext/SST routes these through the Lambda server function, so a cold full-page load is exactly the ~700ms we were seeing. Prefetched RSC payloads come straight from the browser cache.

## Changes

- `web/components/docs/DocsNav.tsx` — sidebar links use `<Link>` (the big win).
- `web/components/docs/Card.tsx` — internal `href`s use `<Link>`; external URLs still render `<a>`.
- `web/components/docs/BannerLink.tsx` — same internal/external branch.
- `web/components/docs/DocsSearch.tsx` — search results use `<Link>` and close the modal on click; arrow-key + Enter still uses the existing `navigate()` path.

## Test plan

- [ ] `npm run build` in `web/` succeeds.
- [ ] Click between docs pages in the sidebar — should feel near-instant (no full page reload, no layout flash).
- [ ] Hover a sidebar link in devtools Network tab — should see an RSC prefetch.
- [ ] Search modal: clicking a result navigates and closes the modal; ArrowDown/Up + Enter still works.
- [ ] In-page `<Card href="/docs/...">` and `<BannerLink href="/docs/...">` use SPA navigation; external URLs still open as full nav.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMcwrVbu4yToDuvg6GPAaf)_