### PR TITLE
docs(sdk): rewrite README for v8 API

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -57,4 +57,4 @@ This rule applies to all Rust files in `relay-pty/src/` and `tests/`.
 
 - Use `serde` derive macros for JSON serialization
 - Use `#[serde(rename_all = "snake_case")]` for enum variants
-- Protocol types must match the TypeScript SDK definitions in `packages/sdk/src/protocol.ts`
+- Protocol types must match the TypeScript definitions in `packages/harness-driver/src/protocol.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@agent-relay/sdk` README documents the current v8 API (`workspace.register`, sigil-routed `sendMessage`, `addListener`, `registerAction`, subpath exports) instead of the removed v7 surface (`relay.as`, `events.on('message.created')`, `relay.actions.register`).
 - `agent-relay local agent list` and `local metrics` now connect only to an existing local broker, so read-only commands no longer start an empty broker and hang after printing results.
 - `agent-relay` CLI attach sessions no longer write successful `view`, `drive`, or `passthrough` attach banners into the interactive terminal buffer.
 - `@agent-relay/cloud`: CLI browser login ignores stray localhost callbacks with an invalid state parameter, so first-time sign-ins are not shown a false hosted error or aborted before the real OAuth callback returns.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,8 +1,8 @@
 # @agent-relay/sdk
 
-Core TypeScript SDK for Agent Relay communication. The SDK gives agents and applications three public capabilities: messaging, delivery, and actions.
+Core TypeScript SDK for Agent Relay: workspace-first messaging, events, actions, and the delivery contract.
 
-Use `@agent-relay/sdk` when your app, service, harness, or worker already owns its runtime and needs to participate in Agent Relay. Use `@agent-relay/harness-driver` when you want Agent Relay to start and supervise Claude, Codex, Gemini, OpenCode, or other local harness processes.
+Use `@agent-relay/sdk` when your app, service, or worker owns its runtime and needs to participate in an Agent Relay workspace. Use `@agent-relay/harness-driver` (with `@agent-relay/harnesses`) when you want Agent Relay to start and supervise Claude, Codex, Gemini, OpenCode, or other local harness processes.
 
 ## Installation
 
@@ -10,12 +10,7 @@ Use `@agent-relay/sdk` when your app, service, harness, or worker already owns i
 npm install @agent-relay/sdk zod
 ```
 
-## Concepts
-
-- **Messaging** is durable agent communication: identities, channels, DMs, group DMs, threads, reactions, inbox, read state, presence, search, and events.
-- **Delivery** is runtime handoff: taking durable messages from Agent Relay and injecting them into a live agent process, service, app server, browser worker, or harness.
-- **Actions** are typed capabilities: discoverable operations with Zod schemas, policy hooks, audit events, and structured result/error envelopes.
-- **Runtime** is optional managed execution. Daemon startup, PTY/headless sessions, spawn/release, harness defaults, logs, readiness, and workflow supervision belong in `@agent-relay/harness-driver`.
+`zod` is optional; action schemas accept Zod schemas, any `safeParse`-style validator, or plain JSON Schema.
 
 ## Quick start
 
@@ -26,218 +21,215 @@ const relay = new AgentRelay({
   workspaceKey: process.env.RELAY_WORKSPACE_KEY!,
 });
 
-const reviewer = await relay.agents.register({ name: 'reviewer' });
-const agent = relay.as(reviewer);
+// register() returns a live, agent-scoped client
+const reviewer = await relay.workspace.register({ name: 'reviewer', type: 'agent' });
 
-await agent.channels.join('reviews');
+await reviewer.channels.create({ name: 'reviews', topic: 'Release review' });
 
-agent.events.on('message.created', async (event) => {
-  if (event.channel !== 'reviews') return;
+relay.addListener('message.created', async (event) => {
+  if (event.type !== 'message.created') return;
+  if (event.envelope.channel?.name !== 'reviews') return;
 
-  await agent.messages.reply({
-    messageId: event.message.id,
+  await reviewer.reply({
+    messageId: event.message.messageId,
     text: 'Received. I will review this thread.',
   });
-  await agent.messages.markRead(event.message.id);
 });
 
-await agent.messages.send({
-  channel: 'reviews',
+await reviewer.sendMessage({
+  to: '#reviews',
   text: 'Reviewer is online.',
 });
 ```
 
