### PR TITLE
Throttle MCP reminder injection by agent activity, not just elapsed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- PTY message injection re-sends the full MCP reply-instructions `<system-reminder>` block only after the agent has produced ~64KB of output since the last one (in addition to the 5-minute cooldown), and `agent-relay wrap` now applies the same throttle instead of attaching the block to every delivery — idle agents receiving channel chatter no longer burn tokens on repeated identical reminders; subsequent deliveries carry the one-line hint instead.
+
 ### Added
 
 - `agent-relay-broker` and `@agent-relay/harness-driver` accept explicit workspace keys and broker instance names, so local and cloud brokers can join the same Relay workspace with stable, addressable names.

--- a/crates/broker/src/broker/injection_format.rs
+++ b/crates/broker/src/broker/injection_format.rs
@@ -1,3 +1,60 @@
+use std::time::{Duration, Instant};
+
+/// Minimum wall-clock gap between full MCP reminder blocks.
+pub(crate) const MCP_REMINDER_COOLDOWN: Duration = Duration::from_secs(300);
+
+/// Minimum PTY output produced since the last full reminder before another
+/// one is allowed. Output volume is the proxy for "the agent actually worked
+/// and may have compacted the earlier reminder out of its context". An agent
+/// that only sat at the prompt receiving messages still has the previous
+/// reminder verbatim in context, so repeating it only burns tokens.
+pub(crate) const MCP_REMINDER_ACTIVITY_BYTES: usize = 64 * 1024;
+
+/// Decides when an injected delivery should carry the full multi-line MCP
+/// reminder block versus the one-line short hint.
+///
+/// The first delivery always gets the full block (the agent has never seen
+/// the reply instructions). After that, both gates must pass: the cooldown
+/// has elapsed AND the worker emitted enough PTY output since the last block
+/// that the earlier copy may have drifted out of context.
+pub(crate) struct McpReminderThrottle {
+    last_sent_at: Option<Instant>,
+    output_bytes_since_sent: usize,
+}
+
+impl McpReminderThrottle {
+    pub(crate) fn new() -> Self {
+        Self {
+            last_sent_at: None,
+            output_bytes_since_sent: 0,
+        }
+    }
+
+    /// Record PTY output produced by the worker. Counting is skipped until
+    /// the first reminder is sent — the volume only matters relative to it.
+    pub(crate) fn note_output_bytes(&mut self, bytes: usize) {
+        if self.last_sent_at.is_some() && self.output_bytes_since_sent < MCP_REMINDER_ACTIVITY_BYTES
+        {
+            self.output_bytes_since_sent = self.output_bytes_since_sent.saturating_add(bytes);
+        }
+    }
+
+    pub(crate) fn should_include(&self, now: Instant) -> bool {
+        match self.last_sent_at {
+            None => true,
+            Some(sent_at) => {
+                now.duration_since(sent_at) >= MCP_REMINDER_COOLDOWN
+                    && self.output_bytes_since_sent >= MCP_REMINDER_ACTIVITY_BYTES
+            }
+        }
+    }
+
+    pub(crate) fn note_sent(&mut self, now: Instant) {
+        self.last_sent_at = Some(now);
+        self.output_bytes_since_sent = 0;
+    }
+}
+
 fn workspace_context_label(
     workspace_id: Option<&str>,
     workspace_alias: Option<&str>,
@@ -335,5 +392,47 @@ mod tests {
         assert!(result.contains("mcp__agent-relay__send_dm"));
         assert!(result.contains("mcp__agent-relay__post_message"));
         assert!(result.contains("Relay message from alice [evt_9]: retry body"));
+    }
+
+    #[test]
+    fn reminder_throttle_includes_on_first_delivery() {
+        let throttle = McpReminderThrottle::new();
+        assert!(throttle.should_include(Instant::now()));
+    }
+
+    #[test]
+    fn reminder_throttle_suppresses_within_cooldown() {
+        let mut throttle = McpReminderThrottle::new();
+        let start = Instant::now();
+        throttle.note_sent(start);
+        throttle.note_output_bytes(MCP_REMINDER_ACTIVITY_BYTES);
+        assert!(!throttle.should_include(start + MCP_REMINDER_COOLDOWN - Duration::from_secs(1)));
+        assert!(throttle.should_include(start + MCP_REMINDER_COOLDOWN));
+    }
+
+    #[test]
+    fn reminder_throttle_suppresses_idle_worker_past_cooldown() {
+        let mut throttle = McpReminderThrottle::new();
+        let start = Instant::now();
+        throttle.note_sent(start);
+        // No output since the last reminder: the previous block is still in
+        // the agent's context no matter how much time has passed.
+        assert!(!throttle.should_include(start + MCP_REMINDER_COOLDOWN * 10));
+        throttle.note_output_bytes(MCP_REMINDER_ACTIVITY_BYTES - 1);
+        assert!(!throttle.should_include(start + MCP_REMINDER_COOLDOWN * 10));
+        throttle.note_output_bytes(1);
+        assert!(throttle.should_include(start + MCP_REMINDER_COOLDOWN * 10));
+    }
+
+    #[test]
+    fn reminder_throttle_resets_output_counter_on_send() {
+        let mut throttle = McpReminderThrottle::new();
+        let start = Instant::now();
+        throttle.note_sent(start);
+        throttle.note_output_bytes(MCP_REMINDER_ACTIVITY_BYTES);
+        let later = start + MCP_REMINDER_COOLDOWN;
+        assert!(throttle.should_include(later));
+        throttle.note_sent(later);
+        assert!(!throttle.should_include(later + MCP_REMINDER_COOLDOWN));
     }
 }

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -25,7 +25,7 @@ use crate::broker::{
         ThrottleState, ACTIVITY_BUFFER_KEEP_BYTES, ACTIVITY_BUFFER_MAX_BYTES, ACTIVITY_WINDOW,
         VERIFICATION_WINDOW,
     },
