### PR TITLE
Fix web deploy: serve the Pear hero image with a plain img

### DIFF
--- a/web/app/pear/page.tsx
+++ b/web/app/pear/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
 
 import { GitHubStarsBadge } from '../../components/GitHubStars';
@@ -166,18 +165,16 @@ export default function PearPage() {
 
           {/* Product screenshot */}
           <div className={s.mockWrap}>
-            <Image
+            {/* Plain img: the SST/OpenNext image optimizer has no working sharp
+                runtime, so next/image's /_next/image endpoint 500s. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
               className={s.shot}
               src="/img/pear-app.png"
               alt="Pear desktop app: the claude-1 and codex-1 agents coordinating in the #general channel"
               width={2342}
               height={1744}
-              sizes="(max-width: 64rem) 100vw, 64rem"
-              priority
-              // Served as-is: the SST/OpenNext image optimizer has no working
-              // sharp runtime, so /_next/image 500s. unoptimized serves the
-              // static asset directly.
-              unoptimized
+              loading="eager"
             />
           </div>
         </section>

--- a/web/app/pear/page.tsx
+++ b/web/app/pear/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import pearShot from '../../public/img/pear-app.png';
 import { GitHubStarsBadge } from '../../components/GitHubStars';
 import { SiteFooter } from '../../components/SiteFooter';
 import { SiteNav } from '../../components/SiteNav';
@@ -169,8 +168,10 @@ export default function PearPage() {
           <div className={s.mockWrap}>
             <Image
               className={s.shot}
-              src={pearShot}
+              src="/img/pear-app.png"
               alt="Pear desktop app: the claude-1 and codex-1 agents coordinating in the #general channel"
+              width={2342}
+              height={1744}
               sizes="(max-width: 64rem) 100vw, 64rem"
               priority
             />

--- a/web/app/pear/page.tsx
+++ b/web/app/pear/page.tsx
@@ -174,6 +174,10 @@ export default function PearPage() {
               height={1744}
               sizes="(max-width: 64rem) 100vw, 64rem"
               priority
+              // Served as-is: the SST/OpenNext image optimizer has no working
+              // sharp runtime, so /_next/image 500s. unoptimized serves the
+              // static asset directly.
+              unoptimized
             />
           </div>
         </section>


### PR DESCRIPTION
## Problem

The production deploy of the Pear landing page failed at build:

```
./public/img/pear-app.png
Error: Could not load the "sharp" module using the linux-x64 runtime
```

`next/image` with a **static import** makes Next generate a blur placeholder at build time via `sharp`. The committed lockfile only carries the **darwin** sharp binaries (generated on macOS), so `npm ci` on the linux CI runner can't load sharp.

## What didn't work

- **Installing sharp in CI**: any fresh `npm install` in this monorepo re-resolves the tree (lockfile built with lenient peer resolution due to a React 18/19 `@lobehub/*` conflict) and prunes 360+ real packages — breaks the build.
- **`next/image` with runtime optimization**: fixes the build, but the SST/OpenNext image-optimizer Lambda *also* has no working sharp — verified `/_next/image?...` returns **HTTP 500** on the preview, so the hero would be broken in production.

## Fix

sharp is unavailable in **both** the build runner and the Lambda runtime, so `next/image` can't optimize the screenshot in this setup anyway. Drop `next/image` and serve the static `/img/pear-app.png` asset with a plain `<img>` (explicit dimensions, `loading="eager"`). No sharp at build or runtime; no workflow or lockfile changes.

Tradeoff: the screenshot is served as-is (~880 KB) without responsive resizing — fine for a single hero image.

## Verification

- `next build` passes; `/pear` prerenders (and the page bundle shrinks now that the next/image client runtime is gone).
- The earlier preview deploy of this branch already served the static asset at HTTP 200 with the page emitting a plain asset URL (no `/_next/image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)