### PR TITLE
feat(harness-driver): add lifecycle-aware SpawnedAgentHandle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -964,6 +964,55 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+  # Publish @agent-relay/harnesses after the publish-packages matrix, which is
+  # where its exact-version workspace deps (@agent-relay/sdk and
+  # @agent-relay/harness-driver) land on the registry. Publishing harnesses
+  # before those exist would leave a window where
+  # `npm install @agent-relay/harnesses@<v>` cannot resolve its dependencies —
+  # the same install race the broker/sdk ordering above is built to avoid.
+  publish-harnesses:
+    name: Publish @agent-relay/harnesses
+    needs: [build, publish-packages]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'all'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: .
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/harnesses
+        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish to NPM
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/harnesses
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
+            exit 0
+          fi
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
   # package=main publishes only the root `agent-relay` tarball, but that
   # tarball pins several @agent-relay/* runtime dependencies to the freshly
   # bumped version. Publish those direct deps first so a main-only release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1577,13 +1577,18 @@ jobs:
   # Create git tag and release
   create-release:
     name: Create Release
-    needs: [build, build-broker, build-standalone, verify-binaries, publish-main]
+    needs: [build, build-broker, build-standalone, verify-binaries, publish-main, publish-harnesses]
     runs-on: ubuntu-latest
+    # publish-harnesses only runs for package=all; for a package=main release it
+    # is skipped, which must not block the tag. Gate on "not failed" rather than
+    # "succeeded" so a real harness publish failure stops the release but a
+    # skipped one does not.
     if: |
       always() &&
       github.event.inputs.package != 'cli-prerelease' &&
       github.event.inputs.dry_run != 'true' &&
       needs.publish-main.result == 'success' &&
+      (needs.publish-harnesses.result == 'success' || needs.publish-harnesses.result == 'skipped') &&
       needs.publish-main.outputs.published == 'true'
 
     steps:
@@ -2060,6 +2065,7 @@ jobs:
         publish-sdk-internal-deps,
         publish-broker-packages,
         publish-packages,
+        publish-harnesses,
         publish-brand-only,
         publish-sdk-py,
         publish-main,
@@ -2102,6 +2108,7 @@ jobs:
           echo "| Publish SDK Internal Deps | ${{ needs.publish-sdk-internal-deps.result == 'success' && '✅' || (needs.publish-sdk-internal-deps.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-internal-deps.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Broker Packages | ${{ needs.publish-broker-packages.result == 'success' && '✅' || (needs.publish-broker-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-broker-packages.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Packages | ${{ needs.publish-packages.result == 'success' && '✅' || (needs.publish-packages.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-packages.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish Harnesses | ${{ needs.publish-harnesses.result == 'success' && '✅' || (needs.publish-harnesses.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-harnesses.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Brand | ${{ needs.publish-brand-only.result == 'success' && '✅' || (needs.publish-brand-only.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-brand-only.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Python SDK | ${{ needs.publish-sdk-py.result == 'success' && '✅' || (needs.publish-sdk-py.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-sdk-py.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Main | ${{ needs.publish-main.result == 'success' && '✅' || (needs.publish-main.result == 'skipped' && '⏭️' || '❌') }} ${{ needs.publish-main.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@agent-relay/harnesses` is now published to npm, so external SDK consumers can install the prebuilt PTY harnesses (`claude`, `codex`, `gemini`, …) and the `definePtyHarness`/`defineHarness`/`createHuman` author helpers.
 - `agent-relay drive` and `agent-relay passthrough` add adaptive predictive echo so typing stays responsive when driving a high-latency or remote agent, and stays invisible on fast local links.
 - `@agent-relay/harness-driver` exports a reusable `PredictiveEchoEngine` so other attach UIs (CLI, Electron, browser) can share one predictive-echo implementation.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `@agent-relay/harnesses` is now published to npm, so external SDK consumers can install the prebuilt PTY harnesses (`claude`, `codex`, `gemini`, …) and the `definePtyHarness`/`defineHarness`/`createHuman` author helpers.
