### PR TITLE
Fetch GitHub stars after hydration

### DIFF
--- a/web/app/api/github-stars/route.ts
+++ b/web/app/api/github-stars/route.ts
@@ -1,0 +1,42 @@
+type GitHubRepoResponse = {
+  stargazers_count?: number;
+};
+
+export const dynamic = 'force-dynamic';
+
+function unavailable() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Cache-Control': 'no-store, max-age=0',
+    },
+  });
+}
+
+export async function GET() {
+  try {
+    const response = await fetch('https://api.github.com/repos/agentworkforce/relay', {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'agentrelay-web',
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) return unavailable();
+
+    const data = (await response.json()) as GitHubRepoResponse;
+    if (typeof data.stargazers_count !== 'number') return unavailable();
+
+    return Response.json(
+      { stargazers_count: data.stargazers_count },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=300, s-maxage=300',
+        },
+      }
+    );
+  } catch {
+    return unavailable();
+  }
+}

--- a/web/components/GitHubStars.tsx
+++ b/web/components/GitHubStars.tsx
@@ -1,8 +1,13 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import s from './github-stars.module.css';
 
 type GitHubRepoResponse = {
   stargazers_count?: number;
 };
+
+const RETRY_DELAYS_MS = [0, 1000, 3000];
 
 function GithubIcon() {
   return (
@@ -16,14 +21,12 @@ function formatStarCount(stars: number): string {
   return stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : String(stars);
 }
 
-async function getGitHubStars(): Promise<string | null> {
+async function fetchGitHubStars(): Promise<string | null> {
   try {
-    const response = await fetch('https://api.github.com/repos/agentworkforce/relay', {
+    const response = await fetch('/api/github-stars', {
       headers: {
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'agentrelay-web',
+        Accept: 'application/json',
       },
-      next: { revalidate: 3600 },
     });
 
     if (!response.ok) return null;
@@ -35,8 +38,31 @@ async function getGitHubStars(): Promise<string | null> {
   }
 }
 
-export async function GitHubStarsBadge() {
-  const count = await getGitHubStars();
+async function getGitHubStars(): Promise<string | null> {
+  for (const delay of RETRY_DELAYS_MS) {
+    if (delay > 0) await new Promise((resolve) => window.setTimeout(resolve, delay));
+
+    const stars = await fetchGitHubStars();
+    if (stars) return stars;
+  }
+
+  return null;
+}
+
+export function GitHubStarsBadge() {
+  const [count, setCount] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    getGitHubStars().then((stars) => {
+      if (mounted) setCount(stars);
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   return (
     <a


### PR DESCRIPTION
## Summary
- fetch GitHub star counts after hydration instead of during page prerender
- add a same-origin `/api/github-stars` endpoint that only caches successful counts for 5 minutes
- return uncached `204` responses on GitHub errors or malformed data so empty results are retried instead of baked into the page cache

## Verification
- ./node_modules/.bin/eslint web/components/GitHubStars.tsx web/app/api/github-stars/route.ts
- /Users/will/Projects/AgentWorkforce/relay/node_modules/.bin/prettier --check web/components/GitHubStars.tsx web/app/api/github-stars/route.ts
- curl -i http://localhost:3000/api/github-stars returns 200, cache-control public max-age=300, and stargazers_count 664
- local browser check shows the badge hydrating to 664 stars