### PR TITLE
Serve README at llm.txt

### DIFF
--- a/web/app/llm.txt/route.ts
+++ b/web/app/llm.txt/route.ts
@@ -1,0 +1,12 @@
+import readme from '../../../README.md?raw';
+
+export const dynamic = 'force-static';
+
+export function GET() {
+  return new Response(readme, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Add a static /llm.txt route in the web app
- Serve the repository README.md through that route so llm.txt stays aligned with the canonical repo README instead of maintaining separate text
- Return the README as text/plain with a one-day public cache

## Verification
- npm run build (web)
- curl -i http://127.0.0.1:3111/llm.txt returned 200 OK, text/plain; charset=utf-8, and README content