### PR TITLE
fix(broker): handle write_pty frames in PTY worker

### DIFF
--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -493,6 +493,37 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     }
                                 }
                             }
+                            "write_pty" => {
+                                // Raw input forwarded by the broker (typically
+                                // from POST /api/input/{name} via
+                                // `client.sendInput()`). The payload is
+                                // `{ "data": "<bytes-as-utf8-string>" }`; we
+                                // write those bytes verbatim to the PTY so the
+                                // child process sees the keystrokes.
+                                match frame.payload.get("data").and_then(Value::as_str) {
+                                    Some(data) => {
+                                        if let Err(e) = pty.write_all(data.as_bytes()) {
+                                            tracing::warn!(
+                                                target = "agent_relay::worker::pty",
+                                                error = %e,
+                                                "failed to write input to pty"
+                                            );
+                                            let _ = send_frame(&out_tx, "worker_error", frame.request_id, json!({
+                                                "code": "pty_write_failed",
+                                                "message": e.to_string(),
+                                                "retryable": true,
+                                            })).await;
+                                        }
+                                    }
+                                    None => {
+                                        let _ = send_frame(&out_tx, "worker_error", frame.request_id, json!({
+                                            "code": "invalid_payload",
+                                            "message": "write_pty payload must include 'data' string",
+                                            "retryable": false,
+                                        })).await;
+                                    }
+                                }
+                            }
                             "ping" => {
                                 let ts = frame.payload.get("ts_ms").and_then(Value::as_u64).unwrap_or_default();
                                 let _ = send_frame(&out_tx, "pong", frame.request_id, json!({"ts_ms": ts})).await;


### PR DESCRIPTION
## Summary

Fixes #920.

`AgentRelayClient.sendInput()` / `POST /api/input/{name}` returned success for PTY workers but the bytes never reached the child process. The HTTP route forwards a `write_pty` frame via `workers.send_to_worker(..., "write_pty", ...)` (`crates/broker/src/runtime/api.rs:893`), but `crates/broker/src/pty_worker.rs` only handled `resize_pty` and `snapshot_pty` — `write_pty` fell through to the catch-all and emitted `worker_error: unsupported message type 'write_pty'`. Interactive clients (e.g. Pear's terminal tabs attaching to a spawned Claude/Codex PTY) could not type into the terminal.

## Change

Add a `write_pty` arm to the PTY worker's stdin frame handler in `crates/broker/src/pty_worker.rs` that:

- Pulls the `data` string from the payload (matching `runtime/api.rs`'s `json!({ "data": data })` shape).
- Calls `pty.write_all(data.as_bytes())` to push the keystrokes through the existing write queue.
- Emits a `worker_error` frame only on malformed payloads (`invalid_payload`) or PTY write failures (`pty_write_failed`, retryable).

The HTTP route is already correct — this just teaches the worker to honor the frame the route is already sending.

## Test plan

- [x] `cargo build -p agent-relay-broker` succeeds.
- [x] `cargo test -p agent-relay-broker --lib pty` — all 57 PTY tests pass.
- [ ] Manual repro from the issue body: spawn a PTY agent, call `client.sendInput(name, 'printf READY\n\r')`, confirm the snapshot now contains `READY` and no `worker_error` event is emitted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBGmUZsieyg2dtTFUYCbKT)_