### PR TITLE
fix(plugins): default plugin base URLs to gateway.relaycast.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@agent-relay/sdk` no longer emits client-side analytics or depends on `@agent-relay/telemetry`; SDK/API attribution uses Relaycast origin metadata instead.
 - `agent-relay` CLI telemetry now posts through the hosted ingestion proxy at `https://i.agentrelay.com` by default.
 - `agent-relay local run` delegates YAML, TypeScript, and Python workflow execution to `@relayflows/cli` instead of bundling TypeScript workflows inside the Relay CLI.
+- The `codex-relay-skill` and `gemini-relay-extension` plugins now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK; set `RELAY_BASE_URL` to keep using the legacy `https://api.relaycast.dev` host.
 
 ### Deprecated
 

--- a/plugins/codex-relay-skill/README.md
+++ b/plugins/codex-relay-skill/README.md
@@ -121,12 +121,12 @@ Use Relaycast when workers need to message each other directly, not only the lea
 
 ## Environment variables
 
-| Variable           | Required | Default                     | Description                                                          |
-| ------------------ | -------- | --------------------------- | -------------------------------------------------------------------- |
-| `RELAY_API_KEY`    | No       | `""` in the template config | Relaycast workspace key                                              |
-| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | Relaycast API base URL                                           |
-| `RELAY_AGENT_TYPE` | No       | `agent`                     | Default Relaycast agent type                                         |
-| `RELAY_AGENT_NAME` | No       | unset                       | Optional stable relay identity when your workflow wants a fixed name |
+| Variable           | Required | Default                         | Description                                                          |
+| ------------------ | -------- | ------------------------------- | -------------------------------------------------------------------- |
+| `RELAY_API_KEY`    | No       | `""` in the template config     | Relaycast workspace key                                              |
+| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | Relaycast API base URL                                               |
+| `RELAY_AGENT_TYPE` | No       | `agent`                         | Default Relaycast agent type                                         |
+| `RELAY_AGENT_NAME` | No       | unset                           | Optional stable relay identity when your workflow wants a fixed name |
 
 ## Plugin structure
 

--- a/plugins/codex-relay-skill/README.md
+++ b/plugins/codex-relay-skill/README.md
@@ -63,7 +63,7 @@ features.codex_hooks = true
 [mcp_servers.agent-relay]
 command = "npx"
 args = ["-y", "agent-relay", "mcp"]
-env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://api.relaycast.dev", RELAY_AGENT_TYPE = "agent" }
+env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://gateway.relaycast.dev", RELAY_AGENT_TYPE = "agent" }
 ```
 
 2. Copy hooks config:
@@ -124,7 +124,7 @@ Use Relaycast when workers need to message each other directly, not only the lea
 | Variable           | Required | Default                     | Description                                                          |
 | ------------------ | -------- | --------------------------- | -------------------------------------------------------------------- |
 | `RELAY_API_KEY`    | No       | `""` in the template config | Relaycast workspace key                                              |
-| `RELAY_BASE_URL`   | No       | `https://api.relaycast.dev` | Relaycast API base URL                                               |
+| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | Relaycast API base URL                                           |
 | `RELAY_AGENT_TYPE` | No       | `agent`                     | Default Relaycast agent type                                         |
 | `RELAY_AGENT_NAME` | No       | unset                       | Optional stable relay identity when your workflow wants a fixed name |
 

--- a/plugins/codex-relay-skill/codex-config/config.toml
+++ b/plugins/codex-relay-skill/codex-config/config.toml
@@ -6,4 +6,4 @@ features.codex_hooks = true
 [mcp_servers.agent-relay]
 command = "npx"
 args = ["-y", "agent-relay", "mcp"]
-env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://api.relaycast.dev", RELAY_AGENT_TYPE = "agent" }
+env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://gateway.relaycast.dev", RELAY_AGENT_TYPE = "agent" }

--- a/plugins/codex-relay-skill/hooks/prompt-inbox.sh
+++ b/plugins/codex-relay-skill/hooks/prompt-inbox.sh
@@ -17,7 +17,7 @@ fi
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
 LAST_POLL_FILE="${RELAY_DIR}/last-poll"
-DEFAULT_BASE_URL="https://api.relaycast.dev"
+DEFAULT_BASE_URL="https://gateway.relaycast.dev"
 EMPTY_OUTPUT='{}'
 MAX_RENDERED_MESSAGES=20
 MIN_POLL_INTERVAL=3

