### PR TITLE
security: bump @slack/web-api to ^7.16.0 to clear axios prototype pollution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `web`: PR preview SST deploys use and comment the generated CloudFront URL and AWS's managed disabled cache policy instead of creating per-preview Cloudflare DNS records, ACM certificates, and custom CloudFront cache policies.
 
+### Security
+
+- `@agent-relay/slack-primitive` bumps `@slack/web-api` to `^7.16.0`, which raises its transitive `axios` floor to `^1.16.0` and clears GHSA-q8qp-cvcw-x6jj (prototype pollution gadgets in HTTP adapter allowing credential injection) and GHSA-3w6x-2g7m-8v23 (invisible JSON response tampering via `parseReviver`).
+
 ## [7.1.0] - 2026-05-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2903,9 +2903,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2918,6 @@
       "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2941,9 +2935,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2959,9 +2950,6 @@
       "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4700,36 +4688,6 @@
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
       }
-    },
-    "node_modules/@slack/web-api": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.2.tgz",
-      "integrity": "sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/types": "^2.21.0",
-        "@types/node": ">=18",
-        "@types/retry": "0.12.0",
-        "axios": "^1.15.0",
-        "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.4",
-        "is-electron": "2.2.2",
-        "is-stream": "^2",
-        "p-queue": "^6",
-        "p-retry": "^4",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
-      }
-    },
-    "node_modules/@slack/web-api/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
@@ -6720,14 +6678,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bail": {
@@ -17014,7 +16998,7 @@
       "version": "7.1.0",
       "dependencies": {
         "@agent-relay/workflow-types": "7.1.0",
-        "@slack/web-api": "^7.15.2"
+        "@slack/web-api": "^7.16.0"
       },
       "devDependencies": {
         "@agent-relay/github-primitive": "7.1.0",
@@ -17022,6 +17006,36 @@
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
+    },
+    "packages/slack-primitive/node_modules/@slack/web-api": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.16.0.tgz",
+      "integrity": "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "packages/slack-primitive/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",

--- a/packages/slack-primitive/package.json
+++ b/packages/slack-primitive/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@agent-relay/workflow-types": "7.1.0",
-    "@slack/web-api": "^7.15.2"
+    "@slack/web-api": "^7.16.0"
   },
   "devDependencies": {
     "@agent-relay/github-primitive": "7.1.0",


### PR DESCRIPTION
## Summary

Resolves two Dependabot advisories against the transitive `axios` dependency. Rather than overriding the transitive, this bumps the actual source dependency — `@slack/web-api` 7.15.2 → 7.16.0 — which tightens its axios constraint from `^1.15.0` to `^1.16.0` and lifts the floor above the vulnerable range.

Advisories cleared:
- **[GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj)** (high, CVSS 7.4) — prototype pollution read-side gadgets in axios's HTTP adapter enabling credential injection and request hijacking.
- **[GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23)** (moderate, CVSS 6.5) — invisible JSON response tampering via a prototype pollution gadget in `parseReviver`.

## Why upgrade rather than override

The first cut of this PR added an `axios: ^1.15.2` entry to the root `package.json` `overrides`. Upgrading the source dependency is cleaner:

- No `overrides` workaround pinning a transitive we don't own — `axios` stays out of our `package.json` entirely.
- Addresses the issue at the declaration site (`packages/slack-primitive/package.json`), so future Dependabot bumps to `@slack/web-api` flow through normally instead of fighting a pin.
- `@slack/web-api` 7.15.2 → 7.16.0 is a minor bump with no API surface changes (dep set is identical apart from the axios floor). Inside the existing `^7.15.2` range, so no consumer impact.

## Test plan

- [x] `npm audit` — `axios` advisory gone (22 → 21 total; high 4 → 3).
- [x] `npm install --package-lock-only` is idempotent after the change.
- [x] Lockfile resolves `axios` to `1.16.1` and `@slack/web-api` to `7.16.0`.
- [ ] CI green.