-You can also create a new workspace directly:
+You can also create a workspace from scratch and persist its key:
 
 ```ts
-const relay = await AgentRelay.createWorkspace({
-  name: 'review-workspace',
+const relay = await AgentRelay.createWorkspace({ name: 'review-workspace' });
+console.log(relay.workspaceKey); // persist for `new AgentRelay({ workspaceKey })`
+```
+
+## Workspace API
+
+```ts
+const info = await relay.workspace.info();
+
+// single in -> single out, array in -> array out
+const planner = await relay.workspace.register({ name: 'planner', type: 'agent' });
+const [reviewer, engineer] = await relay.workspace.register([
+  { name: 'reviewer', type: 'agent' },
+  { name: 'engineer', type: 'agent' },
+]);
+
+// rehydrate a client in a fresh process from a persisted token
+const planner2 = await relay.workspace.reconnect({ apiToken: planner.token! });
+```
+
+Agent names are unique within a workspace, so `register` rejects a name that is already taken. Each returned `RelayAgentClient` carries the agent's identity (`id`, `name`, `handle`, `token`) plus a messaging surface scoped to that agent.
+
+## Sending messages
+
+Messages are sent _from_ a registered participant — there is no top-level `relay.sendMessage`. The live client carries `sendMessage`, `reply`, and `react`, and `to` routes by sigil:
+
+```ts
+await reviewer.channels.join('reviews');
+
+// `to` is '#channel', '@name' (DM), or ['@a', '@b'] (group DM)
+const sent = await planner.sendMessage({
+  to: '#reviews',
+  text: 'Please review the delivery adapter.',
+  mentions: [reviewer], // prepends '@reviewer' when not already in the text
+});
+
+await reviewer.reply({ messageId: sent.messageId, text: 'Reviewing now.' });
+await planner.react({ messageId: sent.messageId, emoji: 'eyes' });
+
+await reviewer.sendMessage({ to: '@planner', text: 'Done with the first pass.' });
+await planner.sendMessage({ to: ['@reviewer', '@engineer'], text: 'Standup in 5.' });
+```
+
+The rest of the messaging surface lives on the client's `agents`, `channels`, `messages`, `threads`, and `inbox` namespaces:
+
+```ts
+const history = await reviewer.messages.list('reviews', { limit: 50 });
+const thread = await reviewer.threads.get(sent.messageId);
+const results = await reviewer.messages.search('delivery adapter', { channel: 'reviews' });
+const inbox = await reviewer.inbox.get();
+await reviewer.messages.markRead(sent.messageId);
+await reviewer.messages.dm({ to: 'planner', text: 'Shipping the summary now.' });
+```
+
+## Events
+
+`relay.addListener(selector, handler)` is the single listener entry point. The selector is a dotted event name, a `'*'`/prefix wildcard (for example `'message.*'`), or a predicate. It returns an unsubscribe function and opens the event stream automatically — a workspace-key client streams all workspace-visible events, an agent-scoped client streams through its own connection.
+
+```ts
+const unsubscribe = relay.addListener('message.created', async (event) => {
+  if (event.type !== 'message.created') return;
+  console.log(event.envelope.channel?.name, event.message.text);
+});
+
+unsubscribe();
+```
+
+String selectors deliver normalized, dotted events: `message.created`, `message.updated`, `thread.reply`, `dm.received`, `group_dm.received`, `message.read`, `message.reacted`, `action.*`, and `agent.status.*`. Message events carry `{ message, envelope }`, where `envelope` flattens `from`, `to`, `channel`, and `parent`.
+
+Predicate builders narrow subscriptions without manual filtering:
+
+```ts
+relay.addListener(
+  relay.events.message.created().in('#reviews').mentions(reviewer),
+  async (event) => {
+    // predicates deliver the raw event: { type: 'messageCreated', channel, message }
+    await reviewer.reply({ messageId: event.message.messageId, text: 'On it.' });
+  }
+);
+
+relay.addListener(relay.action('review.submit_vote').completed(), (event) => {
+  console.log(event.output);
 });
 ```
 
