### PR TITLE
fix(build): externalize @slack/web-api in build:cjs + declare as root dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/local-mount": "^0.2.2",
         "@relayfile/sdk": "^0.6.0",
+        "@slack/web-api": "^7.16.0",
         "agent-trajectories": "^0.5.8",
         "commander": "^12.1.0",
         "dotenv": "^17.2.3",
@@ -1284,6 +1285,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4687,6 +4689,36 @@
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
       }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.16.0.tgz",
+      "integrity": "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
@@ -17021,36 +17053,6 @@
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
-    },
-    "packages/slack-primitive/node_modules/@slack/web-api": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.16.0.tgz",
-      "integrity": "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/types": "^2.21.0",
-        "@types/node": ">=18",
-        "@types/retry": "0.12.0",
-        "axios": "^1.16.0",
-        "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.4",
-        "is-electron": "2.2.2",
-        "is-stream": "^2",
-        "p-queue": "^6",
-        "p-retry": "^4",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
-      }
-    },
-    "packages/slack-primitive/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@relaycast/sdk": "^1.1.0",
     "@relayfile/local-mount": "^0.2.2",
     "@relayfile/sdk": "^0.6.0",
+    "@slack/web-api": "^7.16.0",
     "agent-trajectories": "^0.5.8",
     "commander": "^12.1.0",
     "dotenv": "^17.2.3",

--- a/scripts/build-cjs.mjs
+++ b/scripts/build-cjs.mjs
@@ -14,8 +14,12 @@ await build({
   bundle: true,
   target: 'node18',
   logLevel: 'info',
-  // Exclude native dependencies from bundle - they're loaded dynamically at runtime
-  external: ['better-sqlite3', 'ssh2'],
+  // Exclude native dependencies from bundle - they're loaded dynamically at runtime.
+  // @slack/web-api lives in the @agent-relay/slack-primitive workspace (whose
+  // source is bundled here); keep it external + declared as a runtime dep so the
+  // CJS build doesn't have to resolve/bundle the Slack SDK (it isn't installed in
+  // every publish context) and consumers load it from node_modules at runtime.
+  external: ['better-sqlite3', 'ssh2', '@slack/web-api'],
   banner: {
     js: "const import_meta_url = require('node:url').pathToFileURL(__filename).href;",
   },


### PR DESCRIPTION
## What
- `scripts/build-cjs.mjs`: add `@slack/web-api` to esbuild `external` (mirrors `ssh2`/`better-sqlite3`).
- root `package.json`: declare `@slack/web-api: ^7.16.0` (matches `@agent-relay/slack-primitive`); lockfile hoists it to root (7.15.2→7.16.0).

## Why
`build:cjs` bundles the `@agent-relay/slack-primitive` workspace **source**, which imports `@slack/web-api`. esbuild had to resolve+bundle it, but it isn't installed in every publish context → **`Could not resolve "@slack/web-api"`** broke `build:cjs` and the agent-relay publish. Externalizing it (loaded at runtime) + declaring it as a root dep fixes the build deterministically and keeps it resolvable at runtime for consumers.

## Verified
`npm run build:cjs` now passes (exit 0, `dist/index.cjs` produced); `@slack/web-api` is a runtime `require()` in the output, not inlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)