### PR TITLE
[codex] Move local message controls under local agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `codex-relay-skill` and `gemini-relay-extension` now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK. Set `RELAY_BASE_URL` to keep using `https://api.relaycast.dev`.
+- `agent-relay local agent message hold|flush|auto <name>` now owns local broker delivery controls; the old top-level `agent-relay agent message ...` path was removed.
 
 ### Fixed
 

--- a/packages/cli/src/cli/bootstrap.test.ts
+++ b/packages/cli/src/cli/bootstrap.test.ts
@@ -19,6 +19,9 @@ const expectedLeafCommands = [
   'local agent release',
   'local agent set-model',
   'local agent attach',
+  'local agent message flush',
+  'local agent message hold',
+  'local agent message auto',
   // top-level composite status + maintenance + telemetry + mcp
   'status',
   'version',
@@ -44,14 +47,11 @@ const expectedLeafCommands = [
   'workspace set_key',
   'workspace join',
   'workspace switch',
-  // agent (messaging directory)
+  // workspace agents
   'agent register',
   'agent list',
   'agent add',
   'agent remove',
-  'agent message flush',
-  'agent message hold',
-  'agent message auto',
   // channel
   'channel create',
   'channel list',

--- a/packages/cli/src/cli/commands/agent.ts
+++ b/packages/cli/src/cli/commands/agent.ts
@@ -1,5 +1,4 @@
 import type { Command } from 'commander';
-import type { HarnessDriverClient } from '@agent-relay/harness-driver';
 
 import {
   addSdkOptions,
@@ -9,77 +8,13 @@ import {
   withSdkDefaults,
   type SdkCommandDeps,
 } from '../lib/sdk-command.js';
-import { createBrokerClient } from '../lib/attach-broker.js';
-import {
-  defaultStateDir,
-  readConnectionFileFromDisk,
-  resolveBrokerConnection,
-  type BrokerConnectionOptions,
-} from '../lib/broker-connection.js';
 
-export type AgentMessageBrokerOptions = BrokerConnectionOptions;
-
-export interface AgentCommandDependencies extends SdkCommandDeps {
-  connectLocal: (cwd: string, options: AgentMessageBrokerOptions) => Promise<HarnessDriverClient>;
-  cwd: () => string;
-  readConnectionFile: (stateDir: string) => unknown;
-  getDefaultStateDir: () => string;
-  env: NodeJS.ProcessEnv;
-  fetch: typeof globalThis.fetch;
-}
+export type AgentCommandDependencies = SdkCommandDeps;
 
 function withAgentDefaults(overrides: Partial<AgentCommandDependencies> = {}): AgentCommandDependencies {
-  const deps = {
-    ...withSdkDefaults(overrides),
-    cwd: () => process.cwd(),
-    readConnectionFile: readConnectionFileFromDisk,
-    getDefaultStateDir: defaultStateDir,
-    env: process.env,
-    fetch: globalThis.fetch,
-    ...overrides,
-  } as AgentCommandDependencies;
-  deps.connectLocal ??= async (_cwd: string, options: AgentMessageBrokerOptions) => {
-    const connection = resolveBrokerConnection(options, {
-      readConnectionFile: deps.readConnectionFile,
-      getDefaultStateDir: deps.getDefaultStateDir,
-      env: deps.env,
-    });
-    if (!connection) {
-      throw new Error(
-        'Error: could not locate broker connection. Pass --broker-url, set RELAY_BROKER_URL, ' +
-          'or run from a directory containing .agentworkforce/relay/connection.json.'
-      );
-    }
-    return createBrokerClient(connection, deps.fetch);
-  };
-  return deps;
-}
-
-async function runLocalBroker(
-  deps: AgentCommandDependencies,
-  options: AgentMessageBrokerOptions,
-  fn: (client: HarnessDriverClient) => Promise<void>
-): Promise<void> {
-  try {
-    await fn(await deps.connectLocal(deps.cwd(), options));
-  } catch (err) {
-    deps.error(err instanceof Error ? err.message : String(err));
-    deps.exit(1);
-  }
-}
-
-function addBrokerOptions(command: Command): Command {
-  return command
-    .option('--broker-url <url>', 'Broker base URL (overrides RELAY_BROKER_URL and connection.json)')
-    .option('--api-key <key>', 'Broker API key (overrides RELAY_BROKER_API_KEY and connection.json)')
-    .option('--state-dir <dir>', 'Directory containing connection.json (default: .agentworkforce/relay/)');
-}
-
-function brokerOptionsFromOpts(opts: Record<string, unknown>): AgentMessageBrokerOptions {
   return {
-    brokerUrl: opts.brokerUrl as string | undefined,
-    apiKey: opts.apiKey as string | undefined,
-    stateDir: opts.stateDir as string | undefined,
+    ...withSdkDefaults(overrides),
+    ...overrides,
   };
 }
 
@@ -141,41 +76,6 @@ export function registerAgentCommands(
       const relay = deps.createWorkspaceRelay(sdkOptionsFromOpts(opts));
       await relay.agents.delete(name);
       deps.log(`Removed agent ${name}.`);
-    });
-  });
-
-  const message = group.command('message').description('Control local broker message delivery for an agent');
-
-  addBrokerOptions(
-    message
-      .command('flush')
-      .description('Flush queued relay messages into a held local agent')
-      .argument('<name>', 'Agent name')
-  ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      printJson(deps, { name, ...(await client.flushPending(name)) });
-    });
-  });
-
-  addBrokerOptions(
-    message
-      .command('hold')
-      .description('Hold new relay messages for a local agent until flushed')
-      .argument('<name>', 'Agent name')
-  ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      printJson(deps, { name, ...(await client.setInboundDeliveryMode(name, 'manual_flush')) });
-    });
-  });
-
-  addBrokerOptions(
-    message
-      .command('auto')
-      .description('Resume automatic relay message injection for a local agent')
-      .argument('<name>', 'Agent name')
-  ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      printJson(deps, { name, ...(await client.setInboundDeliveryMode(name, 'auto_inject')) });
     });
   });
 }

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -16,6 +16,8 @@ function harness(overrides: Partial<LocalAgentDependencies> = {}) {
     listAgents: vi.fn(async () => [{ name: 'lead' }]),
     release: vi.fn(async () => undefined),
     setModel: vi.fn(async () => ({ name: 'lead', model: 'opus', success: true })),
+    flushPending: vi.fn(async () => ({ flushed: 2 })),
+    setInboundDeliveryMode: vi.fn(async (_name: string, mode: string) => ({ mode, flushed: 0 })),
   };
   const attach = vi.fn(async () => 0);
   const log = vi.fn();