-    injection_format::format_injection_for_worker_with_workspace,
+    injection_format::{format_injection_for_worker_with_workspace, McpReminderThrottle},
 };
 use crate::cli::command_parse::parse_cli_command;
 use crate::cli::PtyCommand;
@@ -314,8 +314,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    const MCP_REMINDER_COOLDOWN: Duration = Duration::from_secs(300);
-    let mut last_mcp_reminder_at: Option<Instant> = None;
+    let mut mcp_reminder_throttle = McpReminderThrottle::new();
     let mut pending_worker_injections: VecDeque<PendingWorkerInjection> = VecDeque::new();
     let mut pending_worker_delivery_ids: HashSet<DeliveryId> = HashSet::new();
     let wait_for_agent_relay_boot = codex_agent_relay_boot_expected(&resolved_cli, &effective_args);
@@ -625,6 +624,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     Some(chunk) => {
                         last_pty_output_time = Instant::now();
                         reported_idle = false;
+                        mcp_reminder_throttle.note_output_bytes(chunk.len());
                         // Child is provably alive — reset the no-PID exit counter.
                         pty.reset_no_pid_checks();
                         startup_total_bytes = startup_total_bytes.saturating_add(chunk.len());
@@ -994,13 +994,8 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                         pty_auto.auto_suggestion_visible = false;
                     }
 