+- `@agent-relay/harnesses` is now published to npm, so SDK consumers can install the prebuilt PTY harnesses and harness-authoring helpers.
 - `agent-relay drive` and `agent-relay passthrough` add adaptive predictive echo so typing stays responsive when driving a high-latency or remote agent, and stays invisible on fast local links.
 - `@agent-relay/harness-driver` exports a reusable `PredictiveEchoEngine` so other attach UIs (CLI, Electron, browser) can share one predictive-echo implementation.
 - `@agent-relay/sdk` `relay.addListener(...)` on a workspace client now receives all workspace-visible events: `events.connect()` opens the relaycast 2.5 workspace stream when no agent client is present, so the documented `relay.addListener('message.created', ...)` quickstart path streams without registering an agent.

--- a/packages/harness-driver/src/agent-handle.ts
+++ b/packages/harness-driver/src/agent-handle.ts
@@ -82,6 +82,10 @@ export class SpawnedAgentHandle implements SpawnAgentResult {
    * a prior exit from broker history, so it is safe to call after the fact.
    */
   waitForExit(timeoutMs?: number): Promise<AgentExitInfo> {
+    // Ensure the broker event stream is live — `onEvent` only registers a
+    // listener; without an active connection no events ever arrive. Idempotent.
+    this.client.connectEvents();
+
     const already = this.exit;
     if (already) return Promise.resolve(already);
 
@@ -108,6 +112,9 @@ export class SpawnedAgentHandle implements SpawnAgentResult {
    * if the agent exits first, or with `{ reason: 'timeout' }` after `timeoutMs`.
    */
   waitForIdle(timeoutMs?: number): Promise<AgentIdleInfo> {
+    // Ensure the broker event stream is live (see waitForExit). Idempotent.
+    this.client.connectEvents();
+
     const already = this.exit;
     if (already) return Promise.resolve({ reason: 'exited', exit: already });
 

--- a/packages/harness-driver/src/agent-handle.ts
+++ b/packages/harness-driver/src/agent-handle.ts
@@ -115,14 +115,17 @@ export class SpawnedAgentHandle implements SpawnAgentResult {
       let timer: ReturnType<typeof setTimeout> | undefined;
       const settle = (info: AgentIdleInfo) => {
         if (timer) clearTimeout(timer);
-        unsubIdle();
-        unsubExit();
+        unsub();
         resolve(info);
       };
-      const unsubIdle = this.client.addListener('agentIdle', (payload) => {
-        if (payload.name === this.name) settle({ reason: 'idle', idleSecs: payload.idleSecs });
-      });
-      const unsubExit = this.client.onEvent((event: BrokerEvent) => {
+      // Idle and exit both arrive on the broker event stream. The named
+      // `agentIdle` event bus is only populated by call-site hooks (not broker
+      // events) in direct-client usage, so it must not be used here.
+      const unsub = this.client.onEvent((event: BrokerEvent) => {
+        if (event.kind === 'agent_idle' && event.name === this.name) {
+          settle({ reason: 'idle', idleSecs: event.idle_secs });
+          return;
+        }
         const exit = matchExit(event, this.name);
         if (exit) settle({ reason: 'exited', exit });
       });

--- a/packages/harness-driver/src/agent-handle.ts
+++ b/packages/harness-driver/src/agent-handle.ts
@@ -1,0 +1,150 @@
+/**
+ * Lifecycle-aware handle for a spawned agent.
+ *
+ * `HarnessDriverClient.spawnPty()` / `spawnCli()` / `spawnHeadless()` return one
+ * of these instead of a bare {@link SpawnAgentResult}. It is a structural
+ * superset of `SpawnAgentResult` (it still carries `name` / `runtime` /
+ * `sessionId` / `pid`), so existing callers are unaffected, and it adds the
+ * promise-based lifecycle operations consumers previously had to reconstruct
+ * from the raw broker event stream:
+ *
+ *   - `waitForExit()` — resolve when the agent exits, with `code` / `signal`.
+ *   - `waitForIdle()` — resolve on the next idle signal (or on exit).
+ *   - `exit` / `exitCode` / `exitSignal` — synchronous view of a prior exit.
+ *   - `release()` — release the agent via the broker.
+ *
+ * All operations are backed by the client's broker event stream and its event
+ * history, so they are replay-correct: calling `waitForExit()` after the agent
+ * has already exited resolves immediately from history rather than hanging.
+ */
+import type { HarnessDriverClient } from './client.js';
+import type { AgentRuntime, BrokerEvent } from './protocol.js';
+import type { SpawnAgentResult } from './types.js';
+
+export interface AgentExitInfo {
+  /** `'exited'` when the agent exited; `'timeout'` when the wait elapsed first. */
+  reason: 'exited' | 'timeout';
+  /** Process exit code, when the broker reported one. */
+  code?: number;
+  /** Terminating signal, when the agent was killed by one. */
+  signal?: string;
+}
+
+export interface AgentIdleInfo {
+  /** `'idle'` on an idle signal, `'exited'` if the agent exited first, `'timeout'` otherwise. */
+  reason: 'idle' | 'exited' | 'timeout';
+  /** Seconds the agent has been idle, when `reason === 'idle'`. */
+  idleSecs?: number;
+  /** Exit details, when `reason === 'exited'`. */
+  exit?: AgentExitInfo;
+}
+
+export class SpawnedAgentHandle implements SpawnAgentResult {
+  readonly name: string;
+  readonly runtime: AgentRuntime;
+  readonly sessionId?: string;
+  readonly pid?: number;
+
+  constructor(
+    result: SpawnAgentResult,
+    private readonly client: HarnessDriverClient
+  ) {
+    this.name = result.name;
+    this.runtime = result.runtime;
+    this.sessionId = result.sessionId;
+    this.pid = result.pid;
+  }
+
+  /** Exit info if the agent has already exited (from broker event history), else `undefined`. */
+  get exit(): AgentExitInfo | undefined {
+    const exited = this.client.getLastEvent('agent_exited', this.name);
+    if (exited && exited.kind === 'agent_exited') {
+      return { reason: 'exited', code: exited.code, signal: exited.signal };
+    }
+    const exit = this.client.getLastEvent('agent_exit', this.name);
+    if (exit && exit.kind === 'agent_exit') {
+      return { reason: 'exited' };
+    }
+    return undefined;
+  }
+
+  get exitCode(): number | undefined {
+    return this.exit?.code;
+  }
+
+  get exitSignal(): string | undefined {
+    return this.exit?.signal;
+  }
+
+  /**
+   * Resolve when the agent exits (with `code` / `signal` when the broker reports
+   * them), or with `{ reason: 'timeout' }` if `timeoutMs` elapses first. Replays
+   * a prior exit from broker history, so it is safe to call after the fact.
+   */
+  waitForExit(timeoutMs?: number): Promise<AgentExitInfo> {
+    const already = this.exit;
+    if (already) return Promise.resolve(already);
+
+    return new Promise<AgentExitInfo>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (info: AgentExitInfo) => {
+        if (timer) clearTimeout(timer);
+        unsub();
+        resolve(info);
+      };
+      const unsub = this.client.onEvent((event: BrokerEvent) => {
+        const exit = matchExit(event, this.name);
+        if (exit) settle(exit);
+      });
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => settle({ reason: 'timeout' }), timeoutMs);
+      }
+    });
+  }
+
+  /**
+   * Resolve on the next idle signal for this agent (edge-triggered: a fresh
+   * signal after the call, matching how runners poll-then-nudge). Also resolves
+   * if the agent exits first, or with `{ reason: 'timeout' }` after `timeoutMs`.
+   */
+  waitForIdle(timeoutMs?: number): Promise<AgentIdleInfo> {
+    const already = this.exit;
+    if (already) return Promise.resolve({ reason: 'exited', exit: already });
+
+    return new Promise<AgentIdleInfo>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (info: AgentIdleInfo) => {
+        if (timer) clearTimeout(timer);
+        unsubIdle();
+        unsubExit();
+        resolve(info);
+      };
+      const unsubIdle = this.client.addListener('agentIdle', (payload) => {
+        if (payload.name === this.name) settle({ reason: 'idle', idleSecs: payload.idleSecs });
+      });
+      const unsubExit = this.client.onEvent((event: BrokerEvent) => {
+        const exit = matchExit(event, this.name);
+        if (exit) settle({ reason: 'exited', exit });
+      });
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => settle({ reason: 'timeout' }), timeoutMs);
+      }
+    });
+  }
+
+  /** Release the agent via the broker. */
+  release(reason?: string): Promise<{ name: string }> {
+    return this.client.release(this.name, reason);
+  }
+}
+
+/** Match an exit `BrokerEvent` for `name`, normalising the two exit kinds. */
+function matchExit(event: BrokerEvent, name: string): AgentExitInfo | undefined {
+  if (event.kind === 'agent_exited' && event.name === name) {
+    return { reason: 'exited', code: event.code, signal: event.signal };
+  }
+  if (event.kind === 'agent_exit' && event.name === name) {
+    return { reason: 'exited' };
+  }
+  return undefined;
+}

