### PR TITLE
Fix publish checks for harness-driver broker path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -461,13 +461,13 @@ jobs:
   # mocking. Each matrix leg:
   #   1. Stages the platform's broker binary into its package tree and
   #      injects os/cpu so the package validates like the published one.
-  #   2. `npm pack`s the SDK (with packages/sdk/bin emptied so the SDK
-  #      tarball cannot fall back to a bundled binary).
+  #   2. `npm pack`s the harness driver and SDK (with packages/sdk/bin emptied
+  #      so the SDK tarball cannot fall back to a bundled binary).
   #   3. `npm pack`s the matching broker package.
-  #   4. Installs both tarballs into a scratch project.
+  #   4. Installs the tarballs into a scratch project.
   #   5. Asserts getBrokerBinaryPath() resolves through the optional-dep
   #      package and returns an executable file.
-  #   6. Runs AgentRelayClient.spawn() end-to-end and shuts it down.
+  #   6. Runs HarnessDriverClient.spawn() end-to-end and shuts it down.
   # Gates publish-broker-packages — we do not ship if any platform fails.
   smoke-broker-packages:
     name: Smoke ${{ matrix.platform }}
@@ -560,7 +560,7 @@ jobs:
             fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
           "
 
-      - name: Pack SDK, broker, and internal deps
+      - name: Pack harness driver, SDK, and broker
         shell: bash
         run: |
           set -euo pipefail
@@ -572,16 +572,9 @@ jobs:
           # resolution path instead of the legacy bundled fallback.
           rm -rf packages/sdk/bin
           mkdir -p packages/sdk/bin
