### PR TITLE
fix(cloud): tolerate stray CLI login callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@agent-relay/cloud`: CLI browser login keeps waiting after stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not aborted before the real OAuth callback returns.
 - `agent-relay-broker` harness configs now report harness PIDs instead of wrapper worker PIDs, validate app-server protocol/auth/host settings at spawn, and give app-server release requests time to finish.
 - `@agent-relay/sdk` normalizes broker `pid: null` spawn responses to `undefined` while PTY harness PIDs are reported asynchronously.
 - `web`: PR preview SST deploys use and comment the generated CloudFront URL and AWS's managed disabled cache policy instead of creating per-preview Cloudflare DNS records, ACM certificates, and custom CloudFront cache policies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `@agent-relay/cloud`: CLI browser login keeps waiting after stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not aborted before the real OAuth callback returns.
+- `@agent-relay/cloud`: CLI browser login ignores stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not shown a false hosted error or aborted before the real OAuth callback returns.
 - `agent-relay-broker` harness configs now report harness PIDs instead of wrapper worker PIDs, validate app-server protocol/auth/host settings at spawn, and give app-server release requests time to finish.
 - `@agent-relay/sdk` normalizes broker `pid: null` spawn responses to `undefined` while PTY harness PIDs are reported asynchronously.
 - `web`: PR preview SST deploys use and comment the generated CloudFront URL and AWS's managed disabled cache policy instead of creating per-preview Cloudflare DNS records, ACM certificates, and custom CloudFront cache policies.

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -211,13 +211,11 @@ describe('ensureAuthenticated', () => {
     expect(state).toBeTruthy();
 
     const strayResponse = await fetch(callbackUrl, { redirect: 'manual' });
-    expect(strayResponse.status).toBe(302);
+    expect(strayResponse.status).toBe(400);
+    await expect(strayResponse.text()).resolves.toContain('Ignored invalid CLI login callback');
 
     const stillWaiting = await Promise.race([
-      authPromise.then(
-        () => 'resolved',
-        () => 'rejected'
-      ),
+      authPromise.then(() => 'resolved', () => 'rejected'),
       new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 25)),
     ]);
     expect(stillWaiting).toBe('pending');

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -215,7 +215,10 @@ describe('ensureAuthenticated', () => {
     await expect(strayResponse.text()).resolves.toContain('Ignored invalid CLI login callback');
 
     const stillWaiting = await Promise.race([
-      authPromise.then(() => 'resolved', () => 'rejected'),
+      authPromise.then(
+        () => 'resolved',
+        () => 'rejected'
+      ),
       new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 25)),
     ]);
     expect(stillWaiting).toBe('pending');

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -7,9 +7,19 @@ const fsMocks = vi.hoisted(() => ({
   rm: vi.fn(),
 }));
 
+const childProcessMocks = vi.hoisted(() => ({
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+  })),
+}));
+
 vi.mock('node:fs/promises', () => ({
   default: fsMocks,
   ...fsMocks,
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: childProcessMocks.spawn,
 }));
 
 import { ensureAuthenticated, readStoredAuth, refreshStoredAuth } from './auth.js';
@@ -52,6 +62,7 @@ beforeEach(() => {
   fsMocks.mkdir.mockResolvedValue(undefined);
   fsMocks.rm.mockReset();
   fsMocks.rm.mockResolvedValue(undefined);
+  childProcessMocks.spawn.mockClear();
 });
 
 describe('readStoredAuth', () => {
@@ -179,6 +190,53 @@ describe('ensureAuthenticated', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const calledUrl = String(fetchSpy.mock.calls[0][0]);
     expect(calledUrl).toContain('origin.example');
+  });
+
+  it('keeps waiting after a stray local callback with an invalid state', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const authPromise = ensureAuthenticated('https://example.com/cloud', { force: true });
+
+    await vi.waitFor(() => {
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Opening browser for cloud login: '));
+    });
+
+    const loginLine = logSpy.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.startsWith('Opening browser for cloud login: '));
+    expect(loginLine).toBeTruthy();
+
+    const loginUrl = new URL(String(loginLine).slice('Opening browser for cloud login: '.length));
+    const callbackUrl = new URL(String(loginUrl.searchParams.get('redirect_uri')));
+    const state = loginUrl.searchParams.get('state');
+    expect(state).toBeTruthy();
+
+    const strayResponse = await fetch(callbackUrl, { redirect: 'manual' });
+    expect(strayResponse.status).toBe(302);
+
+    const stillWaiting = await Promise.race([
+      authPromise.then(() => 'resolved', () => 'rejected'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 25)),
+    ]);
+    expect(stillWaiting).toBe('pending');
+
+    callbackUrl.searchParams.set('state', String(state));
+    callbackUrl.searchParams.set('access_token', 'access-token');
+    callbackUrl.searchParams.set('refresh_token', 'refresh-token');
+    callbackUrl.searchParams.set('access_token_expires_at', '2999-01-01T00:00:00.000Z');
+    callbackUrl.searchParams.set('api_url', 'https://example.com/cloud');
+
+    const successResponse = await fetch(callbackUrl, { redirect: 'manual' });
+    expect(successResponse.status).toBe(302);
+
+    await expect(authPromise).resolves.toEqual({
+      apiUrl: 'https://example.com/cloud',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    });
+    expect(fsMocks.writeFile).toHaveBeenCalledOnce();
+
+    logSpy.mockRestore();
   });
 });
 

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -214,7 +214,10 @@ describe('ensureAuthenticated', () => {
     expect(strayResponse.status).toBe(302);
 
     const stillWaiting = await Promise.race([
-      authPromise.then(() => 'resolved', () => 'rejected'),
+      authPromise.then(
+        () => 'resolved',
+        () => 'rejected'
+      ),
       new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 25)),
     ]);
     expect(stillWaiting).toBe('pending');

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -165,11 +165,6 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
           status: 'error',
           detail: 'Invalid state parameter',
         });
-        if (!settled) {
-          settled = true;
-          server.close();
-          reject(new Error('Invalid state parameter in CLI login callback'));
-        }
         return;
       }
 

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -161,10 +161,9 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
       // Validate state parameter first (CSRF protection) — this check
       // must run unconditionally, before any user-controlled values.
       if (returnedState !== state) {
-        redirectToHostedCliAuthPage(response, apiUrl, {
-          status: 'error',
-          detail: 'Invalid state parameter',
-        });
+        response.statusCode = 400;
+        response.setHeader('content-type', 'text/plain; charset=utf-8');
+        response.end('Ignored invalid CLI login callback. Return to your terminal to continue login.');
         return;
       }
 


### PR DESCRIPTION
## Summary
- ignore stray invalid-state localhost callbacks locally instead of surfacing a false hosted auth error
- keep the CLI browser-login loopback server alive until the real OAuth callback arrives
- add regression coverage for a bad localhost callback followed by the real OAuth callback
- document the first-time sign-in fix in the changelog

## Tests
- `npx vitest run packages/cloud/src/auth.test.ts`
- `npm --prefix packages/cloud run build`

## Notes
- Checked `wrangler tail cloud-web-worker --status error`; no worker errors appeared during the bounded tail.
- `agentworkforce login` consumes this through `@agent-relay/cloud`, so Workforce should be published against the fixed Relay Cloud package after this lands.