### PR TITLE
Add Grok CLI connect support

### DIFF
--- a/crates/broker/src/cli_mcp_args.rs
+++ b/crates/broker/src/cli_mcp_args.rs
@@ -229,6 +229,13 @@ fn side_effect_files_for(cli: &str, existing_args: &[String], cwd: &Path) -> Res
             .collect());
     }
 
+    if cli_lower == "grok" {
+        return Ok(home_dir_from_env()
+            .map(|home| home.join(".grok").join("config.toml"))
+            .into_iter()
+            .collect());
+    }
+
     Ok(Vec::new())
 }
 

--- a/crates/broker/src/pty.rs
+++ b/crates/broker/src/pty.rs
@@ -191,7 +191,7 @@ fn resolve_command_path(command: &str) -> String {
             {
                 let home = env::var("HOME").unwrap_or_else(|_| String::from("/root"));
                 OsString::from(format!(
-                    "{home}/.local/bin:{home}/.opencode/bin:{home}/.claude/local:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
+                    "{home}/.local/bin:{home}/.grok/bin:{home}/.opencode/bin:{home}/.claude/local:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
                 ))
             }
             #[cfg(windows)]

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -557,8 +557,8 @@ pub fn ensure_opencode_config_with_result(
 /// Configure the relaycast MCP server for any supported CLI tool.
 ///
 /// Returns extra CLI arguments to append when spawning the agent.
-/// For Gemini/Droid this runs a pre-spawn `mcp add` command (removing first
-/// for idempotency). For Opencode this writes `opencode.json` on disk.
+/// For Gemini/Droid/Grok this runs a pre-spawn `mcp add` command (removing
+/// first for idempotency). For Opencode this writes `opencode.json` on disk.
 ///
 /// # Parameters
 /// Write `.cursor/mcp.json` in the given directory with the Agent Relay MCP server
@@ -646,7 +646,7 @@ pub fn ensure_cursor_mcp_config(
     Ok(changed)
 }
 
-/// - `cli`: CLI tool name (e.g. "claude", "codex", "gemini", "droid", "opencode", "cursor")
+/// - `cli`: CLI tool name (e.g. "claude", "codex", "gemini", "droid", "grok", "opencode", "cursor")
 /// - `agent_name`: the name of the agent being spawned
 /// - `api_key`: optional relay API key (empty or `None` means omit)
 /// - `base_url`: optional relay base URL (empty or `None` means omit)
@@ -723,6 +723,7 @@ pub async fn configure_relaycast_mcp_with_result(
     let is_codex = cli_lower == "codex";
     let is_gemini = cli_lower == "gemini";
     let is_droid = cli_lower == "droid";
+    let is_grok = cli_lower == "grok";
     let is_opencode = cli_lower == "opencode";
     let is_cursor = cli_lower == "cursor" || cli_lower == "cursor-agent" || cli_lower == "agent"; // "agent" is cursor-agent's binary name
 
@@ -881,6 +882,17 @@ pub async fn configure_relaycast_mcp_with_result(
             workspaces_json,
             default_workspace,
             None,
+        )
+        .await?;
+    } else if is_grok {
+        configure_grok_mcp(
+            cli,
+            api_key,
+            base_url,
+            Some(agent_name),
+            agent_token,
+            workspaces_json,
+            default_workspace,
         )
         .await?;
     } else if is_opencode && !existing_args.iter().any(|a| a == "--agent") {
@@ -1134,6 +1146,127 @@ async fn configure_gemini_droid_mcp(
                         "failed to configure relaycast MCP for {cli}: `{cli} mcp add` timed out after 15s. \
                          Please configure the relaycast MCP server manually:\n  {manual_cmd}"
                     );
+            }
+            _ => {}
+        },
+        Err(error) => {
+            anyhow::bail!(
+                "failed to configure relaycast MCP for {cli}: could not run `{cli} mcp add`: {error}. \
+                 Please configure the relaycast MCP server manually:\n  {manual_cmd}"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn grok_manual_mcp_add_cmd(cli: &str) -> String {
+    format!(
+        "{cli} mcp add relaycast --command npx --args=-y --args=agent-relay --args=mcp --env RELAY_API_KEY=<key> --env RELAY_BASE_URL=<url>"
+    )
+}
+
+fn grok_mcp_add_args(
+    api_key: Option<&str>,
+    base_url: Option<&str>,
+    agent_name: Option<&str>,
+    agent_token: Option<&str>,
+    workspaces_json: Option<&str>,
+    default_workspace: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "relaycast".to_string(),
+        "--command".to_string(),
+        "npx".to_string(),
+        "--args=-y".to_string(),
+        format!("--args={AGENT_RELAY_MCP_PACKAGE}"),
+        format!("--args={AGENT_RELAY_MCP_SUBCOMMAND}"),
+    ];
+
+    let mut push_env = |key: &str, value: Option<&str>| {
+        if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+            args.push("--env".to_string());
+            args.push(format!("{key}={value}"));
+        }
+    };
+
+    push_env("RELAY_API_KEY", api_key);
+    push_env("RELAY_BASE_URL", base_url);
+    push_env("RELAY_AGENT_NAME", agent_name);
+    push_env("RELAY_AGENT_TYPE", Some("agent"));
+    push_env("RELAY_STRICT_AGENT_NAME", Some("1"));
+    if agent_token
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        push_env("RELAY_AGENT_TOKEN", agent_token);
+        push_env("RELAY_SKIP_BOOTSTRAP", Some("1"));
+    }
+    push_env("RELAY_WORKSPACES_JSON", workspaces_json);
+    push_env("RELAY_DEFAULT_WORKSPACE", default_workspace);
+
+    args
+}
+
+async fn configure_grok_mcp(
+    cli: &str,
+    api_key: Option<&str>,
+    base_url: Option<&str>,
+    agent_name: Option<&str>,
+    agent_token: Option<&str>,
+    workspaces_json: Option<&str>,
+    default_workspace: Option<&str>,
+) -> Result<()> {
+    let exe = shlex::split(cli)
+        .and_then(|parts| parts.first().cloned())
+        .unwrap_or_else(|| cli.trim().to_string());
+    let manual_cmd = grok_manual_mcp_add_cmd(&exe);
+
+    let _ = std::process::Command::new(&exe)
+        .args(["mcp", "remove", "relaycast"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .and_then(|mut child| child.wait());
+
+    let mut mcp_cmd = Command::new(&exe);
+    mcp_cmd.args(grok_mcp_add_args(
+        api_key,
+        base_url,
+        agent_name,
+        agent_token,
+        workspaces_json,
+        default_workspace,
+    ));
+    mcp_cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    match mcp_cmd.spawn() {
+        Ok(mut child) => match tokio::time::timeout(Duration::from_secs(15), child.wait()).await {
+            Ok(Ok(status)) if !status.success() => {
+                anyhow::bail!(
+                    "failed to configure relaycast MCP for {cli}: `{cli} mcp add` exited with code {:?}. \
+                     Please configure the relaycast MCP server manually:\n  {manual_cmd}",
+                    status.code()
+                );
+            }
+            Ok(Err(error)) => {
+                anyhow::bail!(
+                    "failed to configure relaycast MCP for {cli}: {error}. \
+                     Please configure the relaycast MCP server manually:\n  {manual_cmd}"
+                );
+            }
+            Err(_) => {
+                let _ = child.kill().await;
+                anyhow::bail!(
+                    "failed to configure relaycast MCP for {cli}: `{cli} mcp add` timed out after 15s. \
+                     Please configure the relaycast MCP server manually:\n  {manual_cmd}"
+                );
             }
             _ => {}
         },
@@ -1583,6 +1716,37 @@ mod tests {
         assert!(args.contains(&"RELAY_AGENT_TYPE=agent".to_string()));
         assert!(args.contains(&"RELAY_STRICT_AGENT_NAME=1".to_string()));
         assert!(args.contains(&"RELAY_AGENT_TOKEN=tok_droid_123".to_string()));
+    }
+
+    #[test]
+    fn grok_mcp_add_args_use_equals_form_for_dash_args() {
+        let args = super::grok_mcp_add_args(
+            Some("rk_live_xyz"),
+            Some("https://api.relaycast.dev"),
+            Some("GrokWorker"),
+            Some("tok_grok_123"),
+            Some(r#"{"workspaces":["rw_1"]}"#),
+            Some("rw_1"),
+        );
+
+        assert_eq!(args[0], "mcp");
+        assert_eq!(args[1], "add");
+        assert_eq!(args[2], "relaycast");
+        assert!(args.contains(&"--command".to_string()));
+        assert!(args.contains(&"npx".to_string()));
+        assert!(args.contains(&"--args=-y".to_string()));
+        assert!(args.contains(&"--args=agent-relay".to_string()));
+        assert!(args.contains(&"--args=mcp".to_string()));
+        assert!(args.contains(&"--env".to_string()));
+        assert!(args.contains(&"RELAY_API_KEY=rk_live_xyz".to_string()));
+        assert!(args.contains(&"RELAY_BASE_URL=https://api.relaycast.dev".to_string()));
+        assert!(args.contains(&"RELAY_AGENT_NAME=GrokWorker".to_string()));
+        assert!(args.contains(&"RELAY_AGENT_TYPE=agent".to_string()));
+        assert!(args.contains(&"RELAY_STRICT_AGENT_NAME=1".to_string()));
+        assert!(args.contains(&"RELAY_AGENT_TOKEN=tok_grok_123".to_string()));
+        assert!(args.contains(&"RELAY_SKIP_BOOTSTRAP=1".to_string()));
+        assert!(args.contains(&r#"RELAY_WORKSPACES_JSON={"workspaces":["rw_1"]}"#.to_string()));
+        assert!(args.contains(&"RELAY_DEFAULT_WORKSPACE=rw_1".to_string()));
     }
 
     #[test]

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -19,7 +19,7 @@ vi.mock('@agent-relay/cloud', () => ({
   defaultApiUrl: () => 'https://cloud.test',
   ensureAuthenticated: vi.fn(),
   getProviderHelpText: () =>
-    'anthropic (alias: claude), openai (alias: codex), google (alias: gemini), cursor, opencode, droid',
+    'anthropic (alias: claude), openai (alias: codex), google (alias: gemini), xai (alias: grok), cursor, opencode, droid',
   getRunLogs: vi.fn(),
   getRunStatus: (...args: unknown[]) => cloudMocks.getRunStatus(...args),
   listWorkflowSchedules: (...args: unknown[]) => cloudMocks.listWorkflowSchedules(...args),
@@ -89,6 +89,7 @@ describe('registerCloudCommands', () => {
     expect(connect?.registeredArguments[0]?.description).toContain('anthropic (alias: claude)');
     expect(connect?.registeredArguments[0]?.description).toContain('openai (alias: codex)');
     expect(connect?.registeredArguments[0]?.description).toContain('google (alias: gemini)');
+    expect(connect?.registeredArguments[0]?.description).toContain('xai (alias: grok)');
   });
 
   it('run requires a workflow argument', () => {

--- a/packages/cli/src/cli/lib/auth-ssh.ts
+++ b/packages/cli/src/cli/lib/auth-ssh.ts
@@ -80,6 +80,7 @@ function normalizeProvider(providerArg: string): string {
     claude: 'anthropic',
     codex: 'openai',
     gemini: 'google',
+    grok: 'xai',
   };
   return providerMap[providerInput] || providerInput;
 }

--- a/packages/cli/src/cli/lib/connect-daytona.ts
+++ b/packages/cli/src/cli/lib/connect-daytona.ts
@@ -50,6 +50,7 @@ function normalizeProvider(providerArg: string): string {
     claude: 'anthropic',
     codex: 'openai',
     gemini: 'google',
+    grok: 'xai',
   };
   return providerMap[providerInput] || providerInput;
 }

--- a/packages/cloud/src/connect.test.ts
+++ b/packages/cloud/src/connect.test.ts
@@ -7,6 +7,7 @@ describe('normalizeProvider', () => {
     expect(normalizeProvider('claude')).toBe('anthropic');
     expect(normalizeProvider('codex')).toBe('openai');
     expect(normalizeProvider('gemini')).toBe('google');
+    expect(normalizeProvider('grok')).toBe('xai');
   });
 
   it('lowercases and trims unknown values without rewriting them', () => {
@@ -23,5 +24,6 @@ describe('getProviderHelpText', () => {
     expect(help).toContain('anthropic (alias: claude)');
     expect(help).toContain('openai (alias: codex)');
     expect(help).toContain('google (alias: gemini)');
+    expect(help).toContain('xai (alias: grok)');
   });
 });

--- a/packages/cloud/src/connect.ts
+++ b/packages/cloud/src/connect.ts
@@ -19,6 +19,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
   claude: 'anthropic',
   codex: 'openai',
   gemini: 'google',
+  grok: 'xai',
 };
 
 export function getProviderHelpText(): string {
@@ -42,7 +43,7 @@ export interface ConnectProviderIo {
 }
 
 export interface ConnectProviderOptions {
-  /** Provider id or alias (`anthropic`/`claude`, `openai`/`codex`, `google`/`gemini`, …). */
+  /** Provider id or alias (`anthropic`/`claude`, `openai`/`codex`, `google`/`gemini`, `xai`/`grok`, …). */
   provider: string;
   /** Override the Cloud API URL. Defaults to `defaultApiUrl()`. */
   apiUrl?: string;

--- a/packages/cloud/src/permissions.ts
+++ b/packages/cloud/src/permissions.ts
@@ -16,6 +16,7 @@ export type AgentCli =
   | 'goose'
   | 'opencode'
   | 'droid'
+  | 'grok'
   | 'cursor'
   | 'cursor-agent'
   | 'agent'

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -205,7 +205,15 @@ export type GetPatchesResponse = {
   patches: Record<string, { patch: string; hasChanges: boolean }>;
 };
 
-export const SUPPORTED_PROVIDERS = ['anthropic', 'openai', 'google', 'cursor', 'opencode', 'droid'] as const;
+export const SUPPORTED_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'google',
+  'xai',
+  'cursor',
+  'opencode',
+  'droid',
+] as const;
 
 export const REFRESH_WINDOW_MS = 60_000;
 export const AUTH_FILE_PATH = path.join(os.homedir(), '.agent-relay', 'cloud-auth.json');

--- a/packages/config/src/cli-auth-config.test.ts
+++ b/packages/config/src/cli-auth-config.test.ts
@@ -19,4 +19,12 @@ describe('CLI auth config', () => {
 
     expect(CLI_AUTH_CONFIG.opencode.successPatterns.some((pattern) => pattern.test(transcript))).toBe(true);
   });
+
+  it('configures Grok auth through the xAI provider', () => {
+    expect(CLI_AUTH_CONFIG.xai.command).toBe('grok');
+    expect(CLI_AUTH_CONFIG.xai.args).toEqual(['login']);
+    expect(CLI_AUTH_CONFIG.xai.deviceFlowArgs).toEqual(['login', '--device-auth']);
+    expect(CLI_AUTH_CONFIG.xai.credentialPath).toBe('~/.grok/auth.json');
+    expect(CLI_AUTH_CONFIG.xai.installCommand).toContain('https://x.ai/cli/install.sh');
+  });
 });

--- a/packages/config/src/cli-auth-config.ts
+++ b/packages/config/src/cli-auth-config.ts
@@ -247,6 +247,47 @@ export const CLI_AUTH_CONFIG: Record<string, CLIAuthConfig> = {
     ],
     successPatterns: [/success/i, /authenticated/i, /logged\s*in/i, /ready/i],
   },
+  xai: {
+    command: 'grok',
+    args: ['login'],
+    deviceFlowArgs: ['login', '--device-auth'],
+    supportsDeviceFlow: true,
+    urlPattern: /(https:\/\/[^\s]+)/,
+    credentialPath: '~/.grok/auth.json',
+    displayName: 'Grok',
+    installCommand:
+      'mkdir -p "$HOME/.local/bin" && curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR="$HOME/.local/bin" bash',
+    waitTimeout: 30000,
+    prompts: [
+      {
+        pattern: /open.*browser|press.*enter|sign\s*in|log\s*in|authenticate/i,
+        response: '\r',
+        delay: 200,
+        description: 'Login prompt',
+      },
+      {
+        pattern: /device\s*code|verification\s*code|one-time\s*code/i,
+        response: '\r',
+        delay: 200,
+        description: 'Device code prompt',
+      },
+    ],
+    successPatterns: [/success/i, /authenticated/i, /logged\s*in/i, /signed\s*in/i],
+    errorPatterns: [
+      {
+        pattern: /auth.*failed|authentication\s*error|oauth\s*error|invalid\s*(?:code|token)/i,
+        message: 'Grok authentication failed',
+        recoverable: true,
+        hint: 'Please try logging in again. In SSH or container environments, use the device-code flow.',
+      },
+      {
+        pattern: /network\s*error|ENOTFOUND|ECONNREFUSED|timeout/i,
+        message: 'Network error during Grok authentication',
+        recoverable: true,
+        hint: 'Please check network access to auth.x.ai and cli-chat-proxy.grok.com, then try again.',
+      },
+    ],
+  },
   opencode: {
     command: 'opencode',
     args: ['auth', 'login'],

--- a/packages/sdk-py/src/agent_relay/types.py
+++ b/packages/sdk-py/src/agent_relay/types.py
@@ -32,7 +32,7 @@ SwarmPattern = Literal[
     "review-loop",
 ]
 
-AgentCli = Literal["claude", "codex", "gemini", "aider", "goose", "opencode", "droid", "cursor", "cursor-agent", "agent"]
+AgentCli = Literal["claude", "codex", "gemini", "grok", "aider", "goose", "opencode", "droid", "cursor", "cursor-agent", "agent"]
 AgentStatus = Literal["healthy", "restarting", "dead", "released"]
 CrashCategory = Literal["oom", "segfault", "error", "signal", "unknown"]
 WorkflowOnError = Literal["fail", "skip", "retry"]

--- a/packages/sdk/src/cli-registry.ts
+++ b/packages/sdk/src/cli-registry.ts
@@ -40,6 +40,7 @@ export interface CliDefinition {
  */
 export const COMMON_SEARCH_PATHS = [
   '~/.local/bin',
+  '~/.grok/bin',
   '~/.opencode/bin',
   '~/.claude/local',
   '/usr/local/bin',
@@ -84,6 +85,12 @@ const CLI_REGISTRY: Record<AgentCli, CliDefinition> = {
   droid: {
     binaries: ['droid'],
     nonInteractiveArgs: (task, extra = []) => ['exec', task, ...extra],
+  },
+  grok: {
+    binaries: ['grok'],
+    nonInteractiveArgs: (task, extra = []) => ['-p', task, ...extra],
+    bypassFlag: '--always-approve',
+    searchPaths: ['~/.grok/bin'],
   },
   aider: {
     binaries: ['aider'],

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -133,6 +133,7 @@ const DEFAULT_AGENT_NAMES: Record<string, string> = {
   droid: 'Droid',
   gemini: 'Gemini',
   goose: 'Goose',
+  grok: 'Grok',
   opencode: 'OpenCode',
 };
 


### PR DESCRIPTION
## Summary
- add xAI/Grok to CLI auth config, provider aliases, supported provider lists, and SDK CLI registries
- configure Relay MCP for Grok via `grok mcp add` with Relay env vars and track `~/.grok/config.toml` side effects
- include Grok in TS/Python SDK CLI types and worker PATH lookup

## Tests
- `npm --prefix packages/config test -- cli-auth-config.test.ts`
- `npm test -- --run packages/cloud/src/connect.test.ts`
- `npm test -- --run packages/cli/src/cli/commands/cloud.test.ts`
- `cargo test -p agent-relay-broker grok_mcp_add_args_use_equals_form_for_dash_args`
- `npm run build:config && npm --prefix packages/cloud run build`
- `npm --prefix packages/github-primitive run build && npm --prefix packages/slack-primitive run build && npm run build:utils && npm run build:trajectory && npm run build:policy && npm run build:hooks && npm run build:memory && npm run build:telemetry && npm run build:sdk && cd packages/cli && npx tsc --noEmit`