### PR TITLE
feat: emit origin_actor from spawned agents (JS SDK + per-worker)

### DIFF
--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -233,11 +233,15 @@ pub fn spawn_env_vars(
         ("RELAY_CHANNELS".to_string(), channels.to_string()),
         ("RELAY_STRICT_AGENT_NAME".to_string(), "1".to_string()),
     ];
-    // Forward the detected harness so spawned agents using the JS SDK
-    // (`@relaycast/sdk`, which resolves harness from env and has no
-    // process-tree fallback) report it to the backend instead of "unknown".
+    // Per-worker attribution: tell the spawned agent's JS SDK its origin_actor
+    // path (`agent-relay-cli/agent/<harness>`) via env, so its relaycast
+    // telemetry is attributed to the harness it runs rather than "unknown".
+    // See cloud/plans/origin-actor.md.
     if let Some(harness) = harness {
-        env.push(("AGENT_RELAY_HARNESS".to_string(), harness.to_string()));
+        env.push((
+            "AGENT_RELAY_ORIGIN_ACTOR".to_string(),
+            format!("agent-relay-cli/agent/{harness}"),
+        ));
     }
     if let Some(workspaces_json) = workspaces_json
         .map(str::trim)
@@ -280,7 +284,7 @@ mod tests {
     use super::{spawn_env_vars, terminate_child, Spawner};
 
     #[test]
-    fn spawn_env_vars_forwards_harness_when_present() {
+    fn spawn_env_vars_sets_origin_actor_path_when_harness_present() {
         let env = spawn_env_vars(
             "a",
             "rk_live_x",
@@ -290,17 +294,17 @@ mod tests {
             None,
             Some("codex"),
         );
-        let harness = env
+        let origin_actor = env
             .iter()
-            .find(|(k, _)| k == "AGENT_RELAY_HARNESS")
+            .find(|(k, _)| k == "AGENT_RELAY_ORIGIN_ACTOR")
             .map(|(_, v)| v.as_str());
-        assert_eq!(harness, Some("codex"));
+        assert_eq!(origin_actor, Some("agent-relay-cli/agent/codex"));
     }
 
     #[test]
-    fn spawn_env_vars_omits_harness_when_absent() {
+    fn spawn_env_vars_omits_origin_actor_when_absent() {
         let env = spawn_env_vars("a", "rk_live_x", "https://gw", "#c", None, None, None);
-        assert!(env.iter().all(|(k, _)| k != "AGENT_RELAY_HARNESS"));
+        assert!(env.iter().all(|(k, _)| k != "AGENT_RELAY_ORIGIN_ACTOR"));
     }
 
     #[tokio::test]

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -316,7 +316,10 @@ fn sanitize_orchestrator_harness(raw: &str) -> Option<String> {
     Some(trimmed.chars().take(120).collect::<String>().to_lowercase())
 }
 
-fn infer_harness_from_command(command: &str) -> Option<&'static str> {
+/// Map a CLI command (e.g. `claude`, `codex`, `gemini`) to its canonical
+/// harness id. Used for orchestrator detection and for per-worker origin_actor
+/// attribution (the broker knows the CLI it spawns).
+pub(crate) fn infer_harness_from_command(command: &str) -> Option<&'static str> {
     let lower = command.to_lowercase();
     let normalized = lower.replace('\\', "/");
     let base = normalized

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -697,6 +697,25 @@ impl WorkerRegistry {
             }
             command.env(key, value);
         }
+        // Per-worker origin_actor: tag this agent's relaycast telemetry with the
+        // CLI it runs (`agent-relay-cli/agent/<harness>`). The agent's JS SDK
+        // reads AGENT_RELAY_ORIGIN_ACTOR. Don't override an explicit value set
+        // via harness_config env.
+        if !harness_env
+            .iter()
+            .any(|(k, _)| k == "AGENT_RELAY_ORIGIN_ACTOR")
+        {
+            if let Some(harness) = spec
+                .cli
+                .as_deref()
+                .and_then(crate::telemetry::infer_harness_from_command)
+            {
+                command.env(
+                    "AGENT_RELAY_ORIGIN_ACTOR",
+                    format!("agent-relay-cli/agent/{harness}"),
+                );
+            }
+        }
         for (key, value) in &harness_env {
             command.env(key, value);
         }

--- a/crates/broker/src/wrap.rs
+++ b/crates/broker/src/wrap.rs
@@ -1063,7 +1063,8 @@ pub(crate) async fn run_wrap(
                                         &channels,
                                         Some(&child_workspaces_json),
                                         default_workspace_id.as_deref(),
-                                        crate::telemetry::orchestrator_harness_opt(),
+                                        // Per-worker: the harness this agent runs.
+                                        crate::telemetry::infer_harness_from_command(&params.cli),
                                     );
                                     // Pre-register the child agent so its MCP server
                                     // starts with a valid token (avoiding "Not registered"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.3.3",
+  "version": "8.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -1177,7 +1177,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1612,7 +1611,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1630,7 +1628,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1648,7 +1645,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1666,7 +1662,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1684,7 +1679,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1702,7 +1696,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1720,7 +1713,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1738,7 +1730,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1756,7 +1747,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1774,7 +1764,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1792,7 +1781,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1810,7 +1798,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1828,7 +1815,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1846,7 +1832,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1864,7 +1849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1882,7 +1866,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1900,7 +1883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1918,7 +1900,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1936,7 +1917,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1954,7 +1934,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1972,7 +1951,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1990,7 +1968,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2008,7 +1985,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2026,7 +2002,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2044,7 +2019,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2062,7 +2036,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5564,11 +5537,11 @@
       }
     },
     "node_modules/@relaycast/sdk": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-2.5.1.tgz",
-      "integrity": "sha512-QnIFYgeKIFlisNF0EJyJNJkn4YvWVbsU/0Il9TWp5USvt79jkd9I1kFbg409+ySi9UwrKUYt+e6HfIwewIXidg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-3.1.1.tgz",
+      "integrity": "sha512-r7hGpbJ4+hgUpJ8LTvup9vVeEKOyG38w9qTeDd4/cmWA1X2zLdznl82j7wVIORk5hnpHCuzddVUwB9BdvtsH5w==",
       "dependencies": {
-        "@relaycast/types": "2.5.1",
+        "@relaycast/types": "3.1.1",
         "zod": "^4.3.6"
       }
     },
