### PR TITLE
Preserve legacy Codex MCP opt-out

### DIFF
--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -815,7 +815,7 @@ pub async fn configure_agent_relay_mcp_with_result(
     if is_codex
         && !existing_args
             .iter()
-            .any(|a| a.contains("mcp_servers.agent-relay"))
+            .any(|a| a.contains("mcp_servers.agent-relay") || a.contains("mcp_servers.relaycast"))
     {
         let mcp_command = agent_relay_mcp_command();
         // NOTE: All values passed via codex `--config` are parsed as TOML.
@@ -1853,6 +1853,27 @@ mod tests {
             vec!["--config", "check_for_update_on_startup=false"],
             "should only return update suppression when user already provided mcp_servers.agent-relay config"
         );
+    }
+
+    #[tokio::test]
+    async fn codex_opt_out_when_legacy_relaycast_config_already_in_args() {
+        let temp = tempdir().expect("tempdir");
+        let existing = vec![
+            "--config".to_string(),
+            "mcp_servers.relaycast.command=custom".to_string(),
+        ];
+        let args = super::configure_agent_relay_mcp(
+            "codex",
+            "Agent",
+            Some("rk_live_abc"),
+            None,
+            &existing,
+            temp.path(),
+        )
+        .await
+        .expect("configure codex mcp opt-out");
+
+        assert_eq!(args, vec!["--config", "check_for_update_on_startup=false"]);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## **User description**
## Summary
- keep canonical Codex MCP injection on mcp_servers.agent-relay
- also treat legacy mcp_servers.relaycast args as already configured so migration does not double-inject
- add regression coverage for the legacy opt-out path

## Test
- cargo test -p agent-relay-broker snippets


___

## **CodeAnt-AI Description**
**Preserve legacy Codex MCP opt-out**

### What Changed
- Codex no longer adds Agent Relay MCP setup when an older `mcp_servers.relaycast` config is already present.
- The existing update-suppression setting is still kept, so users avoid repeated startup prompts.
- Added coverage for the legacy config path to prevent the opt-out from breaking during migration.

### Impact
`✅ Fewer duplicate Codex MCP setups`
`✅ Smoother migration from legacy relaycast config`
`✅ Fewer startup prompts for existing users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