-## Messaging
+`relay.events.message` exposes `created()` (with `.in(channel)` and `.mentions(agent)`), `read()`, and `reacted()`. `relay.action(name)` exposes `.completed()`, `.failed()`, `.denied()`, and `.calledBy(agent)`. Agent handles also carry `status.becomes(...)` and `tools.called(...)` builders, which fire when a managed harness feeds session events into the relay.
 
-The core client covers the communication surface agents need during a run:
-
-- Register agent, human, and system identities.
-- Join, list, create, update, mute, archive, and inspect channels.
-- Send channel messages, direct messages, and group DMs.
-- Reply in threads and fetch message history.
-- Add and remove reactions.
-- Search messages and inspect inbox state.
-- Subscribe to events for messages, threads, DMs, reactions, channel changes, presence, files, webhooks, and action invocations.
-
-Example:
-
-```ts
-const lead = relay.as(await relay.agents.register({ name: 'lead' }));
-
-await lead.channels.create({
-  name: 'release',
-  topic: 'Release readiness',
-});
-
-await lead.messages.send({
-  channel: 'release',
-  text: 'Please review the migration guide.',
-});
-
-const thread = await lead.messages.reply({
-  messageId: 'msg_123',
-  text: 'Tracking docs feedback here.',
-});
-
-await lead.messages.react({
-  messageId: thread.id,
-  emoji: 'eyes',
-});
-```
-
-## Delivery
-
-Delivery is the session handoff contract. Relay stores messages durably; a session is the thing that can receive those messages inside an agent, service, browser worker, or managed harness:
-
-- Harnesses create sessions with stable agent identity.
-- Sessions declare capabilities such as delivery modes, observable events, actions, and lifecycle operations.
-- Sessions receive durable Relay messages with delivery context and return explicit receipts: `accepted`, `delivered`, `deferred`, or `failed`.
-- `DeliveryRunner` can drain inbox items into either a session `receiveMessage(...)` contract or a legacy `inject(...)` adapter.
-- Send operations support idempotency keys so retries do not duplicate messages.
-
-Managed harness delivery, such as injecting messages into a PTY or headless app server, belongs in `@agent-relay/harness-driver`. The SDK stays responsible for the public delivery contract.
-
-Minimum session contract:
-
-```ts
-import {
-  DeliveryRunner,
-  MINIMAL_AGENT_SESSION_CAPABILITIES,
-  normalizeAgentIdentity,
-  type AgentSession,
-} from '@agent-relay/sdk';
-
-const session: AgentSession = {
-  identity: normalizeAgentIdentity({ id: 'agent_reviewer', name: 'reviewer', handle: '@reviewer' }),
-  capabilities: {
-    ...MINIMAL_AGENT_SESSION_CAPABILITIES,
-    delivery: { modes: ['immediate', 'next-tool-call', 'on-idle'], queue: true },
-    events: { emits: ['status.changed', 'tool.called', 'tool.completed', 'file.changed'] },
-    actions: { invoke: true, expose: false },
-  },
-  async receiveMessage(message, context) {
-    const job = await service.enqueue({
-      id: message.id,
-      text: message.text,
-      threadId: message.threadId,
-      priority: context.priority ?? 'normal',
-      deliveryMode: context.mode,
-    });
-
-    return job.ready
-      ? { status: 'delivered', deliveryId: job.id }
-      : { status: 'deferred', deliveryId: job.id, availableAt: job.availableAt };
-  },
-  onEvent(emit) {
-    return service.onStatus((status) => emit({ type: 'status.changed', status }));
-  },
-  async release(reason) {
-    await service.release(reason);
-  },
-};
-
-await new DeliveryRunner({
-  messaging: relay.as(reviewer).messaging,
-  delivery: session,
-  agentName: 'reviewer',
-}).start();
-```
+The low-level stream is still available as `relay.events` (`connect()`, `disconnect()`, `subscribe(channels)`, and `on(...)`). Note that `events.on(...)` uses camelCase event keys such as `'messageCreated'`; the dotted names belong to `addListener`.
 
 ## Actions
 
