### PR TITLE
ci(publish): publish @agent-relay/harnesses on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -964,6 +964,55 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+  # Publish @agent-relay/harnesses after the publish-packages matrix, which is
+  # where its exact-version workspace deps (@agent-relay/sdk and
+  # @agent-relay/harness-driver) land on the registry. Publishing harnesses
+  # before those exist would leave a window where
+  # `npm install @agent-relay/harnesses@<v>` cannot resolve its dependencies —
+  # the same install race the broker/sdk ordering above is built to avoid.
+  publish-harnesses:
+    name: Publish @agent-relay/harnesses
+    needs: [build, publish-packages]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'all'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: .
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/harnesses
+        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish to NPM
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/harnesses
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
+            exit 0
+          fi
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
   # package=main publishes only the root `agent-relay` tarball, but that
   # tarball pins several @agent-relay/* runtime dependencies to the freshly
   # bumped version. Publish those direct deps first so a main-only release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1577,13 +1577,18 @@ jobs:
   # Create git tag and release
   create-release:
     name: Create Release
-    needs: [build, build-broker, build-standalone, verify-binaries, publish-main]
+    needs: [build, build-broker, build-standalone, verify-binaries, publish-main, publish-harnesses]
     runs-on: ubuntu-latest
+    # publish-harnesses only runs for package=all; for a package=main release it
+    # is skipped, which must not block the tag. Gate on "not failed" rather than
+    # "succeeded" so a real harness publish failure stops the release but a
+    # skipped one does not.
     if: |
       always() &&
       github.event.inputs.package != 'cli-prerelease' &&
       github.event.inputs.dry_run != 'true' &&
       needs.publish-main.result == 'success' &&
+      (needs.publish-harnesses.result == 'success' || needs.publish-harnesses.result == 'skipped') &&
       needs.publish-main.outputs.published == 'true'
 
     steps:
@@ -2060,6 +2065,7 @@ jobs:
         publish-sdk-internal-deps,
         publish-broker-packages,
         publish-packages,
+        publish-harnesses,
         publish-brand-only,
         publish-sdk-py,
         publish-main,
@@ -2102,6 +2108,7 @@ jobs:
           echo "| Publish SDK Internal Deps | ${{ needs.publish-sdk-internal-deps.result == 'success' && '✅' || (needs.publish-sdk-internal-deps.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-internal-deps.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Broker Packages | ${{ needs.publish-broker-packages.result == 'success' && '✅' || (needs.publish-broker-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-broker-packages.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Packages | ${{ needs.publish-packages.result == 'success' && '✅' || (needs.publish-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-packages.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish Harnesses | ${{ needs.publish-harnesses.result == 'success' && '✅' || (needs.publish-harnesses.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-harnesses.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Brand | ${{ needs.publish-brand-only.result == 'success' && '✅' || (needs.publish-brand-only.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-brand-only.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Python SDK | ${{ needs.publish-sdk-py.result == 'success' && '✅' || (needs.publish-sdk-py.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-py.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Main | ${{ needs.publish-main.result == 'success' && '✅' || (needs.publish-main.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-main.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@agent-relay/harnesses` is now published to npm, so external SDK consumers can install the prebuilt PTY harnesses (`claude`, `codex`, `gemini`, …) and the `definePtyHarness`/`defineHarness`/`createHuman` author helpers.
 - `agent-relay drive` and `agent-relay passthrough` add adaptive predictive echo so typing stays responsive when driving a high-latency or remote agent, and stays invisible on fast local links.
 - `@agent-relay/harness-driver` exports a reusable `PredictiveEchoEngine` so other attach UIs (CLI, Electron, browser) can share one predictive-echo implementation.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `@agent-relay/harnesses` is now published to npm, so external SDK consumers can install the prebuilt PTY harnesses (`claude`, `codex`, `gemini`, …) and the `definePtyHarness`/`defineHarness`/`createHuman` author helpers.
+- `@agent-relay/harnesses` is now published to npm, so SDK consumers can install the prebuilt PTY harnesses and harness-authoring helpers.
 - `agent-relay drive` and `agent-relay passthrough` add adaptive predictive echo so typing stays responsive when driving a high-latency or remote agent, and stays invisible on fast local links.
 - `@agent-relay/harness-driver` exports a reusable `PredictiveEchoEngine` so other attach UIs (CLI, Electron, browser) can share one predictive-echo implementation.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.


### PR DESCRIPTION
## **User description**
## What

Wires `@agent-relay/harnesses` into the release pipeline so it actually gets published to npm.

## Why

`@agent-relay/harnesses` is set up as a public package (no `private` flag, `publishConfig.access: public`, versioned in lockstep at the release version) but appeared **nowhere** in `publish.yml` — not in the package dropdown, the SDK-internal-deps matrix, or any pack step. As a result it was never published (`npm view @agent-relay/harnesses` → 404), even though:

- It's the public author surface: prebuilt PTY harnesses (`claude`, `codex`, `gemini`, `cursor`, `droid`, `opencode`, `aider`, `goose`) plus `definePtyHarness` / `defineHarness` / `createHuman`.
- It's documented on the public docs site (`web/content/docs/harnesses.mdx`, plus quickstart / typescript-sdk / migration / actions).
- **relayflows** lists "`@agent-relay/harnesses` is NOT published to npm" as the #1 blocker in its v8 SDK migration plan, with "publish from the relay repo first" as the preferred resolution.

## How

Adds a `publish-harnesses` job to the `package=all` path. It runs **after** `publish-packages` — the matrix where its exact-version workspace deps (`@agent-relay/sdk`, `@agent-relay/harness-driver`) land on the registry — so an external `npm install @agent-relay/harnesses@<v>` can always resolve its dependencies. This respects the same install-ordering discipline the broker/SDK jobs already use.

The job mirrors the existing publish pattern: `--provenance` (OIDC), `--ignore-scripts`, and the skip-if-already-exists guard for safe re-runs.

## Notes

- First publish must be done manually (with a token) to create the package on npm, after which the npm **trusted publisher** (OIDC) can be configured to point at this repo + `publish.yml`. Subsequent releases then publish via provenance with no token.
- No change needed to the post-publish verification workflow — it's CLI-install-focused and doesn't enumerate `harnesses` (which isn't a dep of the `agent-relay` CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Publish `@agent-relay/harnesses` to npm during releases**

### What Changed
- Release runs now publish `@agent-relay/harnesses` alongside the other packages
- The package is published only after its runtime dependencies are already on npm, so installs like `npm install @agent-relay/harnesses@<version>` can resolve cleanly
- Repeated release runs still skip publishing if that exact version is already on npm

### Impact
`✅ External SDK users can install harnesses`
`✅ Fewer broken installs for released versions`
`✅ Safer repeat release runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
