### PR TITLE
fix(broker): pre-register Claude PTY workers so Relaycast MCP boots fast (#926)

### DIFF
--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -6,7 +6,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::cli::command_parse::{normalize_cli_name, parse_cli_command};
 use crate::listen_api::{
     broadcast_if_relevant, listen_api_router, DeliveryRouteError, ListenApiConfig,
     ListenApiRequest, SetInboundDeliveryModeOk,

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -230,14 +230,15 @@ impl BrokerRuntime {
                     };
                     let effective_task = normalize_initial_task(task.clone());
 
-                    // Pre-register agent token for all CLIs. Claude needs it
-                    // too: without RELAY_AGENT_TOKEN + RELAY_SKIP_BOOTSTRAP=1 in
-                    // the relaycast MCP env, `@relaycast/mcp` runs bootstrap
-                    // (network registration) before responding to the MCP
-                    // initialize handshake, and Claude drops the pending server
-                    // before any relaycast tool names land in deferred_tools
-                    // (issue #926). A short timeout keeps spawn latency bounded
-                    // while still giving the registration call a real chance.
+                    // Pre-register an agent token for every spawned worker.
+                    // `@relaycast/mcp` needs RELAY_AGENT_TOKEN +
+                    // RELAY_SKIP_BOOTSTRAP=1 in its environment to expose
+                    // tools immediately; otherwise it runs network
+                    // registration before responding to the MCP initialize
+                    // handshake, the client drops the pending server, and
+                    // no relaycast tool names land in deferred_tools. The
+                    // short timeout keeps spawn latency bounded while still
+                    // giving the registration call a real chance.
                     let worker_relay_key = {
                         let ws_token = relaycast_ws_spawn_token(&ws_value);
                         if ws_token.is_some() {

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -230,23 +230,18 @@ impl BrokerRuntime {
                     };
                     let effective_task = normalize_initial_task(task.clone());
 
-                    // Pre-register agent token. Claude doesn't need this — it
-                    // bakes the API key into --mcp-config JSON and self-registers.
-                    // Non-Claude CLIs need the token injected into their CLI args
-                    // at spawn time, so we do a quick (3s) registration attempt.
-                    let cli_command = parse_cli_command(&cli)
-                        .map(|(cmd, _)| cmd)
-                        .unwrap_or_else(|_| cli.clone());
-                    let cli_name_lower = normalize_cli_name(&cli_command).to_lowercase();
-                    let is_claude =
-                        cli_name_lower == "claude" || cli_name_lower.starts_with("claude:");
+                    // Pre-register agent token for all CLIs. Claude needs it
+                    // too: without RELAY_AGENT_TOKEN + RELAY_SKIP_BOOTSTRAP=1 in
+                    // the relaycast MCP env, `@relaycast/mcp` runs bootstrap
+                    // (network registration) before responding to the MCP
+                    // initialize handshake, and Claude drops the pending server
+                    // before any relaycast tool names land in deferred_tools
+                    // (issue #926). A short timeout keeps spawn latency bounded
+                    // while still giving the registration call a real chance.
                     let worker_relay_key = {
                         let ws_token = relaycast_ws_spawn_token(&ws_value);
                         if ws_token.is_some() {
                             ws_token
-                        } else if is_claude {
-                            // Claude self-registers via its MCP server — skip blocking call
-                            None
                         } else {
                             const REG_TIMEOUT: Duration = Duration::from_secs(3);
                             match tokio::time::timeout(
@@ -445,18 +440,10 @@ impl BrokerRuntime {
                         let effective_task = normalize_initial_task(task_opt.clone());
 
                         // Pre-register (same logic as primary WS spawn path).
-                        let cli_command = parse_cli_command(&cli)
-                            .map(|(cmd, _)| cmd)
-                            .unwrap_or_else(|_| cli.clone());
-                        let cli_name_lower = normalize_cli_name(&cli_command).to_lowercase();
-                        let is_claude =
-                            cli_name_lower == "claude" || cli_name_lower.starts_with("claude:");
                         let worker_relay_key = {
                             let ws_token = relaycast_ws_spawn_token(&ws_value);
                             if ws_token.is_some() {
                                 ws_token
-                            } else if is_claude {
-                                None
                             } else {
                                 const REG_TIMEOUT: Duration = Duration::from_secs(3);
                                 match tokio::time::timeout(


### PR DESCRIPTION
## Summary

Fixes #926. Claude PTY workers were receiving the "Relaycast MCP tools are available" system reminder but `ToolSearch` could not find any `mcp__relaycast__*` tools, forcing the worker to fall back to inline replies.

### Root cause

The WS spawn path in `crates/broker/src/runtime/relaycast_events.rs` explicitly skipped pre-registration for Claude with the comment _"Claude self-registers via its MCP server — skip blocking call"_. That assumption was wrong: when `RELAY_AGENT_TOKEN` is not provided in the relaycast MCP env, `@relaycast/mcp` runs a blocking bootstrap (network registration) before responding to the MCP initialize/tools-list handshake. Claude treats the relaycast server as pending until the handshake completes, then drops it when the deferred-tools snapshot lands empty — so no `mcp__relaycast__*` names ever become callable.

A working session (e.g. Codex) hits the other branch of the same function, which pre-registers and passes both `RELAY_AGENT_TOKEN` and `RELAY_SKIP_BOOTSTRAP=1` into the MCP config. With those set, `@relaycast/mcp` skips the network round trip and exposes tools immediately.

### Fix

Remove the Claude special-case in both WS spawn entries (primary and fallback paths) so all CLIs are pre-registered uniformly. The existing 3-second timeout still bounds spawn latency on registration failure; on failure the worker falls back to self-registration exactly as it does today for non-Claude CLIs. The relaycast MCP env wiring (`snippets.rs::relaycast_server_config`) already adds `RELAY_SKIP_BOOTSTRAP=1` whenever `RELAY_AGENT_TOKEN` is present, so no changes are needed downstream.

Other spawn paths (`runtime/api.rs`, `runtime/maintenance.rs`, `wrap.rs`) already pre-register Claude — this brings the WS spawn path in line with them.

## Test plan

- [x] `cargo check -p agent-relay-broker` passes
- [x] `cargo test -p agent-relay-broker --lib` — 625 passed, 0 failed
- [ ] Verify on a real Pear/broker launch that a Claude PTY worker sees `mcp__relaycast__*` tools in `ToolSearch` after spawn


---
_Generated by [Claude Code](https://claude.ai/code/session_0159GTNzizGYTZWT6DcV8Vnf)_