### PR TITLE
Report connected account usage from cloud CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-relay cloud usage` reports remaining Codex and Claude account usage for connected cloud agents, with JSON output for automation.
 - `@agent-relay/config` `CLI_AUTH_CONFIG` adds an `xai` provider (Grok CLI): `grok login --device-auth` device-code connect, `~/.grok/auth.json` credential capture, and the official x.ai installer as the sandbox fallback — so cloud sandboxes can authenticate the `grok` harness from a connected account instead of an API key.
 - `@agent-relay/sdk` wires the durable delivery surface to the Relaycast backend: `inbox.list`, `inbox.subscribe`, `inbox.ack/fail/defer`, and `deliveries.ack/fail/defer` now use the hosted delivery ledger, agent-scoped capabilities report `serverDeliveryState: true`, and `DeliveryRunner` works against Relaycast-backed inbox items.
 

--- a/memory/INCIDENT-20260612T141510Z.md
+++ b/memory/INCIDENT-20260612T141510Z.md
@@ -1,0 +1,18 @@
+# relayfile mount-root invariant incident
+
+- timestamp: 20260612T141510Z
+- local root: /home/daytona/workspace/memory/workspace
+- invariant: mount root must always be a directory
+- detected kind: missing
+- reason: local root does not exist
+
+## Recovery
+
+The mount root is gone. Confirm whether the directory was deleted
+by another process (rm -rf, git clean -fdx, sync tool, etc.).
+To recreate a clean mount, pass `--reset-after-clobber` to
+`relayfile mount` (or set `RELAYFILE_RESET_AFTER_CLOBBER=1`).
+The daemon will refuse to start without this acknowledgment.
+
+See `docs/architecture/mount-invariants.md` for the protected
+invariants and the full recovery procedure.

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -5,6 +5,7 @@ const cloudMocks = vi.hoisted(() => ({
   runWorkflow: vi.fn(),
   scheduleWorkflow: vi.fn(),
   listWorkflowSchedules: vi.fn(),
+  listAccountUsage: vi.fn(),
   getRunStatus: vi.fn(),
   syncWorkflowPatch: vi.fn(),
 }));
@@ -22,6 +23,7 @@ vi.mock('@agent-relay/cloud', () => ({
     'anthropic (alias: claude), openai (alias: codex), google (alias: gemini), cursor, opencode, droid',
   getRunLogs: vi.fn(),
   getRunStatus: (...args: unknown[]) => cloudMocks.getRunStatus(...args),
+  listAccountUsage: (...args: unknown[]) => cloudMocks.listAccountUsage(...args),
   listWorkflowSchedules: (...args: unknown[]) => cloudMocks.listWorkflowSchedules(...args),
   readStoredAuth: vi.fn(),
   runWorkflow: (...args: unknown[]) => cloudMocks.runWorkflow(...args),
@@ -68,6 +70,7 @@ describe('registerCloudCommands', () => {
       'logout',
       'whoami',
       'connect',
+      'usage',
       'run',
       'schedule',
       'schedules',
@@ -102,6 +105,41 @@ describe('registerCloudCommands', () => {
     expect(optionNames).toContain('--resume');
     expect(optionNames).toContain('--start-from');
     expect(optionNames).toContain('--previous-run-id');
+  });
+
+  it('usage renders remaining account usage', async () => {
+    const { program, deps } = createHarness();
+    cloudMocks.listAccountUsage.mockResolvedValueOnce([
+      {
+        id: 'agent-1',
+        displayName: 'Codex',
+        modelProvider: 'openai',
+        isActive: true,
+        accountEmail: 'person@example.com',
+        usage: {
+          provider: 'openai',
+          status: 'available',
+          source: 'codex-oauth',
+          fetchedAt: '2026-06-12T10:00:00.000Z',
+          windows: [
+            {
+              id: 'session',
+              label: 'Session',
+              usedPercent: 65,
+              remainingPercent: 35,
+              resetAt: '2026-06-12T15:00:00.000Z',
+              windowMinutes: 300,
+            },
+          ],
+        },
+      },
+    ]);
+
+    await program.parseAsync(['node', 'agent-relay', 'cloud', 'usage']);
+
+    expect(cloudMocks.listAccountUsage).toHaveBeenCalledWith({});
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('Codex (openai active)'));
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('35% left'));
   });
 
   it('status requires a runId argument', () => {

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -19,8 +19,12 @@ import {
   syncWorkflowPatch,
   cancelWorkflow,
   connectProvider,
+  listAccountUsage,
   getProviderHelpText,
   normalizeProvider,
+  type AccountUsageSnapshot,
+  type AccountUsageWindow,
+  type CloudAgentUsageRecord,
   type WhoAmIResponse,
   type WorkflowFileType,
   type WorkflowSchedule,
@@ -175,6 +179,70 @@ function renderScheduleList(schedules: WorkflowSchedule[], log: (...args: unknow
     log(
       `${schedule.id}  ${schedule.status}  ${formatScheduleCadence(schedule)}  ${schedule.name} (${lastRun})`
     );
+  }
+}
+
+function formatUsagePercent(value: number): string {
+  return `${Math.round(value)}%`;
+}
+
+function formatUsageReset(value: string | null | undefined): string {
+  if (!value) {
+    return 'reset unknown';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'reset unknown';
+  }
+  return `resets ${date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })}`;
+}
+
+function getTightestUsageWindow(usage: AccountUsageSnapshot | null | undefined): AccountUsageWindow | null {
+  if (!usage || usage.status !== 'available') {
+    return null;
+  }
+  return [...usage.windows]
+    .filter((window) => Number.isFinite(window.remainingPercent))
+    .sort((left, right) => left.remainingPercent - right.remainingPercent)[0] ?? null;
+}
+
+function renderAccountUsage(agents: CloudAgentUsageRecord[], log: (...args: unknown[]) => void): void {
+  if (agents.length === 0) {
+    log('No cloud agents found.');
+    return;
+  }
+
+  for (const agent of agents) {
+    const label = agent.displayName || agent.name || agent.id;
+    const provider = agent.modelProvider || agent.harness || 'unknown';
+    const active = agent.isActive === true ? ' active' : '';
+    const account = agent.accountEmail ? ` ${agent.accountEmail}` : '';
+    const usage = agent.usage;
+    const window = getTightestUsageWindow(usage);
+
+    if (window) {
+      log(
+        `${label} (${provider}${active})${account}: ${formatUsagePercent(window.remainingPercent)} left, ${window.label.toLowerCase()} ${formatUsagePercent(window.usedPercent)} used, ${formatUsageReset(window.resetAt)}`
+      );
+      continue;
+    }
+
+    if (usage?.status === 'unsupported') {
+      log(`${label} (${provider}${active})${account}: usage not supported for this credential`);
+      continue;
+    }
+
+    if (usage?.status === 'error') {
+      log(`${label} (${provider}${active})${account}: usage unavailable (${usage.error || 'provider request failed'})`);
+      continue;
+    }
+
+    log(`${label} (${provider}${active})${account}: usage unavailable`);
   }
 }
 
@@ -358,6 +426,22 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
           provider: trackedProvider,
           ...(errorClass ? { error_class: errorClass } : {}),
         });
+      }
+    });
+
+  // ── usage ──────────────────────────────────────────────────────────────────
+
+  cloudCommand
+    .command('usage')
+    .description('Show remaining Codex and Claude account usage for connected cloud agents')
+    .option('--api-url <url>', 'Cloud API base URL')
+    .option('--json', 'Print raw JSON response', false)
+    .action(async (options: { apiUrl?: string; json?: boolean }) => {
+      const agents = await listAccountUsage({ apiUrl: options.apiUrl });
+      if (options.json) {
+        deps.log(JSON.stringify({ agents }, null, 2));
+      } else {
+        renderAccountUsage(agents, deps.log);
       }
     });
 

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -206,9 +206,11 @@ function getTightestUsageWindow(usage: AccountUsageSnapshot | null | undefined):
   if (!usage || usage.status !== 'available') {
     return null;
   }
-  return [...usage.windows]
-    .filter((window) => Number.isFinite(window.remainingPercent))
-    .sort((left, right) => left.remainingPercent - right.remainingPercent)[0] ?? null;
+  return (
+    [...usage.windows]
+      .filter((window) => Number.isFinite(window.remainingPercent))
+      .sort((left, right) => left.remainingPercent - right.remainingPercent)[0] ?? null
+  );
 }
 
 function renderAccountUsage(agents: CloudAgentUsageRecord[], log: (...args: unknown[]) => void): void {
@@ -238,7 +240,9 @@ function renderAccountUsage(agents: CloudAgentUsageRecord[], log: (...args: unkn
     }
 
     if (usage?.status === 'error') {
-      log(`${label} (${provider}${active})${account}: usage unavailable (${usage.error || 'provider request failed'})`);
+      log(
+        `${label} (${provider}${active})${account}: usage unavailable (${usage.error || 'provider request failed'})`
+      );
       continue;
     }
 

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -36,6 +36,11 @@ export {
   type ConnectProviderResult,
 } from './connect.js';
 
+export {
+  listAccountUsage,
+  type ListAccountUsageOptions,
+} from './usage.js';
+
 export { createWorkspace, issueWorkspaceToken } from './workspaces.js';
 
 export {
@@ -110,6 +115,9 @@ export {
   type WorkspaceTokenRecord,
   type ProactiveDeploymentResponse,
   type ProactiveAgentRecord,
+  type AccountUsageSnapshot,
+  type AccountUsageWindow,
+  type CloudAgentUsageRecord,
   type WorkspaceSecretRecord,
   type WorkflowFileType,
   type RunWorkflowResponse,

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -36,10 +36,7 @@ export {
   type ConnectProviderResult,
 } from './connect.js';
 
-export {
-  listAccountUsage,
-  type ListAccountUsageOptions,
-} from './usage.js';
+export { listAccountUsage, type ListAccountUsageOptions } from './usage.js';
 
 export { createWorkspace, issueWorkspaceToken } from './workspaces.js';
 

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -99,6 +99,37 @@ export type ProactiveAgentRecord = {
   [key: string]: unknown;
 };
 
+export type AccountUsageWindow = {
+  id: string;
+  label: string;
+  usedPercent: number;
+  remainingPercent: number;
+  resetAt: string | null;
+  windowMinutes: number | null;
+};
+
+export type AccountUsageSnapshot = {
+  provider: string;
+  status: 'available' | 'unsupported' | 'unavailable' | 'error';
+  source: 'claude-oauth' | 'codex-oauth' | 'none';
+  fetchedAt: string;
+  windows: AccountUsageWindow[];
+  credits?: {
+    balance: number | null;
+    unlimited: boolean;
+  };
+  plan?: string | null;
+  error?: string;
+};
+
+export type CloudAgentUsageRecord = ProactiveAgentRecord & {
+  modelProvider?: string;
+  authType?: string;
+  accountEmail?: string | null;
+  isActive?: boolean;
+  usage?: AccountUsageSnapshot | null;
+};
+
 export type WorkspaceSecretRecord = {
   name: string;
   value?: string;

--- a/packages/cloud/src/usage.test.ts
+++ b/packages/cloud/src/usage.test.ts
@@ -17,21 +17,23 @@ describe('listAccountUsage', () => {
     const auth = { apiUrl: 'https://cloud.test' };
     authMocks.ensureAuthenticated.mockResolvedValueOnce(auth);
     authMocks.authorizedApiFetch.mockResolvedValueOnce({
-      response: new Response(JSON.stringify({
-        agents: [
-          {
-            id: 'agent-1',
-            displayName: 'Codex',
-            usage: {
-              provider: 'openai',
-              status: 'available',
-              source: 'codex-oauth',
-              fetchedAt: '2026-06-12T10:00:00.000Z',
-              windows: [],
+      response: new Response(
+        JSON.stringify({
+          agents: [
+            {
+              id: 'agent-1',
+              displayName: 'Codex',
+              usage: {
+                provider: 'openai',
+                status: 'available',
+                source: 'codex-oauth',
+                fetchedAt: '2026-06-12T10:00:00.000Z',
+                windows: [],
+              },
             },
-          },
-        ],
-      })),
+          ],
+        })
+      ),
     });
 
     const agents = await listAccountUsage({ apiUrl: 'https://cloud.test' });

--- a/packages/cloud/src/usage.test.ts
+++ b/packages/cloud/src/usage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  ensureAuthenticated: vi.fn(),
+  authorizedApiFetch: vi.fn(),
+}));
+
+vi.mock('./auth.js', () => ({
+  ensureAuthenticated: (...args: unknown[]) => authMocks.ensureAuthenticated(...args),
+  authorizedApiFetch: (...args: unknown[]) => authMocks.authorizedApiFetch(...args),
+}));
+
+import { listAccountUsage } from './usage.js';
+
+describe('listAccountUsage', () => {
+  it('loads cloud agents with usage snapshots', async () => {
+    const auth = { apiUrl: 'https://cloud.test' };
+    authMocks.ensureAuthenticated.mockResolvedValueOnce(auth);
+    authMocks.authorizedApiFetch.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({
+        agents: [
+          {
+            id: 'agent-1',
+            displayName: 'Codex',
+            usage: {
+              provider: 'openai',
+              status: 'available',
+              source: 'codex-oauth',
+              fetchedAt: '2026-06-12T10:00:00.000Z',
+              windows: [],
+            },
+          },
+        ],
+      })),
+    });
+
+    const agents = await listAccountUsage({ apiUrl: 'https://cloud.test' });
+
+    expect(agents[0].id).toBe('agent-1');
+    expect(authMocks.ensureAuthenticated).toHaveBeenCalledWith('https://cloud.test');
+    expect(authMocks.authorizedApiFetch).toHaveBeenCalledWith(auth, '/api/v1/cloud-agents?usage=1', {
+      method: 'GET',
+    });
+  });
+
+  it('throws cloud errors', async () => {
+    authMocks.ensureAuthenticated.mockResolvedValueOnce({ apiUrl: 'https://cloud.test' });
+    authMocks.authorizedApiFetch.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ error: 'nope' }), { status: 500 }),
+    });
+
+    await expect(listAccountUsage({ apiUrl: 'https://cloud.test' })).rejects.toThrow('nope');
+  });
+});

--- a/packages/cloud/src/usage.ts
+++ b/packages/cloud/src/usage.ts
@@ -1,0 +1,26 @@
+import { authorizedApiFetch, ensureAuthenticated } from './auth.js';
+import { defaultApiUrl, type CloudAgentUsageRecord } from './types.js';
+
+export type ListAccountUsageOptions = {
+  apiUrl?: string;
+};
+
+export async function listAccountUsage(
+  options: ListAccountUsageOptions = {}
+): Promise<CloudAgentUsageRecord[]> {
+  const apiUrl = options.apiUrl || defaultApiUrl();
+  const auth = await ensureAuthenticated(apiUrl);
+  const { response } = await authorizedApiFetch(auth, '/api/v1/cloud-agents?usage=1', {
+    method: 'GET',
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | { agents?: CloudAgentUsageRecord[]; error?: string }
+    | null;
+
+  if (!response.ok || !Array.isArray(payload?.agents)) {
+    throw new Error(payload?.error || `Failed to load account usage: ${response.status} ${response.statusText}`);
+  }
+
+  return payload.agents;
+}

--- a/packages/cloud/src/usage.ts
+++ b/packages/cloud/src/usage.ts
@@ -14,12 +14,15 @@ export async function listAccountUsage(
     method: 'GET',
   });
 
-  const payload = (await response.json().catch(() => null)) as
-    | { agents?: CloudAgentUsageRecord[]; error?: string }
-    | null;
+  const payload = (await response.json().catch(() => null)) as {
+    agents?: CloudAgentUsageRecord[];
+    error?: string;
+  } | null;
 
   if (!response.ok || !Array.isArray(payload?.agents)) {
-    throw new Error(payload?.error || `Failed to load account usage: ${response.status} ${response.statusText}`);
+    throw new Error(
+      payload?.error || `Failed to load account usage: ${response.status} ${response.statusText}`
+    );
   }
 
   return payload.agents;


### PR DESCRIPTION
## Summary
- add `@agent-relay/cloud` `listAccountUsage()` for `/api/v1/cloud-agents?usage=1`
- add `agent-relay cloud usage` with human-readable and `--json` output
- document the new CLI command in the changelog

Paired Cloud PR: https://github.com/AgentWorkforce/cloud/pull/2103

## Tests
- `git diff --check`
- `npx tsc -p packages/cloud/tsconfig.json --noEmit`
- `npx vitest run packages/cloud/src/usage.test.ts packages/cloud/src/connect.test.ts packages/cli/src/cli/commands/cloud.test.ts`

Note: the Vitest run prints an existing Commander validation message for an invalid `--env` fixture, while still reporting all tests passing.