### PR TITLE
fix(cloud): forward OAuth callback to sandbox 127.0.0.1, not localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `agent-relay cloud connect <provider>` (and `agent-relay auth`) bind the OAuth callback tunnel on both `127.0.0.1` and `::1`, so provider CLIs that advertise a `localhost` loopback redirect (e.g. codex's `http://localhost:1455/auth/callback`) reconcile even when the browser resolves `localhost` to IPv6 first; previously the IPv4-only tunnel dropped the callback and login hung forever.
+- `agent-relay cloud connect <provider>` (and `agent-relay auth`) forward the OAuth callback to the sandbox's `127.0.0.1` explicitly instead of the hostname `localhost`, and bind the local listener on both `127.0.0.1` and `::1`. codex serves its `http://localhost:1455/auth/callback` on IPv4 loopback only, but the Daytona sandbox resolves `localhost` to `::1` first — so the previous forward dialed a dead `::1:1455` inside the sandbox and login hung forever. Both ends of the tunnel are now IPv4-correct.
 - `@agent-relay/cloud` pins the codex CLI installed into the auth sandbox (`@openai/codex@0.138.0`) instead of tracking `latest`, keeping `cloud connect codex` reproducible against codex's frequent releases.
 - `agent-relay local agent list` and `local metrics` now connect only to an existing local broker, so read-only commands no longer start an empty broker and hang after printing results.
 - `agent-relay` CLI attach sessions no longer write successful `view`, `drive`, or `passthrough` attach banners into the interactive terminal buffer.

--- a/packages/cloud/src/lib/ssh-interactive.test.ts
+++ b/packages/cloud/src/lib/ssh-interactive.test.ts
@@ -179,6 +179,49 @@ describe('wrapWithLaunchCheckpoint', () => {
   });
 });
 
