### PR TITLE
feat(pear): add /pear/download redirect to latest macOS build

### DIFF
--- a/web/app/pear/download/route.ts
+++ b/web/app/pear/download/route.ts
@@ -9,8 +9,7 @@
 // The binary is mirrored into pear-releases by the pear repo's "mirror-release"
 // workflow whenever a GitHub Release is published. GitHub resolves `latest`
 // server-side, so this redirect target is constant.
-const LATEST_DMG =
-  'https://github.com/AgentWorkforce/pear-releases/releases/latest/download/Pear-arm64.dmg';
+const LATEST_DMG = 'https://github.com/AgentWorkforce/pear-releases/releases/latest/download/Pear-arm64.dmg';
 
 export function GET() {
   return new Response(null, {

--- a/web/app/pear/download/route.ts
+++ b/web/app/pear/download/route.ts
@@ -1,0 +1,24 @@
+// Stable, public download link for the latest Pear build (macOS, Apple Silicon).
+//
+// Redirects to the newest published asset in the PUBLIC AgentWorkforce/pear-releases
+// repo, so we can hand out a single branded URL that always points at the current
+// release without exposing the private `pear` source repo:
+//
+//   wget --content-disposition https://origin.agentrelay.net/pear/download
+//
+// The binary is mirrored into pear-releases by the pear repo's "mirror-release"
+// workflow whenever a GitHub Release is published. GitHub resolves `latest`
+// server-side, so this redirect target is constant.
+const LATEST_DMG =
+  'https://github.com/AgentWorkforce/pear-releases/releases/latest/download/Pear-arm64.dmg';
+
+export function GET() {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: LATEST_DMG,
+      // Short cache: keep the link snappy without pinning it across a release.
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+}

--- a/web/app/pear/download/route.ts
+++ b/web/app/pear/download/route.ts
@@ -6,8 +6,7 @@
 // resolves "latest" server-side — is a constant target:
 //
 //   wget --content-disposition https://origin.agentrelay.net/pear/download
-const LATEST_DMG =
-  'https://github.com/AgentWorkforce/pear/releases/latest/download/pear-arm64.dmg';
+const LATEST_DMG = 'https://github.com/AgentWorkforce/pear/releases/latest/download/pear-arm64.dmg';
 
 export function GET() {
   return new Response(null, {

--- a/web/app/pear/download/route.ts
+++ b/web/app/pear/download/route.ts
@@ -1,15 +1,13 @@
 // Stable, public download link for the latest Pear build (macOS, Apple Silicon).
 //
-// Redirects to the newest published asset in the PUBLIC AgentWorkforce/pear-releases
-// repo, so we can hand out a single branded URL that always points at the current
-// release without exposing the private `pear` source repo:
+// Redirects to the newest published installer on the public AgentWorkforce/pear
+// repo. electron-builder publishes the DMG under a fixed filename
+// (`pear-arm64.dmg`), so GitHub's `releases/latest/download/<name>` URL — which
+// resolves "latest" server-side — is a constant target:
 //
 //   wget --content-disposition https://origin.agentrelay.net/pear/download
-//
-// The binary is mirrored into pear-releases by the pear repo's "mirror-release"
-// workflow whenever a GitHub Release is published. GitHub resolves `latest`
-// server-side, so this redirect target is constant.
-const LATEST_DMG = 'https://github.com/AgentWorkforce/pear-releases/releases/latest/download/Pear-arm64.dmg';
+const LATEST_DMG =
+  'https://github.com/AgentWorkforce/pear/releases/latest/download/pear-arm64.dmg';
 
 export function GET() {
   return new Response(null, {


### PR DESCRIPTION
## What

Adds a route handler at `web/app/pear/download/route.ts` that 302-redirects to the latest published Pear build:

```
https://origin.agentrelay.net/pear/download
→ https://github.com/AgentWorkforce/pear/releases/latest/download/pear-arm64.dmg
```

## Why

A single stable, branded, no-auth URL to share for downloading Pear:

```
wget --content-disposition https://origin.agentrelay.net/pear/download
```

Now that `AgentWorkforce/pear` is open source, it points straight at that repo's own releases. The installer ships under a fixed filename (`pear-arm64.dmg`, see AgentWorkforce/pear#110), so GitHub's server-side `releases/latest` resolution makes the redirect target constant — no API call, no token.

## Note

The link 404s until `pear` has its first published release carrying the `pear-arm64.dmg` asset (i.e. the first publish after AgentWorkforce/pear#110 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)