### PR TITLE
Make broker diagnostic logs opt-in

### DIFF
--- a/.trajectories/completed/2026-05/traj_u3loicehnwb4.json
+++ b/.trajectories/completed/2026-05/traj_u3loicehnwb4.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_u3loicehnwb4",
+  "version": 1,
+  "task": {
+    "title": "Gate broker diagnostic logs behind env flag"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-21T04:14:44.815Z",
+  "completedAt": "2026-05-21T04:14:45.063Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-21T04:14:44.956Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_1itfbmg9tn3r",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-21T04:14:44.956Z",
+      "endedAt": "2026-05-21T04:14:45.063Z",
+      "events": [
+        {
+          "ts": 1779336884957,
+          "type": "decision",
+          "content": "Default broker tracing filter to off: Default broker tracing filter to off",
+          "raw": {
+            "question": "Default broker tracing filter to off",
+            "chosen": "Default broker tracing filter to off",
+            "alternatives": [],
+            "reasoning": "PTY worker stderr is parsed as stream fallback output when it is not JSON, so warn-level tracing must not be emitted unless explicitly requested."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Made broker tracing quiet by default with AGENT_RELAY_BROKER_LOG or RUST_LOG opt-in and corrected PTY tracing targets.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/private/tmp/relay-quiet-broker-logs",
+  "tags": [],
+  "_trace": {
+    "startRef": "db037b0557e7353e169e92293f4adde06e48a6c6",
+    "endRef": "db037b0557e7353e169e92293f4adde06e48a6c6"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_u3loicehnwb4.md
+++ b/.trajectories/completed/2026-05/traj_u3loicehnwb4.md
@@ -1,0 +1,33 @@
+# Trajectory: Gate broker diagnostic logs behind env flag
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** May 21, 2026 at 12:14 AM
+> **Completed:** May 21, 2026 at 12:14 AM
+
+---
+
+## Summary
+
+Made broker tracing quiet by default with AGENT_RELAY_BROKER_LOG or RUST_LOG opt-in and corrected PTY tracing targets.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Default broker tracing filter to off
+
+- **Chose:** Default broker tracing filter to off
+- **Reasoning:** PTY worker stderr is parsed as stream fallback output when it is not JSON, so warn-level tracing must not be emitted unless explicitly requested.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Default broker tracing filter to off: Default broker tracing filter to off

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-20T11:46:17.517Z",
+  "lastUpdated": "2026-05-21T04:14:45.258Z",
   "trajectories": {
     "traj_05xg7j388bc4": {
       "title": "Add browser workflow step integration",
@@ -1124,6 +1124,13 @@
       "startedAt": "2026-05-20T11:36:34.306Z",
       "completedAt": "2026-05-20T11:46:17.506Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/.msd-autofix-1bdf6c0b/.trajectories/completed/2026-05/traj_af7iew24eiip.json"
+    },
+    "traj_u3loicehnwb4": {
+      "title": "Gate broker diagnostic logs behind env flag",
+      "status": "completed",
+      "startedAt": "2026-05-21T04:14:44.815Z",
+      "completedAt": "2026-05-21T04:14:45.063Z",
+      "path": "/private/tmp/relay-quiet-broker-logs/.trajectories/completed/2026-05/traj_u3loicehnwb4.json"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay history` and `agent-relay replies` now resolve the project broker session even when `AGENT_RELAY_STATE_DIR` points elsewhere.
 - `agent-relay doctor` now fails with an actionable diagnostic for half-started, stale-connection, and unresolved-API-key-template brokers instead of reporting "healthy".
 - CLI readiness checks use the live VT grid and cursor position to avoid false ready states in alternate screens and menus.
+- Broker diagnostic logs are quiet by default; use `AGENT_RELAY_BROKER_LOG=1` or `RUST_LOG=...` to opt in without contaminating PTY streams.
 - `agent-relay history --from <agent>` returns the newest messages after chronological sorting.
 - `agent-relay replies --unread` prints nothing when there are no unread messages.
 - Messaging `--limit` values clamp invalid negative inputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay history` and `agent-relay replies` now resolve the project broker session even when `AGENT_RELAY_STATE_DIR` points elsewhere.
 - `agent-relay doctor` now fails with an actionable diagnostic for half-started, stale-connection, and unresolved-API-key-template brokers instead of reporting "healthy".
 - CLI readiness checks use the live VT grid and cursor position to avoid false ready states in alternate screens and menus.
-- Broker diagnostic logs are quiet by default; use `AGENT_RELAY_BROKER_LOG=1` or `RUST_LOG=...` to opt in without contaminating PTY streams.
+- Broker diagnostic logs default to `~/.agentworkforce/relay/logs/{brokerId}.log` instead of stderr, keeping PTY streams clean. Set `AGENT_RELAY_BROKER_LOG=off` to disable, `AGENT_RELAY_BROKER_LOG=stderr` to print to stderr, and use `RUST_LOG=...` for finer-grained filters.
 - `agent-relay history --from <agent>` returns the newest messages after chronological sorting.
 - `agent-relay replies --unread` prints nothing when there are no unread messages.
 - Messaging `--limit` values clamp invalid negative inputs.
@@ -91,11 +91,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.3.2] - 2026-05-20
 
 ### Product Perspective
+
 #### User-Impacting Fixes
+
 - Stop worker stderr from rendering inside agent xterm (#931) (#931)
 
 ### Technical Perspective
+
 #### Releases
+
 - v6.3.2
 
 ---
@@ -103,15 +107,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.3.1] - 2026-05-20
 
 ### Product Perspective
+
 #### User-Impacting Fixes
+
 - Pre-register Claude PTY workers so Relaycast MCP boots fast (#926)
 
 ### Technical Perspective
+
 #### Dependencies & Tooling
+
 - Retrigger flaky macOS Rust Tests
 - Drop change-implying framing from PTY pre-register note
 
 #### Releases
+
 - v6.3.1
 
 ---
@@ -119,7 +128,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.3.0] - 2026-05-20
 
 ### Technical Perspective
+
 #### Releases
+
 - v6.3.0
 
 ---
@@ -127,11 +138,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2.8] - 2026-05-20
 
 ### Product Perspective
+
 #### User-Impacting Fixes
+
 - Tighten PTY chrome scrubbing, document idle override, tame stale-state warning (#930) (#930)
 
 ### Technical Perspective
+
 #### Releases
+
 - v6.2.8
 
 ---
@@ -139,7 +154,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2.7] - 2026-05-20
 
 ### Technical Perspective
+
 #### Releases
+
 - v6.2.7
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay history` and `agent-relay replies` now resolve the project broker session even when `AGENT_RELAY_STATE_DIR` points elsewhere.
 - `agent-relay doctor` now fails with an actionable diagnostic for half-started, stale-connection, and unresolved-API-key-template brokers instead of reporting "healthy".
 - CLI readiness checks use the live VT grid and cursor position to avoid false ready states in alternate screens and menus.
-- Broker diagnostic logs default to `~/.agentworkforce/relay/logs/{brokerId}.log` instead of stderr, keeping PTY streams clean. Set `AGENT_RELAY_BROKER_LOG=off` to disable, `AGENT_RELAY_BROKER_LOG=stderr` to print to stderr, and use `RUST_LOG=...` for finer-grained filters.
+- Broker diagnostic logs write to a platform-standard directory with daily rotation: macOS `~/Library/Logs/agent-relay/{brokerId}.log.YYYY-MM-DD`, Linux `~/.local/state/agent-relay/logs/...`, Windows `%LOCALAPPDATA%\agent-relay\Logs\...`. Set `AGENT_RELAY_BROKER_LOG=off` to disable, `AGENT_RELAY_BROKER_LOG=stderr` to print to stderr, and use `RUST_LOG=...` for finer-grained filters.
+- `agent-relay log {path,list,view,rotate,clear}` inspects and prunes broker tracing logs. `log rotate --keep-days 7` removes rotated files older than the retention window; `log clear --broker-id <id>` wipes a single broker's logs.
 - `agent-relay history --from <agent>` returns the newest messages after chronological sorting.
 - `agent-relay replies --unread` prints nothing when there are no unread messages.
 - Messaging `--limit` values clamp invalid negative inputs.

--- a/crates/broker/src/cli/mod.rs
+++ b/crates/broker/src/cli/mod.rs
@@ -58,12 +58,53 @@ impl Commands {
             Commands::Wrap { .. } => "wrap",
         }
     }
+
+    /// Identifier used to name this process' tracing log file. For broker-style
+    /// subcommands (init, pty, headless, wrap) we prefer the broker / agent
+    /// name; for short-lived utility subcommands we fall back to a
+    /// `{command}-{pid}` tag so concurrent invocations don't clobber each
+    /// other's log file.
+    fn log_identifier(&self) -> String {
+        let pid = std::process::id();
+        match self {
+            Commands::Init(cmd) => {
+                let name = cmd.name.trim();
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+                std::env::current_dir()
+                    .ok()
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| format!("broker-{pid}"))
+            }
+            Commands::Pty(cmd) => {
+                non_empty_name(cmd.agent_name.as_deref()).unwrap_or_else(|| format!("pty-{pid}"))
+            }
+            Commands::Headless(cmd) => non_empty_name(cmd.agent_name.as_deref())
+                .unwrap_or_else(|| format!("headless-{pid}")),
+            Commands::Wrap { cli, .. } => format!("wrap-{cli}-{pid}"),
+            Commands::McpArgs(_) => format!("mcp_args-{pid}"),
+            Commands::DumpPty(cmd) => format!("dump_pty-{}-{}", cmd.name, pid),
+            Commands::Swarm(_) => format!("swarm-{pid}"),
+        }
+    }
+}
+
+fn non_empty_name(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 pub(crate) async fn run() -> Result<()> {
-    runtime::init_tracing();
-
     let cli = Cli::parse();
+    runtime::init_tracing(&cli.command.log_identifier());
+
     let telemetry = TelemetryClient::new();
     telemetry.track(TelemetryEvent::CliCommandRun {
         command_name: cli.command.telemetry_name().to_string(),

--- a/crates/broker/src/pty.rs
+++ b/crates/broker/src/pty.rs
@@ -502,7 +502,7 @@ impl PtySession {
                 Ok(Some(_status)) => {
                     // Child exited and we successfully reaped it.
                     tracing::info!(
-                        target = "agent_relay::worker::pty",
+                        target: "agent_relay::worker::pty",
                         pid = ?self.child_pid,
                         "has_exited: try_wait returned Ok(Some) — child reaped"
                     );
@@ -516,7 +516,7 @@ impl PtySession {
                     // ECHILD or other error — child was already reaped by
                     // someone else (e.g. shutdown() or a signal handler).
                     tracing::info!(
-                        target = "agent_relay::worker::pty",
+                        target: "agent_relay::worker::pty",
                         pid = ?self.child_pid,
                         error = %e,
                         "has_exited: try_wait returned Err — treating as exited"
@@ -545,7 +545,7 @@ impl PtySession {
                 if errno == libc::ESRCH {
                     // No such process — child is gone.
                     tracing::info!(
-                        target = "agent_relay::worker::pty",
+                        target: "agent_relay::worker::pty",
                         pid = pid,
                         "has_exited: kill(0) returned ESRCH — process gone"
                     );
@@ -555,7 +555,7 @@ impl PtySession {
             }
 
             tracing::trace!(
-                target = "agent_relay::worker::pty",
+                target: "agent_relay::worker::pty",
                 pid = pid,
                 "has_exited: child appears alive"
             );
@@ -571,14 +571,14 @@ impl PtySession {
         {
             let count = self.no_pid_alive_checks.fetch_add(1, Ordering::Relaxed) + 1;
             tracing::debug!(
-                target = "agent_relay::worker::pty",
+                target: "agent_relay::worker::pty",
                 consecutive_checks = count,
                 threshold = NO_PID_THRESHOLD,
                 "has_exited: no PID available, try_wait says Ok(None)"
             );
             if count >= NO_PID_THRESHOLD {
                 tracing::warn!(
-                    target = "agent_relay::worker::pty",
+                    target: "agent_relay::worker::pty",
                     consecutive_checks = count,
                     "has_exited: no PID and try_wait stuck at Ok(None) for {} checks — assuming child exited",
                     count
@@ -591,7 +591,7 @@ impl PtySession {
         #[cfg(not(unix))]
         {
             tracing::trace!(
-                target = "agent_relay::worker::pty",
+                target: "agent_relay::worker::pty",
                 pid = ?live_pid,
                 "has_exited: child appears alive"
             );
@@ -630,7 +630,7 @@ impl PtySession {
                         Ok(None) => {
                             if std::time::Instant::now() >= deadline {
                                 tracing::warn!(
-                                    target = "agent_relay::worker::pty",
+                                    target: "agent_relay::worker::pty",
                                     "shutdown: child did not exit within 2s after kill"
                                 );
                                 break;

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -214,7 +214,7 @@ async fn try_emit_worker_ready(
 
     if timed_out && !startup_ready {
         tracing::warn!(
-            target = "agent_relay::worker::pty",
+            target: "agent_relay::worker::pty",
             worker = %worker_name,
             timeout_secs = STARTUP_READY_TIMEOUT.as_secs(),
             "startup readiness timed out; emitting worker_ready fallback"
@@ -476,7 +476,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     Ok(p) if p.rows > 0 && p.cols > 0 => {
                                         if let Err(e) = pty.resize(p.rows, p.cols) {
                                             tracing::warn!(
-                                                target = "agent_relay::worker::pty",
+                                                target: "agent_relay::worker::pty",
                                                 rows = p.rows, cols = p.cols, error = %e,
                                                 "failed to resize pty"
                                             );
@@ -509,7 +509,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     Some(data) => {
                                         if let Err(e) = pty.write_all(data.as_bytes()) {
                                             tracing::warn!(
-                                                target = "agent_relay::worker::pty",
+                                                target: "agent_relay::worker::pty",
                                                 error = %e,
                                                 "failed to write input to pty"
                                             );
@@ -687,7 +687,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             && clean_text.lines().any(|line| line.trim() == "/exit")
                         {
                             tracing::info!(
-                                target = "agent_relay::worker::pty",
+                                target: "agent_relay::worker::pty",
                                 "agent issued /exit — shutting down"
                             );
                             flush_stream_buffer!();
@@ -734,7 +734,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                 parse_continuity_command(&continuity_buffer)
                             {
                                 tracing::info!(
-                                    target = "agent_relay::worker::pty",
+                                    target: "agent_relay::worker::pty",
                                     action = %action.as_str(),
                                     content_len = content.len(),
                                     "detected KIND: continuity command in PTY output"
@@ -840,7 +840,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                 let pa = pending_activities.remove(i).unwrap();
                                 if let Some(pattern) = matched {
                                     tracing::debug!(
-                                        target = "agent_relay::worker::pty",
+                                        target: "agent_relay::worker::pty",
                                         delivery_id = %pa.delivery_id,
                                         event_id = %pa.event_id,
                                         pattern = %pattern,
@@ -859,7 +859,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     .await;
                                 } else {
                                     tracing::debug!(
-                                        target = "agent_relay::worker::pty",
+                                        target: "agent_relay::worker::pty",
                                         delivery_id = %pa.delivery_id,
                                         event_id = %pa.event_id,
                                         "delivery activity window expired"
@@ -892,7 +892,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                         };
                         if !trimmed.is_empty() {
                             tracing::info!(
-                                target = "agent_relay::worker::pty",
+                                target: "agent_relay::worker::pty",
                                 output_len = trimmed.len(),
                                 "PTY channel closed; captured output available"
                             );
@@ -1153,13 +1153,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     if !late_output.is_empty() {
                         let clean = strip_ansi(&late_output);
                         tracing::warn!(
-                            target = "agent_relay::worker::pty",
+                            target: "agent_relay::worker::pty",
                             output = %clean,
                             "watchdog: captured late output from exiting child"
                         );
                     }
                     tracing::info!(
-                        target = "agent_relay::worker::pty",
+                        target: "agent_relay::worker::pty",
                         "watchdog: child process exited"
                     );
                     let mut exit_payload = json!({
@@ -1189,7 +1189,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             + pending_activities.len();
                         if pending_count > 0 {
                             tracing::debug!(
-                                target = "agent_relay::worker::pty",
+                                target: "agent_relay::worker::pty",
                                 silent_secs = silent_duration.as_secs(),
                                 pending_delivery_count = pending_count,
                                 "watchdog: no PTY output while delivery work is pending — marking blocked_on_send"
@@ -1201,7 +1201,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             })).await;
                         } else {
                             tracing::debug!(
-                                target = "agent_relay::worker::pty",
+                                target: "agent_relay::worker::pty",
                                 silent_secs = silent_duration.as_secs(),
                                 "watchdog: no PTY output for {}s — marking idle",
                                 silent_duration.as_secs()

--- a/crates/broker/src/runtime/util.rs
+++ b/crates/broker/src/runtime/util.rs
@@ -25,7 +25,7 @@ pub(crate) enum TracingDestination {
     Off,
     /// Write to stderr (legacy "print" behavior).
     Stderr,
-    /// Write to `~/.agentworkforce/relay/logs/{broker_id}.log` (the default).
+    /// Write to a daily-rotated log file inside [`broker_log_dir`].
     File,
 }
 
@@ -79,17 +79,40 @@ fn sanitize_filename_segment(value: &str) -> String {
     out
 }
 
-/// Default log file path: `~/.agentworkforce/relay/logs/{broker_id}.log`.
+/// Platform-standard directory for broker tracing logs.
 ///
-/// Returns `None` only when the home directory cannot be resolved.
-pub(crate) fn log_file_path(broker_id: &str) -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    Some(
-        home.join(".agentworkforce")
-            .join("relay")
-            .join("logs")
-            .join(format!("{}.log", sanitize_filename_segment(broker_id))),
-    )
+/// - macOS: `~/Library/Logs/agent-relay`
+/// - Linux / other Unix: `$XDG_STATE_HOME/agent-relay/logs` (defaults to
+///   `~/.local/state/agent-relay/logs`)
+/// - Windows: `%LOCALAPPDATA%\agent-relay\Logs`
+///
+/// Returns `None` only when neither the platform-specific directory nor the
+/// home directory can be resolved.
+pub(crate) fn broker_log_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir()?;
+        Some(home.join("Library").join("Logs").join("agent-relay"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let local = dirs::data_local_dir()?;
+        Some(local.join("agent-relay").join("Logs"))
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let state = dirs::state_dir()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".local").join("state")))?;
+        Some(state.join("agent-relay").join("logs"))
+    }
+}
+
+/// Filename prefix used for this broker's rolling log file.
+///
+/// `tracing_appender::rolling::daily` appends a `.YYYY-MM-DD` suffix, so files
+/// land as `{broker_id}.log.YYYY-MM-DD` in the log directory.
+pub(crate) fn broker_log_file_prefix(broker_id: &str) -> String {
+    format!("{}.log", sanitize_filename_segment(broker_id))
 }
 
 pub(crate) fn log_startup_phase(enabled: bool, started_at: Instant, message: impl AsRef<str>) {
@@ -127,22 +150,15 @@ pub(crate) fn init_tracing(broker_id: &str) {
     let (writer, guard) = match destination {
         TracingDestination::Stderr => tracing_appender::non_blocking(std::io::stderr()),
         TracingDestination::File => {
-            let Some(log_path) = log_file_path(broker_id) else {
+            let Some(log_dir) = broker_log_dir() else {
                 return;
             };
-            if let Some(parent) = log_path.parent() {
-                if std::fs::create_dir_all(parent).is_err() {
-                    return;
-                }
+            if std::fs::create_dir_all(&log_dir).is_err() {
+                return;
             }
-            match std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path)
-            {
-                Ok(file) => tracing_appender::non_blocking(file),
-                Err(_) => return,
-            }
+            let appender =
+                tracing_appender::rolling::daily(&log_dir, broker_log_file_prefix(broker_id));
+            tracing_appender::non_blocking(appender)
         }
         TracingDestination::Off => unreachable!(),
     };
@@ -214,8 +230,8 @@ pub(crate) fn delivery_retry_interval() -> Duration {
 #[cfg(test)]
 mod tests {
     use super::{
-        log_file_path, sanitize_filename_segment, tracing_destination, tracing_filter_directive,
-        TracingDestination,
+        broker_log_dir, broker_log_file_prefix, sanitize_filename_segment, tracing_destination,
+        tracing_filter_directive, TracingDestination,
     };
 
     #[test]
@@ -293,12 +309,32 @@ mod tests {
     }
 
     #[test]
-    fn log_file_path_uses_agentworkforce_logs_dir() {
-        if let Some(path) = log_file_path("my-broker") {
-            let path_str = path.to_string_lossy();
+    fn broker_log_file_prefix_includes_log_suffix() {
+        assert_eq!(broker_log_file_prefix("my-broker"), "my-broker.log");
+        assert_eq!(broker_log_file_prefix(""), "broker.log");
+    }
+
+    #[test]
+    fn broker_log_dir_uses_platform_standard_layout() {
+        let Some(dir) = broker_log_dir() else {
+            return;
+        };
+        let path_str = dir.to_string_lossy().replace('\\', "/");
+
+        if cfg!(target_os = "macos") {
             assert!(
-                path_str.contains(".agentworkforce/relay/logs/my-broker.log"),
-                "unexpected log path: {path_str}"
+                path_str.contains("/Library/Logs/agent-relay"),
+                "expected macOS Library/Logs path, got: {path_str}"
+            );
+        } else if cfg!(target_os = "windows") {
+            assert!(
+                path_str.to_ascii_lowercase().contains("agent-relay/logs"),
+                "expected Windows LocalAppData layout, got: {path_str}"
+            );
+        } else {
+            assert!(
+                path_str.contains("agent-relay/logs"),
+                "expected Unix state path, got: {path_str}"
             );
         }
     }

--- a/crates/broker/src/runtime/util.rs
+++ b/crates/broker/src/runtime/util.rs
@@ -18,19 +18,78 @@ fn env_flag_value_enabled(value: &str) -> bool {
     )
 }
 
-pub(crate) fn tracing_filter_directive(
-    rust_log: Option<&str>,
-    broker_log_flag: Option<&str>,
-) -> String {
-    if let Some(value) = rust_log.map(str::trim).filter(|value| !value.is_empty()) {
-        return value.to_string();
-    }
+/// Where broker tracing output should be written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TracingDestination {
+    /// Disable the tracing subscriber entirely.
+    Off,
+    /// Write to stderr (legacy "print" behavior).
+    Stderr,
+    /// Write to `~/.agentworkforce/relay/logs/{broker_id}.log` (the default).
+    File,
+}
 
-    if broker_log_flag.is_some_and(env_flag_value_enabled) {
-        "info".to_string()
-    } else {
-        "off".to_string()
+/// Parse the `AGENT_RELAY_BROKER_LOG` env var into a destination.
+///
+/// Defaults to [`TracingDestination::File`] when the env var is unset or empty.
+/// Recognised values:
+/// - `off`, `none`, `0`, `false`, `no` → [`TracingDestination::Off`]
+/// - `stderr`, `print` → [`TracingDestination::Stderr`]
+/// - `file`, `1`, `true`, `yes`, `on` → [`TracingDestination::File`]
+///
+/// Unknown values fall back to `File` so a typo never silently loses logs.
+pub(crate) fn tracing_destination(env_value: Option<&str>) -> TracingDestination {
+    let Some(value) = env_value.map(str::trim).filter(|v| !v.is_empty()) else {
+        return TracingDestination::File;
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "off" | "none" | "0" | "false" | "no" => TracingDestination::Off,
+        "stderr" | "print" => TracingDestination::Stderr,
+        _ => TracingDestination::File,
     }
+}
+
+/// Pick the level filter directive for the tracing subscriber.
+///
+/// `RUST_LOG` always wins when set, so callers can use the standard tracing
+/// directive syntax (e.g. `agent_relay::worker::pty=debug`). Otherwise we
+/// default to `info`, which keeps the file log useful without being noisy.
+pub(crate) fn tracing_filter_directive(rust_log: Option<&str>) -> String {
+    rust_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "info".to_string())
+}
+
+fn sanitize_filename_segment(value: &str) -> String {
+    let mut out: String = value
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if out.is_empty() {
+        out.push_str("broker");
+    }
+    out
+}
+
+/// Default log file path: `~/.agentworkforce/relay/logs/{broker_id}.log`.
+///
+/// Returns `None` only when the home directory cannot be resolved.
+pub(crate) fn log_file_path(broker_id: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".agentworkforce")
+            .join("relay")
+            .join("logs")
+            .join(format!("{}.log", sanitize_filename_segment(broker_id))),
+    )
 }
 
 pub(crate) fn log_startup_phase(enabled: bool, started_at: Instant, message: impl AsRef<str>) {
@@ -50,16 +109,48 @@ pub(crate) fn unix_timestamp_secs() -> u64 {
         .as_secs()
 }
 
-pub(crate) fn init_tracing() {
+/// Initialise the global tracing subscriber for this broker process.
+///
+/// Destination is controlled by `AGENT_RELAY_BROKER_LOG`; level filter by
+/// `RUST_LOG`. See [`tracing_destination`] for accepted env values.
+pub(crate) fn init_tracing(broker_id: &str) {
     let rust_log = std::env::var("RUST_LOG").ok();
-    let broker_log_flag = std::env::var(BROKER_LOG_ENV).ok();
-    let filter_directive =
-        tracing_filter_directive(rust_log.as_deref(), broker_log_flag.as_deref());
-    let (writer, guard) = tracing_appender::non_blocking(std::io::stderr());
+    let broker_log = std::env::var(BROKER_LOG_ENV).ok();
+    let destination = tracing_destination(broker_log.as_deref());
+
+    if destination == TracingDestination::Off {
+        return;
+    }
+
+    let filter_directive = tracing_filter_directive(rust_log.as_deref());
+
+    let (writer, guard) = match destination {
+        TracingDestination::Stderr => tracing_appender::non_blocking(std::io::stderr()),
+        TracingDestination::File => {
+            let Some(log_path) = log_file_path(broker_id) else {
+                return;
+            };
+            if let Some(parent) = log_path.parent() {
+                if std::fs::create_dir_all(parent).is_err() {
+                    return;
+                }
+            }
+            match std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)
+            {
+                Ok(file) => tracing_appender::non_blocking(file),
+                Err(_) => return,
+            }
+        }
+        TracingDestination::Off => unreachable!(),
+    };
+
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_new(filter_directive)
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("off")),
+            tracing_subscriber::EnvFilter::try_new(&filter_directive)
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .with_target(true)
         .with_writer(writer)
@@ -122,26 +213,94 @@ pub(crate) fn delivery_retry_interval() -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::tracing_filter_directive;
+    use super::{
+        log_file_path, sanitize_filename_segment, tracing_destination, tracing_filter_directive,
+        TracingDestination,
+    };
 
     #[test]
-    fn tracing_filter_defaults_to_off() {
-        assert_eq!(tracing_filter_directive(None, None), "off");
-        assert_eq!(tracing_filter_directive(Some(""), Some("0")), "off");
+    fn tracing_destination_defaults_to_file() {
+        assert_eq!(tracing_destination(None), TracingDestination::File);
+        assert_eq!(tracing_destination(Some("")), TracingDestination::File);
+        assert_eq!(tracing_destination(Some("   ")), TracingDestination::File);
     }
 
     #[test]
-    fn tracing_filter_uses_broker_log_flag_for_info() {
-        assert_eq!(tracing_filter_directive(None, Some("1")), "info");
-        assert_eq!(tracing_filter_directive(None, Some("true")), "info");
+    fn tracing_destination_recognises_off_aliases() {
+        for value in ["off", "OFF", "none", "0", "false", "no"] {
+            assert_eq!(
+                tracing_destination(Some(value)),
+                TracingDestination::Off,
+                "value `{value}` should disable tracing"
+            );
+        }
+    }
+
+    #[test]
+    fn tracing_destination_recognises_stderr_aliases() {
+        for value in ["stderr", "STDERR", "print", "Print"] {
+            assert_eq!(
+                tracing_destination(Some(value)),
+                TracingDestination::Stderr,
+                "value `{value}` should route to stderr"
+            );
+        }
+    }
+
+    #[test]
+    fn tracing_destination_recognises_file_aliases() {
+        for value in ["file", "FILE", "1", "true", "yes", "on", "unknown-value"] {
+            assert_eq!(
+                tracing_destination(Some(value)),
+                TracingDestination::File,
+                "value `{value}` should route to file"
+            );
+        }
+    }
+
+    #[test]
+    fn tracing_filter_defaults_to_info_when_rust_log_unset() {
+        assert_eq!(tracing_filter_directive(None), "info");
+        assert_eq!(tracing_filter_directive(Some("")), "info");
+        assert_eq!(tracing_filter_directive(Some("   ")), "info");
     }
 
     #[test]
     fn tracing_filter_prefers_rust_log_directive() {
         assert_eq!(
-            tracing_filter_directive(Some("agent_relay::worker::pty=debug"), Some("1")),
+            tracing_filter_directive(Some("agent_relay::worker::pty=debug")),
             "agent_relay::worker::pty=debug"
         );
+    }
+
+    #[test]
+    fn sanitize_filename_segment_replaces_unsafe_chars() {
+        assert_eq!(
+            sanitize_filename_segment("agent name/with:weird*chars"),
+            "agent-name-with-weird-chars"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_segment_keeps_safe_chars() {
+        assert_eq!(sanitize_filename_segment("alpha-Beta_01"), "alpha-Beta_01");
+    }
+
+    #[test]
+    fn sanitize_filename_segment_falls_back_to_broker() {
+        assert_eq!(sanitize_filename_segment(""), "broker");
+        assert_eq!(sanitize_filename_segment("///"), "---");
+    }
+
+    #[test]
+    fn log_file_path_uses_agentworkforce_logs_dir() {
+        if let Some(path) = log_file_path("my-broker") {
+            let path_str = path.to_string_lossy();
+            assert!(
+                path_str.contains(".agentworkforce/relay/logs/my-broker.log"),
+                "unexpected log path: {path_str}"
+            );
+        }
     }
 }
 

--- a/crates/broker/src/runtime/util.rs
+++ b/crates/broker/src/runtime/util.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const BROKER_LOG_ENV: &str = "AGENT_RELAY_BROKER_LOG";
+
 pub(crate) fn startup_debug_enabled() -> bool {
     std::env::var("AGENT_RELAY_STARTUP_DEBUG")
         .map(|value| {
@@ -7,6 +9,28 @@ pub(crate) fn startup_debug_enabled() -> bool {
             !trimmed.is_empty() && trimmed != "0" && !trimmed.eq_ignore_ascii_case("false")
         })
         .unwrap_or(false)
+}
+
+fn env_flag_value_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+pub(crate) fn tracing_filter_directive(
+    rust_log: Option<&str>,
+    broker_log_flag: Option<&str>,
+) -> String {
+    if let Some(value) = rust_log.map(str::trim).filter(|value| !value.is_empty()) {
+        return value.to_string();
+    }
+
+    if broker_log_flag.is_some_and(env_flag_value_enabled) {
+        "info".to_string()
+    } else {
+        "off".to_string()
+    }
 }
 
 pub(crate) fn log_startup_phase(enabled: bool, started_at: Instant, message: impl AsRef<str>) {
@@ -27,11 +51,15 @@ pub(crate) fn unix_timestamp_secs() -> u64 {
 }
 
 pub(crate) fn init_tracing() {
+    let rust_log = std::env::var("RUST_LOG").ok();
+    let broker_log_flag = std::env::var(BROKER_LOG_ENV).ok();
+    let filter_directive =
+        tracing_filter_directive(rust_log.as_deref(), broker_log_flag.as_deref());
     let (writer, guard) = tracing_appender::non_blocking(std::io::stderr());
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            tracing_subscriber::EnvFilter::try_new(filter_directive)
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("off")),
         )
         .with_target(true)
         .with_writer(writer)
@@ -81,8 +109,7 @@ pub(crate) fn command_targets_self(cmd_event: &BrokerCommandEvent, self_agent_id
 pub(crate) fn env_flag_enabled(name: &str) -> bool {
     std::env::var(name)
         .ok()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on"))
+        .is_some_and(|value| env_flag_value_enabled(&value))
 }
 
 pub(crate) fn delivery_retry_interval() -> Duration {
@@ -91,6 +118,31 @@ pub(crate) fn delivery_retry_interval() -> Duration {
         .and_then(|raw| raw.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_DELIVERY_RETRY_MS);
     Duration::from_millis(ms.max(50))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tracing_filter_directive;
+
+    #[test]
+    fn tracing_filter_defaults_to_off() {
+        assert_eq!(tracing_filter_directive(None, None), "off");
+        assert_eq!(tracing_filter_directive(Some(""), Some("0")), "off");
+    }
+
+    #[test]
+    fn tracing_filter_uses_broker_log_flag_for_info() {
+        assert_eq!(tracing_filter_directive(None, Some("1")), "info");
+        assert_eq!(tracing_filter_directive(None, Some("true")), "info");
+    }
+
+    #[test]
+    fn tracing_filter_prefers_rust_log_directive() {
+        assert_eq!(
+            tracing_filter_directive(Some("agent_relay::worker::pty=debug"), Some("1")),
+            "agent_relay::worker::pty=debug"
+        );
+    }
 }
 
 pub(crate) fn http_api_local_delivery_timeout() -> Duration {

--- a/packages/sdk/src/__tests__/broker-logs.test.ts
+++ b/packages/sdk/src/__tests__/broker-logs.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the broker-logs SDK helpers.
+ *
+ * The helpers are filesystem-only, so we stage a fake log directory in tmp
+ * and pass it explicitly via the `dir` option.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, statSync, utimesSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import {
+  clearBrokerLogs,
+  getBrokerLogDir,
+  listBrokerLogs,
+  pruneBrokerLogs,
+  tailBrokerLog,
+} from '../broker-logs.js';
+
+function stageLog(dir: string, name: string, content: string, ageDays = 0): string {
+  const path = join(dir, name);
+  writeFileSync(path, content);
+  if (ageDays > 0) {
+    const past = (Date.now() - ageDays * 24 * 60 * 60 * 1000) / 1000;
+    utimesSync(path, past, past);
+  }
+  return path;
+}
+
+describe('broker-logs SDK helpers', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'broker-logs-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('getBrokerLogDir returns a platform-appropriate path', () => {
+    const path = getBrokerLogDir();
+    if (process.platform === 'darwin') {
+      assert.match(path, /Library\/Logs\/agent-relay$/);
+    } else if (process.platform === 'win32') {
+      assert.match(path.toLowerCase(), /agent-relay[\\/]logs$/);
+    } else {
+      assert.match(path, /agent-relay\/logs$/);
+    }
+  });
+
+  test('listBrokerLogs returns empty array when directory missing', async () => {
+    const missing = join(dir, 'does-not-exist');
+    const files = await listBrokerLogs(missing);
+    assert.deepEqual(files, []);
+  });
+
+  test('listBrokerLogs parses current and rotated filenames', async () => {
+    stageLog(dir, 'alpha.log', 'current\n');
+    stageLog(dir, 'alpha.log.2026-05-20', 'old\n');
+    stageLog(dir, 'beta.log.2026-05-21', 'beta\n');
+    stageLog(dir, 'unrelated.txt', 'skip\n');
+
+    const files = await listBrokerLogs(dir);
+    const byName = Object.fromEntries(files.map((f) => [f.name, f]));
+
+    assert.equal(files.length, 3);
+    assert.equal(byName['alpha.log'].brokerId, 'alpha');
+    assert.equal(byName['alpha.log'].date, null);
+    assert.equal(byName['alpha.log.2026-05-20'].brokerId, 'alpha');
+    assert.equal(byName['alpha.log.2026-05-20'].date, '2026-05-20');
+    assert.equal(byName['beta.log.2026-05-21'].brokerId, 'beta');
+  });
+
+  test('tailBrokerLog returns the newest matching file', async () => {
+    stageLog(dir, 'proj.log.2026-05-19', 'old-1\nold-2\nold-3\n', 5);
+    stageLog(dir, 'proj.log', 'new-1\nnew-2\nnew-3\nnew-4\n');
+
+    const result = await tailBrokerLog('proj', { dir, lines: 2 });
+    assert.ok(result);
+    assert.match(result.path, /proj\.log$/);
+    assert.equal(result.content, 'new-3\nnew-4');
+  });
+
+  test('tailBrokerLog returns null when no log file exists', async () => {
+    const result = await tailBrokerLog('missing', { dir });
+    assert.equal(result, null);
+  });
+
+  test('pruneBrokerLogs deletes rotated files older than keepDays', async () => {
+    const fresh = stageLog(dir, 'proj.log.2026-05-20', 'fresh\n', 1);
+    const stale = stageLog(dir, 'proj.log.2026-05-01', 'stale\n', 20);
+    const current = stageLog(dir, 'proj.log', 'current\n');
+
+    const { removed, kept } = await pruneBrokerLogs({ dir, keepDays: 7 });
+
+    const removedPaths = removed.map((f) => f.path);
+    const keptPaths = kept.map((f) => f.path);
+
+    assert.deepEqual(removedPaths, [stale]);
+    assert.ok(keptPaths.includes(fresh));
+    assert.ok(keptPaths.includes(current));
+    assert.equal(existsSync(stale), false);
+    assert.equal(existsSync(fresh), true);
+    assert.equal(existsSync(current), true);
+  });
+
+  test('pruneBrokerLogs never deletes the current un-suffixed file', async () => {
+    const current = stageLog(dir, 'proj.log', 'still-active\n', 365);
+    const { removed, kept } = await pruneBrokerLogs({ dir, keepDays: 7 });
+    assert.equal(removed.length, 0);
+    assert.equal(kept.length, 1);
+    assert.equal(kept[0].path, current);
+  });
+
+  test('pruneBrokerLogs respects brokerId filter', async () => {
+    const aOld = stageLog(dir, 'a.log.2026-04-01', 'a\n', 30);
+    const bOld = stageLog(dir, 'b.log.2026-04-01', 'b\n', 30);
+
+    const { removed } = await pruneBrokerLogs({ dir, keepDays: 7, brokerId: 'a' });
+
+    assert.deepEqual(
+      removed.map((f) => f.path),
+      [aOld]
+    );
+    assert.equal(existsSync(bOld), true);
+  });
+
+  test('pruneBrokerLogs dryRun reports without deleting', async () => {
+    const stale = stageLog(dir, 'proj.log.2026-01-01', 'stale\n', 200);
+    const { removed } = await pruneBrokerLogs({ dir, keepDays: 7, dryRun: true });
+    assert.equal(removed.length, 1);
+    assert.equal(existsSync(stale), true);
+  });
+
+  test('clearBrokerLogs removes every file in scope', async () => {
+    const a = stageLog(dir, 'a.log', 'a\n');
+    const b = stageLog(dir, 'b.log.2026-05-20', 'b\n');
+    const c = stageLog(dir, 'c.log', 'c\n');
+
+    const removed = await clearBrokerLogs({ dir });
+
+    assert.equal(removed.length, 3);
+    for (const path of [a, b, c]) assert.equal(existsSync(path), false);
+  });
+
+  test('clearBrokerLogs honors brokerId filter', async () => {
+    const a = stageLog(dir, 'a.log', 'a\n');
+    const b = stageLog(dir, 'b.log', 'b\n');
+    const removed = await clearBrokerLogs({ dir, brokerId: 'a' });
+    assert.equal(removed.length, 1);
+    assert.equal(existsSync(a), false);
+    assert.equal(existsSync(b), true);
+  });
+});

--- a/packages/sdk/src/broker-logs.ts
+++ b/packages/sdk/src/broker-logs.ts
@@ -1,0 +1,238 @@
+/**
+ * Helpers for the broker's tracing log directory.
+ *
+ * The Rust broker writes its diagnostic logs to a platform-standard directory
+ * with daily rotation (see `crates/broker/src/runtime/util.rs::broker_log_dir`).
+ * This module mirrors that path so the TypeScript CLI can list, tail, prune,
+ * and clear those files without spawning the broker.
+ */
+
+import { homedir, platform } from 'node:os';
+import { join } from 'node:path';
+import { readdir, stat, unlink, open, type FileHandle } from 'node:fs/promises';
+
+export interface BrokerLogFile {
+  /** Absolute path to the log file. */
+  path: string;
+  /** Just the file name, e.g. `myproject.log.2026-05-21`. */
+  name: string;
+  /** Broker identifier inferred from the filename (the prefix before `.log`). */
+  brokerId: string;
+  /**
+   * The rotation date suffix in `YYYY-MM-DD` form, or `null` for the
+   * pre-rotation file laid down before `tracing-appender` rolled over.
+   */
+  date: string | null;
+  /** File size in bytes. */
+  size: number;
+  /** Last-modified time. */
+  mtime: Date;
+}
+
+const LOG_NAME_PATTERN = /^(?<brokerId>.+)\.log(?:\.(?<date>\d{4}-\d{2}-\d{2}))?$/;
+
+/**
+ * Resolve the platform-standard broker log directory. Matches the Rust
+ * implementation in `runtime/util.rs::broker_log_dir`.
+ *
+ * - macOS: `~/Library/Logs/agent-relay`
+ * - Linux / other Unix: `$XDG_STATE_HOME/agent-relay/logs` (default
+ *   `~/.local/state/agent-relay/logs`)
+ * - Windows: `%LOCALAPPDATA%\agent-relay\Logs`
+ */
+export function getBrokerLogDir(): string {
+  const home = homedir();
+  switch (platform()) {
+    case 'darwin':
+      return join(home, 'Library', 'Logs', 'agent-relay');
+    case 'win32': {
+      const localAppData = process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local');
+      return join(localAppData, 'agent-relay', 'Logs');
+    }
+    default: {
+      const stateHome =
+        process.env.XDG_STATE_HOME && process.env.XDG_STATE_HOME.length > 0
+          ? process.env.XDG_STATE_HOME
+          : join(home, '.local', 'state');
+      return join(stateHome, 'agent-relay', 'logs');
+    }
+  }
+}
+
+/** List all broker log files (current + rotated) in [`getBrokerLogDir`]. */
+export async function listBrokerLogs(dir?: string): Promise<BrokerLogFile[]> {
+  const logDir = dir ?? getBrokerLogDir();
+  let entries: string[];
+  try {
+    entries = await readdir(logDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const files: BrokerLogFile[] = [];
+  for (const name of entries) {
+    const match = LOG_NAME_PATTERN.exec(name);
+    if (!match || !match.groups) continue;
+    const fullPath = join(logDir, name);
+    let info;
+    try {
+      info = await stat(fullPath);
+    } catch {
+      continue;
+    }
+    if (!info.isFile()) continue;
+    files.push({
+      path: fullPath,
+      name,
+      brokerId: match.groups.brokerId,
+      date: match.groups.date ?? null,
+      size: info.size,
+      mtime: info.mtime,
+    });
+  }
+
+  files.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  return files;
+}
+
+/**
+ * Read the last `lines` lines of a broker's log. Picks the most recent file
+ * matching `brokerId`. Returns `null` when no log file exists for that id.
+ */
+export async function tailBrokerLog(
+  brokerId: string,
+  options: { lines?: number; dir?: string } = {}
+): Promise<{ path: string; content: string } | null> {
+  const lines = options.lines ?? 200;
+  const files = (await listBrokerLogs(options.dir)).filter((f) => f.brokerId === brokerId);
+  if (files.length === 0) return null;
+  const target = files[0]; // newest first
+  return { path: target.path, content: await tailFile(target.path, lines) };
+}
+
+export interface PruneBrokerLogsOptions {
+  /** Override the log directory. Defaults to [`getBrokerLogDir`]. */
+  dir?: string;
+  /**
+   * Keep rotated files newer than this many days. `0` removes everything
+   * except the current (un-suffixed) file. Default: 7.
+   */
+  keepDays?: number;
+  /** When true, list candidates but don't delete. */
+  dryRun?: boolean;
+  /** Restrict to a single broker id. */
+  brokerId?: string;
+}
+
+export interface PruneBrokerLogsResult {
+  removed: BrokerLogFile[];
+  kept: BrokerLogFile[];
+}
+
+/**
+ * Delete rotated log files older than `keepDays` days. The current
+ * un-suffixed file is always kept because `tracing-appender` is writing to it.
+ */
+export async function pruneBrokerLogs(options: PruneBrokerLogsOptions = {}): Promise<PruneBrokerLogsResult> {
+  const keepDays = options.keepDays ?? 7;
+  const cutoff = Date.now() - keepDays * 24 * 60 * 60 * 1000;
+  const files = await listBrokerLogs(options.dir);
+  const removed: BrokerLogFile[] = [];
+  const kept: BrokerLogFile[] = [];
+
+  for (const file of files) {
+    if (options.brokerId && file.brokerId !== options.brokerId) {
+      kept.push(file);
+      continue;
+    }
+    // Never delete the current (un-suffixed) file — it's being written to.
+    if (file.date === null) {
+      kept.push(file);
+      continue;
+    }
+    if (file.mtime.getTime() >= cutoff) {
+      kept.push(file);
+      continue;
+    }
+    if (!options.dryRun) {
+      try {
+        await unlink(file.path);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+    removed.push(file);
+  }
+
+  return { removed, kept };
+}
+
+export interface ClearBrokerLogsOptions {
+  dir?: string;
+  /** Restrict to a single broker id. When omitted, removes all log files. */
+  brokerId?: string;
+  /** When true, list candidates but don't delete. */
+  dryRun?: boolean;
+}
+
+/** Delete every log file (including the current one) matching the filter. */
+export async function clearBrokerLogs(options: ClearBrokerLogsOptions = {}): Promise<BrokerLogFile[]> {
+  const files = await listBrokerLogs(options.dir);
+  const target = options.brokerId ? files.filter((f) => f.brokerId === options.brokerId) : files;
+
+  if (options.dryRun) return target;
+
+  for (const file of target) {
+    try {
+      await unlink(file.path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+  return target;
+}
+
+async function tailFile(filePath: string, lines: number): Promise<string> {
+  const CHUNK = 8192;
+  let fh: FileHandle | undefined;
+  try {
+    fh = await open(filePath, 'r');
+    const { size } = await fh.stat();
+    if (size === 0) return '';
+
+    if (size <= CHUNK) {
+      const buf = Buffer.alloc(size);
+      await fh.read(buf, 0, size, 0);
+      return tailLines(buf.toString('utf-8'), lines);
+    }
+
+    const chunks: Buffer[] = [];
+    let position = size;
+    let newlines = 0;
+    while (position > 0 && newlines <= lines) {
+      const readSize = Math.min(CHUNK, position);
+      position -= readSize;
+      const buf = Buffer.alloc(readSize);
+      await fh.read(buf, 0, readSize, position);
+      chunks.unshift(buf);
+      newlines += countNewlines(buf);
+    }
+    const combined = Buffer.concat(chunks).toString('utf-8');
+    return tailLines(combined, lines);
+  } finally {
+    if (fh) await fh.close();
+  }
+}
+
+function tailLines(text: string, count: number): string {
+  const split = text.split('\n');
+  if (split.length > 0 && split[split.length - 1] === '') split.pop();
+  return split.slice(-count).join('\n');
+}
+
+function countNewlines(buf: Buffer): number {
+  let n = 0;
+  for (const byte of buf) if (byte === 0x0a) n++;
+  return n;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,6 +23,7 @@ export type { RelayCastOptions, ClientOptions } from '@relaycast/sdk';
 export * from './pty.js';
 export * from './relay.js';
 export * from './logs.js';
+export * from './broker-logs.js';
 export * from './consensus.js';
 export * from './shadow.js';
 export * from './relay-adapter.js';

--- a/src/cli/bootstrap.test.ts
+++ b/src/cli/bootstrap.test.ts
@@ -63,6 +63,11 @@ const expectedLeafCommands = [
   'cloud logs',
   'cloud sync',
   'cloud cancel',
+  'log path',
+  'log list',
+  'log view',
+  'log rotate',
+  'log clear',
 ];
 
 function collectLeafCommandPaths(program: Command): string[] {

--- a/src/cli/bootstrap.ts
+++ b/src/cli/bootstrap.ts
@@ -32,6 +32,7 @@ import { registerPassthroughCommands } from './commands/passthrough.js';
 import { registerNewCommands } from './commands/new.js';
 import { registerRmCommands } from './commands/rm.js';
 import { registerActivityCommands } from './commands/activity.js';
+import { registerLogCommands } from './commands/log.js';
 import { parseVerblessAlias, runVerblessAliasDispatch } from './lib/spawn-and-attach.js';
 
 dotenvConfig({ quiet: true });
@@ -297,6 +298,7 @@ export function createProgram(options: { name?: string } = {}): Command {
   // composition lives on `new --attach` — see `src/cli/commands/new.ts`.
   registerNewCommands(program);
   registerRmCommands(program);
+  registerLogCommands(program);
 
   return program;
 }

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -1,0 +1,178 @@
+import { readFile } from 'node:fs/promises';
+import { type Command } from 'commander';
+
+import {
+  clearBrokerLogs,
+  getBrokerLogDir,
+  listBrokerLogs,
+  pruneBrokerLogs,
+  tailBrokerLog,
+  type BrokerLogFile,
+} from '@agent-relay/sdk';
+
+export interface LogCommandDependencies {
+  log: (msg: string) => void;
+  error: (msg: string) => void;
+  exit: (code: number) => void;
+}
+
+function defaults(overrides: Partial<LogCommandDependencies> = {}): LogCommandDependencies {
+  return {
+    log: overrides.log ?? ((m) => process.stdout.write(`${m}\n`)),
+    error: overrides.error ?? ((m) => process.stderr.write(`${m}\n`)),
+    exit: overrides.exit ?? ((code) => process.exit(code)),
+  };
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatFile(file: BrokerLogFile): string {
+  const date = file.date ?? 'current';
+  return `${file.name}\t${date}\t${formatSize(file.size)}\t${file.mtime.toISOString()}`;
+}
+
+async function runList(deps: LogCommandDependencies, brokerId?: string): Promise<number> {
+  const files = await listBrokerLogs();
+  const filtered = brokerId ? files.filter((f) => f.brokerId === brokerId) : files;
+  if (filtered.length === 0) {
+    deps.log(brokerId ? `No log files for broker '${brokerId}'.` : 'No broker log files.');
+    deps.log(`Log directory: ${getBrokerLogDir()}`);
+    return 0;
+  }
+  deps.log(`name\tdate\tsize\tmtime`);
+  for (const file of filtered) deps.log(formatFile(file));
+  return 0;
+}
+
+async function runView(
+  deps: LogCommandDependencies,
+  brokerId: string,
+  opts: { lines?: string; file?: string }
+): Promise<number> {
+  const lines = opts.lines ? Number(opts.lines) : 200;
+  if (!Number.isFinite(lines) || lines <= 0) {
+    deps.error(`Invalid --lines value: ${opts.lines}`);
+    return 2;
+  }
+
+  if (opts.file) {
+    try {
+      const content = await readFile(opts.file, 'utf-8');
+      const split = content.split('\n');
+      if (split.length > 0 && split[split.length - 1] === '') split.pop();
+      deps.log(split.slice(-lines).join('\n'));
+      return 0;
+    } catch (err) {
+      deps.error(`Failed to read ${opts.file}: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  const result = await tailBrokerLog(brokerId, { lines });
+  if (!result) {
+    const available = await listBrokerLogs();
+    const ids = Array.from(new Set(available.map((f) => f.brokerId))).sort();
+    deps.error(`No log file found for broker '${brokerId}'.`);
+    if (ids.length > 0) deps.error(`Available broker ids: ${ids.join(', ')}`);
+    else deps.error(`Log directory: ${getBrokerLogDir()}`);
+    return 1;
+  }
+  deps.log(`# ${result.path}`);
+  deps.log(result.content);
+  return 0;
+}
+
+async function runRotate(
+  deps: LogCommandDependencies,
+  opts: { keepDays?: string; brokerId?: string; dryRun?: boolean }
+): Promise<number> {
+  const keepDays = opts.keepDays ? Number(opts.keepDays) : 7;
+  if (!Number.isFinite(keepDays) || keepDays < 0) {
+    deps.error(`Invalid --keep-days value: ${opts.keepDays}`);
+    return 2;
+  }
+  const { removed, kept } = await pruneBrokerLogs({
+    keepDays,
+    brokerId: opts.brokerId,
+    dryRun: opts.dryRun,
+  });
+  const action = opts.dryRun ? 'Would remove' : 'Removed';
+  deps.log(`${action} ${removed.length} rotated file(s); kept ${kept.length}.`);
+  for (const file of removed) deps.log(`  - ${file.name}\t${formatSize(file.size)}`);
+  return 0;
+}
+
+async function runClear(
+  deps: LogCommandDependencies,
+  opts: { brokerId?: string; force?: boolean; dryRun?: boolean }
+): Promise<number> {
+  if (!opts.brokerId && !opts.force && !opts.dryRun) {
+    deps.error('Refusing to delete all broker logs without --force. Pass --broker-id <id> or --force.');
+    return 2;
+  }
+  const removed = await clearBrokerLogs({ brokerId: opts.brokerId, dryRun: opts.dryRun });
+  const action = opts.dryRun ? 'Would remove' : 'Removed';
+  deps.log(`${action} ${removed.length} file(s).`);
+  for (const file of removed) deps.log(`  - ${file.name}`);
+  return 0;
+}
+
+/** Register `agent-relay log <subcommand>` on the supplied commander program. */
+export function registerLogCommands(program: Command, overrides: Partial<LogCommandDependencies> = {}): void {
+  const deps = defaults(overrides);
+  const log = program.command('log').description('Inspect and manage broker tracing logs');
+
+  log
+    .command('path')
+    .description('Print the broker log directory')
+    .action(() => {
+      deps.log(getBrokerLogDir());
+    });
+
+  log
+    .command('list')
+    .description('List broker log files')
+    .argument('[brokerId]', 'Restrict to a single broker id')
+    .action(async (brokerId?: string) => {
+      const code = await runList(deps, brokerId);
+      if (code !== 0) deps.exit(code);
+    });
+
+  log
+    .command('view')
+    .description("Tail a broker's tracing log")
+    .argument('<brokerId>', 'Broker id (filename prefix before .log)')
+    .option('-n, --lines <count>', 'Number of trailing lines to show', '200')
+    .option('--file <path>', 'Read a specific log file instead of the latest one')
+    .action(async (brokerId: string, opts: { lines?: string; file?: string }) => {
+      const code = await runView(deps, brokerId, opts);
+      if (code !== 0) deps.exit(code);
+    });
+
+  log
+    .command('rotate')
+    .description('Prune rotated log files older than --keep-days')
+    .option('--keep-days <days>', 'Retain rotated files newer than this (default 7)', '7')
+    .option('--broker-id <id>', 'Restrict to a single broker id')
+    .option('--dry-run', 'List candidates without deleting', false)
+    .action(async (opts: { keepDays?: string; brokerId?: string; dryRun?: boolean }) => {
+      const code = await runRotate(deps, opts);
+      if (code !== 0) deps.exit(code);
+    });
+
+  log
+    .command('clear')
+    .description('Delete broker log files (including the active one)')
+    .option('--broker-id <id>', 'Restrict to a single broker id')
+    .option('--force', 'Required to delete all logs without --broker-id', false)
+    .option('--dry-run', 'List candidates without deleting', false)
+    .action(async (opts: { brokerId?: string; force?: boolean; dryRun?: boolean }) => {
+      const code = await runClear(deps, opts);
+      if (code !== 0) deps.exit(code);
+    });
+}

--- a/web/content/docs/cli-broker-lifecycle.mdx
+++ b/web/content/docs/cli-broker-lifecycle.mdx
@@ -50,6 +50,42 @@ agent-relay uninstall --dry-run
 - `update` checks for a newer release and installs it unless you pass `--check`.
 - `uninstall` removes runtime files, config, and global binaries. Use `--dry-run` before destructive cleanup.
 
+## Broker diagnostic logs
+
+The broker writes its own tracing logs (separate from per-agent PTY output) to a platform-standard directory with daily rotation:
+
+| Platform | Path |
+| -------- | ---- |
+| macOS | `~/Library/Logs/agent-relay/{brokerId}.log.YYYY-MM-DD` |
+| Linux | `$XDG_STATE_HOME/agent-relay/logs/{brokerId}.log.YYYY-MM-DD` (defaults to `~/.local/state/agent-relay/logs/`) |
+| Windows | `%LOCALAPPDATA%\agent-relay\Logs\{brokerId}.log.YYYY-MM-DD` |
+
+`brokerId` is the broker's `--name` (or the working-directory basename when unnamed). Each day the appender rolls to a new file; the active file has no date suffix.
+
+### Destination — `AGENT_RELAY_BROKER_LOG`
+
+| Value | Behavior |
+| ----- | -------- |
+| unset, `file`, `1`, `true`, `yes`, `on` | (default) write to the rolling log file above |
+| `stderr`, `print` | write to the parent process's stderr instead of a file |
+| `off`, `none`, `0`, `false`, `no` | disable the tracing subscriber entirely |
+
+`RUST_LOG` still controls the level filter when logging is enabled (e.g. `RUST_LOG=agent_relay::worker::pty=debug`). It defaults to `info`.
+
+### Manage the log directory
+
+```bash
+agent-relay log path                      # print the log directory
+agent-relay log list [brokerId]           # list files with size and mtime
+agent-relay log view <brokerId> -n 200    # tail the most recent file
+agent-relay log rotate --keep-days 7      # delete rotated files older than 7 days
+agent-relay log rotate --broker-id myproj --dry-run
+agent-relay log clear --broker-id myproj  # wipe one broker's logs (including the active file)
+agent-relay log clear --force             # wipe every broker's logs
+```
+
+`log rotate` only removes rotated (dated) files — the active log file is never deleted because the broker is writing to it. Use `log clear` for a full reset.
+
 ## Focused test harnesses
 
 ```bash

--- a/web/content/docs/cli-overview.mdx
+++ b/web/content/docs/cli-overview.mdx
@@ -15,7 +15,7 @@ agent-relay --version
 
 ## Main command groups
 
-- Broker lifecycle: `up`, `status`, `down`, `update`, `uninstall`
+- Broker lifecycle: `up`, `status`, `down`, `update`, `uninstall`, `log path|list|view|rotate|clear`
 - Agent management: `spawn`, `who`, `release`, `set-model`, `agents:logs`, `view`
 - Messaging: `send`, `history`, `replies`, `inbox`
 - Workflows: `run`, `workflows list`

--- a/web/content/docs/reference-cli.mdx
+++ b/web/content/docs/reference-cli.mdx
@@ -254,3 +254,27 @@ Flags:
 Returns 1 with a friendly error if the agent doesn't exist (`404`) or the broker is unreachable.
 
 The `new`, `passthrough`, and `rm` verbs above round out the attach-style client surface alongside `view` and `drive`. Together they're the first-class client interface on the broker's HTTP and WebSocket routes.
+
+## `log`
+
+Inspect and prune the broker's daily-rotated tracing logs. The broker writes them to `~/Library/Logs/agent-relay/` (macOS), `~/.local/state/agent-relay/logs/` (Linux), or `%LOCALAPPDATA%\agent-relay\Logs\` (Windows). See the [broker lifecycle docs](/docs/cli-broker-lifecycle) for the env var that controls destination (`AGENT_RELAY_BROKER_LOG`).
+
+```bash
+agent-relay log path
+agent-relay log list [brokerId]
+agent-relay log view <brokerId> [-n 200] [--file <path>]
+agent-relay log rotate [--keep-days 7] [--broker-id <id>] [--dry-run]
+agent-relay log clear [--broker-id <id>] [--force] [--dry-run]
+```
+
+Subcommands:
+
+| Subcommand | Description |
+| ---------- | ----------- |
+| `path` | Print the log directory for the current platform. |
+| `list [brokerId]` | List broker log files (name, date, size, mtime), newest first. Filters by broker id when supplied. |
+| `view <brokerId>` | Tail the newest log file for the broker. `-n / --lines` controls the trailing line count (default 200). `--file <path>` reads a specific rotated file instead. |
+| `rotate` | Delete rotated files older than `--keep-days` (default 7). `--broker-id` scopes to one broker; `--dry-run` previews without deleting. The active un-suffixed file is always kept. |
+| `clear` | Delete every matching file, including the active one. Requires either `--broker-id <id>` or `--force` to avoid accidental full wipes. |
+
+The same logic is available programmatically via the SDK helpers `getBrokerLogDir`, `listBrokerLogs`, `tailBrokerLog`, `pruneBrokerLogs`, and `clearBrokerLogs` exported from `@agent-relay/sdk` — see the [TypeScript SDK docs](/docs/typescript-sdk).

--- a/web/content/docs/typescript-sdk.mdx
+++ b/web/content/docs/typescript-sdk.mdx
@@ -324,6 +324,40 @@ const { agent, result } = await AgentRelay.waitForAny([agent1, agent2], 60000)
 await relay.shutdown()
 ```
 
+### Broker tracing logs
+
+The broker writes its tracing logs to a platform-standard directory (`~/Library/Logs/agent-relay/` on macOS, `~/.local/state/agent-relay/logs/` on Linux, `%LOCALAPPDATA%\agent-relay\Logs\` on Windows) with daily rotation. These helpers inspect and prune those files from Node without spawning the broker.
+
+```typescript
+import {
+  getBrokerLogDir,
+  listBrokerLogs,
+  tailBrokerLog,
+  pruneBrokerLogs,
+  clearBrokerLogs,
+} from '@agent-relay/sdk';
+
+// Resolve the directory for the current platform.
+const dir = getBrokerLogDir();
+
+// List every {brokerId}.log[.YYYY-MM-DD] file, newest first.
+const files = await listBrokerLogs();
+// files: Array<{ path, name, brokerId, date, size, mtime }>
+
+// Tail the most recent log file for a broker.
+const tail = await tailBrokerLog('myproject', { lines: 500 });
+// tail?.path / tail?.content — null if no log file exists
+
+// Retention: remove rotated files older than 7 days. The active
+// un-suffixed file is never touched.
+const { removed, kept } = await pruneBrokerLogs({ keepDays: 7 });
+
+// Wipe one broker's logs (or pass nothing to wipe everything).
+await clearBrokerLogs({ brokerId: 'myproject' });
+```
+
+These wrap the same logic that powers `agent-relay log {path,list,view,rotate,clear}`.
+
 ---
 
 ## Complete Example


### PR DESCRIPTION
## Summary
- Default broker tracing to off unless AGENT_RELAY_BROKER_LOG=1 or RUST_LOG is set.
- Correct PTY tracing target syntax so opt-in filters apply to agent_relay::worker::pty.
- Add changelog and trajectory record.

## Tests
- cargo test --manifest-path crates/broker/Cargo.toml tracing_filter
- cargo test --manifest-path crates/broker/Cargo.toml pty_worker::tests
- cargo fmt --manifest-path crates/broker/Cargo.toml --all -- --check