### PR TITLE
fix(broker): stop worker stderr from rendering inside agent xterm

### DIFF
--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -1188,7 +1188,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             + pending_verifications.len()
                             + pending_activities.len();
                         if pending_count > 0 {
-                            tracing::warn!(
+                            tracing::debug!(
                                 target = "agent_relay::worker::pty",
                                 silent_secs = silent_duration.as_secs(),
                                 pending_delivery_count = pending_count,
@@ -1200,7 +1200,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                 "pending_delivery_count": pending_count,
                             })).await;
                         } else {
-                            tracing::info!(
+                            tracing::debug!(
                                 target = "agent_relay::worker::pty",
                                 silent_secs = silent_duration.as_secs(),
                                 "watchdog: no PTY output for {}s — marking idle",

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -959,6 +959,15 @@ fn spawn_worker_reader<R>(
             )
             .await;
 
+            // Only stdout carries the PTY-output protocol. Stderr is captured
+            // in the worker log file for diagnostics; forwarding it as a
+            // worker_stream event causes tracing logs (e.g. the idle
+            // watchdog) to render inside the agent's xterm buffer, on top of
+            // the CLI's input prompt.
+            if !parse_json {
+                continue;
+            }
+
             let fallback = json!({
                 "v": PROTOCOL_VERSION,
                 "type": "worker_stream",


### PR DESCRIPTION
## Summary
- The pty_worker subprocess is launched with `stderr: Stdio::piped()` (`crates/broker/src/worker.rs:380-382`) and read by `spawn_worker_reader(..., parse_json=false, ...)`. The fallback branch (`worker.rs:961`) was wrapping every non-JSON line as `{"type":"worker_stream","payload":{"stream":"stderr","chunk": line}}` and forwarding it to dashboards.
- Dashboards treat any `worker_stream` chunk as PTY output and append it to the agent's xterm buffer. The result: tracing logs from the pty_worker (e.g. the idle watchdog `"watchdog: no PTY output for Ns — marking idle"`) render *inside* the agent terminal, on top of the CLI's input prompt.
- Fix the leak at the source (stderr is for diagnostics, not PTY output) and quiet the watchdog so it doesn't even hit the log file under the default `RUST_LOG=info` filter.

## Changes
- `crates/broker/src/worker.rs` — in `spawn_worker_reader`, skip the `worker_stream` fallback when `parse_json` is false. The line is still written to the per-worker log file, so debugging context is preserved.
- `crates/broker/src/pty_worker.rs` — downgrade the two idle-watchdog tracing lines from `info`/`warn` to `debug`. The `send_frame("agent_idle" | "agent_blocked_on_send", …)` calls are unchanged, so dashboards still receive the state transitions.

## Test plan
- [ ] `cargo build -p agent-relay-broker`
- [ ] Spawn an agent via a dashboard (e.g. Pear), leave it idle past `NO_OUTPUT_EXIT_TIMEOUT`, and confirm no `watchdog: …` text appears in the xterm buffer.
- [ ] Confirm `agent_idle` / `agent_blocked_on_send` events still arrive in the dashboard (state UI still updates).
- [ ] `cargo test -p agent-relay-broker` (no behavioural change expected for existing tests).