### PR TITLE
Pass spawn `model` through MCP, SDK, and broker to the launched CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,9 +1999,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364a29a475378ca37cf922ae11733d87f2fdead11d54d41880a6e6f73d94866a"
+checksum = "2576286166bc0020d2ca652faf07dc32f127af8c3f854494ca532a71e35bbfd9"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=2.3.0"
+relaycast = "=2.4.0"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -204,6 +204,13 @@ impl BrokerRuntime {
                     let cli = event.agent.cli;
                     let task = Some(event.agent.task).filter(|value| !value.trim().is_empty());
                     let channel = event.agent.channel;
+                    // Carry the requested model through so the launched CLI is
+                    // started with `--model` (see worker.rs). An empty/blank
+                    // model is treated as unset.
+                    let model = event
+                        .agent
+                        .model
+                        .filter(|value| !value.trim().is_empty());
                     let harness_config = match relaycast_harness_config(&ws_value) {
                         Ok(config) => config,
                         Err(error) => {
@@ -247,7 +254,7 @@ impl BrokerRuntime {
                         cli: Some(cli.clone()),
                         session_id,
                         harness_config,
-                        model: None,
+                        model,
                         cwd: None,
                         team: None,
                         shadow_of: None,

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -207,10 +207,7 @@ impl BrokerRuntime {
                     // Carry the requested model through so the launched CLI is
                     // started with `--model` (see worker.rs). An empty/blank
                     // model is treated as unset.
-                    let model = event
-                        .agent
-                        .model
-                        .filter(|value| !value.trim().is_empty());
+                    let model = event.agent.model.filter(|value| !value.trim().is_empty());
                     let harness_config = match relaycast_harness_config(&ws_value) {
                         Ok(config) => config,
                         Err(error) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.3.0",
+  "version": "8.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -1177,6 +1177,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1611,6 +1612,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1628,6 +1630,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1645,6 +1648,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1662,6 +1666,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1679,6 +1684,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1696,6 +1702,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1713,6 +1720,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1730,6 +1738,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1747,6 +1756,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1764,6 +1774,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1781,6 +1792,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1798,6 +1810,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1815,6 +1828,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1832,6 +1846,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1849,6 +1864,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1866,6 +1882,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1883,6 +1900,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1900,6 +1918,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1917,6 +1936,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1934,6 +1954,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1951,6 +1972,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1968,6 +1990,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1985,6 +2008,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2002,6 +2026,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2019,6 +2044,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2036,6 +2062,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18702,45 +18729,45 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.3.0"
+      "version": "8.3.3"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.3.0",
-        "@agent-relay/config": "8.3.0",
-        "@agent-relay/harness-driver": "8.3.0",
-        "@agent-relay/sdk": "8.3.0",
-        "@agent-relay/utils": "8.3.0",
+        "@agent-relay/cloud": "8.3.3",
+        "@agent-relay/config": "8.3.3",
+        "@agent-relay/harness-driver": "8.3.3",
+        "@agent-relay/sdk": "8.3.3",
+        "@agent-relay/utils": "8.3.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^2.5.1",
+        "@relaycast/sdk": "^2.6.0",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -18759,11 +18786,46 @@
         "node": ">=20.9.0"
       }
     },
+    "packages/cli/node_modules/@relaycast/sdk": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-3Qq9CxTl4SmHpRDevyV5Dt8/7eDbJC5FYpayCcc7Rfah1zVQPeSZRa91sWdck8+2WaRNigUS6K/PqFfZ+l0JgQ==",
+      "dependencies": {
+        "@relaycast/types": "2.6.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "packages/cli/node_modules/@relaycast/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/cli/node_modules/@relaycast/types": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-2.6.0.tgz",
+      "integrity": "sha512-nE9ii1A8AbNO0LrCAJhKjo0LohhMdGRts1oEDiChjSpbsdsfyFS7QzKlFRheDKeJpw5nlpesVfhdpB/oKDsvXQ==",
+      "dependencies": {
+        "zod": "^4.3.6"
+      }
+    },
+    "packages/cli/node_modules/@relaycast/types/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "dependencies": {
-        "@agent-relay/config": "8.3.0",
+        "@agent-relay/config": "8.3.3",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -18779,7 +18841,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -18792,35 +18854,35 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.3.0",
+        "@agent-relay/sdk": "8.3.3",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.3.0",
-        "@agent-relay/broker-darwin-x64": "8.3.0",
-        "@agent-relay/broker-linux-arm64": "8.3.0",
-        "@agent-relay/broker-linux-x64": "8.3.0",
-        "@agent-relay/broker-win32-x64": "8.3.0"
+        "@agent-relay/broker-darwin-arm64": "8.3.3",
+        "@agent-relay/broker-darwin-x64": "8.3.3",
+        "@agent-relay/broker-linux-arm64": "8.3.3",
+        "@agent-relay/broker-linux-x64": "8.3.3",
+        "@agent-relay/broker-win32-x64": "8.3.3"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.3.0",
-        "@agent-relay/sdk": "8.3.0"
+        "@agent-relay/harness-driver": "8.3.3",
+        "@agent-relay/sdk": "8.3.3"
       }
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "dependencies": {
-        "@agent-relay/config": "8.3.0"
+        "@agent-relay/config": "8.3.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -18829,7 +18891,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "dependencies": {
         "@relaycast/sdk": "^2.5.1"
       },
@@ -18839,14 +18901,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.3.0",
+      "version": "8.3.3",
       "dependencies": {
-        "@agent-relay/config": "8.3.0",
+        "@agent-relay/config": "8.3.3",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "@agent-relay/sdk": "8.3.3",
     "@agent-relay/utils": "8.3.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^2.5.1",
+    "@relaycast/sdk": "^2.6.0",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -1807,7 +1807,9 @@ function registerAgentRelayTools(
           task,
           channel,
           persona,
-          metadata: model ? { model } : undefined,
+          // Pass model as a first-class spawn field so it reaches the broker and
+          // the launched CLI (--model), not just the agent's display metadata.
+          model: model ?? undefined,
         })
       )
   );

--- a/packages/sdk/src/messaging/normalize.ts
+++ b/packages/sdk/src/messaging/normalize.ts
@@ -604,6 +604,7 @@ export function normalizeMessagingEvent(input: unknown): RelayMessagingEvent {
           ...(normalizeOptionalChannelName(readNullableString(agent, 'channel') ?? undefined)
             ? { channel: normalizeOptionalChannelName(readNullableString(agent, 'channel') ?? undefined) }
             : {}),
+          ...(readString(agent, 'model') ? { model: readString(agent, 'model') } : {}),
           alreadyExisted: readBoolean(agent, 'alreadyExisted', 'already_existed') ?? false,
         },
       };

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -560,6 +560,7 @@ export interface RelayAgentSpawnRequestedEvent {
     cli?: string;
     task?: string;
     channel?: string;
+    model?: string;
     alreadyExisted: boolean;
   };
 }