@@ -97,5 +99,66 @@ describe('local agent subtree', () => {
     const { program, client } = harness();
     await program.parseAsync(['local', 'agent', 'set-model', 'lead', 'opus'], { from: 'user' });
     expect(client.setModel).toHaveBeenCalledWith('lead', 'opus');
+  });
+
+  it('message flush drains a local broker agent queue', async () => {
+    const client = { flushPending: vi.fn(async () => ({ flushed: 2 })) };
+    const connectLocal = vi.fn(async () => client as never);
+    const { program, log } = harness({ connectLocal });
+
+    await program.parseAsync(
+      [
+        'local',
+        'agent',
+        'message',
+        'flush',
+        'claude',
+        '--broker-url',
+        'http://127.0.0.1:3890',
+        '--api-key',
+        'secret',
+        '--state-dir',
+        '/tmp/relay-state',
+      ],
+      { from: 'user' }
+    );
+
+    expect(connectLocal).toHaveBeenCalledWith('/tmp/project', {
+      brokerUrl: 'http://127.0.0.1:3890',
+      apiKey: 'secret',
+      stateDir: '/tmp/relay-state',
+    });
+    expect(client.flushPending).toHaveBeenCalledWith('claude');
+    expect(log).toHaveBeenCalledWith(JSON.stringify({ name: 'claude', flushed: 2 }, null, 2));
+  });
+
+  it('message hold and auto switch local broker delivery mode', async () => {
+    const client = {
+      setInboundDeliveryMode: vi.fn(async (_name: string, mode: string) => ({ mode, flushed: 0 })),
+    };
+    const connectLocal = vi.fn(async () => client as never);
+    const { program, log } = harness({ connectLocal });
+
+    await program.parseAsync(['local', 'agent', 'message', 'hold', 'claude'], { from: 'user' });
+    await program.parseAsync(['local', 'agent', 'message', 'auto', 'claude'], { from: 'user' });
+
+    expect(connectLocal).toHaveBeenNthCalledWith(1, '/tmp/project', {
+      brokerUrl: undefined,
+      apiKey: undefined,
+      stateDir: undefined,
+    });
+    expect(connectLocal).toHaveBeenNthCalledWith(2, '/tmp/project', {
+      brokerUrl: undefined,
+      apiKey: undefined,
+      stateDir: undefined,
+    });
+    expect(client.setInboundDeliveryMode).toHaveBeenNthCalledWith(1, 'claude', 'manual_flush');
+    expect(client.setInboundDeliveryMode).toHaveBeenNthCalledWith(2, 'claude', 'auto_inject');
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify({ name: 'claude', mode: 'manual_flush', flushed: 0 }, null, 2)
+    );
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify({ name: 'claude', mode: 'auto_inject', flushed: 0 }, null, 2)
+    );
   });
 });

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -2,6 +2,13 @@ import type { Command } from 'commander';
 
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
 
