### PR TITLE
[codex] Allow AI crawlers in robots.txt

### DIFF
--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -2,9 +2,22 @@ import type { MetadataRoute } from 'next';
 
 import { absoluteUrl, SITE_URL } from '../lib/site';
 
+const AI_CRAWLERS = [
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'GPTBot',
+  'Claude-SearchBot',
+  'Claude-User',
+  'ClaudeBot',
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
+      ...AI_CRAWLERS.map((userAgent) => ({
+        userAgent,
+        allow: ['/'],
+      })),
       {
         userAgent: '*',
         allow: [
@@ -18,7 +31,6 @@ export default function robots(): MetadataRoute.Robots {
           '/docs/',
           '/blog/',
         ],
-        disallow: ['/openclaw/skill/invite/'],
       },
     ],
     sitemap: absoluteUrl('/sitemap.xml'),


### PR DESCRIPTION
## Summary

- Explicitly allow OpenAI and Anthropic crawler/user-agent traffic in the generated `robots.txt`.
- Remove the previous `/openclaw/skill/invite/` robots disallow so agent-facing invite links can be accessed.

## Why

Agent Relay should be discoverable and retrievable from ChatGPT, Claude, and related AI search/user-directed browsing flows. The invite route is intentionally agent-facing, so robots metadata should not discourage access to it.

## Validation

- `npm run build` from `web/`
- Verified generated `.next/server/app/robots.txt.body` contains the expected AI crawler `Allow: /` entries and no `Disallow` entries.
