### PR TITLE
fix(on): bump relayfile-mount binary v0.1.6 → v0.7.39

### DIFF
--- a/src/cli/commands/on/relayfile-binary.ts
+++ b/src/cli/commands/on/relayfile-binary.ts
@@ -16,7 +16,7 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 
-const RELAYFILE_VERSION = '0.1.6';
+const RELAYFILE_VERSION = '0.7.39';
 const RELEASE_BASE_URL = 'https://github.com/AgentWorkforce/relayfile/releases/download';
 const CHECKSUMS_FILE = 'checksums.txt';
 const CACHE_DIR = path.join(os.homedir(), '.agent-relay', 'bin');


### PR DESCRIPTION
## What
Bump `RELAYFILE_VERSION` in `src/cli/commands/on/relayfile-binary.ts` from `0.1.6` → `0.7.39`.

## Why
The cloud Daytona persona path downloads the `relayfile-mount` Go binary at this pin (version-checked cache → re-downloads on a bump, so **no snapshot swap needed**). **v0.1.6** predates:
- the workspace-export **413→paginate fallback** (relayfile v0.7.33 / #195), and
- **scoped mount-path** support (relayfile v0.7.39 / #206).

So on a large repo (AgentWorkforce/cloud), the daemon does a workspace-wide >128MB bulk export → HTTP 413 → hot-loops → starves the sandbox bootstrap (`bootstrap_timeout`) → no `./cloud`, no PR. That's the root blocker for **AgentWorkforce/cloud#1028** (everything cloud-side — durable launch, region, mount/token scope, writeback path-forms — was already proven correct; this binary was the last gap).

## Pairs with
- relayfile#207 — restores `checksums.txt` on every release (the workflow had regressed; `verifyChecksum()` here is mandatory).
- Backfilled `checksums.txt` onto the existing relayfile **v0.7.39** release, so this bump's download verifies immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)