### PR TITLE
refactor(telemetry): stop sending origin_surface from the CLI/cloud client

### DIFF
--- a/packages/cli/src/cli/bootstrap.ts
+++ b/packages/cli/src/cli/bootstrap.ts
@@ -90,7 +90,6 @@ function resolveSdkVersion(): string | undefined {
 export const SDK_VERSION = resolveSdkVersion();
 
 const AGENT_RELAY_DISTINCT_ID_ENV = 'AGENT_RELAY_DISTINCT_ID';
-const TELEMETRY_SURFACE_ENV = 'AGENT_RELAY_TELEMETRY_SURFACE';
 const TELEMETRY_CLIENT_ENV = 'AGENT_RELAY_TELEMETRY_CLIENT';
 
 function hasConfiguredTelemetryKey(): boolean {
@@ -127,9 +126,6 @@ function propagateTelemetryContextToChildren(): string {
   }
   if (!process.env[ORCHESTRATOR_HARNESS_ENV]) {
     process.env[ORCHESTRATOR_HARNESS_ENV] = orchestratorHarness;
-  }
-  if (!process.env[TELEMETRY_SURFACE_ENV]) {
-    process.env[TELEMETRY_SURFACE_ENV] = 'cli';
   }
   if (!process.env[TELEMETRY_CLIENT_ENV]) {
     process.env[TELEMETRY_CLIENT_ENV] = 'agent-relay';

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -285,7 +285,6 @@ describe('authorizedApiFetch telemetry headers', () => {
   const telemetryEnvKeys = [
     'AGENT_RELAY_DISTINCT_ID',
     'AGENT_RELAY_ORCHESTRATOR_HARNESS',
-    'AGENT_RELAY_TELEMETRY_SURFACE',
     'AGENT_RELAY_TELEMETRY_CLIENT',
     'AGENT_RELAY_CLI_VERSION',
     'AGENT_RELAY_SDK_VERSION',
@@ -307,7 +306,6 @@ describe('authorizedApiFetch telemetry headers', () => {
     clearTelemetryEnv();
     process.env.AGENT_RELAY_DISTINCT_ID = 'abc123def4567890';
     process.env.AGENT_RELAY_ORCHESTRATOR_HARNESS = 'Codex';
-    process.env.AGENT_RELAY_TELEMETRY_SURFACE = 'cli';
     process.env.AGENT_RELAY_TELEMETRY_CLIENT = 'agent-relay';
     process.env.AGENT_RELAY_CLI_VERSION = '7.1.1';
 
@@ -336,7 +334,6 @@ describe('authorizedApiFetch telemetry headers', () => {
     expect(headers.get('authorization')).toBe('Bearer access-token');
     expect(headers.get('x-agent-relay-distinct-id')).toBe('abc123def4567890');
     expect(headers.get('x-relaycast-harness')).toBe('Codex');
-    expect(headers.get('x-relaycast-origin-surface')).toBe('cli');
     expect(headers.get('x-relaycast-origin-client')).toBe('agent-relay');
     expect(headers.get('x-relaycast-origin-version')).toBe('7.1.1');
   });

--- a/packages/cloud/src/telemetry-headers.ts
+++ b/packages/cloud/src/telemetry-headers.ts
@@ -1,12 +1,10 @@
 export const AGENT_RELAY_DISTINCT_ID_HEADER = 'X-Agent-Relay-Distinct-Id';
 export const RELAYCAST_HARNESS_HEADER = 'X-Relaycast-Harness';
-export const RELAYCAST_ORIGIN_SURFACE_HEADER = 'X-Relaycast-Origin-Surface';
 export const RELAYCAST_ORIGIN_CLIENT_HEADER = 'X-Relaycast-Origin-Client';
 export const RELAYCAST_ORIGIN_VERSION_HEADER = 'X-Relaycast-Origin-Version';
 
 const AGENT_RELAY_DISTINCT_ID_ENV = 'AGENT_RELAY_DISTINCT_ID';
 const ORCHESTRATOR_HARNESS_ENV = 'AGENT_RELAY_ORCHESTRATOR_HARNESS';
-const TELEMETRY_SURFACE_ENV = 'AGENT_RELAY_TELEMETRY_SURFACE';
 const TELEMETRY_CLIENT_ENV = 'AGENT_RELAY_TELEMETRY_CLIENT';
 
 const DISTINCT_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
@@ -47,10 +45,6 @@ export function buildAgentRelayTelemetryHeaders(
     maxLength: 120,
     pattern: HEADER_VALUE_ALLOWED,
   });
-  const surface = sanitizeHeaderValue(env[TELEMETRY_SURFACE_ENV], {
-    maxLength: 32,
-    pattern: HEADER_VALUE_ALLOWED,
-  });
   const client = sanitizeHeaderValue(env[TELEMETRY_CLIENT_ENV], {
     maxLength: 80,
     pattern: HEADER_VALUE_ALLOWED,
@@ -61,7 +55,6 @@ export function buildAgentRelayTelemetryHeaders(
   });
 
   if (harness) headers[RELAYCAST_HARNESS_HEADER] = harness;
-  if (surface) headers[RELAYCAST_ORIGIN_SURFACE_HEADER] = surface;
   if (client) headers[RELAYCAST_ORIGIN_CLIENT_HEADER] = client;
   if (version) headers[RELAYCAST_ORIGIN_VERSION_HEADER] = version;
 


### PR DESCRIPTION
## What

Stops the agent-relay CLI / `@agent-relay/cloud` from sending the `X-Relaycast-Origin-Surface` telemetry header.

- `@agent-relay/cloud/src/telemetry-headers.ts` — remove the surface header constant, the `AGENT_RELAY_TELEMETRY_SURFACE` env source, the sanitize block, and the header set.
- `packages/cli/src/cli/bootstrap.ts` — stop defaulting `AGENT_RELAY_TELEMETRY_SURFACE=cli` for spawned children.
- Tests updated to drop the surface assertions.

## Why

Relaycast removed `origin_surface` from the telemetry origin contract ([relaycast#188](https://github.com/AgentWorkforce/relaycast/pull/188)). The origin-actor path (`{app}/{type}/{name}`, e.g. `agent-relay-cli/cli`) already carries what `origin_surface` (`cli|sdk|cloud`) expressed, so the header is dead weight — the engine no longer reads it.

Left unchanged: `origin_client` / `origin_version`, and the CLI's own client-side `surface` event property (a separate analytics dimension on `relaycast_cli_*` events, not the origin header).

## Note on SDK pin

This is independent of the relaycast SDK major bump — dropping a header we *send* needs no new SDK. Re-pinning the `relaycast` Rust crate / `@relaycast/sdk` to 4.x is optional post-publish hygiene (the broker never called the surface API) and is out of scope here.

## Tests

`packages/cloud/src/auth.test.ts` ✓ · `packages/cli/src/cli/bootstrap.test.ts` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)