### PR TITLE
feat(web): pear proactive section, OG pear logo, mobile hero

### DIFF
--- a/web/app/pear/og.png/route.tsx
+++ b/web/app/pear/og.png/route.tsx
@@ -19,13 +19,19 @@ const SHOT_CANDIDATES = [
   path.resolve(process.cwd(), 'web/public/img/pear-app.png'),
 ];
 
+/** Candidate paths for the brand-kit pear mark (transparent). */
+const MARK_CANDIDATES = [
+  path.resolve(process.cwd(), 'public/brand-kit/pear-icon-transparent.png'),
+  path.resolve(process.cwd(), 'web/public/brand-kit/pear-icon-transparent.png'),
+];
+
 /**
- * Read the screenshot and return it as a base64 PNG data URL for embedding into
- * the satori-rendered card. Fails soft: if the file cannot be read the card
- * still renders its frame (just without the screenshot inside).
+ * Read a PNG and return it as a base64 data URL for embedding into the
+ * satori-rendered card. Fails soft: if no candidate can be read the caller
+ * renders its fallback (the card never breaks).
  */
-function loadScreenshot(): string | undefined {
-  for (const candidate of SHOT_CANDIDATES) {
+function loadPng(candidates: string[]): string | undefined {
+  for (const candidate of candidates) {
     try {
       if (fs.existsSync(candidate)) {
         const data = fs.readFileSync(candidate);
@@ -47,10 +53,11 @@ function loadScreenshot(): string | undefined {
  */
 export async function GET() {
   const { fonts, headingFamily, bodyFamily } = await loadBrandFonts();
-  const screenshot = loadScreenshot();
+  const screenshot = loadPng(SHOT_CANDIDATES);
+  const mark = loadPng(MARK_CANDIDATES);
 
   return new ImageResponse(
-    <PearVariant headingFamily={headingFamily} bodyFamily={bodyFamily} screenshot={screenshot} />,
+    <PearVariant headingFamily={headingFamily} bodyFamily={bodyFamily} screenshot={screenshot} mark={mark} />,
     {
       ...OG_SIZE,
       ...(fonts.length > 0 ? { fonts } : {}),

--- a/web/app/pear/og.png/route.tsx
+++ b/web/app/pear/og.png/route.tsx
@@ -10,35 +10,24 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-static';
 
 /**
- * Candidate paths for the Pear desktop-app screenshot. The card is generated at
- * build time, where the working directory is the `web/` package, but we probe a
- * couple of locations so the read also works when traced into a server bundle.
+ * Read a public/ asset as a base64 data URL for embedding into the
+ * satori-rendered card. Both assets are traced for this route via
+ * `outputFileTracingIncludes` in `next.config.mjs`, so they ship with the
+ * standalone/OpenNext bundle.
+ *
+ * We resolve against two roots because `outputFileTracingRoot` is the monorepo
+ * root: at build the cwd is the `web/` package (`public/...`), while the traced
+ * server runs from the monorepo root (`web/public/...`). The first hit wins.
  */
-const SHOT_CANDIDATES = [
-  path.resolve(process.cwd(), 'public/img/pear-app.png'),
-  path.resolve(process.cwd(), 'web/public/img/pear-app.png'),
-];
-
-/** Candidate paths for the brand-kit pear mark (transparent). */
-const MARK_CANDIDATES = [
-  path.resolve(process.cwd(), 'public/brand-kit/pear-icon-transparent.png'),
-  path.resolve(process.cwd(), 'web/public/brand-kit/pear-icon-transparent.png'),
-];
-
-/**
- * Read a PNG and return it as a base64 data URL for embedding into the
- * satori-rendered card. Fails soft: if no candidate can be read the caller
- * renders its fallback (the card never breaks).
- */
-function loadPng(candidates: string[]): string | undefined {
-  for (const candidate of candidates) {
+function loadAsset(publicPath: string): string | undefined {
+  for (const root of ['public', 'web/public']) {
+    const file = path.resolve(process.cwd(), root, publicPath);
     try {
-      if (fs.existsSync(candidate)) {
-        const data = fs.readFileSync(candidate);
-        return `data:image/png;base64,${data.toString('base64')}`;
+      if (fs.existsSync(file)) {
+        return `data:image/png;base64,${fs.readFileSync(file).toString('base64')}`;
       }
     } catch {
-      // Try the next candidate.
+      // Try the next root.
     }
   }
   return undefined;
@@ -53,8 +42,8 @@ function loadPng(candidates: string[]): string | undefined {
  */
 export async function GET() {
   const { fonts, headingFamily, bodyFamily } = await loadBrandFonts();
-  const screenshot = loadPng(SHOT_CANDIDATES);
-  const mark = loadPng(MARK_CANDIDATES);
+  const screenshot = loadAsset('img/pear-app.png');
+  const mark = loadAsset('brand-kit/pear-icon-transparent.png');
 
   return new ImageResponse(
     <PearVariant headingFamily={headingFamily} bodyFamily={bodyFamily} screenshot={screenshot} mark={mark} />,

--- a/web/app/pear/page.tsx
+++ b/web/app/pear/page.tsx
@@ -39,7 +39,12 @@ function PearMark({ className }: { className?: string }) {
     // Plain img: the SST/OpenNext image optimizer has no working sharp
     // runtime, so next/image's /_next/image endpoint 500s.
     // eslint-disable-next-line @next/next/no-img-element
-    <img className={`${s.pearMark} ${className ?? ''}`} src="/brand-kit/pear-icon-transparent.png" alt="" aria-hidden />
+    <img
+      className={`${s.pearMark} ${className ?? ''}`}
+      src="/brand-kit/pear-icon-transparent.png"
+      alt=""
+      aria-hidden
+    />
   );
 }
 
@@ -145,8 +150,8 @@ export default function PearPage() {
               </h1>
             </div>
             <p className={s.lead}>
-              Run a team of AI coding agents in parallel. They split up the work and coordinate with each
-              other.
+              Run a team of AI coding agents in parallel. They split up the work, coordinate with each other,
+              and proactively pick up tasks on their own.
             </p>
             <div className={s.ctaRow}>
               <Link href="#waitlist" className={s.ctaPrimary}>
@@ -199,8 +204,8 @@ export default function PearPage() {
               <h3 className={s.featureName}>They coordinate with each other</h3>
               <p className={s.featureDesc}>
                 Pear gives every agent a real messaging rail — the same channels, DMs, threads, and reactions
-                you&apos;d expect from Slack, built on Agent Relay. Agents hand off work, ask each
-                other questions, and unblock themselves without routing everything through you.
+                you&apos;d expect from Slack, built on Agent Relay. Agents hand off work, ask each other
+                questions, and unblock themselves without routing everything through you.
               </p>
               <ul className={s.bullets}>
                 <li>
@@ -272,8 +277,8 @@ export default function PearPage() {
               <h3 className={s.featureName}>Run agents on your machine or in the cloud</h3>
               <p className={s.featureDesc}>
                 Spin up agents locally in their own terminals, or hand a workstream to a cloud agent and close
-                your laptop — it keeps running and reports back when it lands. Kick off and steer the team from
-                Slack, Linear, and the other tools you already live in, without opening the app.
+                your laptop — it keeps running and reports back when it lands. Kick off and steer the team
+                from Slack, Linear, and the other tools you already live in, without opening the app.
               </p>
               <ul className={s.bullets}>
                 <li>
@@ -432,6 +437,60 @@ export default function PearPage() {
                   <div className={s.usageTotal}>
                     <span>Session total</span>
                     <span className={s.usageTotalVal}>1.84M tokens · $9.27</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <Wave />
+
+          <div className={s.featureRow}>
+            <div className={s.featureCopy}>
+              <span className={s.featureTag}>
+                <PearMark className={s.eyebrowMark} /> Proactive &amp; connected
+              </span>
+              <h3 className={s.featureName}>Agents that pick up work on their own</h3>
+              <p className={s.featureDesc}>
+                Connect Pear to Slack, Linear, GitHub, and the rest of your stack. Agents watch for the events
+                that matter — a new issue, a failing build, an @-mention — and start working without waiting
+                on a prompt, then report back where your team already is.
+              </p>
+              <ul className={s.bullets}>
+                <li>
+                  <Tick /> <span>A new Linear issue or GitHub PR spins up an agent</span>
+                </li>
+                <li>
+                  <Tick /> <span>@-mention in Slack to dispatch or steer a run</span>
+                </li>
+                <li>
+                  <Tick /> <span>Triggers and webhooks kick off work automatically</span>
+                </li>
+              </ul>
+            </div>
+            <div className={s.visual} aria-hidden>
+              <div className={s.visualBar}>
+                <span className={`${s.dot} ${s.dotR}`} />
+                <span className={`${s.dot} ${s.dotY}`} />
+                <span className={`${s.dot} ${s.dotG}`} />
+                <span className={s.visualTitle}>triggers</span>
+              </div>
+              <div className={s.visualBody}>
+                <div className={s.triggers}>
+                  <div className={s.trigger}>
+                    <span className={s.triggerSource}>Linear</span>
+                    <span className={s.triggerText}>New issue · ENG-412</span>
+                    <span className={`${s.triggerState} ${s.runnerLocal}`}>agent on it</span>
+                  </div>
+                  <div className={s.trigger}>
+                    <span className={s.triggerSource}>GitHub</span>
+                    <span className={s.triggerText}>CI failed · #1053</span>
+                    <span className={`${s.triggerState} ${s.runnerLocal}`}>investigating</span>
+                  </div>
+                  <div className={s.trigger}>
+                    <span className={s.triggerSource}>Slack</span>
+                    <span className={s.triggerText}>@pear ship the docs</span>
+                    <span className={`${s.triggerState} ${s.runnerLocal}`}>running</span>
                   </div>
                 </div>
               </div>

--- a/web/app/pear/pear.module.css
+++ b/web/app/pear/pear.module.css
@@ -95,13 +95,9 @@
 }
 
 @media (max-width: 640px) {
+  /* Keep the mark inline beside the headline — don't stack it on top. */
   .heroHead {
-    flex-direction: column;
-    gap: 0.6rem;
-  }
-
-  .headline {
-    text-align: center;
+    gap: 0.75rem;
   }
 }
 
@@ -181,6 +177,21 @@
     animation: shotZoom linear both;
     animation-timeline: scroll(root block);
     animation-range: 0 600px;
+  }
+}
+
+/* On phones, blow the screenshot up well past the viewport so the app UI is
+   actually legible — the extra width overflows to the right and is clipped by
+   the page, anchored to the top-left so the sidebar + channel stay in frame. */
+@media (max-width: 640px) {
+  .mockWrap {
+    width: 200vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: 0;
+  }
+
+  .shot {
+    transform-origin: 0 0;
   }
 }
 
@@ -547,6 +558,55 @@
   border-radius: 999px;
   background: var(--surface);
   border: 1px solid color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* proactive & integrations visual */
+.triggers {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 0.7rem;
+  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.triggerSource {
+  flex: 0 0 auto;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--primary);
+  padding: 0.22rem 0.5rem;
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+.triggerText {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.78rem;
+  color: var(--fg);
+  font-family: var(--font-geist-mono), monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.triggerState {
+  flex: 0 0 auto;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
 }
 
 /* cost & usage visual */

--- a/web/app/pear/pear.module.css
+++ b/web/app/pear/pear.module.css
@@ -190,8 +190,12 @@
     margin-right: 0;
   }
 
+  /* Skip the scroll-zoom on phones: render the full 200vw statically so the
+     size is the same on every browser (not 0.8x on ones without scroll
+     timelines), and let it overflow off the right from the top-left. */
   .shot {
-    transform-origin: 0 0;
+    transform: none;
+    animation: none;
   }
 }
 
@@ -600,13 +604,8 @@
 }
 
 .triggerState {
+  composes: runnerTag;
   flex: 0 0 auto;
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
 }
 
 /* cost & usage visual */

--- a/web/lib/og/template.tsx
+++ b/web/lib/og/template.tsx
@@ -822,33 +822,9 @@ export function LandingVariant({
   );
 }
 
-// ───────────────────────────────────────────────────────────────────────────
-// Pear mark — the ripe-pear glyph from app/pear/page.tsx (green body + brown
-// stem), inlined for satori. Used by the Pear OG card's lockup.
-// ───────────────────────────────────────────────────────────────────────────
-
-const PEAR_BODY_PATH =
-  'M7.681 9.097c1.587-3.151 7.698-1.916 11.958 2.171 2.697 2.586 8.056 1.498 11.498 4.804 3.493 3.354 3.259 9.361-3.053 15.767C23 37 16 37 11.835 33.384c-4.388-3.811-2.476-8.61-4.412-13.585S3.1 9.375 7.681 9.097Z';
-const PEAR_STEM_PATH =
-  'M8.178 9.534c-.43.448-1.114.489-1.527.093-3.208-3.079-3.918-7.544-3.946-7.776-.074-.586.348-1.157.939-1.278.592-.121 1.131.257 1.205.842.006.05.657 3.997 3.359 6.59.413.397.4 1.081-.03 1.529Z';
-
-const PEAR_GREEN = '#A6D388';
-
-function PearMark({ size = 46 }: { size?: number }): ReactElement {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 36 36"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      style={{ display: 'flex' }}
-    >
-      <path fill={PEAR_GREEN} d={PEAR_BODY_PATH} />
-      <path fill="#662113" d={PEAR_STEM_PATH} />
-    </svg>
-  );
-}
+// Brand blue used for the "team" accent in the Pear OG headline, matching the
+// landing page's wordmark and the pear lockup.
+const PEAR_BLUE = '#75B8E2';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Variant: PEAR — left copy column + the Pear desktop-app screenshot pinned
@@ -962,13 +938,11 @@ export function PearVariant({
           position: 'relative',
         }}
       >
-        {/* Lockup: pear mark + "Pear" wordmark + a muted "by Agent Relay". */}
+        {/* Lockup: brand-kit pear mark + "Pear" wordmark + a muted "by Agent Relay". */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 40 }}>
-          {mark ? (
+          {mark && (
             // eslint-disable-next-line @next/next/no-img-element
             <img src={mark} width={52} height={52} alt="" style={{ display: 'flex' }} />
-          ) : (
-            <PearMark size={48} />
           )}
           <span
             style={{
@@ -987,7 +961,7 @@ export function PearVariant({
           </span>
         </div>
 
-        {/* Hero headline, heavier Sora 800 with "team" in pear green. */}
+        {/* Hero headline, heavier Sora 800 with "team" in brand blue. */}
         <div
           style={{
             display: 'flex',
@@ -1003,7 +977,7 @@ export function PearVariant({
           <span style={{ display: 'flex', fontWeight: 800 }}>Pair program</span>
           <span style={{ display: 'flex', flexWrap: 'wrap', fontWeight: 800 }}>
             <span style={{ display: 'flex', fontWeight: 800 }}>with a&nbsp;</span>
-            <span style={{ display: 'flex', fontWeight: 800, color: PEAR_GREEN }}>team</span>
+            <span style={{ display: 'flex', fontWeight: 800, color: PEAR_BLUE }}>team</span>
             <span style={{ display: 'flex', fontWeight: 800 }}>&nbsp;of agents</span>
           </span>
         </div>

--- a/web/lib/og/template.tsx
+++ b/web/lib/og/template.tsx
@@ -938,10 +938,13 @@ export function PearVariant({
   headingFamily,
   bodyFamily,
   screenshot,
+  mark,
 }: {
   headingFamily: string;
   bodyFamily: string;
   screenshot?: string;
+  /** Data URL for the brand-kit pear mark. Falls back to the inline glyph. */
+  mark?: string;
 }): ReactElement {
   return (
     <Frame bodyFamily={bodyFamily}>
@@ -961,7 +964,12 @@ export function PearVariant({
       >
         {/* Lockup: pear mark + "Pear" wordmark + a muted "by Agent Relay". */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 40 }}>
-          <PearMark size={48} />
+          {mark ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={mark} width={52} height={52} alt="" style={{ display: 'flex' }} />
+          ) : (
+            <PearMark size={48} />
+          )}
           <span
             style={{
               display: 'flex',

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -10,8 +10,8 @@ const nextConfig = {
   outputFileTracingRoot: path.resolve(__dirname, '..'),
   outputFileTracingIncludes: {
     '/*': ['content/docs/**/*', 'content/blog/**/*'],
-    // The Pear OG card embeds this screenshot at render time.
-    '/pear/og.png': ['public/img/pear-app.png'],
+    // The Pear OG card embeds these at render time.
+    '/pear/og.png': ['public/img/pear-app.png', 'public/brand-kit/pear-icon-transparent.png'],
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
## **User description**
Follow-up to #1053. Those changes were pushed to the branch **after** #1053 was squash-merged, so they never reached `main` — this PR lands them on top of current `main` (no conflict with the `/pear/download` route from #1052).

## Changes
- **OG card** (`/pear/og.png`): renders the brand-kit blue pear in the lockup instead of the old green glyph. Loaded as a base64 data URL the same way the route already reads the screenshot, with a fail-soft fallback to the inline glyph.
- **New "Proactive & connected" section**: *"Agents that pick up work on their own"* — connect Pear to Slack, Linear, GitHub; agents act on events (new issue, failing build, @-mention) without a prompt. Includes a "triggers" visual.
- **Hero subline** now mentions agents proactively picking up tasks.
- **Mobile hero**: the pear mark stays inline beside the headline (no longer stacks on top), and the product screenshot is blown up to `200vw` anchored top-left so the app UI is legible (overflow clipped by the page).

Desktop is unchanged for the mobile bits (all in `@media (max-width: 640px)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add a proactive agents section and update Pear branding in the hero and Open Graph card

### What Changed
- Added a new “Proactive & connected” section showing agents starting work from Slack, Linear, GitHub, and webhooks without waiting for a prompt
- Updated the hero text to say agents can pick up tasks on their own
- Kept the Pear mark inline with the mobile hero headline and enlarged the mobile screenshot so the app view stays readable
- Swapped the Open Graph card to use the blue Pear mark, with a fallback if the image cannot be loaded

### Impact
`✅ Clearer messaging about proactive agents`
`✅ Easier-to-read mobile hero`
`✅ More accurate social preview branding`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
