### PR TITLE
fix(acp-bridge,openclaw): use AgentRelay.spawnAgent instead of removed spawnPty

### DIFF
--- a/packages/acp-bridge/src/acp-agent.ts
+++ b/packages/acp-bridge/src/acp-agent.ts
@@ -736,7 +736,7 @@ export class RelayACPAgent implements acp.Agent {
 
     try {
       const relay = this.relay!;
-      const agent = await relay.spawnPty({
+      const agent = await relay.spawnAgent({
         name,
         cli,
         task,

--- a/packages/openclaw/src/spawn/process.ts
+++ b/packages/openclaw/src/spawn/process.ts
@@ -171,7 +171,7 @@ export class ProcessSpawnProvider implements SpawnProvider {
         } as NodeJS.ProcessEnv,
       });
 
-      await relay.spawnPty({
+      await relay.spawnAgent({
         name: agentName,
         cli: 'node',
         args: [bridgePath],


### PR DESCRIPTION
## Summary

Fixes the failing CI build on `main` ([run 26520261748](https://github.com/AgentWorkforce/relay/actions/runs/26520261748/job/78109124959)).

After PR #1003 / #1006, `AgentRelay` only exposes `spawnAgent` — `spawnPty` lives only on `AgentRelayClient`. Two callers were still using `relay.spawnPty(...)` on `AgentRelay` instances, which broke the TypeScript build of `@agent-relay/acp-bridge` (the visible CI failure) and would have broken `@agent-relay/openclaw` next.

- `packages/acp-bridge/src/acp-agent.ts:739` — `relay.spawnPty(...)` → `relay.spawnAgent(...)`
- `packages/openclaw/src/spawn/process.ts:174` — same

## Test plan

- [x] `npm run build` is green locally (all 19 turbo tasks)
- [ ] CI on this PR passes

https://claude.ai/code/session_0181Fs6YPkrKrGeRQk3YFqi1

---
_Generated by [Claude Code](https://claude.ai/code/session_0181Fs6YPkrKrGeRQk3YFqi1)_