@@ -5582,9 +5555,9 @@
       }
     },
     "node_modules/@relaycast/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-SUZhhzND7o8Y65KwzYOzymkupoZLMoNvj2BZONrXMf3t2cfYdxGCox4IMUPY8ULzFaITSoG4XSMgoA+fAAIVag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-3.1.1.tgz",
+      "integrity": "sha512-sfBnWGw4LsxCFgDl51bPJTVYtCUAf0kHXLFfw+HKAZUZkWNK9Sg+fkcPlGynsU/LWFFYuvQcFy14yDx3cgq/HA==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -18729,45 +18702,45 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.3.3"
+      "version": "8.3.6"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.3.3",
-        "@agent-relay/config": "8.3.3",
-        "@agent-relay/harness-driver": "8.3.3",
-        "@agent-relay/sdk": "8.3.3",
-        "@agent-relay/utils": "8.3.3",
+        "@agent-relay/cloud": "8.3.6",
+        "@agent-relay/config": "8.3.6",
+        "@agent-relay/harness-driver": "8.3.6",
+        "@agent-relay/sdk": "8.3.6",
+        "@agent-relay/utils": "8.3.6",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^2.6.0",
+        "@relaycast/sdk": "^3.1.1",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -18786,46 +18759,11 @@
         "node": ">=20.9.0"
       }
     },