--- a/packages/harness-driver/src/client.ts
+++ b/packages/harness-driver/src/client.ts
@@ -43,6 +43,7 @@ import type {
   ListAgent,
 } from './types.js';
 import { EventBus } from './event-bus.js';
+import { SpawnedAgentHandle } from './agent-handle.js';
 import type {
   AfterAgentReleaseContext,
   AfterAgentSpawnContext,
@@ -621,7 +622,7 @@ export class HarnessDriverClient {
 
   // ── Agent lifecycle ────────────────────────────────────────────────
 
-  async spawnPty(input: SpawnPtyInput): Promise<SpawnAgentResult> {
+  async spawnPty(input: SpawnPtyInput): Promise<SpawnedAgentHandle> {
     const beforeCtx: BeforeAgentSpawnContext<SpawnPtyInput> = {
       kind: 'pty',
       input,
@@ -638,14 +639,14 @@ export class HarnessDriverClient {
       });
       const result = SpawnAgentResultSchema.parse(rawResult);
       await this.emitAfterSpawn(beforeCtx, resolvedInput, t0, result, undefined);
-      return result;
+      return new SpawnedAgentHandle(result, this);
     } catch (err) {
       await this.emitAfterSpawn(beforeCtx, resolvedInput, t0, undefined, err);
       throw err;
     }
   }
 
-  async spawnCli(input: SpawnCliInput): Promise<SpawnAgentResult> {
+  async spawnCli(input: SpawnCliInput): Promise<SpawnedAgentHandle> {
     const beforeCtx: BeforeAgentSpawnContext<SpawnCliInput> = {
       kind: 'cli',
       input,
@@ -659,7 +660,7 @@ export class HarnessDriverClient {
   private async spawnCliWithContext(
     beforeCtx: BeforeAgentSpawnContext<SpawnCliInput>,
     input: SpawnCliInput
-  ): Promise<SpawnAgentResult> {
+  ): Promise<SpawnedAgentHandle> {
     const t0 = Date.now();
     const resolvedInput = await this.runBeforeSpawn(beforeCtx);
     const transport = resolveSpawnTransport(resolvedInput);
@@ -680,14 +681,14 @@ export class HarnessDriverClient {
       });
       const result = SpawnAgentResultSchema.parse(rawResult);
       await this.emitAfterSpawn(beforeCtx, resolvedInput, t0, result, undefined);
-      return result;
+      return new SpawnedAgentHandle(result, this);
     } catch (err) {
       await this.emitAfterSpawn(beforeCtx, resolvedInput, t0, undefined, err);
       throw err;
     }
   }
 
-  async spawnHeadless(input: SpawnHeadlessInput): Promise<SpawnAgentResult> {
+  async spawnHeadless(input: SpawnHeadlessInput): Promise<SpawnedAgentHandle> {
     const cliInput: SpawnCliInput = { ...input, transport: 'headless' };
     const beforeCtx: BeforeAgentSpawnContext<SpawnCliInput> = {
       kind: 'headless',
@@ -699,11 +700,11 @@ export class HarnessDriverClient {
     return this.spawnCliWithContext(beforeCtx, cliInput);
   }
 
-  async spawnClaude(input: Omit<SpawnCliInput, 'cli'>): Promise<SpawnAgentResult> {
+  async spawnClaude(input: Omit<SpawnCliInput, 'cli'>): Promise<SpawnedAgentHandle> {
     return this.spawnCli({ ...input, cli: 'claude' });
   }
 
-  async spawnOpencode(input: Omit<SpawnCliInput, 'cli'>): Promise<SpawnAgentResult> {
+  async spawnOpencode(input: Omit<SpawnCliInput, 'cli'>): Promise<SpawnedAgentHandle> {
     return this.spawnCli({ ...input, cli: 'opencode' });
   }
 

--- a/packages/harness-driver/src/index.ts
+++ b/packages/harness-driver/src/index.ts
@@ -1,4 +1,5 @@
 export * from './driver-types.js';
+export * from './agent-handle.js';
 export * from './broker-driver.js';
 export * from './actions.js';
 export * from './client.js';


### PR DESCRIPTION
## **User description**
## What

`HarnessDriverClient.spawnPty()` / `spawnCli()` / `spawnHeadless()` (and `spawnClaude`/`spawnOpencode`) now return a **`SpawnedAgentHandle`** instead of a bare `SpawnAgentResult`.

The handle is a **structural superset** of `SpawnAgentResult` (it still carries `name` / `runtime` / `sessionId` / `pid`), so existing callers are unaffected. On top of that it adds the promise-based lifecycle operations consumers previously had to reconstruct by hand from the raw broker event stream:

- `waitForExit(timeoutMs?)` → `{ reason: 'exited' | 'timeout', code?, signal? }`
- `waitForIdle(timeoutMs?)` → `{ reason: 'idle' | 'exited' | 'timeout', idleSecs?, exit? }`
- `exit` / `exitCode` / `exitSignal` — synchronous view of a prior exit
- `release(reason?)`

## Why

Downstream consumers (e.g. the relayflows workflow runner being migrated off the v7 SDK) need an `await agent.waitForExit()` ergonomic with the process exit code. The v7 SDK `Agent` provided this; v8's `spawnPty()` returned a method-less `SpawnAgentResult`, forcing each consumer to re-implement the event→promise bridge — including the fiddly bits (listener-leak cleanup, exit-code capture from the `agent_exited` `BrokerEvent` vs the method-less `agentExited` payload, and the "already exited before you awaited" replay case).

The driver is the right home for this: it owns the ordered broker event stream **and** the event history (`getLastEvent`/`queryEvents`), so it can implement these **replay-correctly** — awaiting after a prior exit resolves immediately from history instead of hanging.

## Notes

- Exit code/signal are sourced from the `agent_exited` `BrokerEvent` (the named `agentExited` event payload is a method-less `DriverAgent` without them).
- `waitForIdle` is edge-triggered (resolves on the next idle signal), matching how runners poll-then-nudge.

## Verification

- `harness-driver` typechecks (`tsc --noEmit`) and builds.
- `harness-driver` test suite passes (26 tests).
- Direct dependents `@agent-relay/harnesses` and `@agent-relay/sdk` typecheck clean (0 errors) against the widened return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add lifecycle-aware agent handles and publish harnesses safely**

### What Changed
- Spawning an agent now returns a handle that can wait for exit, wait for the next idle signal, read the last exit code or signal, and release the agent.
- Exit and idle waits now resolve from prior event history too, so they work even if the agent already exited before the wait started.
- `@agent-relay/harnesses` is now published to npm, so external users can install the prebuilt PTY harnesses and harness-authoring helpers.
- Release creation now waits for harness publishing to succeed, so a failed harness publish blocks the release instead of being missed.

### Impact
`✅ Easier agent shutdown handling`
`✅ Fewer hangs when checking exited agents`
`✅ Installable harness package on npm`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
