### PR TITLE
mcp: recover from invalid Relaycast agent tokens mid-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-relay mcp` recovers from stale Relaycast agent tokens mid-session: a 401 carrying `agent_token_invalid` (or the legacy `Invalid agent token` message) now clears the dead token from the MCP session, returns recovery guidance pointing at `register_agent`, and lets strict-named sessions re-register without a process restart.
+- `@agent-relay/sdk` exports `isInvalidAgentTokenError`, `isInvalidAgentTokenToolResult`, and `agentTokenRecoveryMessage` for consumers that need the same detection contract outside the bundled MCP server.
+- `agent-relay-broker` adds `is_agent_token_invalid`, `is_agent_token_invalid_anyhow`, and `is_agent_token_invalid_code` on `crates/broker/src/relaycast/auth.rs`, and preserves the upstream `RelayError::Api` code through `relay_error_to_anyhow` so the same recovery signal is available to Rust callers.
 - GitHub Actions can sync repository traffic views, clones, popular paths, and referrers into PostHog with daily backfill across GitHub's available traffic window.
 - Broker and TypeScript SDK structured result contracts add the `submit_result` MCP tool, `agent.waitForResult()`, per-spawn `result.onResult`, and `relay.addListener('agentResult', ...)` for typed JSON worker outcomes.
 - `@agent-relay/sdk` and `agent-relay-broker` add broker-executable `pty` and `headless` harness configs, so custom CLIs can be configured without Rust changes while spawn requests remain self-contained.

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -192,6 +192,56 @@ impl AuthSessionSet {
 struct AuthHttpError {
     status: StatusCode,
     message: String,
+    /// Server-supplied error code (e.g. `agent_token_invalid`) when the
+    /// upstream `RelayError::Api` carried one. Kept here so that downstream
+    /// callers can distinguish a stale agent token from a generic 401.
+    code: Option<String>,
+}
+
+/// Error code returned by Relaycast when a previously-issued agent token has
+/// been revoked or expired. Mirrors the contract in relaycast PR #137: any
+/// 401 carrying this code (or the canonical `Invalid agent token` message)
+/// must be treated as recoverable via re-registration.
+pub const AGENT_TOKEN_INVALID_CODE: &str = "agent_token_invalid";
+const AGENT_TOKEN_INVALID_MESSAGE: &str = "Invalid agent token";
+
+/// True when `code` matches the relaycast `agent_token_invalid` contract.
+/// Comparison is case-insensitive to tolerate variant servers.
+pub fn is_agent_token_invalid_code(code: &str) -> bool {
+    code.eq_ignore_ascii_case(AGENT_TOKEN_INVALID_CODE)
+}
+
+/// True when the relaycast error indicates the agent token must be
+/// re-issued. Recognises both the typed `agent_token_invalid` code and the
+/// legacy 401 + `Invalid agent token` message pair so the helper works
+/// against both pre- and post-PR-#137 servers.
+pub fn is_agent_token_invalid(err: &RelayError) -> bool {
+    match err {
+        RelayError::Api {
+            code,
+            status,
+            message,
+        } => {
+            is_agent_token_invalid_code(code)
+                || (*status == 401 && message.trim() == AGENT_TOKEN_INVALID_MESSAGE)
+        }
+        _ => false,
+    }
+}
+
+/// `anyhow::Error`-flavored counterpart to `is_agent_token_invalid` — works
+/// against the `AuthHttpError` wrappers produced by `relay_error_to_anyhow`.
+pub fn is_agent_token_invalid_anyhow(err: &anyhow::Error) -> bool {
+    if let Some(auth_err) = err.downcast_ref::<AuthHttpError>() {
+        if let Some(code) = &auth_err.code {
+            if is_agent_token_invalid_code(code) {
+                return true;
+            }
+        }
+        return auth_err.status == StatusCode::UNAUTHORIZED
+            && auth_err.message.trim() == AGENT_TOKEN_INVALID_MESSAGE;
+    }
+    false
 }
 
 /// Generate a deterministic workspace name based on the current user and working
@@ -658,6 +708,22 @@ impl AuthClient {
                         status: 409,
                     }));
                 }
+                Err(RelayError::Api {
+                    code,
+                    status,
+                    message,
+                }) if is_agent_token_invalid_code(&code)
+                    || (status == 401 && message.trim() == AGENT_TOKEN_INVALID_MESSAGE) =>
+                {
+                    // Surface the typed code even when only the legacy
+                    // status+message pair is present, so downstream callers
+                    // can react with `is_agent_token_invalid_anyhow`.
+                    return Err(relay_error_to_anyhow(RelayError::Api {
+                        code: AGENT_TOKEN_INVALID_CODE.to_string(),
+                        status,
+                        message,
+                    }));
+                }
                 Err(error) => {
                     return Err(relay_error_to_anyhow(error));
                 }
@@ -748,14 +814,18 @@ fn build_relay_client(api_key: &str, base_url: &str) -> Result<RelayCast> {
 }
 
 /// Convert a `RelayError` into an `anyhow::Error`, preserving the HTTP status
-/// so that `is_auth_rejection`, `is_not_found`, and `is_rate_limited` still work.
+/// and server-supplied error code so that `is_auth_rejection`, `is_not_found`,
+/// `is_rate_limited`, and `is_agent_token_invalid_anyhow` still work.
 fn relay_error_to_anyhow(error: RelayError) -> anyhow::Error {
     match &error {
         RelayError::Api {
-            status, message, ..
+            status,
+            message,
+            code,
         } => anyhow::Error::new(AuthHttpError {
             status: StatusCode::from_u16(*status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             message: message.clone(),
+            code: if code.is_empty() { None } else { Some(code.clone()) },
         }),
         _ => anyhow::anyhow!("{error}"),
     }
@@ -796,9 +866,68 @@ mod tests {
     use httpmock::MockServer;
     use serde_json::json;
 
-    use super::{AuthClient, CredentialCache};
+    use super::{
+        is_agent_token_invalid, is_agent_token_invalid_anyhow, is_agent_token_invalid_code,
+        relay_error_to_anyhow, AuthClient, CredentialCache, AGENT_TOKEN_INVALID_CODE,
+    };
+    use relaycast::RelayError;
 
     static RELAY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn agent_token_invalid_code_matches_canonical_string_case_insensitively() {
+        assert!(is_agent_token_invalid_code(AGENT_TOKEN_INVALID_CODE));
+        assert!(is_agent_token_invalid_code("AGENT_TOKEN_INVALID"));
+        assert!(!is_agent_token_invalid_code("unauthorized"));
+    }
+
+    #[test]
+    fn agent_token_invalid_relay_error_detected_via_code_or_legacy_pair() {
+        let typed = RelayError::Api {
+            code: AGENT_TOKEN_INVALID_CODE.to_string(),
+            status: 401,
+            message: "anything".to_string(),
+        };
+        assert!(is_agent_token_invalid(&typed));
+
+        let legacy = RelayError::Api {
+            code: "unauthorized".to_string(),
+            status: 401,
+            message: "Invalid agent token".to_string(),
+        };
+        assert!(is_agent_token_invalid(&legacy));
+
+        let unrelated = RelayError::Api {
+            code: "unauthorized".to_string(),
+            status: 401,
+            message: "bad workspace key".to_string(),
+        };
+        assert!(!is_agent_token_invalid(&unrelated));
+    }
+
+    #[test]
+    fn anyhow_helper_survives_relay_error_to_anyhow_conversion() {
+        let err = relay_error_to_anyhow(RelayError::Api {
+            code: AGENT_TOKEN_INVALID_CODE.to_string(),
+            status: 401,
+            message: "Invalid agent token".to_string(),
+        });
+        assert!(is_agent_token_invalid_anyhow(&err));
+
+        let legacy = relay_error_to_anyhow(RelayError::Api {
+            code: String::new(),
+            status: 401,
+            message: "Invalid agent token".to_string(),
+        });
+        assert!(is_agent_token_invalid_anyhow(&legacy));
+
+        let unrelated = relay_error_to_anyhow(RelayError::Api {
+            code: "agent_already_exists".to_string(),
+            status: 409,
+            message: "name taken".to_string(),
+        });
+        assert!(!is_agent_token_invalid_anyhow(&unrelated));
+    }
 
     /// Remove RELAY_API_KEY from the environment so it doesn't interfere with
     /// mock-server tests. Tests use httpmock and only set up specific auth

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -825,7 +825,11 @@ fn relay_error_to_anyhow(error: RelayError) -> anyhow::Error {
         } => anyhow::Error::new(AuthHttpError {
             status: StatusCode::from_u16(*status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             message: message.clone(),
-            code: if code.is_empty() { None } else { Some(code.clone()) },
+            code: if code.is_empty() {
+                None
+            } else {
+                Some(code.clone())
+            },
         }),
         _ => anyhow::anyhow!("{error}"),
     }

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -206,9 +206,11 @@ pub const AGENT_TOKEN_INVALID_CODE: &str = "agent_token_invalid";
 const AGENT_TOKEN_INVALID_MESSAGE: &str = "Invalid agent token";
 
 /// True when `code` matches the relaycast `agent_token_invalid` contract.
-/// Comparison is case-insensitive to tolerate variant servers.
+/// Comparison is case-insensitive and ignores surrounding whitespace so
+/// `" agent_token_invalid "` matches — kept consistent with the TypeScript
+/// detector's `normalizeCode`.
 pub fn is_agent_token_invalid_code(code: &str) -> bool {
-    code.eq_ignore_ascii_case(AGENT_TOKEN_INVALID_CODE)
+    code.trim().eq_ignore_ascii_case(AGENT_TOKEN_INVALID_CODE)
 }
 
 /// True when the relaycast error indicates the agent token must be
@@ -825,10 +827,13 @@ fn relay_error_to_anyhow(error: RelayError) -> anyhow::Error {
         } => anyhow::Error::new(AuthHttpError {
             status: StatusCode::from_u16(*status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             message: message.clone(),
-            code: if code.is_empty() {
-                None
-            } else {
-                Some(code.clone())
+            code: {
+                let trimmed = code.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
             },
         }),
         _ => anyhow::anyhow!("{error}"),
@@ -883,6 +888,22 @@ mod tests {
         assert!(is_agent_token_invalid_code(AGENT_TOKEN_INVALID_CODE));
         assert!(is_agent_token_invalid_code("AGENT_TOKEN_INVALID"));
         assert!(!is_agent_token_invalid_code("unauthorized"));
+    }
+
+    #[test]
+    fn agent_token_invalid_code_tolerates_surrounding_whitespace() {
+        assert!(is_agent_token_invalid_code("  agent_token_invalid  "));
+        assert!(is_agent_token_invalid_code("\tagent_token_invalid\n"));
+    }
+
+    #[test]
+    fn anyhow_helper_normalizes_codes_with_surrounding_whitespace() {
+        let err = relay_error_to_anyhow(RelayError::Api {
+            code: "  agent_token_invalid  ".to_string(),
+            status: 401,
+            message: "Invalid agent token".to_string(),
+        });
+        assert!(is_agent_token_invalid_anyhow(&err));
     }
 
     #[test]

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -8,6 +8,10 @@ pub(crate) use crate::snippets::{
     configure_relaycast_mcp_with_result, configure_relaycast_mcp_with_token,
 };
 pub(crate) use auth::AuthClient;
+// `is_agent_token_invalid`, `is_agent_token_invalid_anyhow`,
+// `is_agent_token_invalid_code`, and `AGENT_TOKEN_INVALID_CODE` are declared
+// `pub` on `auth` so future callers (bridge, ws, listen_api) can reach them
+// via `crate::relaycast::auth::*` without an unused re-export here.
 pub(crate) use bridge::{map_ws_broker_command, map_ws_event};
 pub(crate) use dm_participants::{resolve_dm_participants_cached, DmParticipantsCache};
 pub(crate) use relaycast::{agent_name_eq, is_self_name};

--- a/packages/cli/src/cli/relaycast-mcp.test.ts
+++ b/packages/cli/src/cli/relaycast-mcp.test.ts
@@ -37,6 +37,95 @@ describe('registerAgentWithRebind', () => {
     });
   });
 
+  it('re-registers when the strict-named identity was dropped from the agents map', async () => {
+    // After an `agent_token_invalid` recovery, the active token is null and
+    // the identity is missing from session.agents. The short-circuit must
+    // fall through to registerOrRotate instead of handing back the dead token.
+    const setSession = vi.fn();
+    const registerOrRotate = vi.fn().mockResolvedValue({
+      id: 'agent_456',
+      name: 'WorkerA',
+      token: 'at_live_fresh',
+      status: 'online',
+    });
+
+    const payload = await registerAgentWithRebind({
+      session: {
+        workspaceKey: 'rk_live_test',
+        agentToken: null,
+        agentName: 'WorkerA',
+        agents: new Map(),
+      },
+      setSession,
+      getRelay: () =>
+        ({
+          agents: { registerOrRotate },
+        }) as never,
+      name: 'WorkerA',
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(registerOrRotate).toHaveBeenCalledOnce();
+    expect(payload).toMatchObject({ token: 'at_live_fresh', registered_name: 'WorkerA' });
+  });
+
+  it('re-registers when the agents map exists but the strict name is absent', async () => {
+    // Edge case: token is still set but the identity was evicted. The session
+    // is in an inconsistent state, so a fresh registration is the safe path.
+    const setSession = vi.fn();
+    const registerOrRotate = vi.fn().mockResolvedValue({
+      id: 'agent_789',
+      name: 'WorkerA',
+      token: 'at_live_rotated',
+      status: 'online',
+    });
+
+    await registerAgentWithRebind({
+      session: {
+        workspaceKey: 'rk_live_test',
+        agentToken: 'at_live_dead',
+        agentName: null,
+        agents: new Map(),
+      },
+      setSession,
+      getRelay: () =>
+        ({
+          agents: { registerOrRotate },
+        }) as never,
+      name: 'WorkerA',
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(registerOrRotate).toHaveBeenCalledOnce();
+  });
+
+  it('prefers the per-identity token from the agents map when available', async () => {
+    const setSession = vi.fn();
+    const registerOrRotate = vi.fn();
+
+    const payload = await registerAgentWithRebind({
+      session: {
+        workspaceKey: 'rk_live_test',
+        agentToken: 'at_live_stale_active',
+        agentName: 'WorkerA',
+        agents: new Map([['WorkerA', { agentName: 'WorkerA', agentToken: 'at_live_per_identity' }]]),
+      },
+      setSession,
+      getRelay: () =>
+        ({
+          agents: { registerOrRotate },
+        }) as never,
+      name: 'WorkerA',
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(registerOrRotate).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({ token: 'at_live_per_identity' });
+  });
+
   it('registers or rotates and updates the bound session token', async () => {
     const setSession = vi.fn();
     const registerOrRotate = vi.fn().mockResolvedValue({

--- a/packages/cli/src/cli/relaycast-mcp.ts
+++ b/packages/cli/src/cli/relaycast-mcp.ts
@@ -12,6 +12,11 @@ import {
   UnsubscribeRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { RelayCast, SDK_VERSION, WsClient, type AgentClient } from '@relaycast/sdk';
+import {
+  agentTokenRecoveryMessage,
+  isInvalidAgentTokenError,
+  isInvalidAgentTokenToolResult,
+} from '@agent-relay/sdk';
 import { z } from 'zod';
 
 const DEFAULT_BASE_URL = 'https://api.relaycast.dev';
@@ -80,7 +85,9 @@ interface SessionState {
   wsInitAttempted: boolean;
 }
 
-type RegistrationSession = Pick<SessionState, 'workspaceKey' | 'agentToken' | 'agentName'>;
+type RegistrationSession = Pick<SessionState, 'workspaceKey' | 'agentToken' | 'agentName'> & {
+  agents?: Map<string, RegisteredAgent>;
+};
 type SessionSetter = (partial: Partial<SessionState>) => void;
 type AgentResultCallbackConfig = {
   url: string;
@@ -337,12 +344,20 @@ export async function registerAgentWithRebind({
   }
 
   if (session.agentToken && effectiveName && strictAgentName) {
-    return {
-      name: effectiveName,
-      token: session.agentToken,
-      registered_name: effectiveName,
-      warnings,
-    };
+    // If the session tracks per-identity agents, only short-circuit when the
+    // strict-named identity is still registered. After an `agent_token_invalid`
+    // recovery the entry is dropped from the map, which lets this fall through
+    // to a fresh registerOrRotate instead of handing back the dead token.
+    const cachedAgent = session.agents?.get(effectiveName);
+    const knowsIdentities = session.agents !== undefined;
+    if (!knowsIdentities || cachedAgent) {
+      return {
+        name: effectiveName,
+        token: cachedAgent?.agentToken ?? session.agentToken,
+        registered_name: effectiveName,
+        warnings,
+      };
+    }
   }
 
   const relay = getRelay();
@@ -604,10 +619,29 @@ function formatInbox(inbox: any, selfName?: string | null): string {
   return lines.length === 1 ? '' : lines.join('\n');
 }
 
+function readAsIdentity(args: unknown[]): string | undefined {
+  const [input] = args;
+  if (typeof input !== 'object' || input === null) return undefined;
+  const as = (input as { as?: unknown }).as;
+  return typeof as === 'string' ? as : undefined;
+}
+
+function invalidAgentTokenToolResult(): JsonToolResult & { isError: true } {
+  const text = agentTokenRecoveryMessage();
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      error: { code: 'agent_token_invalid', message: text },
+    },
+    isError: true,
+  };
+}
+
 function enableInboxPiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
-  getAgentClient: (asIdentity?: string) => AgentClientLike
+  getAgentClient: (asIdentity?: string) => AgentClientLike,
+  invalidateAgentToken: (asIdentity?: string) => void
 ): void {
   const original = mcpServer.registerTool.bind(mcpServer);
   const mutableServer = mcpServer as McpServer & {
@@ -620,24 +654,47 @@ function enableInboxPiggyback(
     }
 
     const wrapped = async (...args: unknown[]) => {
-      const result = await handler(...args);
+      const asIdentity = readAsIdentity(args);
+
+      let result: any;
+      try {
+        result = await handler(...args);
+      } catch (err) {
+        // `register_agent` is the recovery path itself — never invalidate a
+        // freshly-issued token, and let registration errors bubble normally.
+        if (name !== 'register_agent' && isInvalidAgentTokenError(err)) {
+          invalidateAgentToken(asIdentity);
+          return invalidAgentTokenToolResult();
+        }
+        throw err;
+      }
+
+      // Successful response that still carries an "Invalid agent token" body.
+      if (name !== 'register_agent' && isInvalidAgentTokenToolResult(result)) {
+        invalidateAgentToken(asIdentity);
+        if (hasContentArray(result)) {
+          result.content.push({ type: 'text', text: agentTokenRecoveryMessage() });
+        }
+        return result;
+      }
+
       if (SKIP_PIGGYBACK.has(name) || !getSession().agentToken || !hasContentArray(result)) {
         return result;
       }
 
       try {
-        const [input] = args;
-        const asIdentity =
-          typeof input === 'object' && input !== null && typeof (input as { as?: unknown }).as === 'string'
-            ? (input as { as: string }).as
-            : undefined;
         const inbox = await getAgentClient(asIdentity).inbox();
         const inboxText = formatInbox(inbox, asIdentity ?? getSession().agentName);
         if (inboxText) {
           result.content.push({ type: 'text', text: inboxText });
         }
-      } catch {
-        // Inbox piggyback is opportunistic. The original tool result should win.
+      } catch (err) {
+        // Inbox piggyback is opportunistic; the original tool result should
+        // still win. But if the inbox fetch itself reveals an invalid token,
+        // clear the stale identity so the next call doesn't reuse it.
+        if (isInvalidAgentTokenError(err)) {
+          invalidateAgentToken(asIdentity);
+        }
       }
 
       return result;
@@ -1349,6 +1406,33 @@ export function createPatchedRelayMcpServer(options: PatchedMcpServerOptions): M
     }
   };
 
+  const invalidateAgentToken = (asIdentity?: string): void => {
+    const partial: Partial<SessionState> = {};
+    const targetName = asIdentity ?? session.agentName ?? null;
+
+    if (targetName && session.agents.has(targetName)) {
+      const nextAgents = new Map(session.agents);
+      nextAgents.delete(targetName);
+      partial.agents = nextAgents;
+    }
+
+    // Clear the active-session token when the invalidated identity is the
+    // active one (or the caller didn't pin to a particular identity). The
+    // active workspaceKey stays intact so `register_agent` can recover.
+    if (!asIdentity || asIdentity === session.agentName) {
+      if (session.agentToken !== null) {
+        partial.agentToken = null;
+      }
+      if (session.agentName !== null && (!asIdentity || asIdentity === session.agentName)) {
+        partial.agentName = null;
+      }
+    }
+
+    if (Object.keys(partial).length > 0) {
+      setSession(partial);
+    }
+  };
+
   const resolveAgentToken = (asIdentity?: string): string => {
     if (asIdentity) {
       const registered = session.agents.get(asIdentity);
@@ -1373,7 +1457,7 @@ export function createPatchedRelayMcpServer(options: PatchedMcpServerOptions): M
     }).as(agentToken, { autoHeartbeatMs: false });
   };
 
-  enableInboxPiggyback(mcpServer, getSession, getAgentClient);
+  enableInboxPiggyback(mcpServer, getSession, getAgentClient, invalidateAgentToken);
   registerResourceDefinitions(mcpServer, getAgentClient, getRelay);
   mcpServer.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
     session.subscriptions?.subscribe(req.params.uri);

--- a/packages/cli/src/cli/relaycast-mcp.ts
+++ b/packages/cli/src/cli/relaycast-mcp.ts
@@ -13,6 +13,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { RelayCast, SDK_VERSION, WsClient, type AgentClient } from '@relaycast/sdk';
 import {
+  INVALID_AGENT_TOKEN_CODE,
   agentTokenRecoveryMessage,
   isInvalidAgentTokenError,
   isInvalidAgentTokenToolResult,
@@ -631,7 +632,7 @@ function invalidAgentTokenToolResult(): JsonToolResult & { isError: true } {
   return {
     content: [{ type: 'text', text }],
     structuredContent: {
-      error: { code: 'agent_token_invalid', message: text },
+      error: { code: INVALID_AGENT_TOKEN_CODE, message: text },
     },
     isError: true,
   };

--- a/packages/sdk/src/__tests__/relaycast-errors.test.ts
+++ b/packages/sdk/src/__tests__/relaycast-errors.test.ts
@@ -43,6 +43,25 @@ describe('isInvalidAgentTokenError', () => {
     expect(isInvalidAgentTokenError(outer)).toBe(true);
   });
 
+  it('terminates on cyclic `cause` graphs without recursing forever', () => {
+    const a: { message: string; cause?: unknown } = { message: 'outer' };
+    const b: { message: string; cause?: unknown } = { message: 'inner' };
+    a.cause = b;
+    b.cause = a;
+    expect(isInvalidAgentTokenError(a)).toBe(false);
+  });
+
+  it('still finds the marker inside a cyclic chain when one node carries it', () => {
+    const a: { message: string; cause?: unknown } = { message: 'outer' };
+    const b: { statusCode: number; message: string; cause?: unknown } = {
+      statusCode: 401,
+      message: INVALID_AGENT_TOKEN_MESSAGE,
+    };
+    a.cause = b;
+    b.cause = a;
+    expect(isInvalidAgentTokenError(a)).toBe(true);
+  });
+
   it('ignores 401s that are not the agent token contract', () => {
     const err = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
     expect(isInvalidAgentTokenError(err)).toBe(false);

--- a/packages/sdk/src/__tests__/relaycast-errors.test.ts
+++ b/packages/sdk/src/__tests__/relaycast-errors.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  INVALID_AGENT_TOKEN_CODE,
+  INVALID_AGENT_TOKEN_MESSAGE,
+  agentTokenRecoveryMessage,
+  isInvalidAgentTokenError,
+  isInvalidAgentTokenToolResult,
+} from '../relaycast-errors.js';
+
+describe('isInvalidAgentTokenError', () => {
+  it('matches by typed code on the error object itself', () => {
+    const err = Object.assign(new Error('whatever'), { code: INVALID_AGENT_TOKEN_CODE });
+    expect(isInvalidAgentTokenError(err)).toBe(true);
+  });
+
+  it('matches the typed code regardless of case or surrounding whitespace', () => {
+    const err = Object.assign(new Error(), { code: ' AGENT_TOKEN_INVALID ' });
+    expect(isInvalidAgentTokenError(err)).toBe(true);
+  });
+
+  it('matches the legacy 401 + canonical message pair', () => {
+    const err = Object.assign(new Error(INVALID_AGENT_TOKEN_MESSAGE), { statusCode: 401 });
+    expect(isInvalidAgentTokenError(err)).toBe(true);
+  });
+
+  it('accepts `status` as an alternate name for `statusCode`', () => {
+    const err = Object.assign(new Error(INVALID_AGENT_TOKEN_MESSAGE), { status: 401 });
+    expect(isInvalidAgentTokenError(err)).toBe(true);
+  });
+
+  it('walks into a `body.error` envelope when the code lives there', () => {
+    const err = Object.assign(new Error('Unauthorized'), {
+      status: 401,
+      body: { error: { code: INVALID_AGENT_TOKEN_CODE, message: 'irrelevant' } },
+    });
+    expect(isInvalidAgentTokenError(err)).toBe(true);
+  });
+
+  it('walks into nested `cause` chains', () => {
+    const inner = Object.assign(new Error(INVALID_AGENT_TOKEN_MESSAGE), { statusCode: 401 });
+    const outer = Object.assign(new Error('upstream call failed'), { cause: inner });
+    expect(isInvalidAgentTokenError(outer)).toBe(true);
+  });
+
+  it('ignores 401s that are not the agent token contract', () => {
+    const err = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+    expect(isInvalidAgentTokenError(err)).toBe(false);
+  });
+
+  it('returns false for non-object inputs', () => {
+    expect(isInvalidAgentTokenError(null)).toBe(false);
+    expect(isInvalidAgentTokenError(undefined)).toBe(false);
+    expect(isInvalidAgentTokenError('Invalid agent token')).toBe(false);
+  });
+});
+
+describe('isInvalidAgentTokenToolResult', () => {
+  it('detects the canonical message anywhere in the content array', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'noise' },
+        { type: 'text', text: INVALID_AGENT_TOKEN_MESSAGE },
+      ],
+    };
+    expect(isInvalidAgentTokenToolResult(result)).toBe(true);
+  });
+
+  it('ignores results whose content does not include the marker', () => {
+    expect(
+      isInvalidAgentTokenToolResult({
+        content: [{ type: 'text', text: 'all good' }],
+      })
+    ).toBe(false);
+  });
+
+  it('ignores results without a content array', () => {
+    expect(isInvalidAgentTokenToolResult({})).toBe(false);
+    expect(isInvalidAgentTokenToolResult(null)).toBe(false);
+  });
+});
+
+describe('agentTokenRecoveryMessage', () => {
+  it('embeds the typed code and references the register_agent tool', () => {
+    const msg = agentTokenRecoveryMessage();
+    expect(msg).toContain(INVALID_AGENT_TOKEN_CODE);
+    expect(msg).toContain('register_agent');
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -36,6 +36,13 @@ export type {
 export * from './models.js';
 export { RelayCast, RelayError, AgentClient } from '@relaycast/sdk';
 export type { RelayCastOptions, ClientOptions } from '@relaycast/sdk';
+export {
+  INVALID_AGENT_TOKEN_CODE,
+  INVALID_AGENT_TOKEN_MESSAGE,
+  agentTokenRecoveryMessage,
+  isInvalidAgentTokenError,
+  isInvalidAgentTokenToolResult,
+} from './relaycast-errors.js';
 export * from './pty.js';
 export * from './relay.js';
 export * from './logs.js';

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -61,9 +61,14 @@ function readBodyError(body: unknown): { code?: string; message?: string } | nul
  * True when `error` looks like an invalid-agent-token response from
  * Relaycast. Recognises both the typed `agent_token_invalid` code (PR #137)
  * and the legacy status-401 + "Invalid agent token" message pair.
+ *
+ * The optional `visited` set guards against cyclic `cause` graphs
+ * (`a.cause = b; b.cause = a`) — a `WeakSet` so we don't leak references.
  */
-export function isInvalidAgentTokenError(error: unknown): boolean {
+export function isInvalidAgentTokenError(error: unknown, visited: WeakSet<object> = new WeakSet()): boolean {
   if (!error || typeof error !== 'object') return false;
+  if (visited.has(error as object)) return false;
+  visited.add(error as object);
   const err = error as MaybeError;
 
   if (normalizeCode(err.code) === INVALID_AGENT_TOKEN_CODE) return true;
@@ -76,8 +81,8 @@ export function isInvalidAgentTokenError(error: unknown): boolean {
     (typeof err.message === 'string' ? err.message.trim() : '') || (bodyError?.message?.trim() ?? '');
   if (status === 401 && message === INVALID_AGENT_TOKEN_MESSAGE) return true;
 
-  if (err.cause && err.cause !== error) {
-    return isInvalidAgentTokenError(err.cause);
+  if (err.cause) {
+    return isInvalidAgentTokenError(err.cause, visited);
   }
   return false;
 }

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -1,0 +1,121 @@
+/**
+ * Detectors for relaycast `agent_token_invalid` responses.
+ *
+ * Mirrors the recovery contract introduced in relaycast PR #137. The MCP
+ * server (and any SDK consumer) uses these helpers to recognise when a
+ * Relaycast agent token has been invalidated mid-session so the stale
+ * credential can be cleared and the caller pointed at a fresh
+ * `register_agent` call.
+ *
+ * Detection is intentionally structural: the upstream `@relaycast/sdk`
+ * RelayError surfaces a `code` field once PR #137 ships, but until then
+ * (and as a defensive fallback) the status + message pair is enough to
+ * identify an invalid agent token.
+ */
+
+export const INVALID_AGENT_TOKEN_CODE = 'agent_token_invalid';
+export const INVALID_AGENT_TOKEN_MESSAGE = 'Invalid agent token';
+
+interface MaybeError {
+  code?: unknown;
+  statusCode?: unknown;
+  status?: unknown;
+  message?: unknown;
+  body?: unknown;
+  cause?: unknown;
+}
+
+function normalizeCode(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+}
+
+function readStatus(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readBodyError(body: unknown): { code?: string; message?: string } | null {
+  if (!body || typeof body !== 'object') return null;
+  const root = body as { error?: unknown; code?: unknown; message?: unknown };
+  const errorField = root.error;
+  if (errorField && typeof errorField === 'object') {
+    const e = errorField as { code?: unknown; message?: unknown };
+    return {
+      code: typeof e.code === 'string' ? e.code : undefined,
+      message: typeof e.message === 'string' ? e.message : undefined,
+    };
+  }
+  return {
+    code: typeof root.code === 'string' ? root.code : undefined,
+    message: typeof root.message === 'string' ? root.message : undefined,
+  };
+}
+
+/**
+ * True when `error` looks like an invalid-agent-token response from
+ * Relaycast. Recognises both the typed `agent_token_invalid` code (PR #137)
+ * and the legacy status-401 + "Invalid agent token" message pair.
+ */
+export function isInvalidAgentTokenError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as MaybeError;
+
+  if (normalizeCode(err.code) === INVALID_AGENT_TOKEN_CODE) return true;
+
+  const bodyError = readBodyError(err.body);
+  if (bodyError && normalizeCode(bodyError.code) === INVALID_AGENT_TOKEN_CODE) return true;
+
+  const status = readStatus(err.statusCode) ?? readStatus(err.status);
+  const message =
+    (typeof err.message === 'string' ? err.message.trim() : '') ||
+    (bodyError?.message?.trim() ?? '');
+  if (status === 401 && message === INVALID_AGENT_TOKEN_MESSAGE) return true;
+
+  if (err.cause && err.cause !== error) {
+    return isInvalidAgentTokenError(err.cause);
+  }
+  return false;
+}
+
+interface MaybeToolResult {
+  content?: unknown;
+  isError?: unknown;
+  structuredContent?: unknown;
+}
+
+/**
+ * True when a tool result swallowed an invalid-token error into its
+ * content array (the pattern the relaycast MCP server uses when an upstream
+ * call returns `Invalid agent token` in a 401 body).
+ */
+export function isInvalidAgentTokenToolResult(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false;
+  const r = result as MaybeToolResult;
+  if (!Array.isArray(r.content)) return false;
+  return r.content.some((entry) => {
+    if (!entry || typeof entry !== 'object') return false;
+    const e = entry as { type?: unknown; text?: unknown };
+    if (e.type !== 'text' || typeof e.text !== 'string') return false;
+    return e.text.trim() === INVALID_AGENT_TOKEN_MESSAGE;
+  });
+}
+
+/**
+ * Human-readable guidance returned to the MCP client after invalidating a
+ * stale agent token. Matches the wording surfaced by the relaycast MCP
+ * server so prompts that key on this string keep working across both
+ * implementations.
+ */
+export function agentTokenRecoveryMessage(): string {
+  return [
+    `${INVALID_AGENT_TOKEN_CODE}: The selected Relaycast agent token is no longer valid.`,
+    'The stale token was cleared from this MCP session.',
+    'Call the "register_agent" tool with the configured agent name to obtain a fresh token, then retry the failed operation.',
+  ].join(' ');
+}

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -73,8 +73,7 @@ export function isInvalidAgentTokenError(error: unknown): boolean {
 
   const status = readStatus(err.statusCode) ?? readStatus(err.status);
   const message =
-    (typeof err.message === 'string' ? err.message.trim() : '') ||
-    (bodyError?.message?.trim() ?? '');
+    (typeof err.message === 'string' ? err.message.trim() : '') || (bodyError?.message?.trim() ?? '');
   if (status === 401 && message === INVALID_AGENT_TOKEN_MESSAGE) return true;
 
   if (err.cause && err.cause !== error) {


### PR DESCRIPTION
## Summary

Ports the recovery contract from [relaycast PR #137](https://github.com/AgentWorkforce/relaycast/pull/137) into the agent-relay MCP server, SDK, and Rust broker so a revoked or expired Relaycast agent token no longer wedges a session until the process is restarted.

- **SDK** (`packages/sdk/src/relaycast-errors.ts`): shared `INVALID_AGENT_TOKEN_CODE` plus `isInvalidAgentTokenError` / `isInvalidAgentTokenToolResult` / `agentTokenRecoveryMessage`. Recognises both the typed `agent_token_invalid` code (PR #137) and the legacy 401 + `Invalid agent token` pair, plus `body.error` envelopes and nested `cause` chains.
- **MCP server** (`packages/cli/src/cli/relaycast-mcp.ts`): `invalidateAgentToken(asIdentity?)` drops the stale identity from `session.agents` and clears `session.agentToken`/`agentName` only when the invalidated identity is the active one — mirrors the PR's routed-vs-active scoping. `enableInboxPiggyback` now catches thrown invalid-token errors and inspects successful tool-result bodies for the legacy marker, surfacing a structured `isError: true` recovery payload that points at `register_agent`. The opportunistic inbox fetch invalidates too. `register_agent` is exempt so it stays a clean recovery path.
- **MCP server**: `registerAgentWithRebind` short-circuit now requires the strict-named identity to still be in `session.agents`, and prefers the per-identity token when present — so post-invalidation registrations rotate instead of handing back the dead token.
- **Broker** (`crates/broker/src/relaycast/auth.rs`): `AuthHttpError` now carries the upstream `code`, `relay_error_to_anyhow` propagates it, and new `is_agent_token_invalid` / `is_agent_token_invalid_anyhow` / `is_agent_token_invalid_code` helpers + `AGENT_TOKEN_INVALID_CODE` constant let downstream Rust callers react to the same signal. The agent-create path also normalizes legacy 401+message responses to the typed code.

## Test plan

- [x] `npx vitest run packages/cli/src/cli/relaycast-mcp.test.ts packages/cli/src/cli/relaycast-mcp.startup.test.ts` — 22 tests pass (3 new rebind tests, 19 pre-existing).
- [x] `cd packages/sdk && npx vitest run src/__tests__/relaycast-errors.test.ts` — 12 new detector tests pass.
- [x] `cargo test -p agent-relay-broker --lib relaycast::auth::tests` — 17 tests pass (3 new, 14 pre-existing).
- [x] `cargo check -p agent-relay-broker` — clean.
- [x] `cd packages/cli && npx tsc --noEmit` — clean.
- [ ] Manual verification: run `agent-relay mcp` against a workspace, rotate an agent token out-of-band, and confirm the next tool call returns the `agent_token_invalid` recovery message and that calling `register_agent` rebinds without restart.

https://claude.ai/code/session_01TTpJAiAxsgxMqC6RSzMDsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTpJAiAxsgxMqC6RSzMDsV)_