--- a/plugins/codex-relay-skill/hooks/session-start.sh
+++ b/plugins/codex-relay-skill/hooks/session-start.sh
@@ -17,7 +17,7 @@ fi
 KEY_FILE="${RELAY_DIR}/workspace-key"
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
-DEFAULT_BASE_URL="https://api.relaycast.dev"
+DEFAULT_BASE_URL="https://gateway.relaycast.dev"
 
 load_env() {
   if [ -f "$ENV_FILE" ]; then

--- a/plugins/codex-relay-skill/hooks/stop-inbox.sh
+++ b/plugins/codex-relay-skill/hooks/stop-inbox.sh
@@ -16,7 +16,7 @@ else
 fi
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
-DEFAULT_BASE_URL="https://api.relaycast.dev"
+DEFAULT_BASE_URL="https://gateway.relaycast.dev"
 EMPTY_OUTPUT='{}'
 MAX_RENDERED_MESSAGES=20
 

--- a/plugins/codex-relay-skill/scripts/setup.sh
+++ b/plugins/codex-relay-skill/scripts/setup.sh
@@ -155,7 +155,7 @@ ensure_agent_relay_mcp_block() {
       env_seen = 0
       command_line = "command = \"npx\""
       args_line = "args = [\"-y\", \"agent-relay\", \"mcp\"]"
-      env_line = "env = { RELAY_API_KEY = \"\", RELAY_BASE_URL = \"https://api.relaycast.dev\", RELAY_AGENT_TYPE = \"agent\" }"
+      env_line = "env = { RELAY_API_KEY = \"\", RELAY_BASE_URL = \"https://gateway.relaycast.dev\", RELAY_AGENT_TYPE = \"agent\" }"
     }
     function write_missing_keys() {
       if (!command_seen) {

--- a/plugins/gemini-relay-extension/README.md
+++ b/plugins/gemini-relay-extension/README.md
@@ -96,10 +96,10 @@ Each agent registers with the relay and can message the others.
 
 ## Environment variables
 
-| Variable           | Required | Default                     | Description                   |
-| ------------------ | -------- | --------------------------- | ----------------------------- |
-| `RELAY_API_KEY`    | Yes      | —                           | Workspace key (`rk_live_...`) |
-| `RELAY_AGENT_NAME` | No       | auto-generated              | Stable agent identity         |
+| Variable           | Required | Default                         | Description                   |
+| ------------------ | -------- | ------------------------------- | ----------------------------- |
+| `RELAY_API_KEY`    | Yes      | —                               | Workspace key (`rk_live_...`) |
+| `RELAY_AGENT_NAME` | No       | auto-generated                  | Stable agent identity         |
 | `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | API base URL override         |
 
 ## Extension structure

--- a/plugins/gemini-relay-extension/README.md
+++ b/plugins/gemini-relay-extension/README.md
@@ -100,7 +100,7 @@ Each agent registers with the relay and can message the others.
 | ------------------ | -------- | --------------------------- | ----------------------------- |
 | `RELAY_API_KEY`    | Yes      | —                           | Workspace key (`rk_live_...`) |
 | `RELAY_AGENT_NAME` | No       | auto-generated              | Stable agent identity         |
-| `RELAY_BASE_URL`   | No       | `https://api.relaycast.dev` | API base URL override         |
+| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | API base URL override         |
 
 ## Extension structure
 

--- a/plugins/gemini-relay-extension/hooks/after-agent-inbox.sh
+++ b/plugins/gemini-relay-extension/hooks/after-agent-inbox.sh
@@ -4,7 +4,7 @@ set -eu
 
 ALLOW_OUTPUT='{"decision":"allow"}'
 TOKEN_FILE="${HOME}/.relay/token"
-BASE_URL="${RELAY_BASE_URL:-https://api.relaycast.dev}"
+BASE_URL="${RELAY_BASE_URL:-https://gateway.relaycast.dev}"
 INBOX_URL="${BASE_URL}/v1/inbox/check"
 GUARD_DIR="${TMPDIR:-/tmp}/relay-afteragent"
 

--- a/plugins/gemini-relay-extension/hooks/after-tool-inbox.sh
+++ b/plugins/gemini-relay-extension/hooks/after-tool-inbox.sh
@@ -4,7 +4,7 @@ set -eu
 
 EMPTY_OUTPUT='{}'
 TOKEN_FILE="${HOME}/.relay/token"
-BASE_URL="${RELAY_BASE_URL:-https://api.relaycast.dev}"
+BASE_URL="${RELAY_BASE_URL:-https://gateway.relaycast.dev}"
 INBOX_URL="${BASE_URL}/v1/inbox/check"
 
 if ! command -v jq >/dev/null 2>&1; then

--- a/plugins/gemini-relay-extension/hooks/before-model-inject.sh
+++ b/plugins/gemini-relay-extension/hooks/before-model-inject.sh
@@ -49,7 +49,7 @@ MESSAGES=$(curl -fsS -X POST \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  "${RELAY_BASE_URL:-https://api.relaycast.dev}/v1/inbox/check" 2>/dev/null || true)
+  "${RELAY_BASE_URL:-https://gateway.relaycast.dev}/v1/inbox/check" 2>/dev/null || true)
 
 if [ -z "${MESSAGES:-}" ]; then
   printf '%s\n' "$EMPTY_OUTPUT"

--- a/plugins/gemini-relay-extension/hooks/session-end.sh
+++ b/plugins/gemini-relay-extension/hooks/session-end.sh
@@ -10,7 +10,7 @@ KEY_FILE="${HOME}/.relay/workspace-key"
 TOKEN_FILE="${HOME}/.relay/token"
 STATE_FILE="${HOME}/.relay/gemini-session.json"
 WORKERS_FILE="${HOME}/.relay/gemini-workers.json"
-BASE_URL="https://api.relaycast.dev"
+BASE_URL="https://gateway.relaycast.dev"
 AFTER_AGENT_DIR="${TMPDIR:-/tmp}/relay-afteragent"
 BEFORE_MODEL_DIR="${TMPDIR:-/tmp}/relay-beforemodel"
 

--- a/plugins/gemini-relay-extension/relay-server.js
+++ b/plugins/gemini-relay-extension/relay-server.js
@@ -12,7 +12,7 @@ const RELAY_DIR = path.join(os.homedir(), '.relay');
 const KEY_FILE = path.join(RELAY_DIR, 'workspace-key');
 const TOKEN_FILE = path.join(RELAY_DIR, 'token');
 const STATE_FILE = path.join(RELAY_DIR, 'gemini-session.json');
-const DEFAULT_BASE_URL = 'https://api.relaycast.dev';
+const DEFAULT_BASE_URL = 'https://gateway.relaycast.dev';
 
 loadDotEnv(ENV_FILE);
 fs.mkdirSync(RELAY_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Aligns the remaining hardcoded `api.relaycast.dev` defaults with the rest of the stack. The original drift this task targeted — `agent-relay mcp`'s `DEFAULT_BASE_URL` and the duplicated invalid-token error sniffing — was already fixed on main: #1064 (shipped in 8.3.1) moved the MCP server and broker defaults to `gateway.relaycast.dev`, and the MCP server already imports `isInvalidAgentTokenError` / `isInvalidAgentTokenToolResult` / `agentTokenRecoveryMessage` from `@agent-relay/sdk` (`packages/sdk/src/relaycast-errors.ts`).

What was still drifted is the plugins tree, where plugin users landed on the legacy engine while CLI/SDK users hit gateway:

- `plugins/gemini-relay-extension`: `relay-server.js` `DEFAULT_BASE_URL`, four hook scripts, and the README default
- `plugins/codex-relay-skill`: three hook scripts' `DEFAULT_BASE_URL`, the `codex-config/config.toml` template, the `setup.sh` generated config line, and the README

All of these are defaults only — `RELAY_BASE_URL` override behavior is unchanged everywhere. Also adds the `[Unreleased]` changelog entry.

## Behavior change

New plugin installs (and existing installs that never set `RELAY_BASE_URL`) now talk to `gateway.relaycast.dev` instead of the legacy `api.relaycast.dev`. Anyone relying on the implicit legacy default should set `RELAY_BASE_URL=https://api.relaycast.dev`. Existing codex installs whose `config.toml` already pins the old host keep their pin (setup.sh only fills in missing keys).

## Intentionally untouched (noted drift)

- `web/content/openclaw/SKILL.md` documents raw `curl` calls against `api.relaycast.dev` (including its frontmatter `api_base`) — docs change, left for a docs pass.
- `web/content/docs/7.1.1/*` are versioned historical docs.
- Test fixtures that intentionally pin the legacy host: `tests/integration/broker/.mcp.json`, `packages/cli/src/cli/agent-relay-mcp.startup.test.ts` (all explicit `baseUrl`/env values, none assert the default), `crates/broker/src/snippets.rs` / `runtime/tests.rs` / `cli_mcp_args.rs` test code.

## Verification

- `sh -n` on all 8 edited hook/setup scripts; `node --check` on `relay-server.js`
- `npm run build:core` (sdk + cli build) — pass
- `npx vitest run packages/cli` — 343 passed, 5 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)