### PR TITLE
fix(cli): capture orchestrator harness for the detached broker

### DIFF
--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyBrokerStartError, classifyBrokerStartStage, describeError } from './broker-lifecycle.js';
+import {
+  classifyBrokerStartError,
+  classifyBrokerStartStage,
+  describeError,
+  ensureOrchestratorHarnessEnv,
+} from './broker-lifecycle.js';
+import { ORCHESTRATOR_HARNESS_ENV } from '../telemetry/orchestrator-harness.js';
 
 describe('describeError', () => {
   it('returns plain message for a bare Error', () => {
@@ -90,5 +96,32 @@ describe('classifyBrokerStartStage', () => {
 
   it('falls back to startup for everything else', () => {
     expect(classifyBrokerStartStage(new Error('???'), '???', false)).toBe('startup');
+  });
+});
+
+describe('ensureOrchestratorHarnessEnv', () => {
+  it('stamps the detected harness so the detached broker can forward it', () => {
+    const env: NodeJS.ProcessEnv = {};
+    ensureOrchestratorHarnessEnv(env, () => 'claude-code');
+    expect(env[ORCHESTRATOR_HARNESS_ENV]).toBe('claude-code');
+  });
+
+  it('leaves env untouched when detection is unknown', () => {
+    const env: NodeJS.ProcessEnv = {};
+    ensureOrchestratorHarnessEnv(env, () => 'unknown');
+    expect(env[ORCHESTRATOR_HARNESS_ENV]).toBeUndefined();
+  });
+
+  it('does not overwrite an explicit value (e.g. inherited by the detached re-invoke)', () => {
+    const env: NodeJS.ProcessEnv = { [ORCHESTRATOR_HARNESS_ENV]: 'codex' };
+    ensureOrchestratorHarnessEnv(env, () => 'claude-code');
+    expect(env[ORCHESTRATOR_HARNESS_ENV]).toBe('codex');
+  });
+
+  it('passes env through to the detector (reads explicit harness env keys)', () => {
+    const env: NodeJS.ProcessEnv = { RELAYCAST_HARNESS: 'cursor' };
+    // Real detector: reads RELAYCAST_HARNESS from the passed env.
+    ensureOrchestratorHarnessEnv(env);
+    expect(env[ORCHESTRATOR_HARNESS_ENV]).toBe('cursor');
   });
 });

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -1286,7 +1286,7 @@ async function shutdownUpResources(
  */
 export function ensureOrchestratorHarnessEnv(
   env: NodeJS.ProcessEnv,
-  detect: typeof detectOrchestratorHarness = detectOrchestratorHarness,
+  detect: typeof detectOrchestratorHarness = detectOrchestratorHarness
 ): void {
   if (env[ORCHESTRATOR_HARNESS_ENV]) return;
   const harness = detect({ env });

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -5,6 +5,11 @@ import { HarnessDriverClient } from '@agent-relay/harness-driver';
 
 import type { CoreDependencies, CoreProjectPaths, CoreRelay, SpawnedProcess } from '../commands/core.js';
 import { track } from '../telemetry/index.js';
+import {
+  detectOrchestratorHarness,
+  ORCHESTRATOR_HARNESS_ENV,
+  UNKNOWN_ORCHESTRATOR_HARNESS,
+} from '../telemetry/orchestrator-harness.js';
 import { buildBundledAgentRelayMcpCommand } from './agent-relay-mcp-command.js';
 import { errorClassName } from './telemetry-helpers.js';
 
@@ -1262,6 +1267,34 @@ async function shutdownUpResources(
   }
 }
 
+/**
+ * Capture the orchestrator harness (claude-code / codex / cursor / …) into
+ * `env` so the broker can report it to the relaycast backend.
+ *
+ * The broker is launched detached (its own session), so by the time it runs
+ * its own detection its parent is the init process and the process-tree walk
+ * finds nothing. The `agent-relay` CLI, however, still runs in-process under
+ * the harness when `up` is invoked — detect here and stamp
+ * `AGENT_RELAY_ORCHESTRATOR_HARNESS`, which the detached broker reads (env is
+ * checked before the process walk) and forwards as the `X-Relaycast-Harness`
+ * header / `?harness=` query, and which spawned agents inherit too. A value
+ * already present in `env` (explicit override, or the re-invoked detached
+ * `up` inheriting ours) wins.
+ *
+ * Exported for testing; `detect` is injectable so tests don't depend on the
+ * real process tree.
+ */
+export function ensureOrchestratorHarnessEnv(
+  env: NodeJS.ProcessEnv,
+  detect: typeof detectOrchestratorHarness = detectOrchestratorHarness,
+): void {
+  if (env[ORCHESTRATOR_HARNESS_ENV]) return;
+  const harness = detect({ env });
+  if (harness !== UNKNOWN_ORCHESTRATOR_HARNESS) {
+    env[ORCHESTRATOR_HARNESS_ENV] = harness;
+  }
+}
+
 // eslint-disable-next-line complexity
 export async function runUpCommand(options: UpOptions, deps: CoreDependencies): Promise<void> {
   ensureBundledAgentRelayMcpCommand(deps);
@@ -1279,6 +1312,11 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     paths.dataDir = resolved;
     deps.env.AGENT_RELAY_STATE_DIR = resolved;
   }
+
+  // The broker is launched detached (its own session), so it can't walk the
+  // process tree to identify the orchestrator harness — capture it here while
+  // we're still in-process under it. See `ensureOrchestratorHarnessEnv`.
+  ensureOrchestratorHarnessEnv(deps.env);
 
   if (options.background || (options.dashboard === false && !options.foreground)) {
     const preflight = await recoverHalfStartedBroker(paths, deps);


### PR DESCRIPTION
## Problem

[relay#1069](https://github.com/AgentWorkforce/relay/pull/1069) made the broker forward its detected harness to the relaycast backend, but server telemetry (PostHog 296966) **still records `harness: "unknown"` for ~100% of Rust-broker traffic** — verified on v8.3.2/v8.3.3 brokers (`@relaycast/sdk-rust 2.3.0`).

Root cause: the broker is launched **detached** (its own session via `setsid` — `broker-lifecycle.ts` spawns it with `detached: true`). By the time the broker runs `detect_orchestrator_harness`, its parent is the init process, so the parent-PID walk finds no `claude-code` / `codex` / `cursor` ancestor. #1069's forwarding works correctly — it just forwards `"unknown"`.

The asymmetry this explains:

| Path | Runs… | Detection | Result |
|---|---|---|---|
| JS / MCP (`@relaycast/sdk`) | in-process under the harness | parent walk sees the harness ✓ | `claude-code`, `codex` ✅ |
| Rust broker daemon | detached, own session | parent walk sees `launchd`/init ✗ | `unknown` ❌ |

## Fix

The `agent-relay` CLI **is** still in-process under the harness when `up` is invoked. Detect the harness there and stamp `AGENT_RELAY_ORCHESTRATOR_HARNESS` into the env handed to the broker — the established pattern for passing values to the broker (cf. `AGENT_RELAY_STATE_DIR`). The detached broker checks env **before** walking the process tree (`detect_orchestrator_harness` in `crates/broker/src/telemetry.rs`), so it now forwards the real harness, and the agents it spawns inherit it too.

- New `ensureOrchestratorHarnessEnv(env, detect?)` helper, called at the top of `runUpCommand` so both the background (detached re-invoke) and foreground paths inherit it.
- An explicit value already in env wins — including the re-invoked detached `up` inheriting ours, so detection runs once and isn't clobbered.
- `detect` is injectable → unit-tested without depending on the real process tree.

## Tests

- `broker-lifecycle.test.ts`: +4 cases (stamps detected harness; ignores `unknown`; respects explicit value; threads env to the real detector via `RELAYCAST_HARNESS`). Suite green (17 tests).
- CLI `tsc --noEmit` clean; `eslint` clean (the 6 pre-existing warnings are unrelated, in `refreshDashboardAssetsIfStale`).

## Rollout

Ships in the next `agent-relay` release. After adoption, `sdk-rust` rows in 296966 should flip from `unknown` to the real harness. This is the second half of the harness fix (forwarding plumbing #1069 + this detection capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)