### PR TITLE
Docs: serve raw Agent Relay skill markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Relay gives your agents shared channels, threads, DMs, reactions, files, search,
 
 ## Quick Start
 
-### Quick test with an agent? 
+### Quick test with an agent?
+
 Copy this snippet:
+
 ```
 Use this skill https://agentrelay.com/skill.md to spin up a team of agents on the relay so we can work on this problem:
 ```
 
-### Integrate with your app? 
+### Integrate with your app?
+
 Install:
 
 ```bash

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -7,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: ['/', '/skill', '/openclaw', '/openclaw/skill', '/docs/', '/blog/'],
+        allow: ['/', '/skill', '/skill.md', '/openclaw', '/openclaw/skill', '/docs/', '/blog/'],
         disallow: ['/openclaw/skill/invite/'],
       },
     ],

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -27,6 +27,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: absoluteUrl('/skill.md'),
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
       url: absoluteUrl('/openclaw'),
       lastModified: now,
       changeFrequency: 'weekly',

--- a/web/app/skill.md/route.ts
+++ b/web/app/skill.md/route.ts
@@ -1,0 +1,13 @@
+import { readAgentRelaySkillMarkdown } from '../../lib/skill-markdown';
+
+export const dynamic = 'force-static';
+export const revalidate = 86400;
+
+export function GET() {
+  return new Response(readAgentRelaySkillMarkdown(), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}

--- a/web/content/agent-relay/SKILL.md
+++ b/web/content/agent-relay/SKILL.md
@@ -142,5 +142,6 @@ You are probably acting as the outside orchestrator. Use `agent-relay` CLI comma
 ## Canonical Links
 
 - Default hosted handoff: `https://agentrelay.com/skill`
+- Raw markdown handoff: `https://agentrelay.com/skill.md`
 - Orchestrator skill: `https://github.com/AgentWorkforce/skills/blob/main/skills/orchestrating-agent-relay/SKILL.md`
 - Participant skill: `https://github.com/AgentWorkforce/skills/blob/main/skills/using-agent-relay/SKILL.md`

--- a/web/lib/test/skill-md-route.test.ts
+++ b/web/lib/test/skill-md-route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET } from '../../app/skill.md/route';
+
+describe('/skill.md route', () => {
+  it('serves the Agent Relay skill as raw markdown', async () => {
+    const response = GET();
+    const markdown = await response.text();
+
+    expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(markdown).toContain('# Agent Relay Team Onboarding');
+    expect(markdown).toContain('https://agentrelay.com/skill.md');
+    expect(markdown).toContain('orchestrating-agent-relay');
+    expect(markdown).toContain('using-agent-relay');
+  });
+});


### PR DESCRIPTION
## Summary
- add /skill.md as a static raw markdown route for the Agent Relay skill handoff
- include /skill.md in sitemap/robots and the skill canonical links
- add route-level coverage for markdown content type and expected handoff text

## Verification
- git diff --check HEAD~1..HEAD
- npm test (web)
- npm run build (web)

No changelog entry: docs and website skill handoff only.