### PR TITLE
feat(broker): append spawn model to spawned-agent origin_actor

### DIFF
--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -240,7 +240,7 @@ pub fn spawn_env_vars(
     if let Some(harness) = harness {
         env.push((
             "AGENT_RELAY_ORIGIN_ACTOR".to_string(),
-            format!("agent-relay-cli/agent/{harness}"),
+            crate::telemetry::agent_origin_actor(harness, None),
         ));
     }
     if let Some(workspaces_json) = workspaces_json

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -465,6 +465,18 @@ pub(crate) fn orchestrator_harness_opt() -> Option<&'static str> {
 /// `agent-relay-cli/agent/<harness>`. See cloud/plans/origin-actor.md.
 pub(crate) const BROKER_ORIGIN_ACTOR: &str = "agent-relay-cli/cli";
 
+/// Build the `origin_actor` path for a spawned agent:
+/// `agent-relay-cli/agent/<harness>[@<model>]`. The model (when the broker knows
+/// it from the spawn request) is appended so server telemetry can segment by
+/// model; cloud parses a digit-less `@`-suffix as a model. See
+/// cloud/plans/origin-actor.md.
+pub(crate) fn agent_origin_actor(harness: &str, model: Option<&str>) -> String {
+    match model.map(str::trim).filter(|m| !m.is_empty()) {
+        Some(model) => format!("agent-relay-cli/agent/{harness}@{model}"),
+        None => format!("agent-relay-cli/agent/{harness}"),
+    }
+}
+
 /// Best-effort OS release string for telemetry tagging. Shells out to
 /// `uname -r` on unix (broker is unix-only anyway); returns `None` on
 /// failure so we just omit the property rather than risking a crash.
@@ -875,6 +887,23 @@ mod tests {
         );
         assert_eq!(sanitize_orchestrator_harness("bad\nvalue"), None);
         assert_eq!(sanitize_orchestrator_harness(""), None);
+    }
+
+    #[test]
+    fn agent_origin_actor_appends_model_when_present() {
+        assert_eq!(
+            agent_origin_actor("codex", Some("gpt-5")),
+            "agent-relay-cli/agent/codex@gpt-5"
+        );
+        assert_eq!(
+            agent_origin_actor("claude-code", None),
+            "agent-relay-cli/agent/claude-code"
+        );
+        // blank/whitespace model is treated as absent
+        assert_eq!(
+            agent_origin_actor("claude-code", Some("  ")),
+            "agent-relay-cli/agent/claude-code"
+        );
     }
 
     #[test]

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -698,9 +698,10 @@ impl WorkerRegistry {
             command.env(key, value);
         }
         // Per-worker origin_actor: tag this agent's relaycast telemetry with the
-        // CLI it runs (`agent-relay-cli/agent/<harness>`). The agent's JS SDK
-        // reads AGENT_RELAY_ORIGIN_ACTOR. Don't override an explicit value set
-        // via harness_config env.
+        // CLI it runs and the model it was spawned with
+        // (`agent-relay-cli/agent/<harness>[@<model>]`). The agent's JS SDK reads
+        // AGENT_RELAY_ORIGIN_ACTOR. Don't override an explicit value set via
+        // harness_config env.
         if !harness_env
             .iter()
             .any(|(k, _)| k == "AGENT_RELAY_ORIGIN_ACTOR")
@@ -712,7 +713,7 @@ impl WorkerRegistry {
             {
                 command.env(
                     "AGENT_RELAY_ORIGIN_ACTOR",
-                    format!("agent-relay-cli/agent/{harness}"),
+                    crate::telemetry::agent_origin_actor(harness, spec.model.as_deref()),
                 );
             }
         }


### PR DESCRIPTION
Part 2 of **model sourcing** (#3 fast-follow) — the broker producer side. Pairs with cloud#2077 (the parser).

Spawned agents are now attributed as `agent-relay-cli/agent/<harness>@<model>` when the broker knows the model from the spawn request, so `relaycast_server_*` telemetry can segment by model ("what models are people using").

## Changes
- New `telemetry::agent_origin_actor(harness, model)` helper → `agent-relay-cli/agent/<harness>[@<model>]` (blank model omitted).
- `worker.rs` — the `AgentSpec` path, which the relaycast spawn action flows through *with* the requested model (`relaycast_events.rs` carries `event.agent.model`) — passes `spec.model`.
- `spawn_env_vars` uses the same helper (`SpawnParams` has no model → `None`).

## Deferred
Harness **version** stays deferred — it needs a `<cli> --version` subprocess on the spawn hot path. The encoding + cloud parser (cloud#2077) already support `@<version>-<model>` for when it lands.

## Verification
714 broker tests pass (+1 `agent_origin_actor`); clippy + fmt clean.

## Rollout
After this + cloud#2077 merge and a broker release ships, spawned agents with a model report e.g. `agent-relay-cli/agent/codex@gpt-5`, and cloud derives `origin_actor_model=gpt-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)