-    "packages/cli/node_modules/@relaycast/sdk": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-2.6.0.tgz",
-      "integrity": "sha512-3Qq9CxTl4SmHpRDevyV5Dt8/7eDbJC5FYpayCcc7Rfah1zVQPeSZRa91sWdck8+2WaRNigUS6K/PqFfZ+l0JgQ==",
-      "dependencies": {
-        "@relaycast/types": "2.6.0",
-        "zod": "^4.3.6"
-      }
-    },
-    "packages/cli/node_modules/@relaycast/sdk/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "packages/cli/node_modules/@relaycast/types": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-2.6.0.tgz",
-      "integrity": "sha512-nE9ii1A8AbNO0LrCAJhKjo0LohhMdGRts1oEDiChjSpbsdsfyFS7QzKlFRheDKeJpw5nlpesVfhdpB/oKDsvXQ==",
-      "dependencies": {
-        "zod": "^4.3.6"
-      }
-    },
-    "packages/cli/node_modules/@relaycast/types/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "dependencies": {
-        "@agent-relay/config": "8.3.3",
+        "@agent-relay/config": "8.3.6",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -18841,7 +18779,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -18854,35 +18792,35 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.3.3",
+        "@agent-relay/sdk": "8.3.6",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.3.3",
-        "@agent-relay/broker-darwin-x64": "8.3.3",
-        "@agent-relay/broker-linux-arm64": "8.3.3",
-        "@agent-relay/broker-linux-x64": "8.3.3",
-        "@agent-relay/broker-win32-x64": "8.3.3"
+        "@agent-relay/broker-darwin-arm64": "8.3.6",
+        "@agent-relay/broker-darwin-x64": "8.3.6",
+        "@agent-relay/broker-linux-arm64": "8.3.6",
+        "@agent-relay/broker-linux-x64": "8.3.6",
+        "@agent-relay/broker-win32-x64": "8.3.6"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.3.3",
-        "@agent-relay/sdk": "8.3.3"
+        "@agent-relay/harness-driver": "8.3.6",
+        "@agent-relay/sdk": "8.3.6"
       }
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "dependencies": {
-        "@agent-relay/config": "8.3.3"
+        "@agent-relay/config": "8.3.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -18891,9 +18829,9 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "dependencies": {
-        "@relaycast/sdk": "^2.5.1"
+        "@relaycast/sdk": "^3.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.13.10"
@@ -18901,14 +18839,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.3.3",
+      "version": "8.3.6",
       "dependencies": {
-        "@agent-relay/config": "8.3.3",
+        "@agent-relay/config": "8.3.6",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "@agent-relay/sdk": "8.3.6",
     "@agent-relay/utils": "8.3.6",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^2.6.0",
+    "@relaycast/sdk": "^3.1.1",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -405,7 +405,7 @@ describe('createAgentRelayMcpServer', () => {
   });
 
   it('passes telemetry context through Agent Relay MCP clients', async () => {
-    vi.stubEnv('AGENT_RELAY_ORCHESTRATOR_HARNESS', 'claude/opus-48');
+    vi.stubEnv('AGENT_RELAY_ORIGIN_ACTOR', 'agent-relay-cli/agent/claude-code');
     vi.stubEnv('AGENT_RELAY_DISTINCT_ID', 'distinct_test');
 
     const { mod, mocks } = await loadAgentRelayMcpModule();
@@ -421,7 +421,7 @@ describe('createAgentRelayMcpServer', () => {
     expect(mocks.wsClientInstances[0]?.config).toMatchObject({
       token: 'at_live_existing',
       baseUrl: 'https://api.relaycast.dev/',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
 
@@ -430,7 +430,7 @@ describe('createAgentRelayMcpServer', () => {
     expect(agentRelay?.config).toMatchObject({
       apiKey: 'at_live_existing',
       baseUrl: 'https://api.relaycast.dev/',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
 
@@ -445,7 +445,7 @@ describe('createAgentRelayMcpServer', () => {
     expect(workspaceRelay?.config).toMatchObject({
       apiKey: 'rk_live_existing',
       baseUrl: 'https://api.relaycast.dev/',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
 
@@ -467,7 +467,7 @@ describe('createAgentRelayMcpServer', () => {
     expect(bootstrapRelay?.config).toMatchObject({
       apiKey: 'rk_live_bootstrap',
       baseUrl: 'https://api.relaycast.dev/',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
   });

--- a/packages/cli/src/cli/lib/relaycast-telemetry.ts
+++ b/packages/cli/src/cli/lib/relaycast-telemetry.ts
@@ -1,8 +1,18 @@
 export interface RelaycastTelemetryOptions {
-  harness?: string;
+  originActor?: string;
   agentRelayDistinctId?: string;
 }
 
+/**
+ * Explicit `origin_actor` path (`{app}/{type}[/{name}]`), set by the broker for
+ * each spawned agent (`agent-relay-cli/agent/<harness>`). See
+ * cloud/plans/origin-actor.md.
+ */
+const ORIGIN_ACTOR_ENV = 'AGENT_RELAY_ORIGIN_ACTOR';
+/**
+ * Fallback: synthesize a path from the orchestrator harness when no explicit
+ * origin_actor is set (e.g. a standalone MCP running under a harness).
+ */
 const HARNESS_ENV_KEYS = [
   'AGENT_RELAY_HARNESS',
   'AGENT_RELAY_ORCHESTRATOR_HARNESS',
@@ -15,14 +25,21 @@ function nonEmpty(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-export function relaycastTelemetryOptions(env: NodeJS.ProcessEnv = process.env): RelaycastTelemetryOptions {
+export function resolveOriginActor(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const explicit = nonEmpty(env[ORIGIN_ACTOR_ENV]);
+  if (explicit) return explicit;
   const harness = HARNESS_ENV_KEYS.map((key) => nonEmpty(env[key])).find((value): value is string =>
     Boolean(value)
   );
+  return harness ? `agent-relay-cli/agent/${harness}` : undefined;
+}
+
+export function relaycastTelemetryOptions(env: NodeJS.ProcessEnv = process.env): RelaycastTelemetryOptions {
+  const originActor = resolveOriginActor(env);
   const agentRelayDistinctId = nonEmpty(env.AGENT_RELAY_DISTINCT_ID);
 
   return {
-    ...(harness ? { harness } : {}),
+    ...(originActor ? { originActor } : {}),
     ...(agentRelayDistinctId ? { agentRelayDistinctId } : {}),
   };
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -58,6 +58,6 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^2.5.1"
+    "@relaycast/sdk": "^3.1.1"
   }
 }

--- a/packages/sdk/src/__tests__/agent-relay.test.ts
+++ b/packages/sdk/src/__tests__/agent-relay.test.ts
@@ -91,7 +91,7 @@ describe('AgentRelay workspace setup', () => {
     const relay = new AgentRelay({
       workspaceKey: 'rk_live_existing',
       baseUrl: 'https://api.example.test',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
 
@@ -99,7 +99,7 @@ describe('AgentRelay workspace setup', () => {
     expect(relaycastMocks.relayCast).toHaveBeenCalledWith({
       apiKey: 'rk_live_existing',
       baseUrl: 'https://api.example.test',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
   });
@@ -113,7 +113,7 @@ describe('AgentRelay workspace setup', () => {
     const relay = await AgentRelay.createWorkspace({
       name: 'Ops',
       baseUrl: 'https://api.example.test',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
 
@@ -125,13 +125,13 @@ describe('AgentRelay workspace setup', () => {
     expect(relaycastMocks.relayCast).toHaveBeenCalledWith({
       apiKey: 'rk_live_created',
       baseUrl: 'https://api.example.test',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
   });
 
   it('uses Relaycast telemetry from environment variables when options omit it', () => {
-    vi.stubEnv('AGENT_RELAY_HARNESS', 'claude/opus-48');
+    vi.stubEnv('AGENT_RELAY_ORIGIN_ACTOR', 'agent-relay-cli/agent/claude-code');
     vi.stubEnv('AGENT_RELAY_DISTINCT_ID', 'distinct_test');
 
     const relay = new AgentRelay({
@@ -143,7 +143,7 @@ describe('AgentRelay workspace setup', () => {
     expect(relaycastMocks.relayCast).toHaveBeenCalledWith({
       apiKey: 'rk_live_existing',
       baseUrl: 'https://api.example.test',
-      harness: 'claude/opus-48',
+      originActor: 'agent-relay-cli/agent/claude-code',
       agentRelayDistinctId: 'distinct_test',
     });
   });

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -403,7 +403,7 @@ function createRelaycastClient(options: RelaycastMessagingOptions): RelaycastWor
       baseUrl: options.baseUrl,
       retryPolicy: options.retryPolicy,
       ...relaycastTelemetryOptions({
-        harness: options.harness,
+        originActor: options.originActor,
         agentRelayDistinctId: options.agentRelayDistinctId,
       }),
     }) as RelayCastOptions

--- a/packages/sdk/src/relaycast-telemetry.ts
+++ b/packages/sdk/src/relaycast-telemetry.ts
@@ -1,10 +1,20 @@
 export interface RelaycastTelemetryOptions {
-  harness?: string;
+  originActor?: string;
   agentRelayDistinctId?: string;
 }
 
 type Env = Record<string, string | undefined>;
 
+/**
+ * Explicit `origin_actor` path (`{app}/{type}[/{name}]`), set by the broker for
+ * each spawned agent (`agent-relay-cli/agent/<harness>`). See
+ * cloud/plans/origin-actor.md.
+ */
+const ORIGIN_ACTOR_ENV = 'AGENT_RELAY_ORIGIN_ACTOR';
+/**
+ * Fallback: synthesize a path from the orchestrator harness when no explicit
+ * origin_actor is set (e.g. a standalone MCP running under a harness).
+ */
 const HARNESS_ENV_KEYS = [
   'AGENT_RELAY_HARNESS',
   'AGENT_RELAY_ORCHESTRATOR_HARNESS',
@@ -21,18 +31,25 @@ function nonEmpty(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function resolveOriginActor(env: Env): string | undefined {
+  const explicit = nonEmpty(env[ORIGIN_ACTOR_ENV]);
+  if (explicit) return explicit;
+  const harness = HARNESS_ENV_KEYS.map((key) => nonEmpty(env[key])).find(
+    (value): value is string => Boolean(value)
+  );
+  return harness ? `agent-relay-cli/agent/${harness}` : undefined;
+}
+
 export function relaycastTelemetryOptions(
   explicit: RelaycastTelemetryOptions = {},
   env: Env = defaultEnv()
 ): RelaycastTelemetryOptions {
-  const harness =
-    nonEmpty(explicit.harness) ??
-    HARNESS_ENV_KEYS.map((key) => nonEmpty(env[key])).find((value): value is string => Boolean(value));
+  const originActor = nonEmpty(explicit.originActor) ?? resolveOriginActor(env);
   const agentRelayDistinctId =
     nonEmpty(explicit.agentRelayDistinctId) ?? nonEmpty(env.AGENT_RELAY_DISTINCT_ID);
 
   return {
-    ...(harness ? { harness } : {}),
+    ...(originActor ? { originActor } : {}),
     ...(agentRelayDistinctId ? { agentRelayDistinctId } : {}),
   };
 }

--- a/packages/sdk/src/relaycast-telemetry.ts
+++ b/packages/sdk/src/relaycast-telemetry.ts
@@ -34,8 +34,8 @@ function nonEmpty(value: string | undefined): string | undefined {
 function resolveOriginActor(env: Env): string | undefined {
   const explicit = nonEmpty(env[ORIGIN_ACTOR_ENV]);
   if (explicit) return explicit;
-  const harness = HARNESS_ENV_KEYS.map((key) => nonEmpty(env[key])).find(
-    (value): value is string => Boolean(value)
+  const harness = HARNESS_ENV_KEYS.map((key) => nonEmpty(env[key])).find((value): value is string =>
+    Boolean(value)
   );
   return harness ? `agent-relay-cli/agent/${harness}` : undefined;
 }


### PR DESCRIPTION
Completes the `origin_actor` producer rollout for the **JS spawned-agent path (~23%)** — the piece the core (broker's own `agent-relay-cli/cli`, v8.3.6) didn't cover. Consumes `@relaycast/sdk` **3.1.1** (relaycast#187), which renamed the `harness` option → `originActor` / `X-Relaycast-Origin-Actor`.

## JS
- `relaycast-telemetry.ts` (cli + sdk): resolve `originActor` from a new `AGENT_RELAY_ORIGIN_ACTOR` env (the broker sets the per-worker path), falling back to `agent-relay-cli/agent/<orchestrator-harness>` synthesized from the existing harness env. `relaycastTelemetryOptions` now returns `{ originActor }`.
- `messaging/relaycast.ts`: pass `originActor`.
- Bump `@relaycast/sdk` `^2.x → ^3.1.1` (cli + sdk) + lockfile.

## Broker (supersedes the open #1078)
- `spawn_env_vars`: set `AGENT_RELAY_ORIGIN_ACTOR=agent-relay-cli/agent/<harness>` (was `AGENT_RELAY_HARNESS`), with the **per-worker** harness from `infer_harness_from_command(params.cli)` (was the orchestrator harness).
- `worker.rs` (pty/app-server): stamp the same path from `spec.cli`.
- `infer_harness_from_command` → `pub(crate)`.

## Result
Each spawned JS agent reports `agent-relay-cli/agent/<its-harness>` (codex / claude-code / …), **per-agent** — closing the 23%.

## Verification
- 713 broker tests pass; clippy + `fmt --check` clean.
- `sdk` tsc clean; `agent-relay` (6) + `mcp.startup` (20) JS tests pass.
- The cli typecheck against the real 3.1.1 is left to **CI** (the local symlink resolves 2.5.1; verified 3.1.1 publishes both `originActor` and the `model` spawn field, so it'll compile).

## Closes
Supersedes #1078 (per-worker attribution) — please close it in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)