### PR TITLE
Fix local agent list hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `agent-relay local agent list` and `local metrics` now connect only to an existing local broker, so read-only commands no longer start an empty broker and hang after printing results.
 - `@agent-relay/cloud`: CLI browser login ignores stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not shown a false hosted error or aborted before the real OAuth callback returns.
 - Root package builds now compile `@agent-relay/cloud` before SDK and CLI packages that consume its generated declarations, without rewriting a tracked broker binary.
 - `agent-relay-broker` harness configs now report harness PIDs instead of wrapper worker PIDs, validate app-server protocol/auth/host settings at spawn, and give app-server release requests time to finish.

--- a/packages/cli/src/cli/commands/core.ts
+++ b/packages/cli/src/cli/commands/core.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { Command } from 'commander';
 
 import { getProjectPaths, loadTeamsConfig } from '@agent-relay/config';
-import type { BrokerInitArgs } from '@agent-relay/harness-driver';
+import { HarnessDriverClient, type BrokerInitArgs } from '@agent-relay/harness-driver';
 import { checkForUpdates, generateAgentName } from '@agent-relay/utils';
 
 import { runDownCommand, runStatusCommand, runUpCommand } from '../lib/broker-lifecycle.js';
@@ -387,13 +387,16 @@ export function registerCoreCommands(program: Command, overrides: Partial<CoreDe
     .description('Show resource usage for the local broker and its agents')
     .option('--agent <name>', 'Filter to a single agent')
     .action(async (options: { agent?: string }) => {
+      let client: HarnessDriverClient | undefined;
       try {
-        const client = await createRuntimeClient({ cwd: process.cwd(), preferConnect: true });
+        client = HarnessDriverClient.connect({ cwd: process.cwd() });
         const metrics = await client.getMetrics(options.agent);
         deps.log(JSON.stringify(metrics, null, 2));
       } catch (err) {
         deps.error(err instanceof Error ? err.message : String(err));
         deps.exit(1);
+      } finally {
+        client?.disconnect();
       }
     });
 }

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -1,6 +1,14 @@
 import { Command } from 'commander';
 import { describe, expect, it, vi } from 'vitest';
 
+const harnessConnectMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@agent-relay/harness-driver', () => ({
+  HarnessDriverClient: {
+    connect: harnessConnectMock,
+  },
+}));
+
 import { registerLocalAgentCommands, type LocalAgentDependencies } from './local-agent.js';
 
 function harness(overrides: Partial<LocalAgentDependencies> = {}) {
@@ -54,6 +62,29 @@ describe('local agent subtree', () => {
     const { program, client } = harness();
     await program.parseAsync(['local', 'agent', 'list'], { from: 'user' });
     expect(client.listAgents).toHaveBeenCalled();
+  });
+
+  it('list connects to the existing project broker instead of spawning one', async () => {
+    const client = {
+      listAgents: vi.fn(async () => []),
+      disconnect: vi.fn(),
+    };
+    harnessConnectMock.mockReturnValueOnce(client);
+    const log = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    const group = program.command('local');
+    registerLocalAgentCommands(group, {
+      cwd: () => '/tmp/project',
+      log,
+    });
+
+    await program.parseAsync(['local', 'agent', 'list'], { from: 'user' });
+
+    expect(harnessConnectMock).toHaveBeenCalledWith({ cwd: '/tmp/project' });
+    expect(client.listAgents).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('[]');
+    expect(client.disconnect).toHaveBeenCalled();
   });
 
   it('release calls client.release', async () => {

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -1,9 +1,9 @@
 import type { Command } from 'commander';
 
-import type { HarnessDriverClient } from '@agent-relay/harness-driver';
+import { HarnessDriverClient } from '@agent-relay/harness-driver';
 
 import { defaultExit } from '../lib/exit.js';
-import { createRuntimeClient, spawnAgentWithClient } from '../lib/client-factory.js';
+import { spawnAgentWithClient } from '../lib/client-factory.js';
 import { attachDrive } from '../lib/attach-drive.js';
 import { attachView } from '../lib/attach-view.js';
 import { attachPassthrough } from '../lib/attach-passthrough.js';
@@ -44,7 +44,7 @@ export interface LocalAgentDependencies {
 
 function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAgentDependencies {
   return {
-    connect: (cwd: string) => createRuntimeClient({ cwd, preferConnect: true }),
+    connect: async (cwd: string) => HarnessDriverClient.connect({ cwd }),
     attach: runAttach,
     cwd: () => process.cwd(),
     log: (...args: unknown[]) => console.log(...args),
@@ -65,6 +65,8 @@ async function run(
   } catch (err) {
     deps.error(err instanceof Error ? err.message : String(err));
     deps.exit(1);
+  } finally {
+    client?.disconnect?.();
   }
 }
 


### PR DESCRIPTION
## **User description**
## Summary
- make local agent management commands connect to an existing broker instead of spawning an empty broker for read-only/list-style calls
- disconnect one-shot local agent and metrics clients after the command finishes
- add a regression test for local agent list using HarnessDriverClient.connect

## Diagnosis
`relay local agent list` was using `createRuntimeClient({ preferConnect: true })`. When no connection file existed, that helper fell back to `HarnessDriverClient.spawn()`, which started an empty broker. The command could print `[]`, but the spawned broker child, event stream, and lease timer kept the Node process alive.

## Validation
- `npm run build:core`
- `npx vitest run packages/cli/src/cli/commands/local-agent.test.ts`
- `npm --prefix packages/cli run build`
- `npx vitest run packages/cli/src/cli/commands/core.test.ts`
- `node packages/cli/dist/cli/index.js local agent list` exits immediately with the no-running-broker error in a fresh worktree


___

## **CodeAnt-AI Description**
**Stop read-only local commands from starting a broker**

### What Changed
- `local agent list` now connects to an existing local broker instead of starting a new empty one, so it finishes normally after showing the result
- `local metrics` now uses the same connect-only behavior and disconnects when done, which prevents the command from staying open after printing metrics
- Both commands now close their broker connection after use
- Added coverage for listing agents through an existing broker connection

### Impact
`✅ Fewer hangs after read-only local commands`
`✅ Faster exit for agent list`
`✅ Shorter local metrics runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
