### PR TITLE
feat(broker): origin_actor — bump relaycast crate 3.0.0, emit CLI path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,9 +1999,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "2.4.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2576286166bc0020d2ca652faf07dc32f127af8c3f854494ca532a71e35bbfd9"
+checksum = "4f9e462ae4dde5c008f65303cc0c9ee3816d0af19591fa50ae58216a25c29e29"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=2.4.0"
+relaycast = "=3.0.0"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -867,10 +867,9 @@ fn auth_http_status(err: &anyhow::Error) -> Option<StatusCode> {
 
 /// Build a `RelayCast` workspace client from an API key and base URL.
 fn build_relay_client(api_key: &str, base_url: &str) -> Result<RelayCast> {
-    let mut opts = RelayCastOptions::new(api_key).with_base_url(base_url);
-    if let Some(harness) = crate::telemetry::orchestrator_harness_opt() {
-        opts = opts.with_harness(harness);
-    }
+    let opts = RelayCastOptions::new(api_key)
+        .with_base_url(base_url)
+        .with_origin_actor(crate::telemetry::BROKER_ORIGIN_ACTOR);
     RelayCast::new(opts).map_err(|e| anyhow::anyhow!("{e}"))
 }
 

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -72,14 +72,12 @@ impl RelaycastWsClient {
                 );
             }
 
-            let mut ws_opts = WsClientOptions::new(self.workspace_http.api_key.clone())
-                .with_base_url(self.ws_base_url.clone());
-            // Forward the detected harness as the `harness` query param (WS
-            // upgrades can't set custom headers) so the backend can attribute
-            // server events to claude-code / codex / etc. instead of "unknown".
-            if let Some(harness) = crate::telemetry::orchestrator_harness_opt() {
-                ws_opts = ws_opts.with_harness(harness);
-            }
+            // Attribute the broker's own relaycast traffic (the workspace
+            // stream) to the agent-relay CLI as the origin actor — forwarded as
+            // the `origin_actor` query param (WS upgrades can't set headers).
+            let ws_opts = WsClientOptions::new(self.workspace_http.api_key.clone())
+                .with_base_url(self.ws_base_url.clone())
+                .with_origin_actor(crate::telemetry::BROKER_ORIGIN_ACTOR);
             let mut ws = WsClient::new(ws_opts);
 
             match ws.connect().await {
@@ -805,10 +803,9 @@ impl RelaycastHttpClient {
 
 /// Build a `RelayCast` workspace client from an API key and base URL.
 fn build_relay_client(api_key: &str, base_url: &str) -> Option<RelayCast> {
-    let mut opts = RelayCastOptions::new(api_key).with_base_url(base_url);
-    if let Some(harness) = crate::telemetry::orchestrator_harness_opt() {
-        opts = opts.with_harness(harness);
-    }
+    let opts = RelayCastOptions::new(api_key)
+        .with_base_url(base_url)
+        .with_origin_actor(crate::telemetry::BROKER_ORIGIN_ACTOR);
     RelayCast::new(opts).ok()
 }
 

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -456,6 +456,12 @@ pub(crate) fn orchestrator_harness_opt() -> Option<&'static str> {
     (harness != UNKNOWN_ORCHESTRATOR_HARNESS).then_some(harness)
 }
 
+/// `origin_actor` path for the broker's own relaycast traffic (the workspace
+/// stream + agent registration the broker performs on behalf of the CLI). The
+/// agent-relay CLI is the actor; spawned agents are attributed separately as
+/// `agent-relay-cli/agent/<harness>`. See cloud/plans/origin-actor.md.
+pub(crate) const BROKER_ORIGIN_ACTOR: &str = "agent-relay-cli/cli";
+
 /// Best-effort OS release string for telemetry tagging. Shells out to
 /// `uname -r` on unix (broker is unix-only anyway); returns `None` on
 /// failure so we just omit the property rather than risking a crash.


### PR DESCRIPTION
**PR4 (core) of the origin_actor rollout** — plan: [`cloud/plans/origin-actor.md`](https://github.com/AgentWorkforce/cloud/blob/main/plans/origin-actor.md). Aligns the broker producer with the engine 3.0.0 contract (`harness` → `origin_actor`, relaycast#184).

## Changes

- **Bump** the `relaycast` crate pin `=2.4.0 → =3.0.0` (the SDK renamed `with_harness` → `with_origin_actor`; 3.0.0 is published to crates.io).
- The broker's **own** relaycast traffic (workspace stream + agent registration) now sends `origin_actor = agent-relay-cli/cli` via `with_origin_actor`, at all three client sites (the WS handshake + both `build_relay_client` helpers). New `telemetry::BROKER_ORIGIN_ACTOR` const.

This fixes attribution for the broker's own `@relaycast/sdk-rust` traffic — the **majority** of `relaycast_server_*` events — which would otherwise go `unknown` once the gateway (engine 3.0.0) stops reading the old `X-Relaycast-Harness` header.

## Scope (core only, per direction)

This lands the **harness + crate-bump core**. Deliberate fast-follows:

1. **Per-worker spawned-agent path** `agent-relay-cli/agent/<harness>` — extends the open [#1078](https://github.com/AgentWorkforce/relay/pull/1078), and needs the **relay JS SDK** (`@relaycast/sdk`) renamed to send `X-Relaycast-Origin-Actor` so spawned agents are attributed.
2. **Model + version** in the name segment (`@<version>-<model>`) — the per-harness sourcing.

## Verification

- Builds against crate `3.0.0` with **no other reconciliation** needed (clean major bump).
- 709 broker lib tests pass; `clippy` + `cargo fmt --check` clean.

## Note

The broker's own traffic is attributed to `agent-relay-cli/cli` (per the plan's "CLI driving directly" case). The previously-forwarded orchestrator harness (claude-code/codex) now surfaces on the **spawned agents** instead (fast-follow #1), not on the broker's own events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)