### PR TITLE
feat(web): update landing hero copy

### DIFF
--- a/web/app/landing.module.css
+++ b/web/app/landing.module.css
@@ -115,7 +115,7 @@
 
 .headline {
   font-family: var(--font-heading), sans-serif;
-  font-size: clamp(2.2rem, 7vw, 4.5rem);
+  font-size: clamp(3.2rem, 7vw, 5.5rem);
   font-weight: 500;
   line-height: 1.05;
   letter-spacing: -0.03em;
@@ -748,6 +748,32 @@
   max-width: 620px;
 }
 
+/* Sits below the order-6 wave that follows the commands feature. The compound
+   selector outranks the base `.featureSeparator { order: 4 }` regardless of
+   source order, so the divider lands between the commands and A2A features. */
+.featureSeparator.a2aSeparator {
+  order: 6;
+}
+
+.a2aFeature {
+  order: 7;
+  --feature-band-bg: #0b1c2a;
+  padding-top: 36px;
+}
+
+.a2aFeature::before {
+  border-top: 0;
+}
+
+.a2aFeature .featurePreview {
+  order: 1;
+}
+
+.a2aFeature .featureCopy {
+  order: 2;
+  max-width: 620px;
+}
+
 .featureSeparator {
   position: relative;
   order: 4;
@@ -802,6 +828,65 @@
 
 .featureSeparatorWaves path:nth-child(2) {
   opacity: 0.5;
+}
+
+/* A2A separator: a livelier sibling of the plain feature wave. A gradient
+   strand (blue → pear-green → blue) with a soft glow, an extra ghost strand,
+   an opposite tilt, and a gentle horizontal drift. */
+.a2aSeparatorWaves {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  width: 132vw;
+  height: 96px;
+  overflow: visible;
+  opacity: 0.5;
+  transform: translate(-50%, -50%) rotate(-2.4deg);
+  transform-origin: center;
+  filter: drop-shadow(0 0 4px rgba(116, 184, 226, 0.15));
+}
+
+.a2aSeparatorWaves path {
+  stroke: url(#a2aWaveStroke);
+  stroke-linecap: round;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.a2aWaveLead {
+  stroke-width: 1.2;
+  opacity: 0.6;
+}
+
+.a2aWaveTrail {
+  stroke-width: 1;
+  opacity: 0.32;
+}
+
+.a2aWaveGhost {
+  stroke-width: 0.9;
+  opacity: 0.18;
+}
+
+.a2aWaveFlow {
+  animation: a2aWaveDrift 9s ease-in-out infinite alternate;
+  will-change: transform;
+}
+
+@keyframes a2aWaveDrift {
+  from {
+    transform: translateX(-14px);
+  }
+  to {
+    transform: translateX(14px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .a2aWaveFlow {
+    animation: none;
+  }
 }
 
 .messagingFeature .featurePreview {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,6 +4,7 @@ import { GitHubStarsBadge } from '../components/GitHubStars';
 import { SiteFooter } from '../components/SiteFooter';
 import { SiteNav } from '../components/SiteNav';
 import {
+  A2AFeature,
   AgentToolsFeature,
   Deploy,
   DeliveryFeature,
@@ -56,6 +57,8 @@ export default function HomePage() {
           <DeliveryFeature />
           <WaveDivider variant="feature" />
           <AgentToolsFeature />
+          <WaveDivider variant="a2a" className={s.a2aSeparator} />
+          <A2AFeature />
         </section>
       </div>
 

--- a/web/components/home/A2AFeature.tsx
+++ b/web/components/home/A2AFeature.tsx
@@ -1,0 +1,90 @@
+import { FadeIn } from '../FadeIn';
+import s from '../../app/landing.module.css';
+
+/** Syntax-highlight kinds mapped to the editor's CSS module classes. */
+type TokenKind = 'muted' | 'fn' | 'var' | 'kw' | 'str';
+
+const TOKEN_CLASS: Record<TokenKind, string> = {
+  muted: s.codeMuted,
+  fn: s.codeFunction,
+  var: s.codeVariable,
+  kw: s.codeKeyword,
+  str: s.codeString,
+};
+
+/**
+ * An A2A Agent Card, expressed as ordered tokens. Plain segments (including
+ * whitespace/newlines) carry no kind; highlighted segments name the span color.
+ * Rendered into a `pre` whose `white-space: pre-wrap` preserves the spacing here.
+ */
+const AGENT_CARD_TOKENS: ReadonlyArray<{ text: string; kind?: TokenKind }> = [
+  { text: '// Any A2A client can discover and call this agent ', kind: 'muted' },
+  { text: '\n{\n  ' },
+  { text: '"name"', kind: 'var' },
+  { text: ': ' },
+  { text: '"Scout"', kind: 'str' },
+  { text: ',\n  ' },
+  { text: '"protocolVersion"', kind: 'var' },
+  { text: ': ' },
+  { text: '"0.3.0"', kind: 'str' },
+  { text: ',\n  ' },
+  { text: '"url"', kind: 'var' },
+  { text: ': ' },
+  { text: '"https://relay.dev/a2a/scout"', kind: 'str' },
+  { text: ',\n  ' },
+  { text: '"capabilities"', kind: 'var' },
+  { text: ': { ' },
+  { text: '"streaming"', kind: 'var' },
+  { text: ': ' },
+  { text: 'true', kind: 'kw' },
+  { text: ' },\n  ' },
+  { text: '"skills"', kind: 'var' },
+  { text: ': [{ ' },
+  { text: '"id"', kind: 'var' },
+  { text: ': ' },
+  { text: '"triage"', kind: 'str' },
+  { text: ', ' },
+  { text: '"tags"', kind: 'var' },
+  { text: ': [' },
+  { text: '"routing"', kind: 'str' },
+  { text: '] }]\n}' },
+];
+
+export function A2AFeature() {
+  return (
+    <FadeIn direction="up" delay={120} className={`${s.featureCol} ${s.a2aFeature}`}>
+      <div className={`${s.featurePreview} ${s.commandsEditorPreview}`}>
+        <div className={s.editorWindow}>
+          <div className={s.editorTitlebar}>
+            <span />
+            <span />
+            <span />
+            <strong>agent-card.json</strong>
+          </div>
+          <pre className={s.editorCode}>
+            <code>
+              {AGENT_CARD_TOKENS.map(({ text, kind }, i) =>
+                kind ? (
+                  <span key={i} className={TOKEN_CLASS[kind]}>
+                    {text}
+                  </span>
+                ) : (
+                  <span key={i}>{text}</span>
+                )
+              )}
+            </code>
+          </pre>
+        </div>
+      </div>
+      <div className={s.featureCopy}>
+        <h3 className={s.featureTitle}>Speaks A2A out of the box</h3>
+        <ul className={s.featureList}>
+          <li>Every Relay agent publishes an A2A Agent Card, so any A2A client can discover and call it.</li>
+          <li>Bridge agents built on other frameworks over the open Agent2Agent protocol — no custom glue.</li>
+          <li>A2A tasks, messages, and streaming updates map onto Relay channels and threads automatically.</li>
+          <li>Standard endpoints in, durable Relay delivery out, with the full chat history preserved.</li>
+        </ul>
+      </div>
+    </FadeIn>
+  );
+}

--- a/web/components/home/A2AFeature.tsx
+++ b/web/components/home/A2AFeature.tsx
@@ -80,8 +80,12 @@ export function A2AFeature() {
         <h3 className={s.featureTitle}>Speaks A2A out of the box</h3>
         <ul className={s.featureList}>
           <li>Every Relay agent publishes an A2A Agent Card, so any A2A client can discover and call it.</li>
-          <li>Bridge agents built on other frameworks over the open Agent2Agent protocol — no custom glue.</li>
-          <li>A2A tasks, messages, and streaming updates map onto Relay channels and threads automatically.</li>
+          <li>
+            Bridge agents built on other frameworks over the open Agent2Agent protocol — no custom glue.
+          </li>
+          <li>
+            A2A tasks, messages, and streaming updates map onto Relay channels and threads automatically.
+          </li>
           <li>Standard endpoints in, durable Relay delivery out, with the full chat history preserved.</li>
         </ul>
       </div>

--- a/web/components/home/AgentToolsFeature.tsx
+++ b/web/components/home/AgentToolsFeature.tsx
@@ -19,25 +19,43 @@ const TOKEN_CLASS: Record<TokenKind, string> = {
  * The orchestrator.ts snippet, expressed as ordered tokens. Plain segments
  * (including whitespace/newlines) carry no kind; highlighted segments name the
  * span color. Rendered into a `pre` whose `white-space: pre-wrap` preserves the
- * literal spacing here.
+ * literal spacing here. Mirrors the SDK's `registerAction` API from the README.
  */
 const EDITOR_TOKENS: ReadonlyArray<{ text: string; kind?: TokenKind }> = [
-  { text: '// Define callbacks from agent actions ', kind: 'muted' },
+  { text: '// Expose a tool to agents via MCP + CLI ', kind: 'muted' },
   { text: '\nrelay.' },
-  { text: 'on', kind: 'fn' },
-  { text: '(\n engineer.' },
-  { text: 'status', kind: 'var' },
-  { text: '.' },
-  { text: 'becomes', kind: 'fn' },
-  { text: '(' },
-  { text: '"idle"', kind: 'str' },
-  { text: '),\n ' },
+  { text: 'registerAction', kind: 'fn' },
+  { text: '({\n  name: ' },
+  { text: '"submit-vote"', kind: 'str' },
+  { text: ',\n  input: z.' },
+  { text: 'object', kind: 'fn' },
+  { text: '({ vote: z.' },
+  { text: 'enum', kind: 'fn' },
+  { text: '([' },
+  { text: '"yes"', kind: 'str' },
+  { text: ', ' },
+  { text: '"no"', kind: 'str' },
+  { text: ']) }),\n  handler: ' },
   { text: 'async', kind: 'kw' },
-  { text: ' () =>\n relay.' },
-  { text: 'sendMessage', kind: 'fn' },
-  { text: '({\n to: taskManager,\n msg: ' },
-  { text: '`${engineer.handle} is idle. Send the next task.`', kind: 'str' },
-  { text: ',\n }),\n);' },
+  { text: ' ({ agent, input }) => {\n    ' },
+  { text: 'await', kind: 'kw' },
+  { text: ' ' },
+  { text: 'recordVote', kind: 'fn' },
+  { text: '(agent.' },
+  { text: 'name', kind: 'var' },
+  { text: ', input.' },
+  { text: 'vote', kind: 'var' },
+  { text: ');\n  },\n});\n\n' },
+  { text: '// Run a callback when it completes ', kind: 'muted' },
+  { text: '\nrelay.' },
+  { text: 'addListener', kind: 'fn' },
+  { text: '(relay.' },
+  { text: 'action', kind: 'fn' },
+  { text: '(' },
+  { text: '"submit-vote"', kind: 'str' },
+  { text: ').' },
+  { text: 'completed', kind: 'fn' },
+  { text: '(), tally);' },
 ];
 
 export function AgentToolsFeature() {

--- a/web/components/home/Hero.tsx
+++ b/web/components/home/Hero.tsx
@@ -10,11 +10,11 @@ export function Hero() {
       <HeroBackdrop />
       <section className={s.hero}>
         <div className={s.heroLeft}>
-          <h1 className={s.headline}>Headless Slack for Agents</h1>
+          <h1 className={s.headline}>Let your agents talk</h1>
 
           <p className={s.subtitle}>
-            Channels, threads, DMs, reactions, and real-time events built for multi-agent systems. Everything
-            you’d expect from Slack, exposed as an SDK.
+            Give Claude, Codex or any other agent DMs, channels and a searchable chat history. Build your
+            multi-agent system without worrying about the glue.
           </p>
 
           <div className={s.ctas}>

--- a/web/components/home/icons.tsx
+++ b/web/components/home/icons.tsx
@@ -105,7 +105,49 @@ export function ScribbleUnderline() {
  * `feature` is the thin two-stroke rule between feature blocks; `capability`
  * is the taller three-stroke band that opens the context-capabilities group.
  */
-export function WaveDivider({ variant }: { variant: 'feature' | 'capability' }) {
+export function WaveDivider({
+  variant,
+  className,
+}: {
+  variant: 'feature' | 'capability' | 'a2a';
+  /** Extra class merged onto the wrapper — used to reposition via grid `order`. */
+  className?: string;
+}) {
+  if (variant === 'a2a') {
+    // A livelier take on the feature wave: a gradient strand that runs blue →
+    // pear-green → light-blue, a soft glow, an extra ghost strand, and a gentle
+    // drift (see `.a2aSeparatorWaves` in landing.module.css). Tilts the opposite
+    // way from the plain separators so it reads as deliberately different.
+    return (
+      <div
+        className={className ? `${s.featureSeparator} ${className}` : s.featureSeparator}
+        aria-hidden="true"
+      >
+        <svg
+          className={s.a2aSeparatorWaves}
+          viewBox="0 0 1200 60"
+          fill="none"
+          preserveAspectRatio="none"
+        >
+          <defs>
+            <linearGradient id="a2aWaveStroke" x1="0" y1="0" x2="1200" y2="0" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stopColor="#74b8e2" stopOpacity="0" />
+              <stop offset="22%" stopColor="#9ccfff" />
+              <stop offset="52%" stopColor="#a6d388" />
+              <stop offset="80%" stopColor="#74b8e2" />
+              <stop offset="100%" stopColor="#74b8e2" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          <g className={s.a2aWaveFlow}>
+            <path className={s.a2aWaveLead} d="M-120 30 C150 12 360 14 600 30 S1040 50 1320 28" />
+            <path className={s.a2aWaveTrail} d="M-120 38 C168 22 372 24 620 39 S1066 58 1320 36" />
+            <path className={s.a2aWaveGhost} d="M-120 22 C140 6 348 8 580 22 S1012 42 1320 18" />
+          </g>
+        </svg>
+      </div>
+    );
+  }
+
   if (variant === 'capability') {
     return (
       <div className={s.capabilityDivider} aria-hidden="true">
@@ -124,7 +166,10 @@ export function WaveDivider({ variant }: { variant: 'feature' | 'capability' }) 
   }
 
   return (
-    <div className={s.featureSeparator} aria-hidden="true">
+    <div
+      className={className ? `${s.featureSeparator} ${className}` : s.featureSeparator}
+      aria-hidden="true"
+    >
       <svg className={s.featureSeparatorWaves} viewBox="0 0 1200 60" fill="none" preserveAspectRatio="none">
         <path d="M-120 26 C160 42 360 40 600 30 S1040 16 1320 34" />
         <path d="M-120 34 C176 50 376 48 620 38 S1060 24 1320 42" />

--- a/web/components/home/icons.tsx
+++ b/web/components/home/icons.tsx
@@ -123,12 +123,7 @@ export function WaveDivider({
         className={className ? `${s.featureSeparator} ${className}` : s.featureSeparator}
         aria-hidden="true"
       >
-        <svg
-          className={s.a2aSeparatorWaves}
-          viewBox="0 0 1200 60"
-          fill="none"
-          preserveAspectRatio="none"
-        >
+        <svg className={s.a2aSeparatorWaves} viewBox="0 0 1200 60" fill="none" preserveAspectRatio="none">
           <defs>
             <linearGradient id="a2aWaveStroke" x1="0" y1="0" x2="1200" y2="0" gradientUnits="userSpaceOnUse">
               <stop offset="0%" stopColor="#74b8e2" stopOpacity="0" />
@@ -166,10 +161,7 @@ export function WaveDivider({
   }
 
   return (
-    <div
-      className={className ? `${s.featureSeparator} ${className}` : s.featureSeparator}
-      aria-hidden="true"
-    >
+    <div className={className ? `${s.featureSeparator} ${className}` : s.featureSeparator} aria-hidden="true">
       <svg className={s.featureSeparatorWaves} viewBox="0 0 1200 60" fill="none" preserveAspectRatio="none">
         <path d="M-120 26 C160 42 360 40 600 30 S1040 16 1320 34" />
         <path d="M-120 34 C176 50 376 48 620 38 S1060 24 1320 42" />

--- a/web/components/home/index.ts
+++ b/web/components/home/index.ts
@@ -4,6 +4,7 @@ export { WorksWithEveryAgent } from './WorksWithEveryAgent';
 export { DeliveryFeature } from './DeliveryFeature';
 export { ContextCapabilities } from './ContextCapabilities';
 export { AgentToolsFeature } from './AgentToolsFeature';
+export { A2AFeature } from './A2AFeature';
 export { Deploy } from './Deploy';
 export { QuickStart } from './QuickStart';
 export { Waitlist } from './Waitlist';

--- a/web/lib/og/template.tsx
+++ b/web/lib/og/template.tsx
@@ -784,8 +784,23 @@ export function LandingVariant({
         <div style={{ display: 'flex', marginBottom: 44 }}>
           <BrandLockup scale={1.4} />
         </div>
-        {/* Main-page hero: full white (no blue accent) + heavier Sora 800. */}
-        <HeroHeadline headingFamily={headingFamily} fontSize={68} accent={false} fontWeight={800} />
+        {/* Main-page hero: full white (no blue accent), heavier Sora 800,
+            mirroring the live two-line landing headline. */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            fontFamily: headingFamily,
+            fontWeight: 800,
+            fontSize: 76,
+            lineHeight: 1.0,
+            letterSpacing: '-0.045em',
+            color: PALETTE.fg,
+          }}
+        >
+          <span style={{ display: 'flex' }}>Let your</span>
+          <span style={{ display: 'flex' }}>agents talk</span>
+        </div>
         <div
           style={{
             display: 'flex',
@@ -796,7 +811,7 @@ export function LandingVariant({
             maxWidth: 470,
           }}
         >
-          Channels, threads, DMs, reactions, and real-time events built for multi-agent systems.
+          Give Claude, Codex or any agent DMs, channels, and a searchable chat history — without the glue.
         </div>
       </div>
 


### PR DESCRIPTION
Updates the landing page hero to the new messaging.

## Changes
- **Headline:** `Headless Slack for Agents` → `Let your agents talk`
- **Subtitle:** now leads with the value prop — "Give Claude, Codex or any other agent DMs, channels and a searchable chat history. Build your multi-agent system without worrying about the glue."

🤖 Generated with [Claude Code](https://claude.com/claude-code)