### PR TITLE
fix(cloud): bind OAuth callback tunnel dual-stack + pin codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `agent-relay cloud connect <provider>` (and `agent-relay auth`) bind the OAuth callback tunnel on both `127.0.0.1` and `::1`, so provider CLIs that advertise a `localhost` loopback redirect (e.g. codex's `http://localhost:1455/auth/callback`) reconcile even when the browser resolves `localhost` to IPv6 first; previously the IPv4-only tunnel dropped the callback and login hung forever.
+- `@agent-relay/cloud` pins the codex CLI installed into the auth sandbox (`@openai/codex@0.138.0`) instead of tracking `latest`, keeping `cloud connect codex` reproducible against codex's frequent releases.
 - `agent-relay local agent list` and `local metrics` now connect only to an existing local broker, so read-only commands no longer start an empty broker and hang after printing results.
 - `agent-relay` CLI attach sessions no longer write successful `view`, `drive`, or `passthrough` attach banners into the interactive terminal buffer.
 - `@agent-relay/cloud`: CLI browser login ignores stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not shown a false hosted error or aborted before the real OAuth callback returns.

--- a/packages/cloud/src/lib/ssh-interactive.ts
+++ b/packages/cloud/src/lib/ssh-interactive.ts
@@ -161,32 +161,53 @@ export async function runInteractiveSession(
     const { Client } = ssh2;
     const sshClient = new Client();
     let sshReady = false;
-    const tunnel: { server: ReturnType<typeof createServer> | null } = { server: null };
+    // OAuth callback tunnel. The provider CLI runs *inside the sandbox* and
+    // advertises a loopback redirect (e.g. codex prints
+    // redirect_uri=http://localhost:1455/auth/callback). We listen on the same
+    // port locally and forward each connection over SSH into the sandbox, so
+    // the browser's callback reaches the provider CLI and login completes.
+    //
+    // We bind BOTH loopback families. macOS resolves `localhost` to ::1 *and*
+    // 127.0.0.1, and browsers frequently try ::1 first. Binding IPv4 only let
+    // the callback hit a closed ::1 port and get dropped, leaving the provider
+    // CLI waiting on a callback that never arrives ("never reconciles"). Bind
+    // 127.0.0.1 as the primary (its listen/EADDRINUSE result gates readiness)
+    // and ::1 best-effort.
+    const tunnel: { servers: Array<ReturnType<typeof createServer>> } = { servers: [] };
+
+    const makeTunnelServer = () =>
+      runtime.createServer((localSocket) => {
+        sshClient.forwardOut('127.0.0.1', tunnelPort, 'localhost', tunnelPort, (err, stream) => {
+          if (err) {
+            localSocket.end();
+            return;
+          }
+          localSocket.pipe(stream).pipe(localSocket);
+        });
+      });
 
     const sshReadyPromise = new Promise<void>((resolve, reject) => {
       sshClient.on('ready', () => {
         sshReady = true;
 
-        tunnel.server = runtime.createServer((localSocket) => {
-          sshClient.forwardOut('127.0.0.1', tunnelPort, 'localhost', tunnelPort, (err, stream) => {
-            if (err) {
-              localSocket.end();
-              return;
-            }
-            localSocket.pipe(stream).pipe(localSocket);
-          });
-        });
-
-        tunnel.server.on('error', (err: NodeJS.ErrnoException) => {
+        const tunnelV4 = makeTunnelServer();
+        tunnel.servers.push(tunnelV4);
+        tunnelV4.on('error', (err: NodeJS.ErrnoException) => {
           if (err.code === 'EADDRINUSE') {
             io.log(color.dim(`Note: Port ${tunnelPort} in use, OAuth callbacks may not work.`));
           }
           resolve();
         });
-
-        tunnel.server.listen(tunnelPort, '127.0.0.1', () => {
+        tunnelV4.listen(tunnelPort, '127.0.0.1', () => {
           resolve();
         });
+
+        // IPv6 loopback (::1) — best effort; never blocks readiness or surfaces
+        // errors (e.g. hosts without IPv6, or ::1 already bound).
+        const tunnelV6 = makeTunnelServer();
+        tunnel.servers.push(tunnelV6);
+        tunnelV6.on('error', () => {});
+        tunnelV6.listen(tunnelPort, '::1', () => {});
       });
 
       sshClient.on('error', (err) => {
@@ -218,7 +239,7 @@ export async function runInteractiveSession(
       ]);
     } catch (err) {
       io.error(color.red(`Failed to connect via SSH: ${err instanceof Error ? err.message : String(err)}`));
-      if (tunnel.server) tunnel.server.close();
+      tunnel.servers.forEach((s) => s.close());
       sshClient.end();
       throw err;
     }
@@ -446,7 +467,7 @@ export async function runInteractiveSession(
       io.log('');
       io.error(color.red(`Remote auth command failed: ${execError.message}`));
     } finally {
-      if (tunnel.server) tunnel.server.close();
+      tunnel.servers.forEach((s) => s.close());
       sshClient.end();
     }
   } else {

--- a/packages/config/src/cli-auth-config.ts
+++ b/packages/config/src/cli-auth-config.ts
@@ -65,6 +65,17 @@ export interface CLIAuthConfig {
 }
 
 /**
+ * Pinned `@openai/codex` version installed into the auth sandbox.
+ *
+ * The sandbox installs codex fresh per session (`npm install -g
+ * @openai/codex@<version>`). Codex ships multiple releases per day and has
+ * changed its login flow before, so we pin a known version instead of tracking
+ * `latest` to keep `cloud connect codex` reproducible. Bump this deliberately
+ * after verifying a real login still completes via the loopback callback.
+ */
+export const CODEX_PINNED_VERSION = '0.138.0';
+
+/**
  * CLI commands and URL patterns for each provider
  *
  * Each CLI tool outputs an OAuth URL when run without credentials.
@@ -195,7 +206,7 @@ export const CLI_AUTH_CONFIG: Record<string, CLIAuthConfig> = {
     urlPattern: /(https:\/\/[^\s]+)/,
     credentialPath: '~/.codex/auth.json',
     displayName: 'Codex',
-    installCommand: 'npm install -g @openai/codex',
+    installCommand: `npm install -g @openai/codex@${CODEX_PINNED_VERSION}`,
     waitTimeout: 30000,
     prompts: [
       {


### PR DESCRIPTION
## Problem

`agent-relay cloud connect codex` (and `agent-relay auth`) hangs forever after the user completes the browser OAuth — "this never reconciles." The codex login server in the sandbox stays listening on `127.0.0.1:1455` having never received the callback.

## Root cause (investigated against live Daytona sandboxes)

The connect flow opens an SSH tunnel that forwards the provider CLI's loopback OAuth callback from the user's machine into the sandbox:

- codex's login server binds **`127.0.0.1` (IPv4)** inside the sandbox but advertises **`redirect_uri=http://localhost:1455/auth/callback`** — the *hostname* `localhost`, not the literal IP (confirmed in codex `codex-rs/login/src/server.rs`).
- Our local tunnel listener bound **`127.0.0.1` only**.
- macOS `/etc/hosts` maps `localhost` to **both** `::1` and `127.0.0.1`, and browsers commonly try **`::1` first**.
- The browser's callback hit `::1:1455` → nothing listening on our side → callback dropped → codex waits forever.

Reproduced directly: against a live sandbox the tunnel delivers `GET /auth/callback` to codex on `127.0.0.1` (`HTTP 400` on a fake code), while `::1:1455 → ECONNREFUSED`. This is the IPv4/IPv6 loopback class codex itself documents ([#12263](https://github.com/openai/codex/issues/12263), WSL [#3927](https://github.com/openai/codex/issues/3927)).

The codex CLI is also installed unpinned (`npm install -g @openai/codex` = always `latest`), and codex ships multiple releases per day — so the sandbox's codex drifts silently.

## Changes

- **`@agent-relay/cloud`** — bind the OAuth callback tunnel on **both** loopback families: `127.0.0.1` (primary, gates readiness / EADDRINUSE) and `::1` (best-effort). The callback now lands regardless of how the browser resolves `localhost`.
- **`@agent-relay/config`** — pin codex via `CODEX_PINNED_VERSION = '0.138.0'` → `npm install -g @openai/codex@0.138.0`, keeping `cloud connect codex` reproducible.

## Verification

- `tsc --noEmit` clean for `@agent-relay/config` and `@agent-relay/cloud`.
- `vitest`: cloud package 84/84, `cli-auth-config` 15/15 pass.
- Tunnel + callback delivery reproduced end-to-end against live sandboxes.

## Deployment notes

- The tunnel fix ships in `@agent-relay/cloud`, bundled into the CLI — effective on the next CLI build/publish.
- The codex pin is read by the cloud service from the published `@agent-relay/config`; it takes effect once that package is republished/redeployed. The default Daytona `typescript` snapshot does not pre-bake codex (verified), so the pinned install runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)