-                    let include_mcp_reminder = if suppress_multiline_mcp_reminder {
-                        false
-                    } else {
-                        last_mcp_reminder_at
-                            .map(|timestamp| timestamp.elapsed() >= MCP_REMINDER_COOLDOWN)
-                            .unwrap_or(true)
-                    };
+                    let include_mcp_reminder = !suppress_multiline_mcp_reminder
+                        && mcp_reminder_throttle.should_include(Instant::now());
                     let injection = format_injection_for_worker_with_workspace(
                         &pending.delivery.from,
                         &pending.delivery.event_id,
@@ -1013,7 +1008,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                         pending.delivery.workspace_alias.as_deref(),
                     );
                     if include_mcp_reminder {
-                        last_mcp_reminder_at = Some(Instant::now());
+                        mcp_reminder_throttle.note_sent(Instant::now());
                     }
                     if let Err(e) = pty.write_all(injection.as_bytes()) {
                         tracing::warn!(

--- a/crates/broker/src/wrap.rs
+++ b/crates/broker/src/wrap.rs
@@ -24,7 +24,7 @@ use crate::broker::{
         ACTIVITY_BUFFER_KEEP_BYTES, ACTIVITY_BUFFER_MAX_BYTES, ACTIVITY_WINDOW,
         MAX_VERIFICATION_ATTEMPTS, VERIFICATION_WINDOW,
     },
-    injection_format::format_injection_for_worker_with_workspace,
+    injection_format::{format_injection_for_worker_with_workspace, McpReminderThrottle},
 };
 use crate::cli::command_parse::parse_cli_command;
 use crate::runtime::{
@@ -781,6 +781,7 @@ pub(crate) async fn run_wrap(
     let mut pending_injection_interval = tokio::time::interval(Duration::from_millis(50));
     pending_injection_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut pending_wrap_injections: VecDeque<PendingWrapInjection> = VecDeque::new();
+    let mut mcp_reminder_throttle = McpReminderThrottle::new();
 
     // Echo verification state
     let mut pending_verifications: VecDeque<PendingVerification> = VecDeque::new();
@@ -859,6 +860,7 @@ pub(crate) async fn run_wrap(
                         let text = String::from_utf8_lossy(&chunk).to_string();
                         let clean_text = strip_ansi(&text);
                         pty_auto.last_output_time = Instant::now();
+                        mcp_reminder_throttle.note_output_bytes(chunk.len());
 
                         pty_auto.update_auto_suggestion(&text);
                         pty_auto.update_editor_buffer(&text);
@@ -1346,14 +1348,16 @@ pub(crate) async fn run_wrap(
                         pty_auto.auto_suggestion_visible = false;
                     }
                     tracing::debug!("relay from {} → {}", pending.from, pending.target);
+                    let include_reminder = !skip_prompt
+                        && mcp_reminder_throttle.should_include(Instant::now());
                     let injection = format_injection_for_worker_with_workspace(
                         &pending.from,
                         &pending.event_id,
                         &pending.body,
                         &pending.target,
-                        !skip_prompt, // include_reminder
-                        true,         // pre_registered
-                        None,         // assigned_name
+                        include_reminder,
+                        true, // pre_registered
+                        None, // assigned_name
                         pending.workspace_id.as_deref(),
                         pending.workspace_alias.as_deref(),
                     );
@@ -1373,6 +1377,9 @@ pub(crate) async fn run_wrap(
                             queued_at: pending.queued_at,
                         });
                         continue;
+                    }
+                    if include_reminder {
+                        mcp_reminder_throttle.note_sent(Instant::now());
                     }
                     telemetry.track(TelemetryEvent::MessageSend {
                         is_broadcast: pending.target.starts_with('#'),
@@ -1448,12 +1455,17 @@ pub(crate) async fn run_wrap(
                 // Re-inject retries
                 for mut pv in retry_queue {
                     tokio::time::sleep(throttle.delay()).await;
+                    // Retries consult the throttle like first injections: the
+                    // failed attempt usually already echoed the full block, so
+                    // a fresh one within the cooldown is redundant.
+                    let include_reminder = !skip_prompt
+                        && mcp_reminder_throttle.should_include(Instant::now());
                     let injection = format_injection_for_worker_with_workspace(
                         &pv.from,
                         &pv.event_id,
                         &pv.body,
                         &pv.target,
-                        !skip_prompt,
+                        include_reminder,
                         true,
                         None,
                         pv.workspace_id.as_deref(),
@@ -1466,6 +1478,9 @@ pub(crate) async fn run_wrap(
                             "wrap: retry PTY injection write failed"
                         );
                     } else {
+                        if include_reminder {
+                            mcp_reminder_throttle.note_sent(Instant::now());
+                        }
                         tokio::time::sleep(Duration::from_millis(50)).await;
                         let _ = pty.write_all(b"\r");
                         tracing::debug!(


### PR DESCRIPTION
## Problem

Spawned agents get the full ~200-token `<system-reminder>` MCP reply-instructions block re-injected over and over. Two paths:

- `pty_worker.rs` re-attached it once the 5-minute cooldown elapsed — but fleet channel messages typically arrive more than 5 minutes apart, so in practice every delivery carried the full block.
- `wrap.rs` (the "just open a Claude Code in pear" path) attached it **unconditionally to every delivery** — no cooldown at all.

An idle agent that only sits at the prompt receiving `#general` chatter still has the previous reminder verbatim in its context; re-sending it wastes tokens on every forced model turn. Observed in real transcripts: sessions with 8-9 identical reminder blocks and zero agent activity in between.

## Fix

New `McpReminderThrottle` (in `injection_format.rs`) gates the full block on **both**:

1. the existing 5-minute cooldown, and
2. ~64KB of PTY output produced since the last block — output volume as the proxy for "the agent actually worked and may have compacted the earlier reminder out of context".

First delivery always carries the full block. Suppressed deliveries still carry the existing one-line short hint. `wrap.rs` now uses the same throttle as `pty_worker.rs`, including its echo-verification retry path.

## Testing

- 4 new unit tests on the throttle (first-delivery, cooldown, idle-suppression, counter reset)
- `cargo test -p agent-relay-broker --lib`: 717 passed
- `cargo clippy -p agent-relay-broker`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)