### PR TITLE
feat(sdk): wire durable delivery surface to the Relaycast backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@agent-relay/sdk` wires the durable delivery surface to the Relaycast backend: `inbox.list`/`inbox.subscribe` replay and stream the per-recipient delivery ledger, `inbox.ack/fail/defer` and `deliveries.ack/fail/defer` apply real server transitions, capabilities report `serverDeliveryState: true` for agent-scoped clients, and `DeliveryRunner` now works against the hosted backend.
 - `agent-relay-broker` and `@agent-relay/harness-driver` accept explicit workspace keys and broker instance names, so local and cloud brokers can join the same Relay workspace with stable, addressable names.
 - `@agent-relay/harnesses` adds a `grok` PTY harness for the Grok CLI, including Relaycast MCP support for spawned agents.
 - `@agent-relay/harnesses` is now published to npm, so SDK consumers can install the prebuilt PTY harnesses and harness-authoring helpers.

--- a/packages/sdk/src/__tests__/delivery-actions.test.ts
+++ b/packages/sdk/src/__tests__/delivery-actions.test.ts
@@ -13,7 +13,7 @@ import {
   type AgentDeliveryAdapter,
   type InjectionResult,
 } from '../delivery/index.js';
-import type { InboxItem, RelayMessaging } from '../messaging/index.js';
+import { RelaycastMessagingClient, type InboxItem, type RelayMessaging } from '../messaging/index.js';
 import {
   MINIMAL_AGENT_SESSION_CAPABILITIES,
   defineHarness,
@@ -378,6 +378,79 @@ describe('DeliveryRunner', () => {
       state: 'delivered',
       metadata: undefined,
     });
+  });
+
+  it('runs against RelaycastMessagingClient with a durable delivery agent client', async () => {
+    const anyHandlers = new Set<(event: unknown) => void>();
+    const deliveryRow = (id: string, messageId: string) => ({
+      id,
+      messageId,
+      channelId: 'ch-1',
+      agentId: 'agent-1',
+      status: 'accepted',
+      mode: 'wait',
+      reason: 'dm',
+      priority: 'normal',
+      availableAt: null,
+      message: {
+        id: messageId,
+        channelId: 'ch-1',
+        agentId: 'agent-9',
+        agentName: 'Lead',
+        text: `payload ${id}`,
+        threadId: null,
+        createdAt: '2026-06-09T10:00:00.000Z',
+      },
+    });
+    const agent = {
+      connect: vi.fn(),
+      disconnect: vi.fn(async () => {}),
+      on: {
+        any: vi.fn((handler: (event: unknown) => void) => {
+          anyHandlers.add(handler);
+          return () => anyHandlers.delete(handler);
+        }),
+      },
+      deliveries: vi.fn(async () => [deliveryRow('del_1', 'm-100')]),
+      ackDelivery: vi.fn(async (id: string) => ({ ...deliveryRow(id, 'm-100'), status: 'delivered' })),
+      failDelivery: vi.fn(async (id: string) => ({ ...deliveryRow(id, 'm-100'), status: 'failed' })),
+      deferDelivery: vi.fn(async (id: string) => ({ ...deliveryRow(id, 'm-100'), status: 'deferred' })),
+    };
+    const messaging = new RelaycastMessagingClient({
+      relaycast: {} as never,
+      agentClient: agent as never,
+    });
+    const delivery = makeDeliveryAdapter({ status: 'delivered' });
+
+    let resolveFirstResult!: () => void;
+    const firstResult = new Promise<void>((resolve) => {
+      resolveFirstResult = resolve;
+    });
+    const runner = new DeliveryRunner({
+      messaging,
+      delivery,
+      agentName: 'WorkerA',
+      onResult: () => resolveFirstResult(),
+    });
+
+    const running = runner.start();
+    await firstResult;
+    runner.stop();
+    // Yield one more item so the subscription loop observes the stop flag.
+    agent.deliveries.mockResolvedValue([deliveryRow('del_2', 'm-200')]);
+    for (const handler of anyHandlers) {
+      handler({ type: 'delivery.accepted', deliveryId: 'del_2', messageId: 'm-200' });
+    }
+    await running;
+
+    expect(delivery.inject).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(delivery.inject).mock.calls[0][0]).toMatchObject({
+      id: 'm-100',
+      text: 'payload del_1',
+    });
+    expect(agent.ackDelivery).toHaveBeenCalledWith('del_1');
+    expect(agent.failDelivery).not.toHaveBeenCalled();
+    expect(agent.deferDelivery).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/sdk/src/__tests__/messaging.test.ts
+++ b/packages/sdk/src/__tests__/messaging.test.ts
@@ -398,6 +398,231 @@ describe('RelaycastMessagingClient', () => {
       action: 'ack',
       messageId: 'm-1',
     });
+    await expect(client.inbox.list()).resolves.toEqual({ items: [] });
+  });
+});
+
+function makeDeliveryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'del_1',
+    messageId: 'm-100',
+    channelId: 'ch-1',
+    agentId: 'agent-1',
+    status: 'accepted',
+    mode: 'wait',
+    reason: 'dm',
+    priority: 'normal',
+    retryable: null,
+    error: null,
+    availableAt: null,
+    deadline: null,
+    createdAt: '2026-06-09T10:00:00.000Z',
+    updatedAt: null,
+    message: {
+      id: 'm-100',
+      channelId: 'ch-1',
+      agentId: 'agent-9',
+      agentName: 'Lead',
+      text: 'hello worker',
+      threadId: null,
+      createdAt: '2026-06-09T10:00:00.000Z',
+    },
+    ...overrides,
+  };
+}
+
+function createDeliveryAgentClient() {
+  const { client, anyHandlers } = createAgentClient();
+  const agent = {
+    ...client,
+    deliveries: vi.fn(async () => [makeDeliveryRow()]),
+    ackDelivery: vi.fn(async (id: string) => makeDeliveryRow({ id, status: 'delivered' })),
+    failDelivery: vi.fn(async (id: string, options?: { error?: string; retryable?: boolean }) =>
+      makeDeliveryRow({
+        id,
+        status: 'failed',
+        error: options?.error ?? null,
+        retryable: options?.retryable ?? null,
+      })
+    ),
+    deferDelivery: vi.fn(async (id: string, options: { availableAt: string; reason?: string }) =>
+      makeDeliveryRow({
+        id,
+        status: 'deferred',
+        availableAt: options.availableAt,
+        reason: options.reason ?? null,
+      })
+    ),
+  };
+  return { agent, anyHandlers };
+}
+
+describe('RelaycastMessagingClient durable deliveries', () => {
+  it('reports durable delivery capabilities when the agent client exposes the ledger', () => {
+    const { agent } = createDeliveryAgentClient();
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+
+    expect(client.capabilities).toEqual({
+      serverDeliveryState: true,
+      durableDelivery: true,
+      durableAck: true,
+      durableFail: true,
+      durableDefer: true,
+    });
+  });
+
+  it('inbox.list maps delivery ledger rows onto inbox items', async () => {
+    const { agent } = createDeliveryAgentClient();
+    agent.deliveries.mockResolvedValueOnce([
+      makeDeliveryRow(),
+      makeDeliveryRow({
+        id: 'del_2',
+        messageId: 'm-200',
+        status: 'deferred',
+        availableAt: '2026-06-09T11:00:00.000Z',
+        reason: 'busy',
+        message: null,
+      }),
+    ]);
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+
+    const result = await client.inbox.list({ agentName: 'WorkerA', limit: 25 });
+
+    expect(agent.deliveries).toHaveBeenCalledWith({ limit: 25 });
+    expect(result.nextCursor).toBeUndefined();
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      id: 'del_1',
+      state: 'queued',
+      attempts: 0,
+      recipient: { name: 'WorkerA', id: 'agent-1' },
+      message: {
+        id: 'm-100',
+        text: 'hello worker',
+        from: { id: 'agent-9', name: 'Lead' },
+      },
+      metadata: { mode: 'wait', reason: 'dm', priority: 'normal' },
+    });
+    expect(result.items[0].availableAt).toBeUndefined();
+    // A deferred row without an embedded message still yields a usable item.
+    expect(result.items[1]).toMatchObject({
+      id: 'del_2',
+      state: 'deferred',
+      availableAt: '2026-06-09T11:00:00.000Z',
+      message: { id: 'm-200' },
+      metadata: { reason: 'busy' },
+    });
+  });
+
+  it('passes ack/fail/defer transitions through to the delivery ledger', async () => {
+    const { agent } = createDeliveryAgentClient();
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+
+    await expect(client.inbox.ack({ inboxItemId: 'del_1' })).resolves.toEqual({
+      supported: true,
+      action: 'ack',
+      deliveryId: 'del_1',
+      messageId: 'm-100',
+      state: 'delivered',
+    });
+    expect(agent.ackDelivery).toHaveBeenCalledWith('del_1');
+
+    await expect(
+      client.inbox.fail({ inboxItemId: 'del_1', error: 'boom', retry: true })
+    ).resolves.toMatchObject({ supported: true, action: 'fail', state: 'failed' });
+    expect(agent.failDelivery).toHaveBeenCalledWith('del_1', { error: 'boom', retryable: true });
+
+    await expect(
+      client.inbox.defer({ inboxItemId: 'del_1', availableAt: '2026-06-09T12:00:00.000Z', reason: 'busy' })
+    ).resolves.toMatchObject({
+      supported: true,
+      action: 'defer',
+      state: 'deferred',
+      deferUntil: '2026-06-09T12:00:00.000Z',
+    });
+    expect(agent.deferDelivery).toHaveBeenCalledWith('del_1', {
+      availableAt: '2026-06-09T12:00:00.000Z',
+      reason: 'busy',
+    });
+
+    await expect(client.deliveries.ack('del_1')).resolves.toMatchObject({
+      supported: true,
+      action: 'ack',
+      deliveryId: 'del_1',
+    });
+    await expect(client.deliveries.fail('del_1', 'broke')).resolves.toMatchObject({
+      supported: true,
+      action: 'fail',
+    });
+    expect(agent.failDelivery).toHaveBeenLastCalledWith('del_1', { error: 'broke' });
+    await expect(client.deliveries.defer('del_1', '2026-06-09T13:00:00.000Z')).resolves.toMatchObject({
+      supported: true,
+      action: 'defer',
+      deferUntil: '2026-06-09T13:00:00.000Z',
+    });
+    expect(agent.deferDelivery).toHaveBeenLastCalledWith('del_1', {
+      availableAt: '2026-06-09T13:00:00.000Z',
+    });
+
+    // The ledger has no read state; markRead stays an explicit stub.
+    await expect(client.inbox.markRead({ inboxItemId: 'del_1' })).resolves.toMatchObject({
+      supported: false,
+    });
+  });
+
+  it('propagates delivery transition errors from the underlying client', async () => {
+    const { agent } = createDeliveryAgentClient();
+    agent.ackDelivery.mockRejectedValueOnce(new Error('delivery not found'));
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+
+    await expect(client.inbox.ack({ inboxItemId: 'del_missing' })).rejects.toThrow('delivery not found');
+  });
+
+  it('inbox.subscribe seeds from the queue, pushes delivery.accepted events, and dedupes', async () => {
+    const { agent, anyHandlers } = createDeliveryAgentClient();
+    agent.deliveries
+      .mockResolvedValueOnce([makeDeliveryRow()])
+      .mockResolvedValue([
+        makeDeliveryRow(),
+        makeDeliveryRow({ id: 'del_2', messageId: 'm-200', message: null }),
+      ]);
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+
+    const iterator = client.inbox.subscribe({ agentName: 'WorkerA' })[Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value).toMatchObject({ id: 'del_1', recipient: { name: 'WorkerA' } });
+    expect(agent.connect).toHaveBeenCalled();
+
+    for (const handler of anyHandlers) {
+      // Duplicate of the seeded item: skipped before any re-listing.
+      handler({ type: 'delivery.accepted', deliveryId: 'del_1', messageId: 'm-100' });
+      handler({ type: 'delivery.accepted', deliveryId: 'del_2', messageId: 'm-200' });
+      // Repeat announcement of the same delivery: deduped.
+      handler({ type: 'delivery.accepted', deliveryId: 'del_2', messageId: 'm-200' });
+    }
+
+    const second = await iterator.next();
+    expect(second.done).toBe(false);
+    expect(second.value).toMatchObject({ id: 'del_2', state: 'queued' });
+    // One seed list plus exactly one re-list for the new delivery id.
+    expect(agent.deliveries).toHaveBeenCalledTimes(2);
+
+    await iterator.return?.(undefined);
+  });
+
+  it('inbox.subscribe ends when the abort signal fires', async () => {
+    const { agent } = createDeliveryAgentClient();
+    agent.deliveries.mockResolvedValue([]);
+    const client = new RelaycastMessagingClient({ relaycast: createWorkspace(), agentClient: agent });
+    const controller = new AbortController();
+
+    const iterator = client.inbox.subscribe({ signal: controller.signal })[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    controller.abort();
+
+    await expect(pending).resolves.toEqual({ done: true, value: undefined });
   });
 });
 

--- a/packages/sdk/src/messaging/normalize.ts
+++ b/packages/sdk/src/messaging/normalize.ts
@@ -1,4 +1,6 @@
 import type {
+  InboxItem,
+  InboxItemState,
   RelayAgent,
   RelayAgentChannel,
   RelayAgentPresence,
@@ -9,6 +11,7 @@ import type {
   RelayChannelMember,
   RelayChannelMemberRole,
   RelayChannelReadStatus,
+  RelayDeliverySupportedResult,
   RelayGroupDirectConversation,
   RelayInbox,
   RelayInboxDirectSummary,
@@ -476,6 +479,89 @@ export function normalizeChannelReadStatus(input: unknown): RelayChannelReadStat
     agentName: readString(record, 'agentName', 'agent_name') ?? '',
     ...(lastReadId ? { lastReadId } : {}),
     ...(lastReadAt ? { lastReadAt } : {}),
+  };
+}
+
+// Relaycast durable delivery ledger statuses mapped onto relay inbox states.
+// `accepted` means queued for the recipient; the ledger has no `read` state.
+const INBOX_STATE_BY_DELIVERY_STATUS: Record<string, InboxItemState> = {
+  accepted: 'queued',
+  delivered: 'delivered',
+  deferred: 'deferred',
+  failed: 'failed',
+};
+
+export function normalizeInboxItemState(value: string | undefined): InboxItemState {
+  return (value !== undefined ? INBOX_STATE_BY_DELIVERY_STATUS[value] : undefined) ?? 'queued';
+}
+
+function normalizeDeliveryMetadata(record: UnknownRecord): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = {};
+  const mode = readString(record, 'mode');
+  const reason = readNullableString(record, 'reason');
+  const priority = readString(record, 'priority');
+  const retryable = readBoolean(record, 'retryable');
+  const error = readNullableString(record, 'error');
+  const deadline = readNullableString(record, 'deadline');
+  if (mode) metadata.mode = mode;
+  if (reason) metadata.reason = reason;
+  if (priority) metadata.priority = priority;
+  if (retryable !== undefined) metadata.retryable = retryable;
+  if (error) metadata.error = error;
+  if (deadline) metadata.deadline = deadline;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+/**
+ * Normalize a relaycast durable delivery item (a `deliveries` ledger row with
+ * its embedded message payload) into a relay `InboxItem`.
+ */
+export function normalizeInboxItem(input: unknown, context: { recipientName?: string } = {}): InboxItem {
+  const record = isRecord(input) ? input : {};
+  const messageId = readString(record, 'messageId', 'message_id');
+  const channelId = readString(record, 'channelId', 'channel_id');
+  const agentId = readString(record, 'agentId', 'agent_id');
+  const availableAt = readNullableString(record, 'availableAt', 'available_at');
+  const messageRecord = readRecord(record, 'message');
+  const metadata = normalizeDeliveryMetadata(record);
+
+  return {
+    id: readString(record, 'id', 'deliveryId', 'delivery_id') ?? '',
+    recipient: {
+      name: context.recipientName ?? agentId ?? '',
+      ...(agentId ? { id: agentId } : {}),
+    },
+    state: normalizeInboxItemState(readString(record, 'status')),
+    // The relaycast ledger does not expose attempt counts.
+    attempts: 0,
+    ...(availableAt ? { availableAt } : {}),
+    message: normalizeMessage(
+      messageRecord ?? {
+        ...(messageId ? { id: messageId } : {}),
+        ...(channelId ? { channel_id: channelId } : {}),
+      }
+    ),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+/**
+ * Normalize the delivery row returned by a relaycast ack/fail/defer transition
+ * into the relay delivery result contract.
+ */
+export function normalizeDeliveryTransition(
+  action: RelayDeliverySupportedResult['action'],
+  input: unknown
+): RelayDeliverySupportedResult {
+  const record = isRecord(input) ? input : {};
+  const availableAt = readNullableString(record, 'availableAt', 'available_at');
+  return {
+    supported: true,
+    action,
+    deliveryId: readString(record, 'id', 'deliveryId', 'delivery_id') ?? '',
+    messageId: readString(record, 'messageId', 'message_id') ?? '',
+    state: normalizeInboxItemState(readString(record, 'status')),
+    ...(action === 'defer' && availableAt ? { deferUntil: availableAt } : {}),
   };
 }
 

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -10,8 +10,10 @@ import {
   normalizeChannelMember,
   normalizeChannelName,
   normalizeChannelReadStatus,
+  normalizeDeliveryTransition,
   normalizeGroupDirectConversation,
   normalizeInbox,
+  normalizeInboxItem,
   normalizeMessage,
   normalizeMessagingEvent,
   normalizeReaction,
@@ -35,6 +37,7 @@ import type {
   RelayCreateInboundWebhookInput,
   RelayCreateSubscriptionInput,
   RelayCreateWebhookInput,
+  RelayDeliveryResult,
   RelayDeliveryUnsupportedResult,
   RelayEventSubscription,
   RelayInboundWebhook,
@@ -272,6 +275,13 @@ type RelaycastWorkspaceLike = {
   on?: { any(handler: (event: unknown) => void): () => void };
 };
 
+type RelaycastDeliveryStatus = 'accepted' | 'delivered' | 'deferred' | 'failed';
+
+/** The durable delivery methods an agent client must expose for server-backed inbox state. */
+type RelaycastAgentDeliverySurface = Required<
+  Pick<RelaycastAgentLike, 'deliveries' | 'ackDelivery' | 'failDelivery' | 'deferDelivery'>
+>;
+
 type RelaycastAgentLike = {
   me(): Promise<unknown>;
   connect(): void;
@@ -336,6 +346,12 @@ type RelaycastAgentLike = {
     unmute(name: string): Promise<void>;
   };
   inbox(options?: { limit?: number }): Promise<unknown>;
+  // Durable delivery ledger (relaycast 2.5+): per-recipient delivery rows with
+  // FIFO replay of non-terminal items and idempotent ack/fail/defer transitions.
+  deliveries?(options?: { status?: RelaycastDeliveryStatus; limit?: number }): Promise<unknown[]>;
+  ackDelivery?(deliveryId: string): Promise<unknown>;
+  failDelivery?(deliveryId: string, options?: { error?: string; retryable?: boolean }): Promise<unknown>;
+  deferDelivery?(deliveryId: string, options: { availableAt: string; reason?: string }): Promise<unknown>;
   markRead(messageId: string): Promise<unknown>;
   readers(messageId: string): Promise<unknown[]>;
   readStatus(channel: string): Promise<unknown[]>;
@@ -411,13 +427,7 @@ function createRelaycastClient(options: RelaycastMessagingOptions): RelaycastWor
 }
 
 export class RelaycastMessagingClient implements RelayMessagingClient {
-  readonly capabilities: RelayMessagingCapabilities = {
-    serverDeliveryState: false,
-    durableDelivery: false,
-    durableAck: false,
-    durableFail: false,
-    durableDefer: false,
-  };
+  readonly capabilities: RelayMessagingCapabilities;
 
   private readonly relaycast: RelaycastWorkspaceLike;
   private readonly agentClient?: RelaycastAgentLike;
@@ -432,6 +442,16 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     this.agentClient =
       options.agentClient ??
       (options.agentToken ? this.relaycast.as?.(options.agentToken, options.agentClientOptions) : undefined);
+    // Durable delivery state is agent-scoped: it requires an agent client that
+    // exposes the relaycast delivery ledger (deliveries list + transitions).
+    const durable = this.deliverySurface() !== undefined;
+    this.capabilities = {
+      serverDeliveryState: durable,
+      durableDelivery: durable,
+      durableAck: durable,
+      durableFail: durable,
+      durableDefer: durable,
+    };
   }
 
   readonly agents = {
@@ -639,19 +659,66 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
       normalizeInbox(
         await this.requireAgentClient('inbox.get').inbox(definedOptions({ limit: options?.limit }))
       ),
-    list: async (_input?: InboxListInput): Promise<InboxListResult> => ({ items: [] }),
-    subscribe: (_input?: InboxSubscribeInput): AsyncIterable<InboxItem> => this.emptyInboxSubscription(),
-    ack: async (input: InboxAckInput): Promise<RelayDeliveryUnsupportedResult> =>
-      this.unsupportedInboxDelivery('ack', input.inboxItemId),
-    fail: async (input: InboxFailInput): Promise<RelayDeliveryUnsupportedResult> =>
-      this.unsupportedInboxDelivery('fail', input.inboxItemId, input.error),
-    defer: async (input: InboxDeferInput): Promise<RelayDeliveryUnsupportedResult> =>
-      this.unsupportedInboxDelivery('defer', input.inboxItemId, input.reason, input.availableAt),
-    markRead: async (input: InboxMarkReadInput): Promise<RelayDeliveryUnsupportedResult> =>
+    /**
+     * List durable deliveries queued for the authenticated agent. The
+     * relaycast ledger replays non-terminal items (accepted + deferred) in
+     * FIFO order with the message payload embedded. The underlying API has no
+     * cursor, so `nextCursor` is never set and `before`/`after` are ignored.
+     */
+    list: async (input?: InboxListInput): Promise<InboxListResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return { items: [] };
+      const deliveries = await surface.deliveries(definedOptions({ limit: input?.limit }));
+      return {
+        items: deliveries.map((delivery) =>
+          normalizeInboxItem(delivery, definedOptions({ recipientName: input?.agentName }))
+        ),
+      };
+    },
+    /**
+     * Stream durable deliveries: seed from the non-terminal queue, then push
+     * items announced by `delivery.accepted` WebSocket events, deduplicated by
+     * delivery id. Falls back to an empty stream without an agent client.
+     */
+    subscribe: (input?: InboxSubscribeInput): AsyncIterable<InboxItem> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.emptyInboxSubscription();
+      return this.createInboxSubscription(surface, input);
+    },
+    ack: async (input: InboxAckInput): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.unsupportedInboxDelivery('ack', input.inboxItemId);
+      return normalizeDeliveryTransition('ack', await surface.ackDelivery(input.inboxItemId));
+    },
+    fail: async (input: InboxFailInput): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.unsupportedInboxDelivery('fail', input.inboxItemId, input.error);
+      return normalizeDeliveryTransition(
+        'fail',
+        await surface.failDelivery(
+          input.inboxItemId,
+          definedOptions({ error: input.error, retryable: input.retry })
+        )
+      );
+    },
+    defer: async (input: InboxDeferInput): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) {
+        return this.unsupportedInboxDelivery('defer', input.inboxItemId, input.reason, input.availableAt);
+      }
+      return normalizeDeliveryTransition(
+        'defer',
+        await surface.deferDelivery(input.inboxItemId, {
+          availableAt: input.availableAt,
+          ...(input.reason === undefined ? {} : { reason: input.reason }),
+        })
+      );
+    },
+    markRead: async (input: InboxMarkReadInput): Promise<RelayDeliveryResult> =>
       this.unsupportedInboxDelivery(
         'ack',
         input.inboxItemId,
-        'Inbox read state updates require server delivery state.'
+        'The Relaycast delivery ledger has no read state; use inbox.ack to mark a delivery handled.'
       ),
   };
 
@@ -696,28 +763,37 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     ): (() => void) => this.addEventListener(event, handler),
   };
 
+  /**
+   * Durable delivery transitions keyed by the relaycast delivery id (the
+   * `InboxItem.id` returned by `inbox.list`/`inbox.subscribe`). Transitions
+   * are idempotent on the server.
+   */
   readonly deliveries = {
-    ack: async (messageId: string): Promise<RelayDeliveryUnsupportedResult> => ({
-      supported: false,
-      action: 'ack',
-      messageId,
-      reason: 'Durable acknowledgements are not supported by the Relaycast messaging backend yet.',
-    }),
-    fail: async (messageId: string, reason?: string): Promise<RelayDeliveryUnsupportedResult> => ({
-      supported: false,
-      action: 'fail',
-      messageId,
-      ...(reason
-        ? { reason }
-        : { reason: 'Durable failure reporting is not supported by the Relaycast messaging backend yet.' }),
-    }),
-    defer: async (messageId: string, deferUntil?: string): Promise<RelayDeliveryUnsupportedResult> => ({
-      supported: false,
-      action: 'defer',
-      messageId,
-      ...(deferUntil ? { deferUntil } : {}),
-      reason: 'Durable deferral is not supported by the Relaycast messaging backend yet.',
-    }),
+    ack: async (deliveryId: string): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.unsupportedInboxDelivery('ack', deliveryId);
+      return normalizeDeliveryTransition('ack', await surface.ackDelivery(deliveryId));
+    },
+    fail: async (deliveryId: string, reason?: string): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.unsupportedInboxDelivery('fail', deliveryId, reason);
+      return normalizeDeliveryTransition(
+        'fail',
+        await surface.failDelivery(deliveryId, definedOptions({ error: reason }))
+      );
+    },
+    defer: async (deliveryId: string, deferUntil?: string): Promise<RelayDeliveryResult> => {
+      const surface = this.deliverySurface();
+      if (!surface) return this.unsupportedInboxDelivery('defer', deliveryId, undefined, deferUntil);
+      return normalizeDeliveryTransition(
+        'defer',
+        await surface.deferDelivery(deliveryId, {
+          // The relaycast defer transition requires an explicit availability
+          // time; default to a short retry window when none is given.
+          availableAt: deferUntil ?? new Date(Date.now() + 30_000).toISOString(),
+        })
+      );
+    },
   };
 
   readonly integrations = {
@@ -862,6 +938,103 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     return this.relaycast.dmMessages;
   }
 
+  /**
+   * The durable delivery API of the agent client, when present. Requires an
+   * agent-scoped client built from `@relaycast/sdk` 2.5+ (or a compatible
+   * injected `agentClient`).
+   */
+  private deliverySurface(): (RelaycastAgentLike & RelaycastAgentDeliverySurface) | undefined {
+    const agent = this.agentClient;
+    if (
+      !agent ||
+      typeof agent.deliveries !== 'function' ||
+      typeof agent.ackDelivery !== 'function' ||
+      typeof agent.failDelivery !== 'function' ||
+      typeof agent.deferDelivery !== 'function'
+    ) {
+      return undefined;
+    }
+    return agent as RelaycastAgentLike & RelaycastAgentDeliverySurface;
+  }
+
+  private async *createInboxSubscription(
+    agent: RelaycastAgentLike & RelaycastAgentDeliverySurface,
+    input?: InboxSubscribeInput
+  ): AsyncGenerator<InboxItem, void, undefined> {
+    const signal = input?.signal;
+    if (signal?.aborted) return;
+    const recipient = definedOptions({ recipientName: input?.agentName });
+
+    const seen = new Set<string>();
+    const queue: InboxItem[] = [];
+    let stopped = false;
+    let notify: (() => void) | undefined;
+
+    const wake = (): void => {
+      const resolve = notify;
+      notify = undefined;
+      resolve?.();
+    };
+    const push = (item: InboxItem): void => {
+      if (!item.id || seen.has(item.id)) return;
+      seen.add(item.id);
+      queue.push(item);
+      wake();
+    };
+    const stop = (): void => {
+      stopped = true;
+      wake();
+    };
+
+    // Register the event listener before seeding so accepted deliveries that
+    // land mid-seed are not missed; `seen` deduplicates the overlap.
+    const inFlight = new Set<string>();
+    agent.connect();
+    const unsubscribe = agent.on.any((event) => {
+      const record = asRecord(event);
+      if (record.type !== 'delivery.accepted') return;
+      const deliveryId = readStr(record, 'deliveryId', 'delivery_id');
+      if (!deliveryId || seen.has(deliveryId) || inFlight.has(deliveryId)) return;
+      inFlight.add(deliveryId);
+      // The accepted event carries ids only; re-list the non-terminal queue
+      // to pick up the delivery row with its embedded message payload.
+      void agent
+        .deliveries()
+        .then((deliveries) => {
+          const match = deliveries.find((raw) => readStr(asRecord(raw), 'id') === deliveryId);
+          if (match) push(normalizeInboxItem(match, recipient));
+        })
+        .catch(() => {
+          // The delivery already transitioned or the list failed transiently;
+          // it will be replayed by the next non-terminal listing.
+        })
+        .finally(() => {
+          inFlight.delete(deliveryId);
+        });
+    });
+    signal?.addEventListener('abort', stop, { once: true });
+
+    try {
+      for (const raw of await agent.deliveries()) {
+        push(normalizeInboxItem(raw, recipient));
+      }
+      while (!stopped) {
+        const next = queue.shift();
+        if (next) {
+          yield next;
+          continue;
+        }
+        await new Promise<void>((resolve) => {
+          notify = resolve;
+        });
+      }
+    } finally {
+      stopped = true;
+      unsubscribe();
+      signal?.removeEventListener('abort', stop);
+    }
+  }
+
   private async *emptyInboxSubscription(): AsyncIterable<InboxItem> {
     return;
   }
@@ -880,7 +1053,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
         ? { reason }
         : {
             reason:
-              'Relaycast messaging does not expose durable inbox delivery state in this SDK surface yet.',
+              'Durable delivery transitions require an agent-scoped client with the Relaycast delivery API.',
           }),
       ...(deferUntil ? { deferUntil } : {}),
     };

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -332,12 +332,30 @@ export interface RelayDeliveryUnsupportedResult {
   deferUntil?: string;
 }
 
+/** A durable delivery transition (ack/fail/defer) applied by the server. */
+export interface RelayDeliverySupportedResult {
+  supported: true;
+  action: 'ack' | 'fail' | 'defer';
+  /** Durable delivery ledger row the transition applied to. */
+  deliveryId: string;
+  /** Message the delivery carries. */
+  messageId: string;
+  /** Inbox state after the transition. */
+  state: InboxItemState;
+  /** When the delivery becomes available again (defer transitions). */
+  deferUntil?: string;
+}
+
+export type RelayDeliveryResult = RelayDeliverySupportedResult | RelayDeliveryUnsupportedResult;
+
 export interface RelayMessagingCapabilities {
+  /** Server tracks per-recipient delivery state with ack/fail/defer transitions. */
   serverDeliveryState: boolean;
-  durableDelivery: false;
-  durableAck: false;
-  durableFail: false;
-  durableDefer: false;
+  /** Per-recipient delivery ledger with replay of non-terminal items. */
+  durableDelivery: boolean;
+  durableAck: boolean;
+  durableFail: boolean;
+  durableDefer: boolean;
 }
 
 // ── Integrations (webhooks + event subscriptions) ───────────────────────────
@@ -712,16 +730,16 @@ export interface RelayMessagingClient {
     get(options?: { limit?: number }): Promise<RelayInbox>;
     list(input?: InboxListInput): Promise<InboxListResult>;
     subscribe(input?: InboxSubscribeInput): AsyncIterable<InboxItem>;
-    ack(input: InboxAckInput): Promise<RelayDeliveryUnsupportedResult>;
-    fail(input: InboxFailInput): Promise<RelayDeliveryUnsupportedResult>;
-    defer(input: InboxDeferInput): Promise<RelayDeliveryUnsupportedResult>;
-    markRead(input: InboxMarkReadInput): Promise<RelayDeliveryUnsupportedResult>;
+    ack(input: InboxAckInput): Promise<RelayDeliveryResult>;
+    fail(input: InboxFailInput): Promise<RelayDeliveryResult>;
+    defer(input: InboxDeferInput): Promise<RelayDeliveryResult>;
+    markRead(input: InboxMarkReadInput): Promise<RelayDeliveryResult>;
   };
   readonly events: RelayMessagingEventsSurface;
   readonly deliveries: {
-    ack(messageId: string): Promise<RelayDeliveryUnsupportedResult>;
-    fail(messageId: string, reason?: string): Promise<RelayDeliveryUnsupportedResult>;
-    defer(messageId: string, deferUntil?: string): Promise<RelayDeliveryUnsupportedResult>;
+    ack(messageId: string): Promise<RelayDeliveryResult>;
+    fail(messageId: string, reason?: string): Promise<RelayDeliveryResult>;
+    defer(messageId: string, deferUntil?: string): Promise<RelayDeliveryResult>;
   };
   readonly integrations: {
     webhooks: {


### PR DESCRIPTION
## Summary

`RelaycastMessagingClient` stubbed the whole durable delivery surface (`inbox.list` returned `{items: []}`, `inbox.subscribe` was an empty iterator, ack/fail/defer returned "not supported yet") even though the hosted Relaycast engine ships a complete per-recipient delivery ledger and `@relaycast/sdk` 2.5 exposes it (`AgentClient.deliveries`, `ackDelivery`/`failDelivery`/`deferDelivery`, `delivery.*` WS events). This PR makes the surface real and the capability flags truthful.

## Behavior changes

- **`inbox.list`** lists the durable delivery queue: non-terminal rows (accepted + deferred) in FIFO order with embedded message payloads, normalized onto `InboxItem` (`accepted` → `queued`; delivery mode/reason/priority/retryable/error/deadline carried in `metadata`). `nextCursor` is never set — `GET /v1/deliveries` has no cursor.
- **`inbox.subscribe`** is a working async iterator: seeds from the non-terminal queue, then pushes items announced by `delivery.accepted` WS events (the event carries ids only, so the client re-lists to pick up the payload), deduplicated by delivery id with an in-flight guard. Supports `AbortSignal`.
- **`inbox.ack/fail/defer`** and **`deliveries.ack/fail/defer`** call the idempotent ledger transitions and return a new typed `RelayDeliverySupportedResult` (`supported: true`, `deliveryId`, `messageId`, post-transition `state`, `deferUntil`). The `deliveries.*` identifier is the relaycast delivery id (the `InboxItem.id`).
- **`capabilities`** are now computed instead of hardcoded false: `serverDeliveryState`/`durableDelivery`/`durableAck`/`durableFail`/`durableDefer` are all `true` when the client has an agent-scoped connection exposing the delivery API, and remain `false` for workspace-key-only clients (which keep the previous graceful unsupported stubs).
- **`DeliveryRunner`** now passes its `serverDeliveryState` capability gate against the shipping backend; no runner changes were needed. An end-to-end unit test drives the runner over `RelaycastMessagingClient` with a mocked agent client (subscribe → inject → ack).

### Intentionally still unsupported

- `inbox.markRead` stays an explicit stub: the relaycast delivery ledger has no `read` state (statuses are accepted/delivered/deferred/failed).
- `InboxItem.attempts` is always `0` — the ledger does not expose attempt counts.
- `InboxListInput.before`/`after` are ignored — no cursor support in the underlying API.

## Type changes (packages/sdk only)

- `RelayMessagingCapabilities` durable flags widened from literal `false` to `boolean`.
- Added `RelayDeliverySupportedResult` and `RelayDeliveryResult = RelayDeliverySupportedResult | RelayDeliveryUnsupportedResult`; inbox/deliveries transition methods now return `Promise<RelayDeliveryResult>`.
- New normalize helpers: `normalizeInboxItem`, `normalizeInboxItemState`, `normalizeDeliveryTransition`.
- Verified the real `@relaycast/sdk` 2.5.1 `AgentClient` is structurally assignable to the optional delivery surface added to `RelaycastAgentLike`.

## Tests

- `packages/sdk`: `npm run check` clean, `npm run build` clean, `npm test` 83/83 passing (9 files).
- New unit tests: capability detection, delivery-row → `InboxItem` mapping (including deferred rows and null message payloads), ack/fail/defer pass-through and argument mapping, error propagation, subscribe seeding + event push + dedupe, abort-signal termination, and the DeliveryRunner end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)