### PR TITLE
ci(config): use workspace tsc instead of network-fetched typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16025,6 +16025,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
     },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -77,7 +77,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "npx -p typescript@5.7.3 tsc",
+    "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -88,6 +88,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.3",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

`packages/config` was the only workspace package whose build invoked `npx -p typescript@5.7.3 tsc`, reaching out to the npm registry on every turbo cache miss. Every other package (`acp-bridge`, `github-primitive`, `browser-primitive`, `policy`, `cloud`, `telemetry`, `events`, `workflow-types`, …) runs `tsc` directly against a workspace-hoisted compiler.

That network dependency is the most plausible cause of the recent Package Validation failure on main: [run 26379771304](https://github.com/AgentWorkforce/relay/actions/runs/26379771304/job/77646685286). The `Build & Validate` job failed at `Build packages`, while `Publish Fresh Install Build` and `Standalone macOS Smoke` — both of which build the same workspace through different paths — passed in the same run. The triggering merge commit (PR #979) only bumps `quinn-proto` in `Cargo.lock`, so there is no code change to explain a real build break.

## Changes

- `packages/config/package.json`: `"build": "npx -p typescript@5.7.3 tsc"` → `"build": "tsc"`, and declare `typescript: ^5.9.3` as a local devDependency (matches the root workspace pin).
- `package-lock.json`: refreshed.

## Test plan

- [x] `rm -rf packages/config/dist && (cd packages/config && npx tsc)` rebuilds the package cleanly.
- [ ] Package Validation passes on this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaDucK1LQYQpzvqToQapCN)_