+          (cd packages/harness-driver && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd packages/sdk && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           (cd "packages/${{ matrix.broker_pkg }}" && npm pack --ignore-scripts --pack-destination "$TARBALLS")
-          # The build job bumped every workspace to NEW_VERSION. The SDK pins
-          # several internal @agent-relay/* packages at that exact version,
-          # none of which are on the registry yet at this point in the
-          # workflow — so pack them locally and install them alongside the
-          # SDK. Keep this list in sync with packages/sdk/package.json's
-          # `dependencies` whenever a new internal dep is added.
-          (cd packages/cloud && npm pack --ignore-scripts --pack-destination "$TARBALLS")
-          (cd packages/config && npm pack --ignore-scripts --pack-destination "$TARBALLS")
           ls -lh "$TARBALLS"
 
       - name: Install tarballs into scratch project
@@ -593,13 +586,12 @@ jobs:
           echo "SCRATCH=$SCRATCH" >> "$GITHUB_ENV"
           cd "$SCRATCH"
           npm init -y --silent >/dev/null
+          HARNESS_DRIVER_TGZ=$(ls "$TARBALLS"/agent-relay-harness-driver-*.tgz | head -n1)
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
           BROKER_TGZ=$(ls "$TARBALLS"/agent-relay-broker-${{ matrix.platform }}-*.tgz | head -n1)
-          CLOUD_TGZ=$(ls "$TARBALLS"/agent-relay-cloud-*.tgz | head -n1)
-          CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
-          echo "Installing $SDK_TGZ + $BROKER_TGZ + $CLOUD_TGZ + $CONFIG_TGZ"
+          echo "Installing $HARNESS_DRIVER_TGZ + $SDK_TGZ + $BROKER_TGZ"
           npm install --ignore-scripts --no-audit --no-fund \
-            "$SDK_TGZ" "$BROKER_TGZ" "$CLOUD_TGZ" "$CONFIG_TGZ"
+            "$HARNESS_DRIVER_TGZ" "$SDK_TGZ" "$BROKER_TGZ"
           ls node_modules/@agent-relay/
 
       - name: Resolver smoke — getBrokerBinaryPath()
@@ -607,7 +599,7 @@ jobs:
         run: |
           cd "$SCRATCH"
           node --input-type=module -e "
-            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
             import { accessSync, constants } from 'node:fs';
             const expectedPkg = getOptionalDepPackageName();
             const p = getBrokerBinaryPath();
@@ -622,19 +614,19 @@ jobs:
             console.log('OK: resolver returned executable binary from optional-dep package');
           "
 
-      - name: Spawn smoke — AgentRelayClient.spawn()
+      - name: Spawn smoke — HarnessDriverClient.spawn()
         shell: bash
         run: |
           cd "$SCRATCH"
           node --input-type=module -e "
-            import { AgentRelayClient } from '@agent-relay/sdk';
-            const client = await AgentRelayClient.spawn({
+            import { HarnessDriverClient } from '@agent-relay/harness-driver';
+            const client = await HarnessDriverClient.spawn({
               cwd: process.cwd(),
               channels: ['general'],
               startupTimeoutMs: 45000,
               onStderr: (line) => console.error('[broker]', line),
             });
-            console.log('OK: AgentRelayClient.spawn() returned');
+            console.log('OK: HarnessDriverClient.spawn() returned');
             await client.shutdown();
             console.log('OK: client.shutdown() completed');
           " || { echo 'SPAWN_FAILED'; exit 1; }
@@ -648,19 +640,17 @@ jobs:
           mkdir -p "$NEGATIVE"
           cd "$NEGATIVE"
           npm init -y --silent >/dev/null
+          HARNESS_DRIVER_TGZ=$(ls "$TARBALLS"/agent-relay-harness-driver-*.tgz | head -n1)
           SDK_TGZ=$(ls "$TARBALLS"/agent-relay-sdk-*.tgz | head -n1)
-          CLOUD_TGZ=$(ls "$TARBALLS"/agent-relay-cloud-*.tgz | head -n1)
-          CONFIG_TGZ=$(ls "$TARBALLS"/agent-relay-config-*.tgz | head -n1)
-          # Install SDK + every internal required dep whose bumped version
-          # isn't on the registry yet, but skip the broker optional deps
-          # entirely. The resolver should return null and spawn() should
-          # throw the clear error.
+          # Install harness driver and SDK, but skip the broker optional deps
+          # entirely. The resolver should return null and spawn() should throw
+          # the clear error.
           npm install --ignore-scripts --no-audit --no-fund --no-optional \
-            "$SDK_TGZ" "$CLOUD_TGZ" "$CONFIG_TGZ"
+            "$HARNESS_DRIVER_TGZ" "$SDK_TGZ"
           node --input-type=module -e "
-            import { AgentRelayClient } from '@agent-relay/sdk';
+            import { HarnessDriverClient } from '@agent-relay/harness-driver';
             try {
-              await AgentRelayClient.spawn({ cwd: process.cwd() });
+              await HarnessDriverClient.spawn({ cwd: process.cwd() });
               console.error('FAIL: spawn() should have thrown');
               process.exit(1);
             } catch (err) {
@@ -1432,14 +1422,14 @@ jobs:
       - name: Update npm for OIDC support
         run: npm install -g npm@latest
 
-      - name: Wait for root internal dependencies
+      - name: Wait for CLI internal dependencies
         if: github.event.inputs.dry_run != 'true'
         shell: bash
         run: |
           set -euo pipefail
           mapfile -t INTERNAL_DEPS < <(node --input-type=module -e "
             import fs from 'node:fs';
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const pkg = JSON.parse(fs.readFileSync('packages/cli/package.json', 'utf8'));
             const deps = Object.entries(pkg.dependencies ?? {})
               .filter(([name]) => name.startsWith('@agent-relay/'))
               .map(([name, version]) => name + '@' + version);
@@ -1447,7 +1437,7 @@ jobs:
           ")
 
           if [ "${#INTERNAL_DEPS[@]}" -eq 0 ]; then
-            echo "No @agent-relay/* root dependencies to verify."
+            echo "No @agent-relay/* CLI dependencies to verify."
             exit 0
           fi
 
@@ -1462,7 +1452,7 @@ jobs:
             done
 
             if [ "${#missing[@]}" -eq 0 ]; then
-              echo "All root @agent-relay/* dependencies are available on npm."
+              echo "All CLI @agent-relay/* dependencies are available on npm."
               exit 0
             fi
 
@@ -1470,7 +1460,7 @@ jobs:
             sleep 10
           done
 
-          echo "Timed out waiting for root @agent-relay/* dependencies:"
+          echo "Timed out waiting for CLI @agent-relay/* dependencies:"
           printf '  - %s\n' "${missing[@]}"
           exit 1
 
@@ -1989,23 +1979,20 @@ jobs:
     with:
       version: ${{ needs.build.outputs.new_version }}
 
-  # Post-publish cross-platform verification of @agent-relay/sdk and its
-  # per-platform broker optional deps. Installs from the registry on every
-  # target (macOS arm64/x64, Linux x64/arm64, Windows x64) and runs spawn
+  # Post-publish cross-platform verification of @agent-relay/harness-driver and
+  # its per-platform broker optional deps. Installs from the registry on every
+  # target (macOS arm64, Linux x64/arm64, Windows x64) and runs spawn
   # end-to-end. Catches registry-round-trip failures that smoke-broker-packages
   # can't see (missing/wrong os/cpu on published manifests, CDN propagation).
   verify-publish-sdk:
-    name: Verify Published SDK (Cross-Platform)
-    # publish-packages and publish-sdk-only are mutually exclusive: the first
-    # runs on package='all', the second on package='sdk'. Depend on both and
-    # accept a success from either so this gate fires for both release flows.
+    name: Verify Published Harness Driver (Cross-Platform)
     needs: [build, publish-broker-packages, publish-packages, publish-sdk-only]
     if: |
       always() &&
       github.event.inputs.dry_run != 'true' &&
-      (github.event.inputs.package == 'all' || github.event.inputs.package == 'sdk') &&
+      github.event.inputs.package == 'all' &&
       needs.publish-broker-packages.result == 'success' &&
-      (needs.publish-packages.result == 'success' || needs.publish-sdk-only.result == 'success')
+      needs.publish-packages.result == 'success'
     uses: ./.github/workflows/verify-publish-sdk.yml
     with:
       version: ${{ needs.build.outputs.new_version }}

--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -1,7 +1,7 @@
-name: Verify Published SDK (Cross-Platform)
+name: Verify Published Harness Driver (Cross-Platform)
 
-# Clean-room verification that @agent-relay/sdk — freshly installed from the
-# public registry on each target OS/arch — pulls in the correct
+# Clean-room verification that @agent-relay/harness-driver — freshly installed
+# from the public registry on each target OS/arch — pulls in the correct
 # @agent-relay/broker-<platform>-<arch> optional dep and actually spawns a
 # broker end-to-end. This is the last line of defense for the optional-dep
 # pattern: pre-publish the smoke-broker-packages job exercises the logic via
@@ -22,14 +22,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'SDK version to verify (default: latest)'
+        description: 'Package version to verify (default: latest)'
         required: false
         type: string
         default: 'latest'
   workflow_call:
     inputs:
       version:
-        description: 'SDK version to verify'
+        description: 'Package version to verify'
         required: false
         type: string
         default: 'latest'
@@ -39,7 +39,7 @@ env:
 
 jobs:
   verify-sdk:
-    name: Verify @agent-relay/sdk (${{ matrix.platform }})
+    name: Verify @agent-relay/harness-driver (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -77,14 +77,14 @@ jobs:
             VERSION="latest"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "spec=@agent-relay/sdk@$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Using spec: @agent-relay/sdk@$VERSION"
+          echo "spec=@agent-relay/harness-driver@$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using spec: @agent-relay/harness-driver@$VERSION"
 
       # Registry/CDN propagation can lag the publish by up to a minute. Retry
       # with exponential backoff so the first run after publish doesn't miss.
-      # The SDK pins internal runtime deps to the exact same release version;
-      # wait for those too so npm/Bun installs cannot resolve a half-published
-      # SDK that later fails at runtime.
+      # The harness driver pins internal runtime deps to the exact same
+      # release version; wait for those too so npm/Bun installs cannot resolve
+      # a half-published harness driver that later fails at runtime.
       #
       # The matching broker package is included because npm silently skips
       # optionalDependencies that 404 — if the broker tarball hasn't reached
@@ -92,7 +92,7 @@ jobs:
       # no broker installed and the next step would fail confusingly.
       # `npm view <pkg> version` and the actual tarball fetch can hit
       # different caches, so additionally probe the tarball URL directly.
-      - name: Wait for SDK, internal deps, and matching broker on registry
+      - name: Wait for harness driver, internal deps, and matching broker on registry
         shell: bash
         run: |
           set -euo pipefail
@@ -106,8 +106,7 @@ jobs:
 
           PACKAGES=(
             "$SPEC"
-            "@agent-relay/config@$VERSION"
-            "@agent-relay/cloud@$VERSION"
+            "@agent-relay/sdk@$VERSION"
             "${EXPECTED_BROKER}@$VERSION"
           )
 
@@ -136,7 +135,7 @@ jobs:
             fi
 
             if [ "${#missing[@]}" -eq 0 ]; then
-              echo "registry has SDK, internal deps, and ${EXPECTED_BROKER} for $VERSION"
+              echo "registry has harness driver, internal deps, and ${EXPECTED_BROKER} for $VERSION"
               exit 0
             fi
 
@@ -145,10 +144,10 @@ jobs:
             sleep "$WAIT"
           done
 
-          echo "FAIL: registry never surfaced all SDK packages for $VERSION"
+          echo "FAIL: registry never surfaced all harness driver packages for $VERSION"
           exit 1
 
-      - name: Install @agent-relay/sdk into scratch project
+      - name: Install @agent-relay/harness-driver into scratch project
         shell: bash
         run: |
           set -euo pipefail
@@ -163,17 +162,17 @@ jobs:
           echo "=== installed @agent-relay/ packages ==="
           ls node_modules/@agent-relay/
 
-      - name: Verify SDK public entrypoint imports
+      - name: Verify harness driver public entrypoint imports
         shell: bash
         run: |
           cd "$SCRATCH"
           node --input-type=module -e "
-            const sdk = await import('@agent-relay/sdk');
-            if (!sdk.AgentRelayClient) {
-              console.error('FAIL: @agent-relay/sdk missing AgentRelayClient export');
+            const harnessDriver = await import('@agent-relay/harness-driver');
+            if (typeof harnessDriver.HarnessDriverClient !== 'function') {
+              console.error('FAIL: @agent-relay/harness-driver missing HarnessDriverClient export');
               process.exit(1);
             }
-            console.log('OK: @agent-relay/sdk public entrypoint imports');
+            console.log('OK: @agent-relay/harness-driver public entrypoint imports');
           "
 
       - name: Verify only the matching broker package was installed
@@ -212,7 +211,7 @@ jobs:
         run: |
           cd "$SCRATCH"
           node --input-type=module -e "
-            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
             import { accessSync, constants } from 'node:fs';
             const expected = getOptionalDepPackageName();
             const p = getBrokerBinaryPath();
@@ -229,19 +228,19 @@ jobs:
             console.log('OK: resolver returned executable binary from optional-dep package');
           "
 
-      - name: Spawn smoke — AgentRelayClient.spawn()
+      - name: Spawn smoke — HarnessDriverClient.spawn()
         shell: bash
         run: |
           cd "$SCRATCH"
           node --input-type=module -e "
-            import { AgentRelayClient } from '@agent-relay/sdk';
-            const client = await AgentRelayClient.spawn({
+            import { HarnessDriverClient } from '@agent-relay/harness-driver';
+            const client = await HarnessDriverClient.spawn({
               cwd: process.cwd(),
               channels: ['general'],
               startupTimeoutMs: 45000,
               onStderr: (line) => console.error('[broker]', line),
             });
-            console.log('OK: AgentRelayClient.spawn() returned');
+            console.log('OK: HarnessDriverClient.spawn() returned');
             await client.shutdown();
             console.log('OK: client.shutdown() completed');
           "

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -163,8 +163,8 @@ jobs:
 
       # Test: broker binary resolution after installing agent-relay.
       # The broker is delivered as a platform-specific optional-dep of
-      # @agent-relay/sdk (itself a regular dep of agent-relay), so npm
-      # hoists both to node_modules/@agent-relay/ at install time.
+      # @agent-relay/harness-driver (itself a regular dep of agent-relay), so
+      # npm hoists both to node_modules/@agent-relay/ at install time.
       - name: 'Test: broker binary resolves after npm install agent-relay'
         run: |
           rm -rf ~/.npm/_npx 2>/dev/null || true
@@ -174,7 +174,7 @@ jobs:
           npm init -y --silent >/dev/null
           npm install --no-audit --no-fund "${{ steps.pkg.outputs.spec }}"
           node --input-type=module -e "
-            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
             import { accessSync, constants } from 'node:fs';
             const expected = getOptionalDepPackageName();
             const p = getBrokerBinaryPath();
@@ -221,15 +221,15 @@ jobs:
             exit 1
           fi
 
-      # Test 4: Broker binary resolution via SDK resolver.
+      # Test 4: Broker binary resolution via harness driver resolver.
       # The broker ships as a platform-specific optional-dep package
       # (@agent-relay/broker-<platform>-<arch>); getBrokerBinaryPath()
-      # is the canonical way clients find it.
+      # is the canonical way harness owners find it.
       - name: 'Test: broker binary resolves and runs'
         run: |
           cd /tmp/test-project
           node --input-type=module -e "
-            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
             import { accessSync, constants } from 'node:fs';
             import { execFileSync } from 'node:child_process';
             const expected = getOptionalDepPackageName();
@@ -309,14 +309,14 @@ jobs:
           fi
 
       # Broker resolution on macOS arm64. Under the optional-dep model the
-      # SDK's resolver finds the binary at
+      # harness driver's resolver finds the binary at
       # node_modules/@agent-relay/broker-darwin-arm64/bin/agent-relay-broker;
       # running it also exercises macOS code signing end-to-end.
       - name: 'Test: broker binary resolves and runs (macOS arm64)'
         run: |
           cd /tmp/test-project
           node --input-type=module -e "
-            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+            import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
             import { accessSync, constants } from 'node:fs';
             import { execFileSync } from 'node:child_process';
             const expected = getOptionalDepPackageName();

--- a/scripts/post-publish-verify/verify-install.sh
+++ b/scripts/post-publish-verify/verify-install.sh
@@ -221,15 +221,15 @@ else
 fi
 
 # ============================================
-# Test 4: broker binary resolution via SDK resolver
+# Test 4: broker binary resolution via harness driver resolver
 # ============================================
 # The broker is delivered as a platform-specific optional dependency
 # (@agent-relay/broker-<platform>-<arch>). getBrokerBinaryPath() is the
-# canonical way clients locate it at runtime.
+# canonical way harness owners locate it at runtime.
 log_header "Test 4: broker binary resolution"
 
 BROKER_TEST=$(node --input-type=module -e "
-import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/sdk/broker-path';
+import { getBrokerBinaryPath, getOptionalDepPackageName } from '@agent-relay/harness-driver/broker-path';
 import { accessSync, constants } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 try {


### PR DESCRIPTION
## Summary
- Update post-publish broker resolver smoke tests to import from @agent-relay/harness-driver/broker-path.
- Make the root CLI publish guard read packages/cli/package.json so it waits for exact-version @agent-relay/* runtime deps before publishing agent-relay.
- Move cross-platform broker verification from the removed SDK broker surface to @agent-relay/harness-driver and HarnessDriverClient.spawn.

## Verification
- bash -n scripts/post-publish-verify/verify-install.sh
- npm run build:harness-driver
- npm --prefix packages/harness-driver run check
- node --input-type=module -e "import { getBrokerBinaryPath, getOptionalDepPackageName } from @agent-relay/harness-driver/broker-path; console.log(getOptionalDepPackageName()); console.log(typeof getBrokerBinaryPath);"
- npx prettier --check .github/workflows/publish.yml .github/workflows/verify-publish.yml .github/workflows/verify-publish-sdk.yml
- node --input-type=module -e "import fs from node:fs; const pkg = JSON.parse(fs.readFileSync(packages/cli/package.json, utf8)); const deps = Object.entries(pkg.dependencies ?? {}).filter(([name]) => name.startsWith(@agent-relay/)).map(([name, version]) => name + @ + version); console.log(deps.join(\n)); if (deps.length < 5) process.exit(1);"