-Agent Relay actions are exposed through registration and invocation:
-
-- Register actions with names, descriptions, and Zod input/output schemas.
-- Validate inputs before handlers run and validate outputs before callers receive them.
-- Attach policy hooks for allow/deny decisions.
-- Emit audit events for invoked, completed, failed, and denied actions.
-- Expose registered actions as MCP tools for agents that do not embed the SDK.
-
-This keeps action routing available to any runtime without requiring a local broker or spawned harness.
-
-Example:
+Actions are fire-and-forget capabilities: invoking acks immediately, the handler runs in the registering process, and the result is emitted as `action.completed`.
 
 ```ts
 import { z } from 'zod';
 
-const OpenPullRequestInput = z.object({
-  repository: z.string(),
-  branch: z.string(),
-  title: z.string(),
-  body: z.string().optional(),
-});
-
-const OpenPullRequestOutput = z.object({
-  url: z.string().url(),
-  number: z.number().int().positive(),
-});
-
-relay.actions.register({
-  name: 'github.open_pr',
-  description: 'Open a GitHub pull request for a prepared branch.',
-  inputSchema: OpenPullRequestInput,
-  outputSchema: OpenPullRequestOutput,
-  policy: async (_input, ctx) => ({
-    allowed: ctx.caller.type === 'agent' && ctx.caller.name.startsWith('release-'),
-    reason: 'Only release agents can open PRs',
+relay.registerAction({
+  name: 'review.submit_vote',
+  description: 'Submit a review vote for the current proposal.',
+  input: z.object({
+    proposalId: z.string(),
+    vote: z.enum(['approve', 'request_changes', 'abstain']),
   }),
-  handler: async (input, ctx) => {
-    const pr = await github.openPullRequest(input);
-    await ctx.messaging?.messages.direct({
-      to: ctx.caller.name,
-      text: `Opened ${pr.url}`,
-    });
-    return { url: pr.url, number: pr.number };
+  availableTo: [{ name: 'reviewer' }], // omit to allow everyone
+  handler: async ({ input, agent }) => {
+    await reviewStore.recordVote(agent.name, input);
+    return { recorded: true }; // becomes the action.completed payload
   },
 });
 
-const pr = await relay.actions.invoke({
-  name: 'github.open_pr',
-  input: {
-    repository: 'AgentWorkforce/relay',
-    branch: 'codex/core-simplification',
-    title: 'Simplify Agent Relay core surfaces',
-  },
-  caller: { name: 'release-lead', type: 'agent' },
+relay.addListener(relay.action('review.submit_vote').completed(), (event) => {
+  console.log(event.output);
 });
 ```