### PR DESCRIPTION
## Problem

The `add_agent` MCP `model` arg was cosmetic. It was stuffed into agent metadata and never reached the broker, so relay-spawned workers always booted with the session default (e.g. Opus) regardless of the requested model. Verified 2026-06-10: spawning with `model: "haiku"` (and the full id) still booted Opus.

## Change

- **`agent-relay-mcp.ts`** — pass `model` as a first-class spawn field instead of burying it in `metadata`.
- **`sdk/messaging` (types + normalize)** — carry `model` on the `agentSpawnRequested` event so TS consumers see it.
- **`broker/runtime/relaycast_events.rs`** — build `AgentSpec` with the event's `model` (blank treated as unset) instead of hardcoding `model: None`. `worker.rs` already renders `--model` from `spec.model`, so this closes the last gap.
- **dep bump** — `@relaycast/sdk` → `^2.6.0` (packages/cli) and the `relaycast` crate → `=2.4.0` (broker), the published versions that carry `model`.

## Companion / dependency (now landed)

Gating change **AgentWorkforce/relaycast#180** is merged + published:
- npm `@relaycast/types` + `@relaycast/sdk` at **2.6.0**
- `relaycast` crate at **2.4.0**
- relaycast engine deployed.

## Verified

- `packages/cli` `tsc --noEmit` clean — the prior `TS2353: 'model' does not exist` is gone now that `@relaycast/sdk@2.6.0` is resolved.
- `cargo check -p agent-relay-broker` builds against `relaycast 2.4.0`.

## Note

Main-process/broker change — takes effect after the broker is rebuilt. Post-merge sanity: spawn a worker via `add_agent` with `model` set and confirm `--model` reaches the launched CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)