### PR TITLE
fix(web): stabilize preview deployments

### DIFF
--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -54,20 +54,42 @@ jobs:
         run: bash .github/scripts/assert-aws-account.sh "$AWS_ACCOUNT_ID" "$SST_STAGE" deploy
 
       - name: Deploy SST preview
+        id: deploy
         working-directory: web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
-        run: ../node_modules/.bin/sst deploy --stage "$SST_STAGE"
+        run: |
+          set -euo pipefail
+
+          deploy_log="$(mktemp)"
+          ../node_modules/.bin/sst deploy --stage "$SST_STAGE" | tee "$deploy_log"
+
+          preview_url="$(awk '/^[[:space:]]+url: https:\/\// { print $2 }' "$deploy_log" | tail -n 1)"
+          if [ -z "$preview_url" ]; then
+            preview_url="$(awk '/^[[:space:]]+Web: https:\/\// { print $2 }' "$deploy_log" | tail -n 1)"
+          fi
+
+          if [ -z "$preview_url" ]; then
+            echo "Unable to determine preview URL from SST output" >&2
+            exit 1
+          fi
+
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         with:
           script: |
             const prNum = context.payload.pull_request.number;
-            const url = `https://pr-${prNum}.agentrelay.net`;
+            const url = process.env.PREVIEW_URL;
+            if (!url) {
+              throw new Error('Missing preview URL from deploy step');
+            }
             const body = `**Preview deployed!**\n\n` +
               `| Environment | URL |\n` +
               `|-------------|-----|\n` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release workflow changelog generation now writes concise Keep a Changelog sections and skips web-only, release-only, trajectory, PR-review, placeholder, and withdrawn-tag entries.
 
+### Fixed
+
+- `web`: PR preview SST deploys use and comment the generated CloudFront URL and AWS's managed disabled cache policy instead of creating per-preview Cloudflare DNS records, ACM certificates, and custom CloudFront cache policies.
+
 ## [7.0.1] - 2026-05-22
 
 ### Added

--- a/web/sst.config.ts
+++ b/web/sst.config.ts
@@ -1,3 +1,5 @@
+const AWS_MANAGED_CACHING_DISABLED_CACHE_POLICY_ID = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad';
+
 export default $config({
   app(input) {
     return {
@@ -6,13 +8,14 @@ export default $config({
       removal: input?.stage === 'production' ? 'retain' : 'remove',
     };
   },
-  run() {
+  async run() {
     const isProd = $app.stage === 'production';
+    const isPreview = $app.stage.startsWith('pr-');
     const domain = isProd ? 'origin.agentrelay.net' : `${$app.stage}.agentrelay.net`;
     const NEXT_PUBLIC_POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://i.agentrelay.com';
     const NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY ?? '';
 
-    new sst.aws.Nextjs('Web', {
+    const web = new sst.aws.Nextjs('Web', {
       path: '.',
       openNextVersion: '3.9.16',
       environment: {
@@ -20,7 +23,13 @@ export default $config({
         NEXT_PUBLIC_POSTHOG_KEY,
       },
       // Production deploys land on origin.agentrelay.net; SEO canonicals are set in Next metadata.
-      domain: { name: domain, dns: sst.cloudflare.dns({ proxy: true }) },
+      ...(isPreview ? {} : { domain: { name: domain, dns: sst.cloudflare.dns({ proxy: true }) } }),
+      // PR previews use CloudFront's generated URL and should not allocate one custom cache policy per stage.
+      ...(isPreview ? { cachePolicy: AWS_MANAGED_CACHING_DISABLED_CACHE_POLICY_ID } : {}),
     });
+
+    return {
+      url: web.url,
+    };
   },
 });


### PR DESCRIPTION
Summary:
- Reuse AWS managed CachingDisabled for pr-* SST preview stages.
- Skip per-PR Cloudflare DNS and ACM certificate provisioning; PR previews now use the generated SST/CloudFront URL.
- Capture the SST deploy URL and post that actual URL in the PR comment.
- Keep production and non-PR stages on their configured custom-domain path.
- Add a changelog entry for the preview deploy fix.

Validation:
- /Users/will/Projects/AgentWorkforce/relay/node_modules/.bin/prettier --check CHANGELOG.md web/sst.config.ts .github/workflows/preview-web.yml
- /Users/will/Projects/AgentWorkforce/relay/node_modules/.bin/tsc --noEmit --skipLibCheck --target ES2022 --lib DOM,DOM.Iterable,ES2022 --module ESNext --moduleResolution Bundler --strict --esModuleInterop --types node --typeRoots /Users/will/Projects/AgentWorkforce/relay/node_modules/@types /Users/will/Projects/AgentWorkforce/relay/web/.sst/platform/config.d.ts /private/tmp/relay-preview-cache-policy/web/sst.config.ts
- node -e "const fs=require('fs'); const yaml=require('/Users/will/Projects/AgentWorkforce/relay/node_modules/js-yaml'); yaml.load(fs.readFileSync('/private/tmp/relay-preview-cache-policy/.github/workflows/preview-web.yml','utf8')); console.log('preview-web.yml ok')"
- git diff --check origin/main...HEAD
- GitHub Preview Web (SST) run 26306705944 passed and updated the PR comment to https://d5lbjao1551j2.cloudfront.net

Notes:
- The original failing run hit CloudFront TooManyCachePolicies while SST was creating WebServerCachePolicy per preview stage.
- The first PR run got past that blocker, then failed in Cloudflare zone lookup for the per-PR custom domain. This update removes both per-preview quota/failure paths.