### PR TITLE
Predictive echo for remote attach + interactive latency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-relay drive` and `agent-relay passthrough` add mosh-style adaptive predictive echo: printable keystrokes echo locally (underlined until the server confirms them) so typing stays responsive on high-latency/remote brokers, and stays invisible on fast local links. Reconciles against authoritative output and suspends on full-screen TUIs.
+- `@agent-relay/harness-driver` exports the host-agnostic `PredictiveEchoEngine` (with `ScreenModel`/`PredictiveEcho` contracts) so any attach UI — the CLI's headless-xterm host, or an Electron host backing it with a live `@xterm/xterm` terminal — can reuse one predictive-echo implementation. Accepts `string | Uint8Array` input and uses no Node-only APIs, so it runs in a browser/renderer.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.
 - `CORE_SIMPLIFICATION_SCOPE.md` documents the SemVer-major Agent Relay package boundary: core SDK communication, delivery, actions, and optional managed harnesses in `@agent-relay/harness-driver`.
 - `@agent-relay/sdk` adds normalized messaging, delivery, and action APIs: agents, channels, DMs, threads, reactions, inbox, events, `DeliveryRunner`, and `ActionRegistry`.
@@ -37,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `agent-relay-broker` streams interactive PTY output on a ~16ms leading-edge flush (was a fixed 100ms coalescing window), so keystroke echo and live output feel smooth instead of arriving in batches; bulk output still coalesces by size.
+- `@agent-relay/harness-driver` pipelines PTY input over its WebSocket stream (FIFO, settled by ack) instead of stop-and-wait, removing one round-trip of latency per keystroke when driving a remote agent.
 - Relay stores per-project runtime state in `.agentworkforce/relay/` (was `.agent-relay/`), and the global data/log home moves from `~/.agent-relay`, `$XDG_DATA_HOME/agent-relay`, and platform equivalents to `agentworkforce/relay`. The `~/.config/agent-relay` config directory is unchanged.
 - `agent-relay` installs and resolves dashboard UI assets under the install dir (`~/.agentworkforce/relay/dashboard`) instead of `~/.relay/dashboard`, unifying the on-disk footprint. The broker still reads `~/.relay/dashboard` as a fallback and re-downloads assets to the new location on version mismatch.
 - Upgraded relaycast to 2.x (`@relaycast/sdk` and the `relaycast` Rust crate): spawn/release now run as relaycast actions. The broker registers `spawn`/`release` actions on startup and handles `action.invoked` (reading input via the actions API and reporting completion) in place of the removed `command.invoked` protocol; `@agent-relay/openclaw` surfaces `action.invoked` instead of channel slash-commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `agent-relay drive` and `agent-relay passthrough` add mosh-style adaptive predictive echo: printable keystrokes echo locally (underlined until the server confirms them) so typing stays responsive on high-latency/remote brokers, and stays invisible on fast local links. Reconciles against authoritative output and suspends on full-screen TUIs.
-- `@agent-relay/harness-driver` exports the host-agnostic `PredictiveEchoEngine` (with `ScreenModel`/`PredictiveEcho` contracts) so any attach UI — the CLI's headless-xterm host, or an Electron host backing it with a live `@xterm/xterm` terminal — can reuse one predictive-echo implementation. Accepts `string | Uint8Array` input and uses no Node-only APIs, so it runs in a browser/renderer.
+- `agent-relay drive` and `agent-relay passthrough` add adaptive predictive echo so typing stays responsive when driving a high-latency or remote agent, and stays invisible on fast local links.
+- `@agent-relay/harness-driver` exports a reusable `PredictiveEchoEngine` so other attach UIs (CLI, Electron, browser) can share one predictive-echo implementation.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.
 - `CORE_SIMPLIFICATION_SCOPE.md` documents the SemVer-major Agent Relay package boundary: core SDK communication, delivery, actions, and optional managed harnesses in `@agent-relay/harness-driver`.
 - `@agent-relay/sdk` adds normalized messaging, delivery, and action APIs: agents, channels, DMs, threads, reactions, inbox, events, `DeliveryRunner`, and `ActionRegistry`.
@@ -39,8 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `agent-relay-broker` streams interactive PTY output on a ~16ms leading-edge flush (was a fixed 100ms coalescing window), so keystroke echo and live output feel smooth instead of arriving in batches; bulk output still coalesces by size.
-- `@agent-relay/harness-driver` pipelines PTY input over its WebSocket stream (FIFO, settled by ack) instead of stop-and-wait, removing one round-trip of latency per keystroke when driving a remote agent.
+- `agent-relay-broker` streams interactive PTY output more smoothly, so keystroke echo and live output feel responsive instead of arriving in batches.
+- `@agent-relay/harness-driver` reduces PTY input latency when driving a remote agent.
 - Relay stores per-project runtime state in `.agentworkforce/relay/` (was `.agent-relay/`), and the global data/log home moves from `~/.agent-relay`, `$XDG_DATA_HOME/agent-relay`, and platform equivalents to `agentworkforce/relay`. The `~/.config/agent-relay` config directory is unchanged.
 - `agent-relay` installs and resolves dashboard UI assets under the install dir (`~/.agentworkforce/relay/dashboard`) instead of `~/.relay/dashboard`, unifying the on-disk footprint. The broker still reads `~/.relay/dashboard` as a fallback and re-downloads assets to the new location on version mismatch.
 - Upgraded relaycast to 2.x (`@relaycast/sdk` and the `relaycast` Rust crate): spawn/release now run as relaycast actions. The broker registers `spawn`/`release` actions on startup and handles `action.invoked` (reading input via the actions API and reporting completion) in place of the removed `command.invoked` protocol; `@agent-relay/openclaw` surfaces `action.invoked` instead of channel slash-commands.

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -353,12 +353,26 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
     // across chunks; the decoder holds incomplete trailing bytes for the
     // next chunk instead of corrupting them into U+FFFD.
     let mut utf8_decoder = Utf8StreamDecoder::new();
-    // Rate-limited buffering for worker_stream emissions.
-    // Chunks are accumulated and flushed at most every 100ms or when buffer exceeds threshold.
+    // Coalesced buffering for worker_stream emissions, tuned for
+    // interactive (`drive`/`passthrough`) latency. Output flushes on a
+    // leading edge — the first chunk after an idle gap goes out
+    // immediately — then coalesces at ~60Hz during sustained bursts, or
+    // sooner when the buffer crosses the size cap. A trailing flush is
+    // armed via `stream_flush_deadline` so the last chunk of a burst
+    // reaches the client within one interval instead of waiting on a
+    // slower housekeeping tick. The size cap protects the heavy-output
+    // path (large dumps flush by size, not time), so the short interval
+    // only multiplies frame count for light interactive load, where the
+    // volume is negligible.
     let mut stream_buffer = String::new();
     let mut stream_buffer_last_flush = Instant::now();
     const STREAM_BUFFER_MAX: usize = 4096;
-    const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
+    const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(16);
+    // Armed only while output is buffered mid-burst; when `None` the
+    // corresponding select arm parks on `pending()` so idle workers incur
+    // no extra timer wakeups. Declared before the macro so the macro's
+    // mixed-site hygiene resolves it.
+    let mut stream_flush_deadline: Option<tokio::time::Instant> = None;
 
     /// Flush `stream_buffer` via a `worker_stream` frame if non-empty.
     macro_rules! flush_stream_buffer {
@@ -371,6 +385,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                 })).await;
                 stream_buffer_last_flush = Instant::now();
             }
+            stream_flush_deadline = None;
         };
     }
     let mut verification_tick = tokio::time::interval(Duration::from_millis(200));
@@ -694,7 +709,14 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                         if stream_buffer.len() >= STREAM_BUFFER_MAX
                             || stream_buffer_last_flush.elapsed() >= STREAM_FLUSH_INTERVAL
                         {
+                            // Size cap hit, or the leading edge after an idle
+                            // gap — flush now so interactive echo isn't held.
                             flush_stream_buffer!();
+                        } else if stream_flush_deadline.is_none() {
+                            // Mid-burst: arm a trailing flush so the tail of
+                            // this burst lands within one interval.
+                            stream_flush_deadline =
+                                Some(tokio::time::Instant::now() + STREAM_FLUSH_INTERVAL);
                         }
 
                         if pending_verifications.is_empty()
@@ -922,6 +944,17 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                         running = false;
                     }
                 }
+            }
+
+            // Trailing flush for the tail of an output burst. Parks on
+            // `pending()` (never wakes) whenever no flush is armed.
+            _ = async {
+                match stream_flush_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending::<()>().await,
+                }
+            }, if stream_flush_deadline.is_some() => {
+                flush_stream_buffer!();
             }
 
             _ = pending_injection_interval.tick() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "7.1.1",
+  "version": "8.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -7668,6 +7668,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -17796,45 +17805,46 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "7.1.1"
+      "version": "8.0.4"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "7.1.1",
-        "@agent-relay/config": "7.1.1",
-        "@agent-relay/harness-driver": "7.1.1",
-        "@agent-relay/sdk": "7.1.1",
-        "@agent-relay/utils": "7.1.1",
+        "@agent-relay/cloud": "8.0.4",
+        "@agent-relay/config": "8.0.4",
+        "@agent-relay/harness-driver": "8.0.4",
+        "@agent-relay/sdk": "8.0.4",
+        "@agent-relay/utils": "8.0.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^2.5.1",
+        "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
         "dotenv": "^17.2.3",
         "esbuild": "^0.27.2",
@@ -17851,9 +17861,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "dependencies": {
-        "@agent-relay/config": "7.1.1",
+        "@agent-relay/config": "8.0.4",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -17869,7 +17879,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -17882,35 +17892,35 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "7.1.1",
+        "@agent-relay/sdk": "8.0.4",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "7.1.1",
-        "@agent-relay/broker-darwin-x64": "7.1.1",
-        "@agent-relay/broker-linux-arm64": "7.1.1",
-        "@agent-relay/broker-linux-x64": "7.1.1",
-        "@agent-relay/broker-win32-x64": "7.1.1"
+        "@agent-relay/broker-darwin-arm64": "8.0.4",
+        "@agent-relay/broker-darwin-x64": "8.0.4",
+        "@agent-relay/broker-linux-arm64": "8.0.4",
+        "@agent-relay/broker-linux-x64": "8.0.4",
+        "@agent-relay/broker-win32-x64": "8.0.4"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "7.1.1",
-        "@agent-relay/sdk": "7.1.1"
+        "@agent-relay/harness-driver": "8.0.4",
+        "@agent-relay/sdk": "8.0.4"
       }
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "dependencies": {
-        "@agent-relay/config": "7.1.1"
+        "@agent-relay/config": "8.0.4"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -17919,7 +17929,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "dependencies": {
         "@relaycast/sdk": "^2.5.1"
       },
@@ -17929,14 +17939,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "7.1.1",
+      "version": "8.0.4",
       "dependencies": {
-        "@agent-relay/config": "7.1.1",
+        "@agent-relay/config": "8.0.4",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "@agent-relay/utils": "8.0.4",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@relaycast/sdk": "^2.5.1",
+    "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",
     "dotenv": "^17.2.3",
     "esbuild": "^0.27.2",
@@ -79,5 +80,6 @@
   "bugs": {
     "url": "https://github.com/AgentWorkforce/relay/issues"
   },
-  "homepage": "https://github.com/AgentWorkforce/relay#readme"
+  "homepage": "https://github.com/AgentWorkforce/relay#readme",
+  "bundleDependencies": []
 }

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -581,6 +581,9 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           if (settled) return;
           const message = err instanceof Error ? err.message : String(err);
           deps.log(`[drive] input stream send failed: ${message}`);
+          // The keystroke never reached the PTY — drop any optimistic echo
+          // for it so the screen doesn't show input the agent didn't get.
+          predictiveEcho?.rollback();
         });
         predictiveEcho?.onUserInput(outcome.forward);
       }

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -51,6 +51,8 @@ import {
   type PtyInputStreamOptions,
   type PtyInputWriteResult,
 } from '../lib/attach-broker.js';
+import { createPredictiveEcho, type CreatePredictiveEchoOptions } from './predictive-echo-screen.js';
+import type { PredictiveEcho } from '@agent-relay/harness-driver';
 
 type ExitFn = (code: number) => never;
 
@@ -102,6 +104,8 @@ export interface CliPtyInputStream {
   waitUntilOpen(): Promise<void>;
   send(data: string): Promise<PtyInputWriteResult>;
   close(code?: number, reason?: string): void;
+  /** Smoothed input→ack RTT (ms), or null before the first ack. */
+  readonly srttMs?: number | null;
 }
 
 export interface DriveDependencies {
@@ -138,6 +142,11 @@ export interface DriveDependencies {
     name: string,
     options?: PtyInputStreamOptions
   ) => CliPtyInputStream;
+  /**
+   * Builds the adaptive predictive-echo engine, or returns null to disable
+   * it (degenerate terminal). Omitted by tests that want plain pass-through.
+   */
+  createPredictiveEcho?: (opts: CreatePredictiveEchoOptions) => PredictiveEcho | null;
 }
 
 function withDefaults(overrides: Partial<DriveDependencies> = {}): DriveDependencies {
@@ -180,6 +189,7 @@ function withDefaults(overrides: Partial<DriveDependencies> = {}): DriveDependen
       },
     },
     openInputStream: (connection, name, options) => openPtyInputStream(connection, name, fetchFn, options),
+    createPredictiveEcho,
     ...overrides,
   };
 }
@@ -472,6 +482,10 @@ interface DriveSessionState {
   previousMode: InboundDeliveryMode | null;
   initialPending: number;
   initialTerminalRows: number | undefined;
+  /** Local terminal size at attach, for sizing the predictive-echo model. */
+  initialLocalSize: { rows: number; cols: number } | null;
+  /** Painted snapshot bytes, used to seed the predictive-echo model. */
+  snapshotBytes: string;
 }
 
 /**
@@ -500,6 +514,19 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
     let inputStream: CliPtyInputStream | null = null;
     const cleanupSignals: Array<() => void> = [];
 
+    // Adaptive predictive echo masks round-trip latency on remote brokers.
+    // Seeded with the snapshot so its confirmed model matches the screen.
+    const predictiveEcho =
+      deps.createPredictiveEcho?.({
+        cols: state.initialLocalSize?.cols ?? 0,
+        rows: state.initialLocalSize?.rows ?? 0,
+        write: deps.writeChunk,
+        getInputSrtt: () => inputStream?.srttMs ?? null,
+      }) ?? null;
+    if (predictiveEcho) {
+      void predictiveEcho.seed(state.snapshotBytes);
+    }
+
     const paintStatus = (): void => {
       deps.writeChunk(
         renderStatusLine({
@@ -522,6 +549,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
       const size = deps.terminal.getSize();
       if (!size) return;
       terminalRows = size.rows;
+      predictiveEcho?.onResize(size.cols, size.rows);
       void resizeWorker(connection, name, size.rows, size.cols, deps.fetch).then((res) => {
         if (!res.ok) {
           deps.log(`[drive] resize forward failed: ${res.message ?? 'unknown error'}`);
@@ -554,6 +582,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           const message = err instanceof Error ? err.message : String(err);
           deps.log(`[drive] input stream send failed: ${message}`);
         });
+        predictiveEcho?.onUserInput(outcome.forward);
       }
       for (const action of outcome.actions) {
         switch (action) {
@@ -630,6 +659,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
         }
       }
       teardownStdin();
+      predictiveEcho?.reset();
       closeInputStream();
       try {
         socket.close(1000, 'drive client exiting');
@@ -690,10 +720,17 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
       const event = classifyWsEvent(text, name);
       switch (event.kind) {
         case 'worker_stream':
-          deps.writeChunk(event.chunk);
-          // Repaint the status line so the worker's writes don't
-          // obscure it. Cheap — it's just an ANSI escape sequence.
-          paintStatus();
+          if (predictiveEcho) {
+            // The engine owns pass-through (it must restore the cursor
+            // before writing server bytes when predictions are live);
+            // repaint the status line once it has flushed.
+            void predictiveEcho.onServerOutput(event.chunk).then(paintStatus, paintStatus);
+          } else {
+            deps.writeChunk(event.chunk);
+            // Repaint the status line so the worker's writes don't
+            // obscure it. Cheap — it's just an ANSI escape sequence.
+            paintStatus();
+          }
           break;
         case 'delivery_queued':
           pending += 1;
@@ -750,9 +787,17 @@ export async function runDriveSession(
   if (!flipResult) return 1;
   const { previousMode } = flipResult;
 
+  // Tee the snapshot's painted bytes so we can seed the predictive-echo
+  // model with them — its cursor must match the real screen before we
+  // optimistically echo, or predicted glyphs land at the wrong position.
+  let snapshotBytes = '';
+  const captureWrite = (chunk: string): void => {
+    deps.writeChunk(chunk);
+    snapshotBytes += chunk;
+  };
   const snapshotResult = await captureInitialSnapshot(connection, name, previousMode, 'drive', 'drive', {
     fetch: deps.fetch,
-    writeChunk: deps.writeChunk,
+    writeChunk: captureWrite,
     log: deps.log,
     error: deps.error,
     captureAndRenderSnapshot: deps.captureAndRenderSnapshot,
@@ -772,6 +817,8 @@ export async function runDriveSession(
       previousMode,
       initialPending,
       initialTerminalRows,
+      initialLocalSize,
+      snapshotBytes,
     },
     deps
   );

--- a/packages/cli/src/cli/lib/attach-passthrough.test.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.test.ts
@@ -157,6 +157,34 @@ interface FetchScript {
   terminalSize?: { rows: number; cols: number } | null;
   inputStreamOpenError?: Error;
   inputStreamSendError?: Error;
+  /** When set, inject this fake engine via the createPredictiveEcho factory. */
+  predictiveEcho?: FakePredictiveEcho;
+}
+
+/** Records the calls the session routes into the predictive-echo engine. */
+class FakePredictiveEcho {
+  readonly seeded: string[] = [];
+  readonly inputs: string[] = [];
+  readonly outputs: string[] = [];
+  resetCount = 0;
+
+  async seed(data: string): Promise<void> {
+    this.seeded.push(data);
+  }
+
+  onUserInput(forward: Buffer): void {
+    this.inputs.push(forward.toString('utf-8'));
+  }
+
+  async onServerOutput(chunk: string): Promise<void> {
+    this.outputs.push(chunk);
+  }
+
+  onResize(): void {}
+
+  reset(): void {
+    this.resetCount += 1;
+  }
 }
 
 function createHarness(opts: FetchScript = {}): {
@@ -170,6 +198,7 @@ function createHarness(opts: FetchScript = {}): {
   signals: Map<NodeJS.Signals, () => void | Promise<void>>;
   fetchLog: Array<{ url: string; method: string; body?: unknown; headers: Record<string, string> }>;
   inputStreams: FakeInputStream[];
+  predictiveEcho?: FakePredictiveEcho;
 } {
   const writes: string[] = [];
   const errors: unknown[][] = [];
@@ -301,9 +330,22 @@ function createHarness(opts: FetchScript = {}): {
       inputStreams.push(stream);
       return stream;
     }),
+    createPredictiveEcho: opts.predictiveEcho ? () => opts.predictiveEcho ?? null : undefined,
   };
 
-  return { deps, stdin, terminal, sockets, writes, errors, logs, signals, fetchLog, inputStreams };
+  return {
+    deps,
+    stdin,
+    terminal,
+    sockets,
+    writes,
+    errors,
+    logs,
+    signals,
+    fetchLog,
+    inputStreams,
+    predictiveEcho: opts.predictiveEcho,
+  };
 }
 
 afterEach(() => {
@@ -625,6 +667,33 @@ describe('runPassthroughSession', () => {
 
     await signals.get('SIGINT')?.();
     await sessionPromise;
+  });
+
+  // ---- predictive-echo wiring ----
+
+  it('seeds the engine with the snapshot and routes input + output through it', async () => {
+    const fake = new FakePredictiveEcho();
+    const { deps, sockets, stdin } = createHarness({ predictiveEcho: fake });
+    const sessionPromise = runPassthroughSession('Alice', {}, deps);
+    const socket = await openSocket(sockets);
+
+    // Snapshot bytes seeded the confirmed model.
+    expect(fake.seeded.length).toBe(1);
+
+    // Live output is routed through the engine (it owns pass-through), not
+    // written directly.
+    socket.emit('message', jsonMessage({ kind: 'worker_stream', name: 'Alice', chunk: 'live' }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(fake.outputs).toContain('live');
+
+    // Keystrokes are mirrored to the engine for optimistic echo.
+    stdin.type(Buffer.from('hi'));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(fake.inputs).toContain('hi');
+
+    stdin.type(Buffer.from([0x03])); // Ctrl+C detach
+    await sessionPromise;
+    expect(fake.resetCount).toBe(1);
   });
 
   it('skips resize forwarding when stdout is not a TTY', async () => {

--- a/packages/cli/src/cli/lib/attach-passthrough.test.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.test.ts
@@ -180,6 +180,11 @@ class FakePredictiveEcho {
     this.outputs.push(chunk);
   }
 
+  rollbackCount = 0;
+  rollback(): void {
+    this.rollbackCount += 1;
+  }
+
   onResize(): void {}
 
   reset(): void {

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -392,6 +392,9 @@ export async function runPassthroughSession(
           if (settled) return;
           const message = err instanceof Error ? err.message : String(err);
           deps.log(`[passthrough] input stream send failed: ${message}`);
+          // The keystroke never reached the PTY — drop any optimistic echo
+          // for it so the screen doesn't show input the agent didn't get.
+          predictiveEcho?.rollback();
         });
         predictiveEcho?.onUserInput(outcome.forward);
       }

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -51,6 +51,8 @@ import {
   setInboundDeliveryMode,
   type InboundDeliveryMode,
 } from './attach-drive.js';
+import { createPredictiveEcho, type CreatePredictiveEchoOptions } from './predictive-echo-screen.js';
+import type { PredictiveEcho } from '@agent-relay/harness-driver';
 
 type ExitFn = (code: number) => never;
 
@@ -107,6 +109,11 @@ export interface PassthroughDependencies {
   terminal: PassthroughTerminal;
   /** Opens the SDK PTY input stream used for raw human keystrokes. */
   openInputStream: (connection: BrokerConnection, name: string) => CliPtyInputStream;
+  /**
+   * Builds the adaptive predictive-echo engine, or returns null to disable
+   * it (degenerate terminal). Omitted by tests that want plain pass-through.
+   */
+  createPredictiveEcho?: (opts: CreatePredictiveEchoOptions) => PredictiveEcho | null;
 }
 
 function withDefaults(overrides: Partial<PassthroughDependencies> = {}): PassthroughDependencies {
@@ -145,6 +152,7 @@ function withDefaults(overrides: Partial<PassthroughDependencies> = {}): Passthr
       },
     },
     openInputStream: (connection, name) => openPtyInputStream(connection, name, fetchFn),
+    createPredictiveEcho,
     ...overrides,
   };
 }
@@ -296,6 +304,14 @@ export async function runPassthroughSession(
   if (!flipResult) return 1;
   const { previousMode } = flipResult;
 
+  // Tee the snapshot's painted bytes so we can seed the predictive-echo
+  // model with them — its cursor must match the real screen before we
+  // optimistically echo, or predicted glyphs land at the wrong position.
+  let snapshotBytes = '';
+  const captureWrite = (chunk: string): void => {
+    deps.writeChunk(chunk);
+    snapshotBytes += chunk;
+  };
   const snapshotResult = await captureInitialSnapshot(
     connection,
     name,
@@ -304,7 +320,7 @@ export async function runPassthroughSession(
     'attach to',
     {
       fetch: deps.fetch,
-      writeChunk: deps.writeChunk,
+      writeChunk: captureWrite,
       log: deps.log,
       error: deps.error,
       captureAndRenderSnapshot: deps.captureAndRenderSnapshot,
@@ -338,10 +354,24 @@ export async function runPassthroughSession(
     let inputStream: CliPtyInputStream | null = null;
     const cleanupSignals: Array<() => void> = [];
 
+    // Adaptive predictive echo masks round-trip latency on remote brokers.
+    // Seeded with the snapshot so its confirmed model matches the screen.
+    const predictiveEcho =
+      deps.createPredictiveEcho?.({
+        cols: initialLocalSize?.cols ?? 0,
+        rows: initialLocalSize?.rows ?? 0,
+        write: deps.writeChunk,
+        getInputSrtt: () => inputStream?.srttMs ?? null,
+      }) ?? null;
+    if (predictiveEcho) {
+      void predictiveEcho.seed(snapshotBytes);
+    }
+
     const resizeHandler = (): void => {
       const size = deps.terminal.getSize();
       if (!size) return;
       terminalRows = size.rows;
+      predictiveEcho?.onResize(size.cols, size.rows);
       void resizeWorker(connection, name, size.rows, size.cols, deps.fetch).then((res) => {
         if (!res.ok) {
           deps.log(`[passthrough] resize forward failed: ${res.message ?? 'unknown error'}`);
@@ -363,6 +393,7 @@ export async function runPassthroughSession(
           const message = err instanceof Error ? err.message : String(err);
           deps.log(`[passthrough] input stream send failed: ${message}`);
         });
+        predictiveEcho?.onUserInput(outcome.forward);
       }
       for (const action of outcome.actions) {
         switch (action) {
@@ -432,6 +463,7 @@ export async function runPassthroughSession(
         }
       }
       teardownStdin();
+      predictiveEcho?.reset();
       closeInputStream();
       try {
         socket.close(1000, 'passthrough client exiting');
@@ -486,8 +518,15 @@ export async function runPassthroughSession(
       const event = classifyWsEvent(text, name);
       switch (event.kind) {
         case 'worker_stream':
-          deps.writeChunk(event.chunk);
-          paintStatus();
+          if (predictiveEcho) {
+            // The engine owns pass-through (it must restore the cursor
+            // before writing server bytes when predictions are live);
+            // repaint the status line once it has flushed.
+            void predictiveEcho.onServerOutput(event.chunk).then(paintStatus, paintStatus);
+          } else {
+            deps.writeChunk(event.chunk);
+            paintStatus();
+          }
           break;
         case 'other':
           break;

--- a/packages/cli/src/cli/lib/predictive-echo-screen.ts
+++ b/packages/cli/src/cli/lib/predictive-echo-screen.ts
@@ -1,0 +1,102 @@
+/**
+ * {@link ScreenModel} backed by a headless `xterm` terminal. Kept separate
+ * from the prediction engine so the engine can be unit-tested against a
+ * deterministic fake without spinning up a real VT emulator.
+ *
+ * `@xterm/headless` is CommonJS with a default export, and its `write()` is
+ * asynchronous — buffer state only reflects the data once the write callback
+ * fires — so {@link XtermScreenModel.write} resolves on that callback and the
+ * engine awaits it before reading cursor/row state.
+ */
+
+import xtermHeadless from '@xterm/headless';
+
+import { PredictiveEchoEngine, type PredictiveEcho, type ScreenModel } from '@agent-relay/harness-driver';
+
+const { Terminal } = xtermHeadless;
+
+export interface XtermScreenModelOptions {
+  cols: number;
+  rows: number;
+}
+
+class XtermScreenModel implements ScreenModel {
+  private readonly term: InstanceType<typeof Terminal>;
+
+  constructor(options: XtermScreenModelOptions) {
+    this.term = new Terminal({
+      cols: Math.max(options.cols, 1),
+      rows: Math.max(options.rows, 1),
+      allowProposedApi: true,
+      // No scrollback needed — we only reason about the visible viewport.
+      scrollback: 0,
+    });
+  }
+
+  write(data: string): Promise<void> {
+    return new Promise((resolve) => {
+      this.term.write(data, resolve);
+    });
+  }
+
+  cursor(): { row: number; col: number } {
+    const buffer = this.term.buffer.active;
+    return { row: buffer.cursorY, col: buffer.cursorX };
+  }
+
+  rowText(row: number): string {
+    const buffer = this.term.buffer.active;
+    const line = buffer.getLine(buffer.baseY + row);
+    // translateToString(true) trims trailing whitespace cells.
+    return line ? line.translateToString(true) : '';
+  }
+
+  isAltScreen(): boolean {
+    return this.term.buffer.active.type === 'alternate';
+  }
+
+  cols(): number {
+    return this.term.cols;
+  }
+
+  resize(cols: number, rows: number): void {
+    this.term.resize(Math.max(cols, 1), Math.max(rows, 1));
+  }
+
+  dispose(): void {
+    this.term.dispose();
+  }
+}
+
+/** Construct an xterm-backed {@link ScreenModel}. */
+export function createXtermScreenModel(options: XtermScreenModelOptions): XtermScreenModel {
+  return new XtermScreenModel(options);
+}
+
+export type { XtermScreenModel };
+
+export interface CreatePredictiveEchoOptions {
+  cols: number;
+  rows: number;
+  /** Writes raw bytes/escape sequences to the real terminal. */
+  write: (data: string) => void;
+  /** Latest input→ack SRTT (ms) from the PTY input stream, or null. */
+  getInputSrtt: () => number | null;
+}
+
+/**
+ * Default {@link PredictiveEcho} factory used by the interactive attach
+ * clients: an {@link PredictiveEchoEngine} backed by a headless xterm model.
+ * Returns null for a degenerate (zero-size) terminal, where prediction makes
+ * no sense and the caller falls back to plain pass-through.
+ */
+export function createPredictiveEcho(opts: CreatePredictiveEchoOptions): PredictiveEcho | null {
+  if (opts.cols <= 0 || opts.rows <= 0) return null;
+  const model = createXtermScreenModel({ cols: opts.cols, rows: opts.rows });
+  return new PredictiveEchoEngine({
+    model,
+    write: opts.write,
+    now: () => Date.now(),
+    getInputSrtt: opts.getInputSrtt,
+  });
+}

--- a/packages/harness-driver/src/index.ts
+++ b/packages/harness-driver/src/index.ts
@@ -7,3 +7,4 @@ export * from './types.js';
 export * from './transport.js';
 export * from './broker-path.js';
 export * from './harness.js';
+export * from './predictive-echo.js';

--- a/packages/harness-driver/src/predictive-echo.test.ts
+++ b/packages/harness-driver/src/predictive-echo.test.ts
@@ -213,4 +213,75 @@ describe('PredictiveEchoEngine — non-printable input', () => {
     expect(h.engine.hasPredictions).toBe(false);
     expect(h.writes).toEqual([]);
   });
+
+  it('does not predict wide / non-ASCII characters', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, '中'); // CJK, two columns — would desync cursor math
+    expect(h.engine.hasPredictions).toBe(false);
+    expect(h.writes.join('')).not.toContain('\x1b[4m');
+  });
+});
+
+describe('PredictiveEchoEngine — adaptive re-engagement', () => {
+  it('re-engages when latency climbs again after a quiet period', () => {
+    const h = createHarness({ inputSrtt: 5 }); // below threshold → dormant
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(false);
+
+    h.setSrtt(100); // latency spikes back up
+    type(h.engine, 'b');
+    expect(h.engine.hasPredictions).toBe(true);
+    expect(h.writes.join('')).toContain('\x1b[4m');
+  });
+});
+
+describe('PredictiveEchoEngine — off-regime safety', () => {
+  it('suspends (without stranding glyphs) when output moves to a new row', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(true);
+
+    await h.engine.onServerOutput('\n'); // cursor leaves the prediction row
+    expect(h.engine.hasPredictions).toBe(false);
+  });
+
+  it('rolls back on a same-row cursor retreat without erasing confirmed output', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    await h.model.write('hello'); // confirmed prompt; cursor at col 5
+    type(h.engine, 'a'); // predicted at col 5
+    expect(h.engine.hasPredictions).toBe(true);
+    h.writes.length = 0;
+
+    await h.engine.onServerOutput('\r'); // carriage return — cursor retreats
+    expect(h.engine.hasPredictions).toBe(false);
+    // Erased only from the predicted column (5) rightward; 'hello' intact.
+    expect(h.writes.join('')).toContain('\x1b[K');
+    expect(h.model.rowText(0)).toBe('hello');
+  });
+});
+
+describe('PredictiveEchoEngine — explicit rollback', () => {
+  it('discards predictions on rollback() (e.g. a failed send)', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(true);
+    h.writes.length = 0;
+
+    h.engine.rollback();
+    expect(h.engine.hasPredictions).toBe(false);
+    expect(h.writes.join('')).toContain('\x1b[K');
+  });
+});
+
+describe('PredictiveEchoEngine — seed gate', () => {
+  it('does not predict until an in-flight seed has applied', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    const seeding = h.engine.seed(''); // seeded := false synchronously
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(false);
+
+    await seeding;
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(true);
+  });
 });

--- a/packages/harness-driver/src/predictive-echo.test.ts
+++ b/packages/harness-driver/src/predictive-echo.test.ts
@@ -1,0 +1,216 @@
+import { Buffer } from 'node:buffer';
+
+import { describe, expect, it } from 'vitest';
+
+import { PredictiveEchoEngine, type ScreenModel } from './predictive-echo.js';
+
+/**
+ * Minimal deterministic {@link ScreenModel} for engine tests. Interprets just
+ * enough of the server byte stream — printable chars advance the cursor, `\r`
+ * returns to column 0, `\n` moves down — to drive the prediction/reconcile
+ * logic without a real VT emulator.
+ */
+class FakeScreenModel implements ScreenModel {
+  private grid: string[][] = [[]];
+  private cy = 0;
+  private cx = 0;
+  private alt = false;
+  private width: number;
+
+  constructor(width = 80) {
+    this.width = width;
+  }
+
+  setAlt(value: boolean): void {
+    this.alt = value;
+  }
+
+  write(data: string): Promise<void> {
+    for (const ch of data) {
+      if (ch === '\r') {
+        this.cx = 0;
+      } else if (ch === '\n') {
+        this.cy += 1;
+        if (!this.grid[this.cy]) this.grid[this.cy] = [];
+      } else {
+        if (!this.grid[this.cy]) this.grid[this.cy] = [];
+        this.grid[this.cy][this.cx] = ch;
+        this.cx += 1;
+      }
+    }
+    return Promise.resolve();
+  }
+
+  cursor(): { row: number; col: number } {
+    return { row: this.cy, col: this.cx };
+  }
+
+  rowText(row: number): string {
+    const cells = this.grid[row] ?? [];
+    let s = '';
+    for (let i = 0; i < cells.length; i++) s += cells[i] ?? ' ';
+    return s.replace(/\s+$/, '');
+  }
+
+  isAltScreen(): boolean {
+    return this.alt;
+  }
+
+  cols(): number {
+    return this.width;
+  }
+
+  resize(cols: number): void {
+    this.width = cols;
+  }
+}
+
+interface Harness {
+  engine: PredictiveEchoEngine;
+  model: FakeScreenModel;
+  writes: string[];
+  tick: (ms: number) => void;
+  setSrtt: (ms: number | null) => void;
+}
+
+function createHarness(opts: { inputSrtt?: number | null } = {}): Harness {
+  const model = new FakeScreenModel();
+  const writes: string[] = [];
+  let clock = 0;
+  let srtt: number | null = opts.inputSrtt ?? null;
+  const engine = new PredictiveEchoEngine({
+    model,
+    write: (s) => writes.push(s),
+    now: () => clock,
+    getInputSrtt: () => srtt,
+    config: { engageThresholdMs: 30, predictionSgr: '\x1b[4m' },
+  });
+  return {
+    engine,
+    model,
+    writes,
+    tick: (ms) => {
+      clock += ms;
+    },
+    setSrtt: (ms) => {
+      srtt = ms;
+    },
+  };
+}
+
+const type = (engine: PredictiveEchoEngine, s: string) => engine.onUserInput(Buffer.from(s, 'utf-8'));
+
+describe('PredictiveEchoEngine — adaptive activation', () => {
+  it('stays dormant on a fast link (no optimistic echo)', () => {
+    const h = createHarness({ inputSrtt: 5 }); // below threshold
+    type(h.engine, 'a');
+    expect(h.writes).toEqual([]);
+    expect(h.engine.hasPredictions).toBe(false);
+  });
+
+  it('engages once latency crosses the threshold', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(true);
+    // Underlined glyph drawn at row0/col0.
+    expect(h.writes.join('')).toBe('\x1b[1;1H\x1b[4ma\x1b[0m');
+  });
+});
+
+describe('PredictiveEchoEngine — predict then confirm', () => {
+  it('confirms a predicted glyph when the server echoes it', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(true);
+    h.writes.length = 0;
+
+    // Server echoes the same char ~40ms later.
+    h.tick(40);
+    await h.engine.onServerOutput('a');
+
+    // Pass-through repaints 'a' (un-underlined); no predictions remain.
+    expect(h.engine.hasPredictions).toBe(false);
+    expect(h.writes.join('')).toContain('a');
+    // Echo latency was measured.
+    expect(h.engine.echoLatencyMs).toBe(40);
+  });
+
+  it('keeps later predictions underlined until their own echo lands', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    type(h.engine, 'b');
+    expect(h.engine.hasPredictions).toBe(true);
+    h.writes.length = 0;
+
+    await h.engine.onServerOutput('a'); // confirms 'a', 'b' still pending
+    expect(h.engine.hasPredictions).toBe(true);
+    // 'b' re-rendered underlined to the right of the confirmed cursor.
+    expect(h.writes.join('')).toContain('\x1b[4mb\x1b[0m');
+
+    await h.engine.onServerOutput('b');
+    expect(h.engine.hasPredictions).toBe(false);
+  });
+});
+
+describe('PredictiveEchoEngine — rollback', () => {
+  it('rolls back when the server echoes something different', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'x');
+    h.writes.length = 0;
+
+    // Server echoes 'Y' instead of 'x' (e.g. an autocorrect / different glyph).
+    await h.engine.onServerOutput('Y');
+
+    expect(h.engine.hasPredictions).toBe(false);
+    // Clear-to-EOL was emitted to erase the bad prediction.
+    expect(h.writes.join('')).toContain('\x1b[K');
+  });
+
+  it('suspends predictions when the alternate screen is active', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    h.model.setAlt(true);
+    type(h.engine, 'a');
+    expect(h.engine.hasPredictions).toBe(false);
+    expect(h.writes).toEqual([]);
+  });
+});
+
+describe('PredictiveEchoEngine — backspace', () => {
+  it('erases the most recent prediction on backspace', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+    type(h.engine, 'b');
+    expect(h.engine.hasPredictions).toBe(true);
+    h.writes.length = 0;
+
+    type(h.engine, '\x7f'); // DEL
+    // 'b' erased; one prediction ('a') remains.
+    expect(h.writes.join('')).toContain('\x1b[K');
+    type(h.engine, '\x7f'); // erase 'a' too
+    type(h.engine, '\x7f'); // nothing left — no-op for our overlay
+    expect(h.engine.hasPredictions).toBe(false);
+  });
+});
+
+describe('PredictiveEchoEngine — ordering', () => {
+  it('processes concurrent server output in order', async () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, 'a');
+
+    // Fire two chunks without awaiting the first.
+    const p1 = h.engine.onServerOutput('a');
+    const p2 = h.engine.onServerOutput('b');
+    await Promise.all([p1, p2]);
+
+    expect(h.model.rowText(0)).toBe('ab');
+  });
+});
+
+describe('PredictiveEchoEngine — non-printable input', () => {
+  it('does not predict for Enter / control bytes', () => {
+    const h = createHarness({ inputSrtt: 100 });
+    type(h.engine, '\r');
+    expect(h.engine.hasPredictions).toBe(false);
+    expect(h.writes).toEqual([]);
+  });
+});

--- a/packages/harness-driver/src/predictive-echo.ts
+++ b/packages/harness-driver/src/predictive-echo.ts
@@ -1,0 +1,372 @@
+/**
+ * Mosh-style predictive (local) echo for interactive PTY attach sessions.
+ *
+ * On a remote broker, every keystroke's visual feedback is a full round trip:
+ * stdin → broker → agent PTY → echo back → display. With the local terminal
+ * in raw mode (no local echo), typing feels laggy because characters only
+ * appear after that trip completes. This engine masks the latency the way
+ * `mosh` does — it optimistically echoes printable characters locally
+ * (rendered underlined while unconfirmed), then reconciles against the
+ * authoritative server output as it arrives, dropping the underline on
+ * confirmation and rolling back mispredictions.
+ *
+ * The engine is host-agnostic: it depends only on a {@link ScreenModel}
+ * (confirmed cursor/screen state) and a `write` sink. The Agent Relay CLI
+ * backs the model with a headless `xterm` and writes to stdout; an Electron
+ * host (e.g. Pear) can back it with its live `@xterm/xterm` instance and
+ * write to that terminal. No Node-only APIs are used, so it runs in a
+ * browser/renderer as well as in Node.
+ *
+ * Design constraints that shape this implementation:
+ *
+ *   - We keep passing server output straight through to the real terminal
+ *     (the agent's screen must stay byte-for-byte correct). Optimistic
+ *     echo moves the real cursor, so before every pass-through we restore
+ *     the cursor to the *confirmed* position (tracked via {@link ScreenModel})
+ *     and re-render outstanding predictions afterward. This is the trick
+ *     that lets cursor-relative server bytes coexist with local echo.
+ *
+ *   - Predictions are confined to the simple, safe regime: printable
+ *     characters appended at the end of the cursor's current row, on the
+ *     normal (non-alternate) screen. That is exactly where `mosh` is most
+ *     confident, and it makes rollback a safe clear-to-end-of-line (there
+ *     is no confirmed content to the right of the cursor to clobber).
+ *     Anything outside that regime — alt-screen TUIs, unexpected cursor
+ *     moves, mid-line edits — suspends predictions and lets authoritative
+ *     output drive the display.
+ *
+ *   - Activation is adaptive (the `mosh` default): predictions only render
+ *     once measured echo latency crosses a threshold, so on a local broker
+ *     the engine is invisible and risk-free.
+ */
+
+/**
+ * Authoritative confirmed-screen model. The host supplies an implementation:
+ * the CLI wraps a headless `xterm` terminal; an Electron host can back it
+ * with its live `@xterm/xterm` instance. All coordinates are 0-indexed.
+ */
+export interface ScreenModel {
+  /** Feed confirmed server bytes; resolves once buffer state reflects them. */
+  write(data: string): Promise<void>;
+  /** Confirmed cursor position within the viewport. */
+  cursor(): { row: number; col: number };
+  /** Confirmed text of a viewport row, with trailing blanks trimmed. */
+  rowText(row: number): string;
+  /** True when the alternate screen buffer is active (full-screen TUI). */
+  isAltScreen(): boolean;
+  /** Viewport width in columns. */
+  cols(): number;
+  /** Resize the model's viewport. */
+  resize(cols: number, rows: number): void;
+}
+
+export interface PredictionConfig {
+  /**
+   * Echo-latency threshold (ms) at or above which predictions render.
+   * Below it, the engine stays dormant and the (now fast) server echo
+   * provides feedback. Mirrors `mosh`'s adaptive default.
+   */
+  engageThresholdMs: number;
+  /** SGR applied to unconfirmed predicted glyphs. Default: underline. */
+  predictionSgr: string;
+}
+
+export const DEFAULT_PREDICTION_CONFIG: PredictionConfig = {
+  engageThresholdMs: 30,
+  predictionSgr: '\x1b[4m', // underline
+};
+
+/**
+ * Client-facing surface the attach sessions depend on, so a test (or an
+ * alternate host) can inject a fake. {@link PredictiveEchoEngine} satisfies it.
+ */
+export interface PredictiveEcho {
+  /** Prime the confirmed model with already-painted bytes (e.g. the attach
+   *  snapshot) so its cursor matches the real screen before predicting. */
+  seed(data: string): Promise<void>;
+  /** The user typed bytes destined for the agent PTY (post keybind parse). */
+  onUserInput(forward: string | Uint8Array): void;
+  /** A server output chunk; the engine owns its pass-through + reconcile. */
+  onServerOutput(chunk: string): Promise<void>;
+  /** Local terminal resized. */
+  onResize(cols: number, rows: number): void;
+  /** Tear down; subsequent server output is plain pass-through. */
+  reset(): void;
+}
+
+export interface PredictiveEchoDeps {
+  /** Authoritative confirmed-screen model. */
+  model: ScreenModel;
+  /** Writes raw bytes/escape sequences to the real terminal. */
+  write: (data: string) => void;
+  /** Monotonic-ish clock in ms (injectable for tests). */
+  now: () => number;
+  /**
+   * Latest input→ack SRTT from the PTY input stream, or null. Used to
+   * bootstrap the adaptive decision before the first echo is confirmed.
+   */
+  getInputSrtt: () => number | null;
+  config?: Partial<PredictionConfig>;
+}
+
+/** A single optimistically-echoed glyph awaiting server confirmation. */
+interface Prediction {
+  /** 0-indexed column where the glyph was drawn (on {@link predRow}). */
+  col: number;
+  /** The predicted character (single grapheme; we only predict printables). */
+  ch: string;
+  /** Clock time the prediction was made, for echo-latency measurement. */
+  at: number;
+}
+
+const utf8Decoder = new TextDecoder();
+
+/** Normalize input bytes to a string without depending on Node `Buffer`. */
+function inputToString(forward: string | Uint8Array): string {
+  return typeof forward === 'string' ? forward : utf8Decoder.decode(forward);
+}
+
+/** ESC[<row>;<col>H — move cursor (1-indexed args). */
+function cup(row0: number, col0: number): string {
+  return `\x1b[${row0 + 1};${col0 + 1}H`;
+}
+
+/** Is this a single printable character we are willing to predict-echo? */
+function isPredictablePrintable(ch: string): boolean {
+  if (ch.length !== 1) return false;
+  const code = ch.charCodeAt(0);
+  // Printable ASCII excluding space-control; spaces are fine to echo.
+  return code >= 0x20 && code !== 0x7f;
+}
+
+/**
+ * Predictive-echo state machine. One instance per interactive attach
+ * session. Server output is processed through an internal promise chain so
+ * concurrent {@link onServerOutput} calls stay strictly ordered even though
+ * the model's `write` is async.
+ */
+export class PredictiveEchoEngine implements PredictiveEcho {
+  private readonly model: ScreenModel;
+  private readonly write: (data: string) => void;
+  private readonly now: () => number;
+  private readonly getInputSrtt: () => number | null;
+  private readonly config: PredictionConfig;
+
+  /** Outstanding predictions, left-to-right on {@link predRow}. */
+  private predictions: Prediction[] = [];
+  /** Row the current prediction run lives on (0-indexed viewport row). */
+  private predRow = 0;
+  /** Smoothed echo-confirmation latency (ms), or null before first sample. */
+  private echoSrttMs: number | null = null;
+  /** Serializes async server-output processing. */
+  private tail: Promise<void> = Promise.resolve();
+  private disposed = false;
+
+  constructor(deps: PredictiveEchoDeps) {
+    this.model = deps.model;
+    this.write = deps.write;
+    this.now = deps.now;
+    this.getInputSrtt = deps.getInputSrtt;
+    this.config = { ...DEFAULT_PREDICTION_CONFIG, ...deps.config };
+  }
+
+  /**
+   * Prime the confirmed model with bytes already painted to the terminal
+   * (e.g. the attach snapshot) so its cursor/content match the real screen
+   * before any prediction is made. Does not re-write to the terminal.
+   */
+  seed(data: string): Promise<void> {
+    this.tail = this.tail.then(() => this.model.write(data));
+    return this.tail;
+  }
+
+  /** Whether predictions should currently render (adaptive on latency). */
+  private get engaged(): boolean {
+    const srtt = this.echoSrttMs ?? this.getInputSrtt();
+    return srtt !== null && srtt >= this.config.engageThresholdMs;
+  }
+
+  /** True while at least one optimistic glyph is on screen. */
+  get hasPredictions(): boolean {
+    return this.predictions.length > 0;
+  }
+
+  /** Smoothed echo-confirmation latency in ms, or null. (Diagnostics.) */
+  get echoLatencyMs(): number | null {
+    return this.echoSrttMs;
+  }
+
+  /**
+   * The user typed `forward` (the bytes already destined for the agent's
+   * PTY, post keybind-parsing). Optimistically echoes the printable tail
+   * when engaged and in the safe end-of-line regime.
+   */
+  onUserInput(forward: string | Uint8Array): void {
+    if (this.disposed || !this.engaged) return;
+    if (this.model.isAltScreen()) {
+      this.killPredictions();
+      return;
+    }
+
+    const text = inputToString(forward);
+    for (const ch of text) {
+      const code = ch.charCodeAt(0);
+      if (code === 0x7f || code === 0x08) {
+        this.predictBackspace();
+        continue;
+      }
+      if (isPredictablePrintable(ch)) {
+        this.predictPrintable(ch);
+        continue;
+      }
+      // Anything else (Enter, arrows, control bytes) leaves the simple
+      // append regime — stop predicting and let the server drive.
+      this.killPredictions();
+      return;
+    }
+  }
+
+  /** Optimistically echo one printable char at the predicted cursor. */
+  private predictPrintable(ch: string): void {
+    const confirmed = this.model.cursor();
+    const base = this.predictedCursorCol(confirmed);
+    // Only predict appends at the end of the current row's content — the
+    // regime where rollback is a safe clear-to-EOL.
+    if (this.predictions.length === 0) {
+      const rowLen = this.model.rowText(confirmed.row).length;
+      if (confirmed.col !== rowLen) return; // mid-line; don't guess
+      if (confirmed.col >= this.model.cols() - 1) return; // avoid wrap edge
+      this.predRow = confirmed.row;
+    } else if (confirmed.row !== this.predRow) {
+      // Confirmed cursor wandered off the prediction row; bail.
+      this.killPredictions();
+      return;
+    }
+    if (base >= this.model.cols() - 1) return; // would wrap; stay safe
+
+    this.predictions.push({ col: base, ch, at: this.now() });
+    // Render underlined glyph at `base`, leaving the real cursor after it.
+    this.write(`${cup(this.predRow, base)}${this.config.predictionSgr}${ch}\x1b[0m`);
+  }
+
+  /** Roll back the most recent outstanding prediction (local backspace). */
+  private predictBackspace(): void {
+    const last = this.predictions.pop();
+    if (!last) return; // nothing of ours to erase — let the server handle it
+    // Erase the glyph: move onto it, clear to end of line (safe — nothing
+    // confirmed lives to the right of our predictions in this regime).
+    this.write(`${cup(this.predRow, last.col)}\x1b[K`);
+  }
+
+  /** Predicted real-cursor column given the confirmed cursor. */
+  private predictedCursorCol(confirmed: { row: number; col: number }): number {
+    if (this.predictions.length === 0) return confirmed.col;
+    return this.predictions[this.predictions.length - 1].col + 1;
+  }
+
+  /**
+   * Process one server output chunk: pass it through to the terminal and
+   * reconcile predictions against the new confirmed state. Ordered via the
+   * internal promise chain; callers may fire-and-forget.
+   */
+  onServerOutput(chunk: string): Promise<void> {
+    this.tail = this.tail.then(() => this.processServerChunk(chunk));
+    return this.tail;
+  }
+
+  private async processServerChunk(chunk: string): Promise<void> {
+    if (this.disposed) {
+      this.write(chunk);
+      return;
+    }
+
+    const hadPredictions = this.predictions.length > 0;
+    const confirmedBefore = this.model.cursor();
+
+    // 1. Neutralize our optimistic cursor advance so cursor-relative server
+    //    bytes land where the agent intends.
+    if (hadPredictions) {
+      this.write(cup(confirmedBefore.row, confirmedBefore.col));
+    }
+
+    // 2. Pass the authoritative chunk through to the real terminal.
+    this.write(chunk);
+
+    // 3. Advance the confirmed model.
+    await this.model.write(chunk);
+    if (this.disposed) return;
+
+    if (!hadPredictions) return;
+
+    const confirmedAfter = this.model.cursor();
+
+    // 4. Suspend on anything outside the simple append regime.
+    if (this.model.isAltScreen() || confirmedAfter.row !== this.predRow) {
+      this.killPredictions();
+      return;
+    }
+
+    // 5. Drop predictions the server has now confirmed (its own echo
+    //    repainted them, un-underlined, during pass-through). A prediction
+    //    at column < confirmedAfter.col has been overtaken.
+    const stillPending = this.predictions.filter((p) => p.col >= confirmedAfter.col);
+    const confirmedCount = this.predictions.length - stillPending.length;
+    if (confirmedCount > 0) {
+      this.recordEchoLatency(this.predictions[confirmedCount - 1].at);
+    }
+
+    // 6. Validate surviving predictions against confirmed row text. If the
+    //    server echoed something other than what we guessed for an
+    //    overtaken cell, our remaining glyphs are suspect — roll back.
+    const rowText = this.model.rowText(this.predRow);
+    for (const p of this.predictions) {
+      if (p.col < confirmedAfter.col && rowText[p.col] !== p.ch) {
+        this.killPredictions();
+        return;
+      }
+    }
+
+    this.predictions = stillPending;
+
+    // 7. Re-render the survivors to the right of the confirmed cursor and
+    //    park the real cursor at the predicted column.
+    if (this.predictions.length === 0) return;
+    let out = '';
+    for (const p of this.predictions) {
+      out += `${cup(this.predRow, p.col)}${this.config.predictionSgr}${p.ch}\x1b[0m`;
+    }
+    out += cup(this.predRow, this.predictions[this.predictions.length - 1].col + 1);
+    this.write(out);
+  }
+
+  /** Erase all outstanding predicted glyphs and forget them. */
+  private killPredictions(): void {
+    if (this.predictions.length === 0) return;
+    const first = this.predictions[0];
+    const confirmed = this.model.cursor();
+    // Repaint from the first predicted column: restore the confirmed cursor
+    // then clear to end of line (safe in the end-of-line regime).
+    if (confirmed.row === this.predRow) {
+      this.write(`${cup(this.predRow, Math.min(first.col, confirmed.col))}\x1b[K`);
+      this.write(cup(confirmed.row, confirmed.col));
+    }
+    this.predictions = [];
+  }
+
+  private recordEchoLatency(predictedAt: number): void {
+    const sample = this.now() - predictedAt;
+    if (!Number.isFinite(sample) || sample < 0) return;
+    this.echoSrttMs = this.echoSrttMs === null ? sample : this.echoSrttMs * 0.875 + sample * 0.125;
+  }
+
+  onResize(cols: number, rows: number): void {
+    this.killPredictions();
+    this.model.resize(cols, rows);
+  }
+
+  /** Drop all state; subsequent server output is plain pass-through. */
+  reset(): void {
+    this.killPredictions();
+    this.disposed = true;
+  }
+}

--- a/packages/harness-driver/src/predictive-echo.ts
+++ b/packages/harness-driver/src/predictive-echo.ts
@@ -20,19 +20,21 @@
  * Design constraints that shape this implementation:
  *
  *   - We keep passing server output straight through to the real terminal
- *     (the agent's screen must stay byte-for-byte correct). Optimistic
- *     echo moves the real cursor, so before every pass-through we restore
- *     the cursor to the *confirmed* position (tracked via {@link ScreenModel})
- *     and re-render outstanding predictions afterward. This is the trick
- *     that lets cursor-relative server bytes coexist with local echo.
+ *     (the agent's screen must stay byte-for-byte correct). Optimistic echo
+ *     moves the real cursor, so before each pass-through we erase our
+ *     predicted glyphs, repaint the confirmed row tail from
+ *     {@link ScreenModel}, and restore the cursor to the *confirmed*
+ *     position; surviving predictions are re-rendered afterward. Erasing
+ *     first (rather than after) means a chunk that moves off-regime can
+ *     never strand an underline on the old row.
  *
  *   - Predictions are confined to the simple, safe regime: printable
  *     characters appended at the end of the cursor's current row, on the
  *     normal (non-alternate) screen. That is exactly where `mosh` is most
- *     confident, and it makes rollback a safe clear-to-end-of-line (there
- *     is no confirmed content to the right of the cursor to clobber).
- *     Anything outside that regime — alt-screen TUIs, unexpected cursor
- *     moves, mid-line edits — suspends predictions and lets authoritative
+ *     confident, and it keeps rollback to a bounded repaint of the
+ *     predicted region (never touching confirmed content to its left).
+ *     Anything outside that regime — alt-screen TUIs, row changes, cursor
+ *     retreats, mid-line edits — suspends predictions and lets authoritative
  *     output drive the display.
  *
  *   - Activation is adaptive (the `mosh` default): predictions only render
@@ -58,6 +60,8 @@ export interface ScreenModel {
   cols(): number;
   /** Resize the model's viewport. */
   resize(cols: number, rows: number): void;
+  /** Release any underlying resources (e.g. a headless terminal). */
+  dispose?(): void;
 }
 
 export interface PredictionConfig {
@@ -88,6 +92,9 @@ export interface PredictiveEcho {
   onUserInput(forward: string | Uint8Array): void;
   /** A server output chunk; the engine owns its pass-through + reconcile. */
   onServerOutput(chunk: string): Promise<void>;
+  /** Discard outstanding predictions (e.g. the input send failed); repaints
+   *  the confirmed row so no stale optimistic glyphs remain. */
+  rollback(): void;
   /** Local terminal resized. */
   onResize(cols: number, rows: number): void;
   /** Tear down; subsequent server output is plain pass-through. */
@@ -119,24 +126,23 @@ interface Prediction {
   at: number;
 }
 
-const utf8Decoder = new TextDecoder();
-
-/** Normalize input bytes to a string without depending on Node `Buffer`. */
-function inputToString(forward: string | Uint8Array): string {
-  return typeof forward === 'string' ? forward : utf8Decoder.decode(forward);
-}
-
 /** ESC[<row>;<col>H — move cursor (1-indexed args). */
 function cup(row0: number, col0: number): string {
   return `\x1b[${row0 + 1};${col0 + 1}H`;
 }
 
-/** Is this a single printable character we are willing to predict-echo? */
+/**
+ * Is this a single printable character we are willing to predict-echo?
+ *
+ * Restricted to single-column printable ASCII (0x20–0x7e). Wide glyphs
+ * (CJK, emoji) occupy two columns, which would desync the engine's
+ * one-column-per-char cursor math; non-ASCII input falls back to the
+ * server echo rather than risk a misplaced prediction.
+ */
 function isPredictablePrintable(ch: string): boolean {
   if (ch.length !== 1) return false;
   const code = ch.charCodeAt(0);
-  // Printable ASCII excluding space-control; spaces are fine to echo.
-  return code >= 0x20 && code !== 0x7f;
+  return code >= 0x20 && code <= 0x7e;
 }
 
 /**
@@ -161,6 +167,18 @@ export class PredictiveEchoEngine implements PredictiveEcho {
   /** Serializes async server-output processing. */
   private tail: Promise<void> = Promise.resolve();
   private disposed = false;
+  /**
+   * Streaming UTF-8 decoder for byte input. Per-instance and stateful so a
+   * multibyte sequence split across two stdin chunks is held (not decoded as
+   * U+FFFD and mispredicted) until the trailing bytes arrive.
+   */
+  private readonly decoder = new TextDecoder();
+  /**
+   * False only while an in-flight {@link seed} is still applying. Gates
+   * optimistic echo so we never predict from an unseeded (0,0) cursor when
+   * the user types before the snapshot finishes priming the model.
+   */
+  private seeded = true;
 
   constructor(deps: PredictiveEchoDeps) {
     this.model = deps.model;
@@ -176,13 +194,23 @@ export class PredictiveEchoEngine implements PredictiveEcho {
    * before any prediction is made. Does not re-write to the terminal.
    */
   seed(data: string): Promise<void> {
-    this.tail = this.tail.then(() => this.model.write(data));
+    this.seeded = false;
+    this.tail = this.tail
+      .then(() => this.model.write(data))
+      .then(() => {
+        this.seeded = true;
+      });
     return this.tail;
   }
 
-  /** Whether predictions should currently render (adaptive on latency). */
+  /**
+   * Whether predictions should currently render (adaptive on latency).
+   * Prefers the live input→ack SRTT so the engine re-engages promptly when
+   * latency spikes again after a recovery period; the slow-moving echo EWMA
+   * is only a fallback before the first ack.
+   */
   private get engaged(): boolean {
-    const srtt = this.echoSrttMs ?? this.getInputSrtt();
+    const srtt = this.getInputSrtt() ?? this.echoSrttMs;
     return srtt !== null && srtt >= this.config.engageThresholdMs;
   }
 
@@ -202,13 +230,13 @@ export class PredictiveEchoEngine implements PredictiveEcho {
    * when engaged and in the safe end-of-line regime.
    */
   onUserInput(forward: string | Uint8Array): void {
-    if (this.disposed || !this.engaged) return;
+    if (this.disposed || !this.seeded || !this.engaged) return;
     if (this.model.isAltScreen()) {
       this.killPredictions();
       return;
     }
 
-    const text = inputToString(forward);
+    const text = typeof forward === 'string' ? forward : this.decoder.decode(forward, { stream: true });
     for (const ch of text) {
       const code = ch.charCodeAt(0);
       if (code === 0x7f || code === 0x08) {
@@ -282,11 +310,16 @@ export class PredictiveEchoEngine implements PredictiveEcho {
 
     const hadPredictions = this.predictions.length > 0;
     const confirmedBefore = this.model.cursor();
+    const predStartCol = hadPredictions ? this.predictions[0].col : 0;
 
-    // 1. Neutralize our optimistic cursor advance so cursor-relative server
-    //    bytes land where the agent intends.
+    // 1. Erase our optimistic glyphs and repaint the confirmed row tail
+    //    BEFORE the authoritative chunk lands. This both neutralizes the
+    //    cursor advance (so cursor-relative server bytes land correctly) and
+    //    guarantees we never strand an underline — if the chunk turns out to
+    //    move off-regime (newline, alt-screen, cursor jump), there is nothing
+    //    left on the old row to clean up.
     if (hadPredictions) {
-      this.write(cup(confirmedBefore.row, confirmedBefore.col));
+      this.erasePredictionRegion(predStartCol, confirmedBefore);
     }
 
     // 2. Pass the authoritative chunk through to the real terminal.
@@ -295,41 +328,66 @@ export class PredictiveEchoEngine implements PredictiveEcho {
     // 3. Advance the confirmed model.
     await this.model.write(chunk);
     if (this.disposed) return;
-
     if (!hadPredictions) return;
 
     const confirmedAfter = this.model.cursor();
 
-    // 4. Suspend on anything outside the simple append regime.
-    if (this.model.isAltScreen() || confirmedAfter.row !== this.predRow) {
-      this.killPredictions();
+    // 4. Suspend on anything outside the simple append regime: alt-screen, a
+    //    different row, or a cursor that retreated (e.g. `\r` + prompt
+    //    redraw) rather than advancing through the predicted columns. The
+    //    glyphs are already gone (step 1), so this is just dropping state.
+    if (
+      this.model.isAltScreen() ||
+      confirmedAfter.row !== this.predRow ||
+      confirmedAfter.col < confirmedBefore.col
+    ) {
+      this.predictions = [];
       return;
     }
 
     // 5. Drop predictions the server has now confirmed (its own echo
-    //    repainted them, un-underlined, during pass-through). A prediction
-    //    at column < confirmedAfter.col has been overtaken.
+    //    repainted them during pass-through). A prediction at column <
+    //    confirmedAfter.col has been overtaken.
     const stillPending = this.predictions.filter((p) => p.col >= confirmedAfter.col);
     const confirmedCount = this.predictions.length - stillPending.length;
     if (confirmedCount > 0) {
       this.recordEchoLatency(this.predictions[confirmedCount - 1].at);
     }
 
-    // 6. Validate surviving predictions against confirmed row text. If the
-    //    server echoed something other than what we guessed for an
-    //    overtaken cell, our remaining glyphs are suspect — roll back.
+    // 6. Validate overtaken cells: if the server echoed something other than
+    //    what we guessed, the remaining glyphs are suspect — drop them. The
+    //    confirmed content is already on screen from step 2.
     const rowText = this.model.rowText(this.predRow);
     for (const p of this.predictions) {
       if (p.col < confirmedAfter.col && rowText[p.col] !== p.ch) {
-        this.killPredictions();
+        this.predictions = [];
         return;
       }
     }
 
-    this.predictions = stillPending;
-
     // 7. Re-render the survivors to the right of the confirmed cursor and
     //    park the real cursor at the predicted column.
+    this.predictions = stillPending;
+    this.renderPredictions();
+  }
+
+  /**
+   * Repaint the confirmed row from `startCol` to end-of-line, then restore
+   * the cursor to `restoreTo`. Replaces any optimistic glyphs at/after
+   * `startCol` with authoritative model content. Only touches columns
+   * `>= startCol`, so confirmed output to the left is never clobbered. No-op
+   * when the cursor has already left the prediction row (we can't safely
+   * repaint a row we no longer own).
+   */
+  private erasePredictionRegion(startCol: number, restoreTo: { row: number; col: number }): void {
+    if (restoreTo.row !== this.predRow) return;
+    const tail = this.model.rowText(this.predRow).slice(startCol);
+    this.write(`${cup(this.predRow, startCol)}\x1b[K${tail}${cup(restoreTo.row, restoreTo.col)}`);
+  }
+
+  /** Draw the outstanding predicted glyphs underlined, parking the cursor
+   *  just past the last one. */
+  private renderPredictions(): void {
     if (this.predictions.length === 0) return;
     let out = '';
     for (const p of this.predictions) {
@@ -342,15 +400,14 @@ export class PredictiveEchoEngine implements PredictiveEcho {
   /** Erase all outstanding predicted glyphs and forget them. */
   private killPredictions(): void {
     if (this.predictions.length === 0) return;
-    const first = this.predictions[0];
-    const confirmed = this.model.cursor();
-    // Repaint from the first predicted column: restore the confirmed cursor
-    // then clear to end of line (safe in the end-of-line regime).
-    if (confirmed.row === this.predRow) {
-      this.write(`${cup(this.predRow, Math.min(first.col, confirmed.col))}\x1b[K`);
-      this.write(cup(confirmed.row, confirmed.col));
-    }
+    const startCol = this.predictions[0].col;
     this.predictions = [];
+    this.erasePredictionRegion(startCol, this.model.cursor());
+  }
+
+  /** Public rollback: discard predictions (e.g. an input send failed). */
+  rollback(): void {
+    this.killPredictions();
   }
 
   private recordEchoLatency(predictedAt: number): void {
@@ -368,5 +425,6 @@ export class PredictiveEchoEngine implements PredictiveEcho {
   reset(): void {
     this.killPredictions();
     this.disposed = true;
+    this.model.dispose?.();
   }
 }

--- a/packages/harness-driver/src/pty-input-stream.test.ts
+++ b/packages/harness-driver/src/pty-input-stream.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit tests for {@link PtyInputStream}'s pipelining: queued keystrokes are
+ * sent eagerly (no stop-and-wait), settled FIFO as acks arrive, and the
+ * stream reports an input→ack SRTT for adaptive predictive echo.
+ *
+ * `PtyInputStream` constructs `new WebSocket(...)` internally, so we mock the
+ * `ws` module with a controllable fake and grab the live instance.
+ */
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  readonly url: string;
+  readonly listeners = new Map<string, Listener[]>();
+  /** Every send() call: the payload plus its completion callback. */
+  readonly sends: Array<{ data: unknown; cb: (err?: Error) => void }> = [];
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  on(event: string, listener: Listener): this {
+    const bucket = this.listeners.get(event) ?? [];
+    bucket.push(listener);
+    this.listeners.set(event, bucket);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const l of this.listeners.get(event) ?? []) l(...args);
+  }
+
+  send(data: unknown, cb: (err?: Error) => void): void {
+    this.sends.push({ data, cb });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Test helper: complete the WS open + broker readiness handshake. */
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit('open');
+    this.emit('message', Buffer.from(JSON.stringify({ type: 'pty_input_ready', name: 'agent' })));
+  }
+
+  /** Test helper: deliver one ack (FIFO settles the oldest in-flight send). */
+  ack(bytesWritten?: number): void {
+    this.emit(
+      'message',
+      Buffer.from(JSON.stringify({ type: 'pty_input_ack', name: 'agent', bytes_written: bytesWritten }))
+    );
+  }
+}
+
+vi.mock('ws', () => ({ default: FakeWebSocket }));
+
+// Import after the mock is registered.
+const { PtyInputStream } = await import('./transport.js');
+
+function lastSocket(): FakeWebSocket {
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) throw new Error('no FakeWebSocket constructed');
+  return socket;
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PtyInputStream pipelining', () => {
+  it('sends every queued keystroke without waiting for prior acks', async () => {
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    // Three keystrokes typed faster than any ack returns.
+    const p1 = stream.send('a');
+    const p2 = stream.send('b');
+    const p3 = stream.send('c');
+    await Promise.resolve();
+
+    // All three are on the wire — NOT serialized one-ack-at-a-time.
+    expect(socket.sends.map((s) => s.data)).toEqual(['a', 'b', 'c']);
+
+    // Acks settle them in send order.
+    socket.ack(1);
+    await expect(p1).resolves.toMatchObject({ bytes_written: 1 });
+    socket.ack(1);
+    await expect(p2).resolves.toMatchObject({ bytes_written: 1 });
+    socket.ack(1);
+    await expect(p3).resolves.toMatchObject({ bytes_written: 1 });
+  });
+
+  it('reports a smoothed input→ack SRTT once acks arrive', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    expect(stream.srttMs).toBeNull();
+
+    const p = stream.send('a');
+    await Promise.resolve();
+    vi.setSystemTime(40); // 40ms round-trip
+    socket.ack(1);
+    await p;
+
+    expect(stream.srttMs).toBe(40);
+  });
+
+  it('rejects past the high water mark (backpressure)', async () => {
+    const stream = new PtyInputStream({
+      url: 'ws://x/api/input/agent/stream',
+      highWaterMarkBytes: 4,
+    });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    const ok = stream.send('abcd'); // exactly at the mark
+    await Promise.resolve();
+    await expect(stream.send('e')).rejects.toMatchObject({ code: 'input_backpressure' });
+
+    socket.ack(4);
+    await expect(ok).resolves.toMatchObject({ bytes_written: 4 });
+  });
+
+  it('fails all in-flight and queued frames on close', async () => {
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    const p1 = stream.send('a');
+    const p2 = stream.send('b');
+    await Promise.resolve();
+    socket.emit('close', 1006, Buffer.from('gone'));
+
+    await expect(p1).rejects.toMatchObject({ code: 'input_stream_closed' });
+    await expect(p2).rejects.toMatchObject({ code: 'input_stream_closed' });
+  });
+});

--- a/packages/harness-driver/src/transport.ts
+++ b/packages/harness-driver/src/transport.ts
@@ -62,6 +62,8 @@ interface PendingPtyInput {
   resolve: (result: PtyInputWriteResult) => void;
   reject: (error: Error) => void;
   settled: boolean;
+  /** Epoch ms the frame was handed to the WebSocket; used for ack-RTT. */
+  sentAt?: number;
 }
 
 const DEFAULT_INPUT_HIGH_WATER_MARK_BYTES = 1024 * 1024;
@@ -75,11 +77,19 @@ export class PtyInputStream {
   private openResolve?: () => void;
   private openReject?: (error: Error) => void;
   private openTimer: ReturnType<typeof setTimeout> | null = null;
-  private inFlight: PendingPtyInput | null = null;
+  /**
+   * Frames sent over the WebSocket and awaiting their `pty_input_ack`, in
+   * send order. Pipelined rather than stop-and-wait: queued keystrokes are
+   * all sent eagerly (TCP preserves order) and settled FIFO as acks arrive,
+   * so interactive input never pays one round-trip per keystroke.
+   */
+  private readonly inFlight: PendingPtyInput[] = [];
   private bufferedBytes = 0;
   private opened = false;
   private _closed = false;
   private flushing = false;
+  /** EWMA of input→ack round-trip in ms, or null before the first ack. */
+  private _srttMs: number | null = null;
 
   constructor(options: { url: string; apiKey?: string } & PtyInputStreamOptions) {
     this.highWaterMarkBytes = normalizePositiveIntegerOption(
@@ -157,6 +167,21 @@ export class PtyInputStream {
     return this.bufferedBytes;
   }
 
+  /**
+   * Smoothed input→ack round-trip in ms, or null before the first ack.
+   * Cheap latency signal for adaptive predictive echo to bootstrap from
+   * before it has measured its own echo-confirmation latency.
+   */
+  get srttMs(): number | null {
+    return this._srttMs;
+  }
+
+  private recordAckRtt(sampleMs: number): void {
+    if (!Number.isFinite(sampleMs) || sampleMs < 0) return;
+    // Standard RFC 6298-style EWMA (alpha = 1/8).
+    this._srttMs = this._srttMs === null ? sampleMs : this._srttMs * 0.875 + sampleMs * 0.125;
+  }
+
   waitUntilOpen(): Promise<void> {
     return this.openPromise;
   }
@@ -214,7 +239,7 @@ export class PtyInputStream {
   }
 
   private async flush(): Promise<void> {
-    if (this.flushing || this.inFlight || this.queue.length === 0 || this._closed) {
+    if (this.flushing || this.queue.length === 0 || this._closed) {
       return;
     }
     this.flushing = true;
@@ -227,27 +252,29 @@ export class PtyInputStream {
       this.flushing = false;
     }
 
-    if (this.inFlight || this.queue.length === 0 || this._closed) {
-      return;
-    }
-
-    const next = this.queue.shift();
-    if (!next) return;
-    this.inFlight = next;
-    this.ws.send(next.data, (error) => {
-      if (!error) return;
-      if (this.inFlight === next) {
-        this.inFlight = null;
-      }
-      const protocolError = new HarnessDriverProtocolError({
-        code: 'input_stream_send_failed',
-        message: error.message,
-        retryable: true,
-        data: error,
+    // Drain the entire queue in one synchronous pass — no `await` between
+    // here and the loop's end, so a concurrent `flush()` can't interleave.
+    while (this.queue.length > 0 && !this._closed) {
+      const next = this.queue.shift();
+      if (!next) break;
+      next.sentAt = Date.now();
+      this.inFlight.push(next);
+      this.ws.send(next.data, (error) => {
+        if (!error) return;
+        const idx = this.inFlight.indexOf(next);
+        if (idx !== -1) {
+          this.inFlight.splice(idx, 1);
+        }
+        const protocolError = new HarnessDriverProtocolError({
+          code: 'input_stream_send_failed',
+          message: error.message,
+          retryable: true,
+          data: error,
+        });
+        this.settle(next, protocolError);
+        this.failAll(protocolError);
       });
-      this.settle(next, protocolError);
-      this.failAll(protocolError);
-    });
+    }
   }
 
   private handleMessage(data: RawData): void {
@@ -272,14 +299,16 @@ export class PtyInputStream {
     }
 
     if (type === 'pty_input_ack') {
-      const current = this.inFlight;
+      // Acks arrive in send order; settle the oldest outstanding frame.
+      const current = this.inFlight.shift();
       if (!current) return;
-      this.inFlight = null;
+      if (typeof current.sentAt === 'number') {
+        this.recordAckRtt(Date.now() - current.sentAt);
+      }
       this.settle(current, {
         name: typeof message.name === 'string' ? message.name : '',
         bytes_written: typeof message.bytes_written === 'number' ? message.bytes_written : current.bytes,
       });
-      this.flush();
       return;
     }
 
@@ -309,9 +338,9 @@ export class PtyInputStream {
   }
 
   private failAll(error: Error): void {
-    if (this.inFlight) {
-      this.settle(this.inFlight, error);
-      this.inFlight = null;
+    while (this.inFlight.length > 0) {
+      const item = this.inFlight.shift();
+      if (item) this.settle(item, error);
     }
     while (this.queue.length > 0) {
       const item = this.queue.shift();


### PR DESCRIPTION
## **User description**
## Problem

Typing through `agent-relay drive` / `passthrough` felt sluggish and choppy when the broker is remote. The local terminal runs in raw mode with **no local echo**, so every keystroke's visual feedback is a full round trip (stdin → broker → agent PTY → echo back → stdout), and two layers taxed that trip:

1. The broker coalesced PTY output on a fixed **100ms** window, so echo arrived in 100ms-spaced bursts.
2. The harness-driver PTY input stream was **stop-and-wait** — one frame, wait for ack, next frame — costing a full RTT per keystroke on a remote link.

## What this does

### Underlying latency (fast for everyone, local or remote)
- **Broker leading-edge flush** (`pty_worker.rs`): interactive output now flushes on a **~16ms** leading edge via an armed one-shot deadline (smooth bursts, prompt trailing flush, **zero extra timer wakeups when idle**). Bulk output still coalesces by the 4 KB size cap.
- **Input pipelining** (`harness-driver/transport.ts`): FIFO in-flight queue settled by ack instead of stop-and-wait — removes one RTT per keystroke. Also exposes an input→ack **SRTT** signal.

### Adaptive predictive echo (the mosh strategy)
- Printable keystrokes echo **locally and immediately** (underlined until the server confirms them), then reconcile against authoritative output. Mispredictions roll back; full-screen TUIs / mid-line edits **suspend** rather than guess.
- **Adaptive** (mosh default): predictions only engage once measured echo latency crosses a threshold, so on a local broker it's invisible and zero-risk.
- The model is seeded with the attach snapshot so its cursor matches the real screen before predicting.

### Reusable across hosts
The `PredictiveEchoEngine` lives in **`@agent-relay/harness-driver`**, host-agnostic (`string | Uint8Array` input, `TextDecoder`, no Node-only APIs — runs in a browser/renderer). The CLI supplies an `@xterm/headless` `ScreenModel` + stdout sink; an Electron host (e.g. Pear) can back the same engine with its live `@xterm/xterm` terminal. `@xterm/headless` stays a CLI-only dependency.

## Tests
- New: predictive-echo engine (9), input-stream pipelining (4), passthrough wiring (1).
- Full **CLI (358)** and **broker lib** suites green; typecheck / lint / knip / prettier clean.
- Existing attach tests unchanged — predictive echo is an optional DI dependency, so omitting it falls back to the original synchronous pass-through.

## Notes / scope
- On by default but adaptive — no behavior change on fast local links.
- First iteration deliberately covers end-of-line typing (where it matters most); mid-line editing and wrap fall back to plain pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Speed up remote typing and show local predictive echo in attach sessions

### What Changed
- `drive` and `passthrough` now show printable keystrokes immediately on the local terminal when latency is high, then remove the underline once the server confirms them
- Predictive echo stays off on fast links, turns off for full-screen TUIs and other non-simple input, and resets cleanly when the session ends or the terminal is resized
- Interactive output now reaches the terminal in smaller, quicker bursts, and typed input is sent ahead without waiting for each previous acknowledgement

### Impact
`✅ Faster remote typing`
`✅ Fewer choppy keystroke bursts`
`✅ Clearer feedback on high-latency attach sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