+import { createBrokerClient } from '../lib/attach-broker.js';
+import {
+  defaultStateDir,
+  readConnectionFileFromDisk,
+  resolveBrokerConnection,
+  type BrokerConnectionOptions,
+} from '../lib/broker-connection.js';
 import { defaultExit } from '../lib/exit.js';
 import { spawnAgentWithClient } from '../lib/client-factory.js';
 import { attachDrive } from '../lib/attach-drive.js';
@@ -9,6 +16,7 @@ import { attachView } from '../lib/attach-view.js';
 import { attachPassthrough } from '../lib/attach-passthrough.js';
 
 export type AttachMode = 'drive' | 'view' | 'passthrough';
+export type LocalAgentMessageBrokerOptions = BrokerConnectionOptions;
 
 /** Dispatch `local agent attach --mode` to the drive/view/passthrough session runners. */
 export function runAttach(
@@ -31,27 +39,51 @@ type ExitFn = (code: number) => never;
 
 export interface LocalAgentDependencies {
   connect: (cwd: string) => Promise<HarnessDriverClient>;
+  connectLocal: (cwd: string, options: LocalAgentMessageBrokerOptions) => Promise<HarnessDriverClient>;
   attach: (
     name: string,
     mode: AttachMode,
     options: { brokerUrl?: string; apiKey?: string; stateDir?: string }
   ) => Promise<number>;
   cwd: () => string;
+  readConnectionFile: (stateDir: string) => unknown;
+  getDefaultStateDir: () => string;
+  env: NodeJS.ProcessEnv;
+  fetch: typeof globalThis.fetch;
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
   exit: ExitFn;
 }
 
 function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAgentDependencies {
-  return {
+  const deps = {
     connect: async (cwd: string) => HarnessDriverClient.connect({ cwd }),
-    attach: runAttach,
     cwd: () => process.cwd(),
+    readConnectionFile: readConnectionFileFromDisk,
+    getDefaultStateDir: defaultStateDir,
+    env: process.env,
+    fetch: globalThis.fetch,
+    attach: runAttach,
     log: (...args: unknown[]) => console.log(...args),
     error: (...args: unknown[]) => console.error(...args),
     exit: defaultExit,
     ...overrides,
+  } as LocalAgentDependencies;
+  deps.connectLocal ??= async (_cwd: string, options: LocalAgentMessageBrokerOptions) => {
+    const connection = resolveBrokerConnection(options, {
+      readConnectionFile: deps.readConnectionFile,
+      getDefaultStateDir: deps.getDefaultStateDir,
+      env: deps.env,
+    });
+    if (!connection) {
+      throw new Error(
+        'Error: could not locate broker connection. Pass --broker-url, set RELAY_BROKER_URL, ' +
+          'or run from a directory containing .agentworkforce/relay/connection.json.'
+      );
+    }
+    return createBrokerClient(connection, deps.fetch);
   };
+  return deps;
 }
 
 async function run(
@@ -68,6 +100,34 @@ async function run(
   } finally {
     client?.disconnect?.();
   }
+}
+
+async function runLocalBroker(
+  deps: LocalAgentDependencies,
+  options: LocalAgentMessageBrokerOptions,
+  fn: (client: HarnessDriverClient) => Promise<void>
+): Promise<void> {
+  try {
+    await fn(await deps.connectLocal(deps.cwd(), options));
+  } catch (err) {
+    deps.error(err instanceof Error ? err.message : String(err));
+    deps.exit(1);
+  }
+}
+
+function addBrokerOptions(command: Command): Command {
+  return command
+    .option('--broker-url <url>', 'Broker base URL (overrides RELAY_BROKER_URL and connection.json)')
+    .option('--api-key <key>', 'Broker API key (overrides RELAY_BROKER_API_KEY and connection.json)')
+    .option('--state-dir <dir>', 'Directory containing connection.json (default: .agentworkforce/relay/)');
+}
+
+function brokerOptionsFromOpts(opts: Record<string, unknown>): LocalAgentMessageBrokerOptions {
+  return {
+    brokerUrl: opts.brokerUrl as string | undefined,
+    apiKey: opts.apiKey as string | undefined,
+    stateDir: opts.stateDir as string | undefined,
+  };
 }
 
 /**
@@ -195,6 +255,45 @@ export function registerLocalAgentCommands(
         deps.exit(code);
       }
     });
+
+  const message = agent.command('message').description('Control local broker message delivery for an agent');
+
+  addBrokerOptions(
+    message
+      .command('flush')
+      .description('Flush queued relay messages into a held local agent')
+      .argument('<name>', 'Agent name')
+  ).action(async (name: string, opts: Record<string, unknown>) => {
+    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
+      deps.log(JSON.stringify({ name, ...(await client.flushPending(name)) }, null, 2));
+    });
+  });
+
+  addBrokerOptions(
+    message
+      .command('hold')
+      .description('Hold new relay messages for a local agent until flushed')
+      .argument('<name>', 'Agent name')
+  ).action(async (name: string, opts: Record<string, unknown>) => {
+    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
+      deps.log(
+        JSON.stringify({ name, ...(await client.setInboundDeliveryMode(name, 'manual_flush')) }, null, 2)
+      );
+    });
+  });
+
+  addBrokerOptions(
+    message
+      .command('auto')
+      .description('Resume automatic relay message injection for a local agent')
+      .argument('<name>', 'Agent name')
+  ).action(async (name: string, opts: Record<string, unknown>) => {
+    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
+      deps.log(
+        JSON.stringify({ name, ...(await client.setInboundDeliveryMode(name, 'auto_inject')) }, null, 2)
+      );
+    });
+  });
 
   group
     .command('tail')

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { describe, expect, it, vi } from 'vitest';
 
-import { registerAgentCommands, type AgentCommandDependencies } from './agent.js';
+import { registerAgentCommands } from './agent.js';
 import { registerChannelCommands } from './channel.js';
 import { registerMessageCommands } from './message.js';
 import { registerIntegrationCommands } from './integration.js';
@@ -74,138 +74,6 @@ describe('SDK-backed CLI groups', () => {
       expect.objectContaining({ name: 'reviewer', type: 'agent' })
     );
     expect(log).toHaveBeenCalled();
-  });
-
-  it('agent message flush drains a local broker agent queue', async () => {
-    const relay = createRelayMock();
-    const client = { flushPending: vi.fn(async () => ({ flushed: 2 })) };
-    const log = vi.fn();
-    const deps: Partial<AgentCommandDependencies> = {
-      createAgentRelay: () => relay as never,
-      createWorkspaceRelay: () => relay as never,
-      connectLocal: vi.fn(async () => client as never),
-      cwd: () => '/tmp/project',
-      log,
-      error: vi.fn(),
-      exit: vi.fn() as never,
-    };
-    const program = new Command();
-    program.exitOverride();
-    registerAgentCommands(program, deps);
-
-    await program.parseAsync(
-      [
-        'agent',
-        'message',
-        'flush',
-        'claude',
-        '--broker-url',
-        'http://127.0.0.1:3890',
-        '--api-key',
-        'secret',
-        '--state-dir',
-        '/tmp/relay-state',
-      ],
-      { from: 'user' }
-    );
-
-    expect(deps.connectLocal).toHaveBeenCalledWith('/tmp/project', {
-      brokerUrl: 'http://127.0.0.1:3890',
-      apiKey: 'secret',
-      stateDir: '/tmp/relay-state',
-    });
-    expect(client.flushPending).toHaveBeenCalledWith('claude');
-    expect(log).toHaveBeenCalledWith(JSON.stringify({ name: 'claude', flushed: 2 }, null, 2));
-  });
-
-  it('agent message controls resolve broker selection flags with the default local client', async () => {
-    const relay = createRelayMock();
-    const fetch = vi.fn(async () => new Response(JSON.stringify({ flushed: 3 }), { status: 200 }));
-    const readConnectionFile = vi.fn(() => ({ url: 'http://file-broker:1111', api_key: 'file-key' }));
-    const log = vi.fn();
-    const deps: Partial<AgentCommandDependencies> = {
-      createAgentRelay: () => relay as never,
-      createWorkspaceRelay: () => relay as never,
-      cwd: () => '/tmp/project',
-      readConnectionFile,
-      getDefaultStateDir: () => '/tmp/default-state',
-      env: {},
-      fetch: fetch as never,
-      log,
-      error: vi.fn(),
-      exit: vi.fn() as never,
-    };
-    const program = new Command();
-    program.exitOverride();
-    registerAgentCommands(program, deps);
-
-    await program.parseAsync(
-      [
-        'agent',
-        'message',
-        'flush',
-        'claude',
-        '--broker-url',
-        'http://flag-broker:2222/',
-        '--api-key',
-        'flag-key',
-        '--state-dir',
-        '/tmp/relay-state',
-      ],
-      { from: 'user' }
-    );
-
-    expect(readConnectionFile).toHaveBeenCalledWith('/tmp/relay-state');
-    expect(fetch).toHaveBeenCalledWith(
-      'http://flag-broker:2222/api/spawned/claude/flush',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({ 'X-API-Key': 'flag-key' }),
-      })
-    );
-    expect(log).toHaveBeenCalledWith(JSON.stringify({ name: 'claude', flushed: 3 }, null, 2));
-  });
-
-  it('agent message hold and auto switch local broker delivery mode', async () => {
-    const relay = createRelayMock();
-    const client = {
-      setInboundDeliveryMode: vi.fn(async (_name: string, mode: string) => ({ mode, flushed: 0 })),
-    };
-    const log = vi.fn();
-    const deps: Partial<AgentCommandDependencies> = {
-      createAgentRelay: () => relay as never,
-      createWorkspaceRelay: () => relay as never,
-      connectLocal: vi.fn(async () => client as never),
-      cwd: () => '/tmp/project',
-      log,
-      error: vi.fn(),
-      exit: vi.fn() as never,
-    };
-    const program = new Command();
-    program.exitOverride();
-    registerAgentCommands(program, deps);
-
-    await program.parseAsync(['agent', 'message', 'hold', 'claude'], { from: 'user' });
-    await program.parseAsync(['agent', 'message', 'auto', 'claude'], { from: 'user' });
-
-    expect(deps.connectLocal).toHaveBeenNthCalledWith(1, '/tmp/project', {
-      brokerUrl: undefined,
-      apiKey: undefined,
-      stateDir: undefined,
-    });
-    expect(deps.connectLocal).toHaveBeenNthCalledWith(2, '/tmp/project', {
-      brokerUrl: undefined,
-      apiKey: undefined,
-      stateDir: undefined,
-    });
-    expect(client.setInboundDeliveryMode).toHaveBeenNthCalledWith(1, 'claude', 'manual_flush');
-    expect(client.setInboundDeliveryMode).toHaveBeenNthCalledWith(2, 'claude', 'auto_inject');
-    expect(log).toHaveBeenCalledWith(
-      JSON.stringify({ name: 'claude', mode: 'manual_flush', flushed: 0 }, null, 2)
-    );
-    expect(log).toHaveBeenCalledWith(
-      JSON.stringify({ name: 'claude', mode: 'auto_inject', flushed: 0 }, null, 2)
-    );
   });
 
   it('channel set_topic calls channels.update', async () => {

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -4,7 +4,8 @@
  * Attaches to a running agent, flips it into `manual_flush` inbound delivery mode so the
  * broker parks new relay messages in a per-worker queue, and forwards your
  * keystrokes to the worker's PTY. Message queue control is deliberately out of
- * band: use `agent message flush`, `agent message hold`, and `agent message auto`
+ * band: use `local agent message flush`, `local agent message hold`, and
+ * `local agent message auto`
  * from another terminal instead of terminal control chords that agent TUIs may
  * intercept. `Ctrl+C` detaches, restores the worker's previous inbound delivery
  * mode, and leaves the agent running under the broker — `drive` never kills the

--- a/web/content/docs/cli-agent-management.mdx
+++ b/web/content/docs/cli-agent-management.mdx
@@ -81,9 +81,9 @@ Attach modes:
 Drive mode uses out-of-band message controls so terminal control keys can pass through to the agent TUI:
 
 ```bash
-agent-relay agent message hold reviewer
-agent-relay agent message flush reviewer
-agent-relay agent message auto reviewer
+agent-relay local agent message hold reviewer
+agent-relay local agent message flush reviewer
+agent-relay local agent message auto reviewer
 ```
 
 `hold` switches the local agent to manual delivery, `flush` drains pending relay messages into the agent, and `auto` resumes automatic injection. Each command accepts `--broker-url`, `--api-key`, and `--state-dir` when the broker is not discoverable from the current directory. Attach sessions use `Ctrl+C` to detach locally.

--- a/web/content/docs/reference-cli.mdx
+++ b/web/content/docs/reference-cli.mdx
@@ -28,7 +28,7 @@ SDK-backed command groups accept these options:
 | `--token <token>` | `RELAY_AGENT_TOKEN` | Acting agent token. |
 | `--base-url <url>` | `RELAY_BASE_URL` | API base URL override. |
 
-The SDK-backed groups are `channel`, `message`, `integration`, and `capabilities`. Most `agent` commands are SDK-backed; `agent message ...` controls the local broker.
+The SDK-backed groups are `agent`, `channel`, `message`, `integration`, and `capabilities`.
 
 ## Workspaces
 
@@ -48,9 +48,6 @@ The SDK-backed groups are `channel`, `message`, `integration`, and `capabilities
 | `agent-relay agent list [--status <status>]` | List workspace agents. |
 | `agent-relay agent add <name> [--type <type>]` | Add an agent identity. |
 | `agent-relay agent remove <name>` | Remove an agent identity. |
-| `agent-relay agent message hold <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Hold new relay messages for a local broker agent. |
-| `agent-relay agent message flush <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Flush queued relay messages into a held local broker agent. |
-| `agent-relay agent message auto <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Resume automatic relay message injection for a local broker agent. |
 
 `--type` accepts `agent`, `human`, or `system`.
 
@@ -148,9 +145,12 @@ The SDK-backed groups are `channel`, `message`, `integration`, and `capabilities
 | `agent-relay local agent release <name>` | Gracefully release a local managed agent. |
 | `agent-relay local agent set-model <name> <model>` | Best-effort model switch for a running agent. |
 | `agent-relay local agent attach <name> [--mode <mode>]` | Attach to a running agent. |
+| `agent-relay local agent message hold <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Hold new relay messages for a local broker agent. |
+| `agent-relay local agent message flush <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Flush queued relay messages into a held local broker agent. |
+| `agent-relay local agent message auto <name> [--broker-url <url>] [--api-key <key>] [--state-dir <dir>]` | Resume automatic relay message injection for a local broker agent. |
 | `agent-relay local tail [--agent <name>]` | Stream broker events or one agent output stream. |
 
-Local attach mode is one of `view`, `drive`, or `passthrough`. Use `agent message hold`, `agent message flush`, and `agent message auto` to control drive-mode delivery from another terminal. These commands accept the same `--broker-url`, `--api-key`, and `--state-dir` broker selection flags as `local agent attach`.
+Local attach mode is one of `view`, `drive`, or `passthrough`. Use `local agent message hold`, `local agent message flush`, and `local agent message auto` to control drive-mode delivery from another terminal. These commands accept the same `--broker-url`, `--api-key`, and `--state-dir` broker selection flags as `local agent attach`.
 
 ## Cloud
 


### PR DESCRIPTION
## Summary

- Move local broker delivery controls to `agent-relay local agent message hold|flush|auto`.
- Remove the old top-level `agent-relay agent message ...` command registration.
- Update CLI inventory tests, local-agent command tests, docs, and changelog.

## Validation

- `npx vitest run packages/cli/src/cli/bootstrap.test.ts packages/cli/src/cli/commands/local-agent.test.ts packages/cli/src/cli/commands/relaycast-groups.test.ts`
- `npm --prefix packages/cli run build`