+
+- Inputs are validated before the handler runs and outputs are validated before listeners receive them; validation failures surface as `invalid_input` / `invalid_output` errors.
+- The handler receives `{ input, agent, ctx }`, where `agent` is the caller identity and `ctx` carries optional workspace-scoped messaging.
+- `policy` hooks return allow/deny decisions; denials emit `action.denied`.
+- Registered through the workspace client, an action stays in-process. Relay-routed registration — publishing the descriptor and subscribing to `action.invoked` so other agents can call it — requires an agent-scoped connection, which managed harnesses set up for you.
+- `agent-relay mcp` can expose registered actions as typed MCP tools for agents that do not embed the SDK.
+
+## Delivery
+
+The SDK ships the delivery contract used to hand durable Relay messages to a live session: `AgentSession`, `MessageContext`, `MessageReceipt` (`accepted`, `delivered`, `deferred`, or `failed`), `AgentDeliveryAdapter`, and `DeliveryRunner`.
+
+```ts
+import {
+  MINIMAL_AGENT_SESSION_CAPABILITIES,
+  normalizeAgentIdentity,
+  type AgentSession,
+} from '@agent-relay/sdk/session';
+
+const session: AgentSession = {
+  identity: normalizeAgentIdentity({ name: 'reviewer' }),
+  capabilities: {
+    ...MINIMAL_AGENT_SESSION_CAPABILITIES,
+    lifecycle: { release: false },
+  },
+  async receiveMessage(message) {
+    await queue.push(message);
+    return { status: 'delivered', deliveryId: message.id };
+  },
+};
+```
+
+Be aware of what the backend supports today: the Relaycast messaging client reports `capabilities.serverDeliveryState: false` and `durableDelivery: false`. Concretely:
+
+- `inbox.ack(...)`, `inbox.fail(...)`, `inbox.defer(...)`, and `inbox.markRead(...)` resolve with `{ supported: false, ... }` instead of persisting delivery state.
+- `DeliveryRunner.start()` throws a `RelayCapabilityError` because it requires server-backed delivery state.
+
+Until durable delivery ships server-side, drive delivery from messaging events (`addListener`) and inbox reads (`inbox.get()`), and treat the delivery types as the forward contract.
+
+## Subpath exports
+
+The package root re-exports everything; focused entry points are also available:
+
+| Import path                     | Contents                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `@agent-relay/sdk`              | `AgentRelay` plus all of the below.                                        |
+| `@agent-relay/sdk/messaging`    | Messaging client, message/channel/inbox/event types.                       |
+| `@agent-relay/sdk/delivery`     | `DeliveryRunner`, `AgentDeliveryAdapter`, delivery modes and results.      |
+| `@agent-relay/sdk/actions`      | `ActionRegistry`, action definitions, schemas, audit events.               |
+| `@agent-relay/sdk/session`      | `AgentSession`, `HarnessConfig`, `defineHarness`, session events/receipts. |
+| `@agent-relay/sdk/capabilities` | `RelayCapabilityError`, `Unsubscribe`.                                     |
 
 ## Optional managed harnesses
 
-Install the harness driver package for managed local execution:
-
 ```bash
-npm install @agent-relay/harness-driver
+npm install @agent-relay/harness-driver @agent-relay/harnesses
 ```
 
-`@agent-relay/harness-driver` owns:
+`@agent-relay/harness-driver` owns local broker startup, PTY/headless transports, spawn/release lifecycle, and supervision. `@agent-relay/harnesses` provides prebuilt PTY harnesses (`claude`, `codex`, `gemini`, ...) whose `create({ relay })` spawns and self-registers an agent, returning a live client. Keep application-level messaging on `@agent-relay/sdk`; add the harness packages only at the boundary that owns local agent processes.
 
-- Local broker process startup and connection files.
-- PTY and headless harness transports.
-- Claude, Codex, Gemini, OpenCode, and custom CLI spawn defaults.
-- Agent lifecycle hooks, session metadata, idle detection, managed release, and shutdown.
-- Workflow and supervision helpers that coordinate multiple spawned harnesses.
+## Migration from v7
 
-Keep application-level messaging code on `@agent-relay/sdk`; add `@agent-relay/harness-driver` only at the boundary that owns local agent processes.
+Version 8 replaces the token-handoff API with register-returns-client:
 
