### PR TITLE
Track GitHub traffic in PostHog

### DIFF
--- a/.github/scripts/sync-github-traffic-posthog.mjs
+++ b/.github/scripts/sync-github-traffic-posthog.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+const DEFAULT_GITHUB_API_VERSION = '2022-11-28';
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const GITHUB_TRAFFIC_WINDOW_DAYS = 14;
+const DEFAULT_DAILY_LAG_HOURS = 8;
+
+function readEnv(name, fallback = undefined) {
+  const value = process.env[name];
+  return value && value.trim() ? value.trim() : fallback;
+}
+
+function requireEnv(name) {
+  const value = readEnv(name);
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function normalizeHost(host) {
+  return host.replace(/\/+$/, '');
+}
+
+function parseRepository(repository) {
+  const [owner, repo, ...rest] = repository.split('/');
+  if (!owner || !repo || rest.length > 0) {
+    throw new Error(`Expected repository in owner/name form, got "${repository}"`);
+  }
+  return { owner, repo };
+}
+
+function dayFromTimestamp(timestamp) {
+  return timestamp.slice(0, 10);
+}
+
+function utcNoonForDay(day) {
+  return `${day}T12:00:00Z`;
+}
+
+function parseNonNegativeNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+function dailyCutoffDay(lagHours) {
+  const cutoff = new Date(Date.now() - lagHours * 60 * 60 * 1000);
+  return dayFromTimestamp(cutoff.toISOString());
+}
+
+function runIdentity() {
+  const runId = readEnv('GITHUB_RUN_ID');
+  const runAttempt = readEnv('GITHUB_RUN_ATTEMPT');
+  if (runId && runAttempt) {
+    return `${runId}:${runAttempt}`;
+  }
+  return readEnv('GITHUB_TRAFFIC_RUN_ID', new Date().toISOString());
+}
+
+function baseProperties({ repository, owner, repo, capturedAt, distinctId, apiVersion }) {
+  return {
+    source: 'github_actions',
+    repository,
+    github_owner: owner,
+    github_repo: repo,
+    github_api_version: apiVersion,
+    github_traffic_window_days: GITHUB_TRAFFIC_WINDOW_DAYS,
+    captured_at: capturedAt,
+    distinct_id: distinctId,
+    $groups: {
+      repository,
+    },
+    $process_person_profile: false,
+  };
+}
+
+function postHogEvent({ event, distinctId, timestamp, properties }) {
+  return {
+    event,
+    distinct_id: distinctId,
+    timestamp,
+    properties: {
+      ...properties,
+      distinct_id: distinctId,
+    },
+  };
+}
+
+async function githubGetJson({ owner, repo, path, githubToken, apiVersion }) {
+  const url = new URL(`https://api.github.com/repos/${owner}/${repo}${path}`);
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken}`,
+      'X-GitHub-Api-Version': apiVersion,
+      'User-Agent': 'agent-relay-github-traffic-posthog',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    const hint =
+      response.status === 401 || response.status === 403
+        ? '\nGitHub traffic endpoints require repository write access or a fine-grained token with Administration: read. Configure GH_TRAFFIC_TOKEN as a repository secret if the default GITHUB_TOKEN is rejected.'
+        : '';
+    throw new Error(`GitHub API ${response.status} for ${path}: ${body}${hint}`);
+  }
+
+  return response.json();
+}
+
+function buildDailyTrafficEvents({
+  repository,
+  owner,
+  repo,
+  distinctId,
+  capturedAt,
+  apiVersion,
+  views,
+  clones,
+  includePartialDay,
+  dailyLagHours,
+}) {
+  const today = dayFromTimestamp(new Date().toISOString());
+  const cutoffDay = dailyCutoffDay(dailyLagHours);
+  const byDay = new Map();
+
+  for (const item of views.views ?? []) {
+    const day = dayFromTimestamp(item.timestamp);
+    byDay.set(day, {
+      ...(byDay.get(day) ?? {}),
+      day,
+      github_timestamp: item.timestamp,
+      view_count: item.count,
+      view_uniques: item.uniques,
+      has_views: true,
+    });
+  }
+
+  for (const item of clones.clones ?? []) {
+    const day = dayFromTimestamp(item.timestamp);
+    byDay.set(day, {
+      ...(byDay.get(day) ?? {}),
+      day,
+      github_timestamp: item.timestamp,
+      clone_count: item.count,
+      clone_uniques: item.uniques,
+      has_clones: true,
+    });
+  }
+
+  const base = baseProperties({ repository, owner, repo, capturedAt, distinctId, apiVersion });
+  return [...byDay.values()]
+    .filter((item) => includePartialDay || item.day < cutoffDay)
+    .sort((a, b) => a.day.localeCompare(b.day))
+    .map((item) =>
+      postHogEvent({
+        event: 'github_repo_traffic_daily',
+        distinctId,
+        timestamp: utcNoonForDay(item.day),
+        properties: {
+          ...base,
+          traffic_period: 'day',
+          traffic_date: item.day,
+          daily_cutoff_date: cutoffDay,
+          daily_lag_hours: dailyLagHours,
+          github_timestamp: item.github_timestamp ?? `${item.day}T00:00:00Z`,
+          view_count: item.view_count ?? 0,
+          view_uniques: item.view_uniques ?? 0,
+          clone_count: item.clone_count ?? 0,
+          clone_uniques: item.clone_uniques ?? 0,
+          has_views: Boolean(item.has_views),
+          has_clones: Boolean(item.has_clones),
+          includes_partial_day: item.day >= today,
+          $insert_id: `github_repo_traffic_daily:${repository}:${item.day}`,
+        },
+      })
+    );
+}
+
+function availableWindow({ views, clones }) {
+  const days = [
+    ...(views.views ?? []).map((item) => dayFromTimestamp(item.timestamp)),
+    ...(clones.clones ?? []).map((item) => dayFromTimestamp(item.timestamp)),
+  ].sort();
+
+  return {
+    window_start_date: days[0] ?? null,
+    window_end_date: days[days.length - 1] ?? null,
+    available_day_count: new Set(days).size,
+  };
+}
+
+function buildSnapshotEvents({
+  repository,
+  owner,
+  repo,
+  distinctId,
+  capturedAt,
+  apiVersion,
+  views,
+  clones,
+  paths,
+  referrers,
+  dailyEvents,
+}) {
+  const base = baseProperties({ repository, owner, repo, capturedAt, distinctId, apiVersion });
+  const runKey = runIdentity();
+  const window = availableWindow({ views, clones });
+  const today = dayFromTimestamp(new Date().toISOString());
+  const includesPartialDay = window.window_end_date === today;
+
+  const snapshot = postHogEvent({
+    event: 'github_repo_traffic_window_snapshot',
+    distinctId,
+    timestamp: capturedAt,
+    properties: {
+      ...base,
+      traffic_period: 'last_14_days',
+      ...window,
+      includes_partial_day: includesPartialDay,
+      daily_events_sent: dailyEvents.length,
+      view_count: views.count ?? 0,
+      view_uniques: views.uniques ?? 0,
+      clone_count: clones.count ?? 0,
+      clone_uniques: clones.uniques ?? 0,
+      top_path_count: paths.length,
+      top_referrer_count: referrers.length,
+      raw_views_daily: views.views ?? [],
+      raw_clones_daily: clones.clones ?? [],
+      $insert_id: `github_repo_traffic_window_snapshot:${repository}:${runKey}`,
+    },
+  });
+
+  const pathEvents = paths.map((item, index) =>
+    postHogEvent({
+      event: 'github_repo_traffic_path_snapshot',
+      distinctId,
+      timestamp: capturedAt,
+      properties: {
+        ...base,
+        traffic_period: 'last_14_days',
+        rank: index + 1,
+        path: item.path,
+        title: item.title,
+        view_count: item.count ?? 0,
+        view_uniques: item.uniques ?? 0,
+        $insert_id: `github_repo_traffic_path_snapshot:${repository}:${runKey}:${index + 1}:${item.path}`,
+      },
+    })
+  );
+
+  const referrerEvents = referrers.map((item, index) =>
+    postHogEvent({
+      event: 'github_repo_traffic_referrer_snapshot',
+      distinctId,
+      timestamp: capturedAt,
+      properties: {
+        ...base,
+        traffic_period: 'last_14_days',
+        rank: index + 1,
+        referrer: item.referrer,
+        view_count: item.count ?? 0,
+        view_uniques: item.uniques ?? 0,
+        $insert_id: `github_repo_traffic_referrer_snapshot:${repository}:${runKey}:${index + 1}:${item.referrer}`,
+      },
+    })
+  );
+
+  return [snapshot, ...pathEvents, ...referrerEvents];
+}
+
+async function sendPostHogBatch({ host, apiKey, events }) {
+  const response = await fetch(`${normalizeHost(host)}/batch/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      api_key: apiKey,
+      historical_migration: true,
+      batch: events,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`PostHog batch API ${response.status}: ${body}`);
+  }
+}
+
+async function main() {
+  const repository = readEnv('GITHUB_REPOSITORY_NAME', readEnv('GITHUB_REPOSITORY'));
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY_NAME or GITHUB_REPOSITORY is required');
+  }
+
+  const { owner, repo } = parseRepository(repository);
+  const githubToken = requireEnv('GITHUB_TOKEN');
+  const apiVersion = readEnv('GITHUB_API_VERSION', DEFAULT_GITHUB_API_VERSION);
+  const posthogHost = readEnv('POSTHOG_HOST', DEFAULT_POSTHOG_HOST);
+  const dryRun = readEnv('POSTHOG_DRY_RUN', 'false') === 'true';
+  const posthogApiKey = dryRun
+    ? readEnv('POSTHOG_PROJECT_API_KEY', 'dry-run')
+    : requireEnv('POSTHOG_PROJECT_API_KEY');
+  const includePartialDay = readEnv('GITHUB_TRAFFIC_INCLUDE_PARTIAL_DAY', 'false') === 'true';
+  const dailyLagHours = parseNonNegativeNumber(
+    readEnv('GITHUB_TRAFFIC_DAILY_LAG_HOURS', String(DEFAULT_DAILY_LAG_HOURS)),
+    'GITHUB_TRAFFIC_DAILY_LAG_HOURS'
+  );
+  const capturedAt = new Date().toISOString();
+  const distinctId = `github_repo:${repository}`;
+
+  const request = { owner, repo, githubToken, apiVersion };
+  const [views, clones, paths, referrers] = await Promise.all([
+    githubGetJson({ ...request, path: '/traffic/views?per=day' }),
+    githubGetJson({ ...request, path: '/traffic/clones?per=day' }),
+    githubGetJson({ ...request, path: '/traffic/popular/paths' }),
+    githubGetJson({ ...request, path: '/traffic/popular/referrers' }),
+  ]);
+
+  const common = { repository, owner, repo, distinctId, capturedAt, apiVersion };
+  const dailyEvents = buildDailyTrafficEvents({ ...common, views, clones, includePartialDay, dailyLagHours });
+  const snapshotEvents = buildSnapshotEvents({ ...common, views, clones, paths, referrers, dailyEvents });
+  const events = [...dailyEvents, ...snapshotEvents];
+
+  if (events.length === 0) {
+    console.log(`No GitHub traffic events to send for ${repository}`);
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`Dry run: built ${events.length} GitHub traffic events for ${repository}`);
+    console.log(JSON.stringify({ event_count: events.length, events }, null, 2));
+    return;
+  }
+
+  await sendPostHogBatch({ host: posthogHost, apiKey: posthogApiKey, events });
+  console.log(
+    `Sent ${events.length} GitHub traffic events for ${repository} to PostHog (${dailyEvents.length} daily, ${snapshotEvents.length} snapshots)`
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/.github/scripts/sync-github-traffic-posthog.mjs
+++ b/.github/scripts/sync-github-traffic-posthog.mjs
@@ -4,6 +4,7 @@ const DEFAULT_GITHUB_API_VERSION = '2022-11-28';
 const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
 const GITHUB_TRAFFIC_WINDOW_DAYS = 14;
 const DEFAULT_DAILY_LAG_HOURS = 8;
+const REQUEST_TIMEOUT_MS = 15_000;
 
 function readEnv(name, fallback = undefined) {
   const value = process.env[name];
@@ -92,6 +93,7 @@ function postHogEvent({ event, distinctId, timestamp, properties }) {
 async function githubGetJson({ owner, repo, path, githubToken, apiVersion }) {
   const url = new URL(`https://api.github.com/repos/${owner}/${repo}${path}`);
   const response = await fetch(url, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${githubToken}`,
@@ -104,7 +106,7 @@ async function githubGetJson({ owner, repo, path, githubToken, apiVersion }) {
     const body = await response.text();
     const hint =
       response.status === 401 || response.status === 403
-        ? '\nGitHub traffic endpoints require repository write access or a fine-grained token with Administration: read. Configure GH_TRAFFIC_TOKEN as a repository secret if the default GITHUB_TOKEN is rejected.'
+        ? '\nGitHub traffic endpoints require repository write access or a fine-grained token with Administration: read. Configure GH_TRAFFIC_TOKEN as a repository secret.'
         : '';
     throw new Error(`GitHub API ${response.status} for ${path}: ${body}${hint}`);
   }
@@ -276,6 +278,7 @@ function buildSnapshotEvents({
 async function sendPostHogBatch({ host, apiKey, events }) {
   const response = await fetch(`${normalizeHost(host)}/batch/`, {
     method: 'POST',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       'Content-Type': 'application/json',
     },

--- a/.github/workflows/github-traffic-posthog.yml
+++ b/.github/workflows/github-traffic-posthog.yml
@@ -28,15 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Fetch GitHub traffic and send it to PostHog
         env:
           GITHUB_REPOSITORY_NAME: ${{ github.repository }}
           # GitHub traffic endpoints require repository write access or a fine-grained
-          # token with Administration: read. GH_TRAFFIC_TOKEN is recommended; the
-          # workflow token remains a fallback for repositories where it is accepted.
-          GITHUB_TOKEN: ${{ secrets.GH_TRAFFIC_TOKEN || github.token }}
+          # token with Administration: read.
+          GITHUB_TOKEN: ${{ secrets.GH_TRAFFIC_TOKEN }}
           POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://us.i.posthog.com' }}
           # Avoid freezing yesterday's metrics before GitHub has settled them.

--- a/.github/workflows/github-traffic-posthog.yml
+++ b/.github/workflows/github-traffic-posthog.yml
@@ -1,0 +1,46 @@
+name: Track GitHub Traffic in PostHog
+
+on:
+  schedule:
+    # Every 6 hours. Each run backfills the available 14-day GitHub traffic window.
+    - cron: '25 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      include_partial_day:
+        description: Include the current UTC day even though GitHub may still be updating it.
+        type: boolean
+        default: false
+      dry_run:
+        description: Fetch GitHub traffic and print the PostHog event payload without sending it.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-traffic-posthog
+  cancel-in-progress: false
+
+jobs:
+  capture-traffic:
+    name: Capture GitHub traffic snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Fetch GitHub traffic and send it to PostHog
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          # GitHub traffic endpoints require repository write access or a fine-grained
+          # token with Administration: read. GH_TRAFFIC_TOKEN is recommended; the
+          # workflow token remains a fallback for repositories where it is accepted.
+          GITHUB_TOKEN: ${{ secrets.GH_TRAFFIC_TOKEN || github.token }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://us.i.posthog.com' }}
+          # Avoid freezing yesterday's metrics before GitHub has settled them.
+          GITHUB_TRAFFIC_DAILY_LAG_HOURS: '8'
+          GITHUB_TRAFFIC_INCLUDE_PARTIAL_DAY: ${{ github.event_name == 'workflow_dispatch' && inputs.include_partial_day || 'false' }}
+          POSTHOG_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: node .github/scripts/sync-github-traffic-posthog.mjs

--- a/.trajectories/completed/2026-05/traj_17t39ue8exte/summary.md
+++ b/.trajectories/completed/2026-05/traj_17t39ue8exte/summary.md
@@ -1,0 +1,34 @@
+# Trajectory: Add GitHub traffic to PostHog sync
+
+> **Status:** ✅ Completed
+> **Confidence:** 86%
+> **Started:** May 26, 2026 at 09:16 AM
+> **Completed:** May 26, 2026 at 09:17 AM
+
+---
+
+## Summary
+
+Added a scheduled GitHub Actions workflow and Node script that fetch GitHub traffic views, clones, popular paths, and referrers, then sends daily backfill and rolling snapshots to PostHog.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use GitHub traffic REST API and PostHog batch ingestion
+
+- **Chose:** Use GitHub traffic REST API and PostHog batch ingestion
+- **Reasoning:** The traffic page data is exposed through GitHub's traffic endpoints for views, clones, top paths, and referrers; PostHog batch supports historical timestamps and lets the workflow backfill the 14-day window without creating duplicate daily metrics.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Use GitHub traffic REST API and PostHog batch ingestion: Use GitHub traffic REST API and PostHog batch ingestion
+- Implemented a scheduled GitHub traffic sync workflow with deterministic daily PostHog insert IDs, rolling traffic-window snapshots, and validation via endpoint shape checks plus mocked PostHog ingestion.

--- a/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json
+++ b/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_17t39ue8exte",
+  "version": 1,
+  "task": {
+    "title": "Add GitHub traffic to PostHog sync"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-26T13:16:29.926Z",
+  "completedAt": "2026-05-26T13:17:08.417Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-26T13:16:34.333Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_sb9zl355rzy8",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-26T13:16:34.333Z",
+      "endedAt": "2026-05-26T13:17:08.417Z",
+      "events": [
+        {
+          "ts": 1779801394334,
+          "type": "decision",
+          "content": "Use GitHub traffic REST API and PostHog batch ingestion: Use GitHub traffic REST API and PostHog batch ingestion",
+          "raw": {
+            "question": "Use GitHub traffic REST API and PostHog batch ingestion",
+            "chosen": "Use GitHub traffic REST API and PostHog batch ingestion",
+            "alternatives": [],
+            "reasoning": "The traffic page data is exposed through GitHub's traffic endpoints for views, clones, top paths, and referrers; PostHog batch supports historical timestamps and lets the workflow backfill the 14-day window without creating duplicate daily metrics."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1779801398069,
+          "type": "reflection",
+          "content": "Implemented a scheduled GitHub traffic sync workflow with deterministic daily PostHog insert IDs, rolling traffic-window snapshots, and validation via endpoint shape checks plus mocked PostHog ingestion.",
+          "raw": {
+            "confidence": 0.82
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.82"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added a scheduled GitHub Actions workflow and Node script that fetch GitHub traffic views, clones, popular paths, and referrers, then sends daily backfill and rolling snapshots to PostHog.",
+    "approach": "Standard approach",
+    "confidence": 0.86
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/private/tmp/relay-posthog-github-traffic",
+  "tags": [],
+  "_trace": {
+    "startRef": "823805464014c08d1eb6bea9664960c9b957810f",
+    "endRef": "823805464014c08d1eb6bea9664960c9b957810f"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json
+++ b/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json
@@ -42,9 +42,7 @@
             "confidence": 0.82
           },
           "significance": "high",
-          "tags": [
-            "confidence:0.82"
-          ]
+          "tags": ["confidence:0.82"]
         }
       ]
     }

--- a/.trajectories/completed/2026-05/traj_b3g40827t5zh/summary.md
+++ b/.trajectories/completed/2026-05/traj_b3g40827t5zh/summary.md
@@ -1,0 +1,40 @@
+# Trajectory: Address GitHub traffic PostHog PR review comments
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** May 26, 2026 at 09:42 AM
+> **Completed:** May 26, 2026 at 09:44 AM
+
+---
+
+## Summary
+
+Addressed PR review comments by adding 15 second fetch timeouts, removing the unusable github.token traffic API fallback, and pinning checkout with persisted credentials disabled.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Address all actionable PR review comments in one follow-up commit
+
+- **Chose:** Address all actionable PR review comments in one follow-up commit
+- **Reasoning:** The timeout, token fallback, and checkout hardening findings are valid; keeping them together avoids partial review churn and preserves the existing workflow shape.
+
+---
+
+## Chapters
+
+### 1. Work
+
+_Agent: default_
+
+- Address all actionable PR review comments in one follow-up commit: Address all actionable PR review comments in one follow-up commit
+
+---
+
+## Artifacts
+
+**Commits:** 4fe1c2d1
+**Files changed:** 1

--- a/.trajectories/completed/2026-05/traj_b3g40827t5zh/trajectory.json
+++ b/.trajectories/completed/2026-05/traj_b3g40827t5zh/trajectory.json
@@ -1,0 +1,56 @@
+{
+  "id": "traj_b3g40827t5zh",
+  "version": 1,
+  "task": {
+    "title": "Address GitHub traffic PostHog PR review comments"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-26T13:42:50.509Z",
+  "completedAt": "2026-05-26T13:44:38.186Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-26T13:44:32.298Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_xhanzfft2657",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-26T13:44:32.298Z",
+      "endedAt": "2026-05-26T13:44:38.186Z",
+      "events": [
+        {
+          "ts": 1779803072299,
+          "type": "decision",
+          "content": "Address all actionable PR review comments in one follow-up commit: Address all actionable PR review comments in one follow-up commit",
+          "raw": {
+            "question": "Address all actionable PR review comments in one follow-up commit",
+            "chosen": "Address all actionable PR review comments in one follow-up commit",
+            "alternatives": [],
+            "reasoning": "The timeout, token fallback, and checkout hardening findings are valid; keeping them together avoids partial review churn and preserves the existing workflow shape."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR review comments by adding 15 second fetch timeouts, removing the unusable github.token traffic API fallback, and pinning checkout with persisted credentials disabled.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [
+    ".github/scripts/sync-github-traffic-posthog.mjs",
+    ".github/workflows/github-traffic-posthog.yml"
+  ],
+  "projectId": "/private/tmp/relay-posthog-github-traffic",
+  "tags": [],
+  "_trace": {
+    "startRef": "4fe1c2d1b96a9f7b235ba1e1c9a8409414de4d9f",
+    "endRef": "4fe1c2d1b96a9f7b235ba1e1c9a8409414de4d9f"
+  }
+}

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-26T13:17:53.768Z",
+  "lastUpdated": "2026-05-26T13:45:48.966Z",
   "trajectories": {
     "traj_05xg7j388bc4": {
       "title": "Add browser workflow step integration",
@@ -1156,6 +1156,13 @@
       "startedAt": "2026-05-26T13:16:29.926Z",
       "completedAt": "2026-05-26T13:17:08.417Z",
       "path": "/private/tmp/relay-posthog-github-traffic/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json"
+    },
+    "traj_b3g40827t5zh": {
+      "title": "Address GitHub traffic PostHog PR review comments",
+      "status": "completed",
+      "startedAt": "2026-05-26T13:42:50.509Z",
+      "completedAt": "2026-05-26T13:44:38.186Z",
+      "path": "/private/tmp/relay-posthog-github-traffic/.trajectories/completed/2026-05/traj_b3g40827t5zh/trajectory.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-26T11:05:23.883Z",
+  "lastUpdated": "2026-05-26T13:17:53.768Z",
   "trajectories": {
     "traj_05xg7j388bc4": {
       "title": "Add browser workflow step integration",
@@ -1149,6 +1149,13 @@
       "startedAt": "2026-05-26T11:04:15.563Z",
       "completedAt": "2026-05-26T11:05:23.716Z",
       "path": "/private/tmp/relay-owned-mcp/.trajectories/completed/2026-05/traj_cszfl2icaj2t.json"
+    },
+    "traj_17t39ue8exte": {
+      "title": "Add GitHub traffic to PostHog sync",
+      "status": "completed",
+      "startedAt": "2026-05-26T13:16:29.926Z",
+      "completedAt": "2026-05-26T13:17:08.417Z",
+      "path": "/private/tmp/relay-posthog-github-traffic/.trajectories/completed/2026-05/traj_17t39ue8exte/trajectory.json"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- GitHub Actions can sync repository traffic views, clones, popular paths, and referrers into PostHog with daily backfill across GitHub's available traffic window.
 - Broker and TypeScript SDK structured result contracts add the `submit_result` MCP tool, `agent.waitForResult()`, per-spawn `result.onResult`, and `relay.addListener('agentResult', ...)` for typed JSON worker outcomes.
 - `@agent-relay/sdk` adds `AgentRelay.getPersonaSpawnPlan(id)` and a `getPersonaSpawnPlan` export for dry-run inspection of a persona's resolved harness argv, skill installs, mount policy, sidecars, and inputs.
 


### PR DESCRIPTION
## Summary

- Add a scheduled GitHub Actions workflow that pulls repository traffic views, clones, popular paths, and referrers from the GitHub traffic API.
- Send daily PostHog events with deterministic insert IDs so each run can backfill GitHub's available 14-day window without double-counting.
- Send rolling traffic-window, path, and referrer snapshots to preserve the non-daily data GitHub exposes.
- Add an 8-hour daily lag so yesterday's metric is not frozen before GitHub has settled it.
- Add 15 second request timeouts, require the dedicated GitHub traffic token, and harden checkout with a pinned action plus disabled persisted credentials.

## Test Plan

- [x] node --check .github/scripts/sync-github-traffic-posthog.mjs
- [x] actionlint .github/workflows/github-traffic-posthog.yml
- [x] prettier --check .github/scripts/sync-github-traffic-posthog.mjs .github/workflows/github-traffic-posthog.yml .trajectories/index.json .trajectories/completed/2026-05/traj_b3g40827t5zh/trajectory.json .trajectories/completed/2026-05/traj_b3g40827t5zh/summary.md
- [x] gh api traffic endpoint shape checks for views, clones, paths, and referrers
- [x] Mocked PostHog batch smoke test against the new script, including timeout signal checks

## Operational Notes

- Uses existing POSTHOG_PROJECT_API_KEY and optional POSTHOG_HOST.
- Configure GH_TRAFFIC_TOKEN as a repository secret. GitHub traffic endpoints require repository write access or fine-grained Administration: read access.

## Screenshots

N/A