### PR TITLE
fix(cli): default backend to gateway.relaycast.dev

### DIFF
--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -57,7 +57,7 @@ use crate::{broker, listen_api, routing, worker_request};
 
 const DEFAULT_DELIVERY_RETRY_MS: u64 = 1_000;
 const MAX_DELIVERY_RETRIES: u32 = 10;
-const DEFAULT_RELAYCAST_BASE_URL: &str = "https://api.relaycast.dev";
+const DEFAULT_RELAYCAST_BASE_URL: &str = "https://gateway.relaycast.dev";
 const THREAD_HISTORY_LIMIT: usize = 1_000;
 const DEFAULT_HTTP_API_LOCAL_DELIVERY_TIMEOUT_MS: u64 = 3_000;
 const DEFAULT_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: u64 = 20_000;

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -37,7 +37,7 @@ import {
 import { relaycastWorkspaceTelemetryOptions, withRelaycastTelemetry } from './lib/relaycast-telemetry.js';
 import { errorClassName } from './lib/telemetry-helpers.js';
 
-const DEFAULT_BASE_URL = 'https://api.relaycast.dev';
+const DEFAULT_BASE_URL = 'https://gateway.relaycast.dev';
 export const AGENT_RELAY_MCP_VERSION = process.env.AGENT_RELAY_CLI_VERSION ?? SDK_VERSION ?? 'unknown';
 let mcpTelemetryExitHookInstalled = false;
 


### PR DESCRIPTION
## What

Changes the CLI's default Relaycast backend from `https://api.relaycast.dev` to `https://gateway.relaycast.dev` in the two places the default is defined:

- `crates/broker/src/runtime/mod.rs` — `DEFAULT_RELAYCAST_BASE_URL` (broker session fallback)
- `packages/cli/src/cli/agent-relay-mcp.ts` — `DEFAULT_BASE_URL` (local MCP server default)

Overridable via `RELAYCAST_BASE_URL` / `RELAY_BASE_URL`.

## Why

v8 was intended to run on the cloud-hosted **gateway** worker, but the shipped default still pointed at the legacy upstream OSS deploy (`api.relaycast.dev`). Only the gateway re-host wires the PostHog telemetry sink, so engine product events (`relaycast_server_*`) only reach the Agent Relay project once traffic flows through gateway.

Pairs with **cloud#2026**, which tags the gateway deploy `1.0.0` (its `/health` previously reported the engine's `0.1.0` fallback because no version was configured).

## Compatibility checks

The two deploys are different builds with a partially divergent route surface, so this was verified rather than assumed:

- **`/mcp` (gateway 404s it):** ✅ not a problem. v8 does **not** call `{base}/mcp`. The CLI's MCP server is local/stdio and uses `baseUrl` only for `/v1/*` REST + the websocket transport, all of which gateway serves. `/mcp` is the *hosted remote-MCP* endpoint, deliberately moved off gateway to a separate service — unrelated to the CLI base URL.
- **`/v1/*` REST surface:** served by gateway (auth-gated 401s on probe).
- Gateway is the intended v8 backend (confirmed by owner) and is tagged `1.0.0`.

## Remaining pre-merge confirmation

- [ ] `RELAYCAST_POSTHOG_API_KEY` GitHub Actions secret is set non-empty for the gateway stage — `set-secrets.sh` uses `--fallback`, so an empty value silently disables telemetry (wiring itself is verified correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)