+describe('runInteractiveSession — OAuth callback tunnel', () => {
+  it('forwards callbacks to the sandbox IPv4 loopback, not the hostname `localhost`', async () => {
+    // Regression: codex binds its OAuth callback server on 127.0.0.1 only, but
+    // the Daytona sandbox resolves `localhost` to ::1 first. Forwarding to the
+    // hostname dialed ::1:1455 inside the sandbox where nothing listened, so
+    // every callback was refused and login hung. The forward destination must
+    // be the explicit IPv4 address so it always lands on codex.
+    const { fakeSSH2, getClient } = createFakeSSH2({
+      onWrite: (stream) => {
+        queueMicrotask(() => stream.emit('close'));
+      },
+    });
+
+    // Capture the per-connection handler the tunnel registers with createServer
+    // so we can simulate a browser callback hitting the local listener.
+    let connectionHandler: ((socket: unknown) => void) | undefined;
+    const opts = createOptions(fakeSSH2, []);
+    opts.runtime.createServer = ((handler: (socket: unknown) => void) => {
+      connectionHandler = handler;
+      return {
+        listen: (_port: number, _host: string, cb: () => void) => cb(),
+        close: vi.fn(),
+        on: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: test runtime shim
+      } as any;
+      // biome-ignore lint/suspicious/noExplicitAny: test runtime shim
+    }) as any;
+
+    await withMockedStdio(async () => runInteractiveSession(opts));
+
+    expect(connectionHandler).toBeDefined();
+    // Simulate a browser callback arriving on the local tunnel listener.
+    const localSocket = { pipe: vi.fn(() => ({ pipe: vi.fn() })), end: vi.fn() };
+    connectionHandler!(localSocket);
+
+    const forwardOut = getClient().forwardOut;
+    expect(forwardOut).toHaveBeenCalled();
+    const [, , destHost, destPort] = forwardOut.mock.calls[0];
+    expect(destHost).toBe('127.0.0.1');
+    expect(destPort).toBe(1455);
+  });
+});
+
 describe('runInteractiveSession — handler-order and pattern gating', () => {
   it("attaches stream.on('data') before the first stream.write", async () => {
     const listenerCountsAtWrite: number[] = [];

--- a/packages/cloud/src/lib/ssh-interactive.ts
+++ b/packages/cloud/src/lib/ssh-interactive.ts
@@ -167,17 +167,27 @@ export async function runInteractiveSession(
     // port locally and forward each connection over SSH into the sandbox, so
     // the browser's callback reaches the provider CLI and login completes.
     //
-    // We bind BOTH loopback families. macOS resolves `localhost` to ::1 *and*
-    // 127.0.0.1, and browsers frequently try ::1 first. Binding IPv4 only let
-    // the callback hit a closed ::1 port and get dropped, leaving the provider
-    // CLI waiting on a callback that never arrives ("never reconciles"). Bind
-    // 127.0.0.1 as the primary (its listen/EADDRINUSE result gates readiness)
-    // and ::1 best-effort.
+    // Two loopback-family mismatches have to be handled, on opposite ends:
+    //
+    //  1. LOCAL listener — bind BOTH families. macOS resolves `localhost` to
+    //     ::1 *and* 127.0.0.1 and browsers frequently try ::1 first; binding
+    //     IPv4 only let the callback hit a closed ::1 port locally. Bind
+    //     127.0.0.1 as the primary (its listen/EADDRINUSE result gates
+    //     readiness) and ::1 best-effort.
+    //
+    //  2. REMOTE forward target — forward to `127.0.0.1` explicitly, NOT the
+    //     hostname `localhost`. codex binds its callback server on
+    //     `127.0.0.1:1455` (IPv4 loopback only — verified via `ss -tlnp`), but
+    //     the Daytona sandbox resolves `localhost` to `::1` first (its
+    //     /etc/hosts lists the IPv6 entry and getent returns ::1). Forwarding
+    //     to `localhost` therefore dialed `::1:1455` inside the sandbox, where
+    //     nothing listens, so every callback was refused and login hung
+    //     forever. Dialing the IPv4 address directly always lands on codex.
     const tunnel: { servers: Array<ReturnType<typeof createServer>> } = { servers: [] };
 
     const makeTunnelServer = () =>
       runtime.createServer((localSocket) => {
-        sshClient.forwardOut('127.0.0.1', tunnelPort, 'localhost', tunnelPort, (err, stream) => {
+        sshClient.forwardOut('127.0.0.1', tunnelPort, '127.0.0.1', tunnelPort, (err, stream) => {
           if (err) {
             localSocket.end();
             return;


### PR DESCRIPTION
## Problem
`agent-relay cloud connect codex` (and `auth`) hangs after printing the auth URL. The SSH callback tunnel forwarded to the hostname `localhost`, but inside the Daytona sandbox `localhost` resolves to `::1` first while codex binds its `:1455` callback server on `127.0.0.1` (IPv4) **only**. Every browser callback therefore dialed a dead `::1:1455` inside the sandbox → connection refused → login never reconciles.

Verified live in a Daytona sandbox:
- `ss -tlnp` → `LISTEN 127.0.0.1:1455 ((codex))`
- `getent hosts localhost` and Node `dns.lookup('localhost')` both return `::1` ahead of `127.0.0.1`

The prior dual-stack change (`cc27e5476`) fixed only the **local** listener; the regression was the **remote** forward target. A base-image roll flipping `localhost` to IPv6-first is the likely trigger for a previously-working flow breaking.

## Fix
Forward the callback to `127.0.0.1` explicitly so the connection always lands on codex's IPv4 bind, regardless of how the sandbox resolves `localhost`. This is the OpenAI-documented loopback-over-SSH path — no device-auth, no user opt-in.

- `ssh-interactive.ts`: `forwardOut(..., '127.0.0.1', tunnelPort, ...)` instead of `'localhost'`
- Adds a regression test asserting the tunnel forwards to `127.0.0.1:1455`
- CHANGELOG updated (the prior entry described only the half-fix)

## Validation
- `tsc` clean; **85/85** `@agent-relay/cloud` tests pass (incl. new guard)
- Root cause + bind/resolution confirmed against a live sandbox

## Release note
Ships client-side via a relay release: `packages/cli` pins `@agent-relay/cloud` at an exact version, so the release must bump `@agent-relay/cloud` **and** the CLI's pin. No cloud-backend change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