-## Migration from the pre-simplification SDK
-
-| Previous SDK surface                                                                               | SemVer-major target                                                    |
-| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Spawn methods on `AgentRelay`, `HarnessDriverClient.spawn()`, `spawnAgent()`, PTY/headless helpers | Move to `@agent-relay/harness-driver`.                                 |
-| Workflow builder, consensus, shadow agents, and managed run helpers                                | Move to `@agent-relay/harness-driver` or workflow-specific packages.   |
-| Messaging, identities, channels, DMs, threads, presence, read state, and actions                   | Stay in `@agent-relay/sdk`.                                            |
-| Primitive clients such as GitHub or Slack adapters                                                 | Stay in their own packages and integrate through SDK actions/messages. |
-
-Code that only sends and receives Agent Relay messages should keep depending on `@agent-relay/sdk`. Code that starts agents, injects messages into harnesses, or supervises local runs should add `@agent-relay/harness-driver`.
+| v7 surface                                        | v8 replacement                                                                  |
+| ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `relay.agents.register(...)` + `relay.as(token)`  | `relay.workspace.register(...)` returns a live client; `relay.workspace.reconnect({ apiToken })` rehydrates one. |
+| `agent.events.on('message.created', ...)`         | `relay.addListener('message.created', ...)` (dotted names); `events.on(...)` keeps camelCase keys like `'messageCreated'`. |
+| `relay.actions.register(...)`                     | `relay.registerAction({ ..., handler: ({ input, agent, ctx }) => ... })`.         |
+| `relay.actions.invoke(...)`                       | Fire-and-forget invocation through the relay; observe results with `relay.addListener(relay.action(name).completed(), ...)`. |
+| `agent.messages.send({ channel, text })`          | Still works, or use sigil routing: `client.sendMessage({ to: '#channel', text })`. |
+| Spawn/PTY/workflow helpers on `AgentRelay`        | `@agent-relay/harness-driver` and `@agent-relay/harnesses`.                       |
 
 ## Development
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -117,13 +117,10 @@ String selectors deliver normalized, dotted events: `message.created`, `message.
 Predicate builders narrow subscriptions without manual filtering:
 
 ```ts
-relay.addListener(
-  relay.events.message.created().in('#reviews').mentions(reviewer),
-  async (event) => {
-    // predicates deliver the raw event: { type: 'messageCreated', channel, message }
-    await reviewer.reply({ messageId: event.message.messageId, text: 'On it.' });
-  }
-);
+relay.addListener(relay.events.message.created().in('#reviews').mentions(reviewer), async (event) => {
+  // predicates deliver the raw event: { type: 'messageCreated', channel, message }
+  await reviewer.reply({ messageId: event.message.messageId, text: 'On it.' });
+});
 
 relay.addListener(relay.action('review.submit_vote').completed(), (event) => {
   console.log(event.output);
@@ -201,8 +198,8 @@ Until durable delivery ships server-side, drive delivery from messaging events (
 
 The package root re-exports everything; focused entry points are also available:
 
-| Import path                     | Contents                                                                  |
-| ------------------------------- | ------------------------------------------------------------------------- |
+| Import path                     | Contents                                                                   |
+| ------------------------------- | -------------------------------------------------------------------------- |
 | `@agent-relay/sdk`              | `AgentRelay` plus all of the below.                                        |
 | `@agent-relay/sdk/messaging`    | Messaging client, message/channel/inbox/event types.                       |
 | `@agent-relay/sdk/delivery`     | `DeliveryRunner`, `AgentDeliveryAdapter`, delivery modes and results.      |
@@ -222,14 +219,14 @@ npm install @agent-relay/harness-driver @agent-relay/harnesses
 
 Version 8 replaces the token-handoff API with register-returns-client:
 
-| v7 surface                                        | v8 replacement                                                                  |
-| ------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `relay.agents.register(...)` + `relay.as(token)`  | `relay.workspace.register(...)` returns a live client; `relay.workspace.reconnect({ apiToken })` rehydrates one. |
-| `agent.events.on('message.created', ...)`         | `relay.addListener('message.created', ...)` (dotted names); `events.on(...)` keeps camelCase keys like `'messageCreated'`. |
-| `relay.actions.register(...)`                     | `relay.registerAction({ ..., handler: ({ input, agent, ctx }) => ... })`.         |
-| `relay.actions.invoke(...)`                       | Fire-and-forget invocation through the relay; observe results with `relay.addListener(relay.action(name).completed(), ...)`. |
-| `agent.messages.send({ channel, text })`          | Still works, or use sigil routing: `client.sendMessage({ to: '#channel', text })`. |
-| Spawn/PTY/workflow helpers on `AgentRelay`        | `@agent-relay/harness-driver` and `@agent-relay/harnesses`.                       |
+| v7 surface                                       | v8 replacement                                                                                                               |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `relay.agents.register(...)` + `relay.as(token)` | `relay.workspace.register(...)` returns a live client; `relay.workspace.reconnect({ apiToken })` rehydrates one.             |
+| `agent.events.on('message.created', ...)`        | `relay.addListener('message.created', ...)` (dotted names); `events.on(...)` keeps camelCase keys like `'messageCreated'`.   |
+| `relay.actions.register(...)`                    | `relay.registerAction({ ..., handler: ({ input, agent, ctx }) => ... })`.                                                    |
+| `relay.actions.invoke(...)`                      | Fire-and-forget invocation through the relay; observe results with `relay.addListener(relay.action(name).completed(), ...)`. |
+| `agent.messages.send({ channel, text })`         | Still works, or use sigil routing: `client.sendMessage({ to: '#channel', text })`.                                           |
+| Spawn/PTY/workflow helpers on `AgentRelay`       | `@agent-relay/harness-driver` and `@agent-relay/harnesses`.                                                                  |
 
 ## Development
 


### PR DESCRIPTION
## Summary

The published `packages/sdk/README.md` still documented the deleted v7 API and broke users at runtime:

- `relay.as(reviewer)` — `AgentRelay` has no `as()` method in v8.
- `agent.events.on('message.created', ...)` — the low-level events surface uses camelCase keys (`messageCreated`); dotted names only work via `addListener`.
- `relay.actions.register(...)` — `actions` is private; the public API is `relay.registerAction()` with a `{ input, agent, ctx }` handler signature.

## Changes

- **`packages/sdk/README.md`** — rewritten for the current v8 API, with every snippet verified against `agent-relay.ts`, `facade.ts`, `listeners.ts`, the messaging/delivery/session/actions modules, and `package.json` exports:
  - Construction (`new AgentRelay({ workspaceKey })`) and `AgentRelay.createWorkspace()`.
  - `relay.workspace.register()` returning live `RelayAgentClient`s (single/array), `reconnect({ apiToken })`.
  - Sending: `sendMessage` with `#channel` / `@name` / group-DM sigil routing, `reply`, `react`, `messages.dm`, mentions.
  - Events: `addListener` with dotted selectors, wildcards, and predicate builders (`relay.events.message.created().in('#c').mentions(...)`, `relay.action(name).completed()`), plus the camelCase note for the raw `events.on(...)` surface.
  - `registerAction` with Zod schemas, `availableTo`, policy hooks, and the in-process vs relay-routed registration distinction.
  - Delivery documented honestly: the Relaycast backend reports `durableDelivery: false` / `serverDeliveryState: false`, so `inbox.ack/fail/defer` resolve `{ supported: false }` and `DeliveryRunner.start()` throws `RelayCapabilityError` today.
  - Subpath exports table (`/messaging`, `/delivery`, `/actions`, `/session`, `/capabilities`) and a v7 → v8 migration table.
- **`.claude/rules/rust.md`** — protocol type reference now points at `packages/harness-driver/src/protocol.ts` (`packages/sdk/src/protocol.ts` no longer exists).
- **`CHANGELOG.md`** — `Fixed` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)