### PR TITLE
Unify cloud auth session contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@agent-relay/cloud` adds a canonical cloud session and active-workspace contract, including `ensureCloudSession`, `resolveActiveWorkspace`, promoted workspace-store APIs, access-token-only `agent-relay cloud session --json`, and `agent-relay workspace active --json` for cross-language consumers.
 - `@agent-relay/config` `CLI_AUTH_CONFIG` adds an `xai` provider (Grok CLI): `grok login --device-auth` device-code connect, `~/.grok/auth.json` credential capture, and the official x.ai installer as the sandbox fallback — so cloud sandboxes can authenticate the `grok` harness from a connected account instead of an API key.
 - `@agent-relay/sdk` wires the durable delivery surface to the Relaycast backend: `inbox.list`, `inbox.subscribe`, `inbox.ack/fail/defer`, and `deliveries.ack/fail/defer` now use the hosted delivery ledger, agent-scoped capabilities report `serverDeliveryState: true`, and `DeliveryRunner` works against Relaycast-backed inbox items.
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@agent-relay/cloud` refresh now fails with typed, timeout-bounded errors and migrates legacy `~/.agent-relay/cloud-auth.json` credentials into the canonical `~/.agentworkforce/relay/cloud-auth.json` store without dual-writing.
 - `agent-relay-broker` persists pending deliveries on shutdown and on every queue change, redelivers them on restart, reports timeout-fallback verification explicitly, and emits `delivery_dropped` when the per-worker queue cap evicts a message.
 
 ## [8.6.0] - 2026-06-11

--- a/package-lock.json
+++ b/package-lock.json
@@ -18762,7 +18762,7 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "8.4.0",
+      "version": "8.7.0",
       "dependencies": {
         "@agent-relay/config": "8.4.0",
         "@aws-sdk/client-s3": "3.1020.0",

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -18,6 +18,7 @@ vi.mock('@agent-relay/cloud', () => ({
   connectProvider: vi.fn(),
   defaultApiUrl: () => 'https://cloud.test',
   ensureAuthenticated: vi.fn(),
+  ensureCloudSession: vi.fn(),
   getProviderHelpText: () =>
     'anthropic (alias: claude), openai (alias: codex), google (alias: gemini), cursor, opencode, droid',
   getRunLogs: vi.fn(),
@@ -32,6 +33,8 @@ vi.mock('@agent-relay/cloud', () => ({
 vi.mock('../telemetry/index.js', () => ({
   track: vi.fn(),
 }));
+
+import { ensureCloudSession } from '@agent-relay/cloud';
 
 import { buildCloudSyncPatchExcludeArgs, registerCloudCommands, type CloudDependencies } from './cloud.js';
 
@@ -66,6 +69,7 @@ describe('registerCloudCommands', () => {
     expect(cloud?.commands.map((command) => command.name())).toEqual([
       'login',
       'logout',
+      'session',
       'whoami',
       'connect',
       'run',
@@ -76,6 +80,42 @@ describe('registerCloudCommands', () => {
       'sync',
       'cancel',
     ]);
+  });
+
+  it('prints the canonical cloud session as JSON without interactive login', async () => {
+    const { program, deps } = createHarness();
+    vi.mocked(ensureCloudSession).mockResolvedValueOnce({
+      auth: {
+        apiUrl: 'https://cloud.test',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+      },
+      client: {} as never,
+    });
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'cloud',
+      'session',
+      '--json',
+      '--refresh-timeout',
+      '25',
+    ]);
+
+    expect(ensureCloudSession).toHaveBeenCalledWith({
+      apiUrl: 'https://cloud.test',
+      interactive: false,
+      refreshTimeoutMs: 25,
+    });
+    const sessionJson = JSON.parse(String(vi.mocked(deps.log).mock.calls[0][0]));
+    expect(sessionJson).toEqual({
+      apiUrl: 'https://cloud.test',
+      accessToken: 'access-token',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    });
+    expect(sessionJson).not.toHaveProperty('refreshToken');
   });
 
   it('connect requires a provider argument', () => {

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -5,6 +5,7 @@ import { Command, InvalidArgumentError } from 'commander';
 
 import {
   ensureAuthenticated,
+  ensureCloudSession,
   authorizedApiFetch,
   readStoredAuth,
   clearStoredAuth,
@@ -276,6 +277,44 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
     });
 
   // ── whoami ─────────────────────────────────────────────────────────────────
+
+  cloudCommand
+    .command('session')
+    .description('Show the canonical Agent Relay Cloud session')
+    .option('--api-url <url>', 'Cloud API base URL')
+    .option('--json', 'Output the session as JSON')
+    .option(
+      '--refresh-timeout <milliseconds>',
+      'Timeout for refreshing the cloud session',
+      parsePositiveInteger
+    )
+    .action(async (options: { apiUrl?: string; json?: boolean; refreshTimeout?: number }) => {
+      const apiUrl = options.apiUrl || defaultApiUrl();
+      const session = await ensureCloudSession({
+        apiUrl,
+        interactive: false,
+        refreshTimeoutMs: options.refreshTimeout,
+      });
+
+      if (options.json) {
+        deps.log(
+          JSON.stringify(
+            {
+              apiUrl: session.auth.apiUrl,
+              accessToken: session.auth.accessToken,
+              accessTokenExpiresAt: session.auth.accessTokenExpiresAt,
+            },
+            null,
+            2
+          )
+        );
+        return;
+      }
+
+      deps.log(`API URL: ${session.auth.apiUrl}`);
+      deps.log(`Access token expires: ${session.auth.accessTokenExpiresAt}`);
+      deps.log(`Token file: ${AUTH_FILE_PATH}`);
+    });
 
   cloudCommand
     .command('whoami')

--- a/packages/cli/src/cli/commands/workspace.test.ts
+++ b/packages/cli/src/cli/commands/workspace.test.ts
@@ -1,0 +1,86 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agent-relay/cloud', () => ({
+  readWorkspaceStore: vi.fn(() => ({ workspaces: {} })),
+  resolveActiveWorkspace: vi.fn(),
+  setWorkspaceKey: vi.fn(),
+  switchWorkspace: vi.fn(),
+}));
+
+import { resolveActiveWorkspace } from '@agent-relay/cloud';
+
+import { registerWorkspaceCommands, type WorkspaceCommandDependencies } from './workspace.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createHarness() {
+  const exit = vi.fn((code: number) => {
+    throw new Error(`exit:${code}`);
+  }) as unknown as WorkspaceCommandDependencies['exit'];
+
+  const deps: WorkspaceCommandDependencies = {
+    createAgentRelay: vi.fn() as never,
+    createWorkspaceRelay: vi.fn() as never,
+    createWorkspace: vi.fn() as never,
+    log: vi.fn(() => undefined),
+    error: vi.fn(() => undefined),
+    exit,
+  };
+
+  const program = new Command();
+  program.exitOverride();
+  registerWorkspaceCommands(program, deps);
+
+  return { program, deps };
+}
+
+describe('registerWorkspaceCommands', () => {
+  it('prints the active canonical workspace as JSON', async () => {
+    const { program, deps } = createHarness();
+    vi.mocked(resolveActiveWorkspace).mockResolvedValueOnce({
+      name: 'Ops',
+      key: 'rk_live_ops',
+      cloudWorkspaceId: 'rw_ops',
+      relaycastWorkspaceId: 'rc_ops',
+      relayfileWorkspaceId: 'rw_ops',
+      relayauthWorkspaceId: 'rw_ops',
+      organizationId: 'org_1',
+      slug: 'ops',
+      urls: {},
+      apiUrl: 'https://cloud.test',
+    });
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'workspace',
+      'active',
+      '--json',
+      '--api-url',
+      'https://cloud.test',
+      '--refresh-timeout',
+      '25',
+    ]);
+
+    expect(resolveActiveWorkspace).toHaveBeenCalledWith({
+      apiUrl: 'https://cloud.test',
+      interactive: false,
+      refreshTimeoutMs: 25,
+    });
+    expect(JSON.parse(String(vi.mocked(deps.log).mock.calls[0][0]))).toEqual({
+      name: 'Ops',
+      key: 'rk_live_ops',
+      cloudWorkspaceId: 'rw_ops',
+      relaycastWorkspaceId: 'rc_ops',
+      relayfileWorkspaceId: 'rw_ops',
+      relayauthWorkspaceId: 'rw_ops',
+      organizationId: 'org_1',
+      slug: 'ops',
+      urls: {},
+      apiUrl: 'https://cloud.test',
+    });
+  });
+});

--- a/packages/cli/src/cli/commands/workspace.ts
+++ b/packages/cli/src/cli/commands/workspace.ts
@@ -1,9 +1,19 @@
 import type { Command } from 'commander';
+import { InvalidArgumentError } from 'commander';
+import { resolveActiveWorkspace } from '@agent-relay/cloud';
 
 import { printJson, runSdk, withSdkDefaults, type SdkCommandDeps } from '../lib/sdk-command.js';
 import { readWorkspaceStore, setWorkspaceKey, switchWorkspace } from '../lib/workspace-store.js';
 
 export type WorkspaceCommandDependencies = SdkCommandDeps;
+
+function parsePositiveInteger(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('Expected a positive integer.');
+  }
+  return parsed;
+}
 
 export function registerWorkspaceCommands(
   program: Command,
@@ -11,6 +21,36 @@ export function registerWorkspaceCommands(
 ): void {
   const deps = withSdkDefaults(overrides);
   const group = program.command('workspace').description('Create and switch between workspaces');
+
+  group
+    .command('active')
+    .description('Show the active canonical cloud workspace')
+    .option('--api-url <url>', 'Cloud API base URL')
+    .option('--json', 'Output the active workspace as JSON')
+    .option(
+      '--refresh-timeout <milliseconds>',
+      'Timeout for refreshing the cloud session',
+      parsePositiveInteger
+    )
+    .action(async (options: { apiUrl?: string; json?: boolean; refreshTimeout?: number }) => {
+      await runSdk(deps, async () => {
+        const workspace = await resolveActiveWorkspace({
+          apiUrl: options.apiUrl,
+          interactive: false,
+          refreshTimeoutMs: options.refreshTimeout,
+        });
+
+        if (options.json) {
+          printJson(deps, workspace);
+          return;
+        }
+
+        deps.log(`Workspace: ${workspace.name ?? workspace.cloudWorkspaceId}`);
+        deps.log(`Cloud workspace ID: ${workspace.cloudWorkspaceId}`);
+        deps.log(`Relayfile workspace ID: ${workspace.relayfileWorkspaceId}`);
+        deps.log(`Relayauth workspace ID: ${workspace.relayauthWorkspaceId}`);
+      });
+    });
 
   group
     .command('create')

--- a/packages/cli/src/cli/lib/workspace-store.ts
+++ b/packages/cli/src/cli/lib/workspace-store.ts
@@ -1,86 +1,12 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-/**
- * Local store of named workspace keys plus which one is active. Backs the
- * `relay workspace set_key/switch/list` commands and provides a fallback key
- * for SDK-backed commands when no env var or flag is supplied.
- */
-export interface WorkspaceStore {
-  active?: string;
-  workspaces: Record<string, { key: string }>;
-}
-
-const RESERVED_WORKSPACE_NAMES = new Set(['__proto__', 'prototype', 'constructor']);
-
-export function workspaceStorePath(env: NodeJS.ProcessEnv = process.env): string {
-  const dir = env.AGENT_RELAY_HOME ?? path.join(os.homedir(), '.agentworkforce/relay');
-  return path.join(dir, 'workspaces.json');
-}
-
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-  return err instanceof Error && 'code' in err;
-}
-
-export function validateWorkspaceName(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    throw new Error('Workspace name is required.');
-  }
-  if (RESERVED_WORKSPACE_NAMES.has(trimmed)) {
-    throw new Error(`Invalid workspace name "${trimmed}".`);
-  }
-  return trimmed;
-}
-
-export function readWorkspaceStore(env: NodeJS.ProcessEnv = process.env): WorkspaceStore {
-  const file = workspaceStorePath(env);
-  try {
-    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as Partial<WorkspaceStore>;
-    return { active: parsed.active, workspaces: parsed.workspaces ?? {} };
-  } catch (err: unknown) {
-    if (isNodeError(err) && err.code === 'ENOENT') {
-      return { workspaces: {} };
-    }
-    throw err;
-  }
-}
-
-export function writeWorkspaceStore(store: WorkspaceStore, env: NodeJS.ProcessEnv = process.env): void {
-  const file = workspaceStorePath(env);
-  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
-  fs.chmodSync(file, 0o600);
-}
-
-export function setWorkspaceKey(
-  name: string,
-  key: string,
-  env: NodeJS.ProcessEnv = process.env
-): WorkspaceStore {
-  const workspaceName = validateWorkspaceName(name);
-  const store = readWorkspaceStore(env);
-  store.workspaces[workspaceName] = { key };
-  store.active ??= workspaceName;
-  writeWorkspaceStore(store, env);
-  return store;
-}
-
-export function switchWorkspace(name: string, env: NodeJS.ProcessEnv = process.env): WorkspaceStore {
-  const workspaceName = validateWorkspaceName(name);
-  const store = readWorkspaceStore(env);
-  if (!store.workspaces[workspaceName]) {
-    throw new Error(
-      `Unknown workspace "${workspaceName}". Add it with \`relay workspace set_key ${workspaceName} <key>\`.`
-    );
-  }
-  store.active = workspaceName;
-  writeWorkspaceStore(store, env);
-  return store;
-}
-
-export function activeWorkspaceKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const store = readWorkspaceStore(env);
-  return store.active ? store.workspaces[store.active]?.key : undefined;
-}
+export {
+  activeWorkspaceKey,
+  readWorkspaceStore,
+  resolveActiveWorkspaceKey,
+  setActiveWorkspace,
+  setWorkspaceKey,
+  switchWorkspace,
+  validateWorkspaceName,
+  workspaceStorePath,
+  writeWorkspaceStore,
+  type WorkspaceStore,
+} from '@agent-relay/cloud';

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-relay/cloud",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "description": "Cloud SDK for Agent Relay — auth, workflow execution, and provider connections",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cloud/src/api-client.test.ts
+++ b/packages/cloud/src/api-client.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CloudApiClient } from './api-client.js';
+import { CloudAuthError } from './types.js';
+
+describe('CloudApiClient', () => {
+  it('aborts stalled token refresh before issuing an API request', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: string | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+            });
+          })
+      )
+    );
+
+    const client = new CloudApiClient({
+      apiUrl: 'https://cloud.example.test',
+      accessToken: 'stale-access',
+      refreshToken: 'refresh-token',
+      accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
+      refreshTimeoutMs: 25,
+    });
+
+    const request = client.fetch('/api/v1/workflows').catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(25);
+
+    const error = await request;
+    expect(error).toBeInstanceOf(CloudAuthError);
+    expect(error).toMatchObject({ code: 'AUTH_REFRESH_TIMEOUT' });
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/cloud/src/api-client.ts
+++ b/packages/cloud/src/api-client.ts
@@ -1,4 +1,4 @@
-import { REFRESH_WINDOW_MS } from './types.js';
+import { CloudAuthError, DEFAULT_REFRESH_TIMEOUT_MS, REFRESH_WINDOW_MS } from './types.js';
 import { appendAgentRelayTelemetryHeaders } from './telemetry-headers.js';
 
 export type CloudApiClientOptions = {
@@ -7,6 +7,8 @@ export type CloudApiClientOptions = {
   refreshToken: string;
   accessTokenExpiresAt: string;
   refreshTokenExpiresAt?: string;
+  refreshTimeoutMs?: number;
+  onRefresh?: (snapshot: CloudApiClientSnapshot) => void | Promise<void>;
 };
 
 export type CloudApiClientSnapshot = {
@@ -76,7 +78,7 @@ export class CloudApiClient {
   }
 
   async fetch(p: string, init: RequestInit = {}): Promise<Response> {
-    await this.refresh();
+    await this.refresh(false, init.signal ?? undefined);
 
     const response = await fetch(buildApiUrl(this.options.apiUrl, p), {
       ...init,
@@ -87,7 +89,7 @@ export class CloudApiClient {
       return response;
     }
 
-    await this.refresh(true);
+    await this.refresh(true, init.signal ?? undefined);
 
     return fetch(buildApiUrl(this.options.apiUrl, p), {
       ...init,
@@ -109,7 +111,7 @@ export class CloudApiClient {
     }
   }
 
-  private async refresh(force = false): Promise<void> {
+  private async refresh(force = false, signal?: AbortSignal): Promise<void> {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
@@ -118,24 +120,68 @@ export class CloudApiClient {
       return;
     }
 
-    this.refreshPromise = this.doRefresh().finally(() => {
+    this.refreshPromise = this.doRefresh(signal).finally(() => {
       this.refreshPromise = null;
     });
 
     return this.refreshPromise;
   }
 
-  private async doRefresh(): Promise<void> {
-    const response = await fetch(buildApiUrl(this.options.apiUrl, '/api/v1/auth/token/refresh'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ refreshToken: this.refreshToken }),
-    });
+  private async doRefresh(signal?: AbortSignal): Promise<void> {
+    const refreshTimeoutMs = this.options.refreshTimeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS;
+    const controller = new AbortController();
+    let timedOut = false;
+    let callerAborted = false;
+    const abortFromCaller = () => {
+      callerAborted = true;
+      controller.abort();
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        callerAborted = true;
+        controller.abort();
+      } else {
+        signal.addEventListener('abort', abortFromCaller, { once: true });
+      }
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, refreshTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(buildApiUrl(this.options.apiUrl, '/api/v1/auth/token/refresh'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ refreshToken: this.refreshToken }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (timedOut || (!callerAborted && error instanceof Error && error.name === 'AbortError')) {
+        throw new CloudAuthError(
+          'AUTH_REFRESH_TIMEOUT',
+          `Cloud auth refresh timed out after ${refreshTimeoutMs}ms`,
+          { cause: error }
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+      if (signal) {
+        signal.removeEventListener('abort', abortFromCaller);
+      }
+    }
 
     if (!response.ok) {
-      throw new Error(`Failed to refresh API token: ${response.status} ${response.statusText}`);
+      throw new CloudAuthError(
+        'AUTH_REFRESH_EXPIRED',
+        `Failed to refresh API token: ${response.status} ${response.statusText}`
+      );
     }
 
     const payload = (await response.json()) as {
@@ -146,13 +192,14 @@ export class CloudApiClient {
     };
 
     if (!payload.accessToken || !payload.accessTokenExpiresAt || !payload.refreshToken) {
-      throw new Error('Refresh response missing token fields');
+      throw new CloudAuthError('AUTH_REFRESH_EXPIRED', 'Refresh response missing token fields');
     }
 
     this.accessToken = payload.accessToken;
     this.accessTokenExpiresAt = payload.accessTokenExpiresAt;
     this.refreshToken = payload.refreshToken;
     this.refreshTokenExpiresAt = payload.refreshTokenExpiresAt;
+    await this.options.onRefresh?.(this.snapshot());
   }
 
   private buildHeaders(headers: HeaderInput | undefined): Headers {

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -22,8 +22,14 @@ vi.mock('node:child_process', () => ({
   spawn: childProcessMocks.spawn,
 }));
 
-import { authorizedApiFetch, ensureAuthenticated, readStoredAuth, refreshStoredAuth } from './auth.js';
-import type { StoredAuth } from './types.js';
+import {
+  authorizedApiFetch,
+  ensureAuthenticated,
+  ensureCloudSession,
+  readStoredAuth,
+  refreshStoredAuth,
+} from './auth.js';
+import { AUTH_FILE_PATH, CloudAuthError, LEGACY_AUTH_FILE_PATH, type StoredAuth } from './types.js';
 
 const FILE_AUTH: StoredAuth = {
   apiUrl: 'https://file.example/cloud',
@@ -109,6 +115,39 @@ describe('readStoredAuth', () => {
 
     await expect(readStoredAuth(env)).resolves.toEqual(ENV_AUTH);
     expect(fsMocks.readFile).not.toHaveBeenCalled();
+  });
+
+  it('migrates legacy auth to the canonical auth path when canonical auth is absent', async () => {
+    fsMocks.readFile.mockImplementation(async (file: string) => {
+      if (file === AUTH_FILE_PATH) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
+      if (file === LEGACY_AUTH_FILE_PATH) {
+        return JSON.stringify(FILE_AUTH);
+      }
+      throw new Error(`unexpected file ${file}`);
+    });
+
+    await expect(readStoredAuth({})).resolves.toEqual(FILE_AUTH);
+
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(expect.stringContaining('.agentworkforce/relay'), {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(fsMocks.writeFile).toHaveBeenCalledWith(
+      AUTH_FILE_PATH,
+      `${JSON.stringify(FILE_AUTH, null, 2)}\n`,
+      {
+        encoding: 'utf8',
+        mode: 0o600,
+      }
+    );
+    expect(fsMocks.writeFile).not.toHaveBeenCalledWith(
+      LEGACY_AUTH_FILE_PATH,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(fsMocks.rm).not.toHaveBeenCalled();
   });
 });
 
@@ -242,6 +281,19 @@ describe('ensureAuthenticated', () => {
 
     logSpy.mockRestore();
   });
+
+  it('fails fast without opening a browser when non-interactive auth needs login', async () => {
+    await expect(
+      ensureCloudSession({
+        apiUrl: 'https://example.com/cloud',
+        interactive: false,
+      })
+    ).rejects.toMatchObject({
+      code: 'AUTH_BROWSER_REQUIRED',
+    });
+
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
 });
 
 describe('refreshStoredAuth', () => {
@@ -278,6 +330,37 @@ describe('refreshStoredAuth', () => {
     });
     expect(fsMocks.writeFile).not.toHaveBeenCalled();
     expect(fsMocks.mkdir).not.toHaveBeenCalled();
+  });
+
+  it('aborts stalled refresh requests and throws a typed timeout error', async () => {
+    vi.useFakeTimers();
+    const auth: StoredAuth = {
+      apiUrl: 'https://origin.example/cloud',
+      accessToken: 'stale-access',
+      refreshToken: 'stored-refresh',
+      accessTokenExpiresAt: '2026-04-13T12:00:00.000Z',
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: string | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+            });
+          })
+      )
+    );
+
+    const refresh = refreshStoredAuth(auth, { refreshTimeoutMs: 25 }).catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(25);
+
+    const error = await refresh;
+    expect(error).toBeInstanceOf(CloudAuthError);
+    expect(error).toMatchObject({ code: 'AUTH_REFRESH_TIMEOUT' });
+
+    vi.useRealTimers();
   });
 });
 

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -6,8 +6,19 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 
 import { buildApiUrl } from './api-client.js';
+import { CloudApiClient } from './api-client.js';
 import { appendAgentRelayTelemetryHeaders } from './telemetry-headers.js';
-import { AUTH_FILE_PATH, REFRESH_WINDOW_MS, type StoredAuth } from './types.js';
+import {
+  AUTH_FILE_PATH,
+  DEFAULT_REFRESH_TIMEOUT_MS,
+  LEGACY_AUTH_FILE_PATH,
+  REFRESH_WINDOW_MS,
+  CloudAuthError,
+  defaultApiUrl,
+  type CloudSession,
+  type CloudSessionOptions,
+  type StoredAuth,
+} from './types.js';
 
 const envBackedAuth = new WeakSet<StoredAuth>();
 
@@ -49,11 +60,16 @@ function readEnvAuth(env: NodeJS.ProcessEnv = process.env): StoredAuth | null {
 }
 
 function toEnvAuthRefreshError(error: unknown): Error {
+  if (error instanceof CloudAuthError && error.code === 'AUTH_REFRESH_TIMEOUT') {
+    return error;
+  }
+
   const message = error instanceof Error && error.message ? `${error.message}. ` : '';
 
-  return new Error(
+  return new CloudAuthError(
+    'AUTH_ENV_REPROVISION_REQUIRED',
     `${message}Env-backed cloud auth could not be refreshed interactively; re-provision CLOUD_API_URL, CLOUD_API_ACCESS_TOKEN, CLOUD_API_REFRESH_TOKEN, and CLOUD_API_ACCESS_TOKEN_EXPIRES_AT.`,
-    error instanceof Error ? { cause: error } : undefined
+    { cause: error }
   );
 }
 
@@ -81,6 +97,19 @@ export async function readStoredAuth(env: NodeJS.ProcessEnv = process.env): Prom
     const file = await fs.readFile(AUTH_FILE_PATH, 'utf8');
     const parsed = JSON.parse(file) as unknown;
     return isValidStoredAuth(parsed) ? parsed : null;
+  } catch {
+    // Fall through to the one-time migration path below.
+  }
+
+  try {
+    const legacyFile = await fs.readFile(LEGACY_AUTH_FILE_PATH, 'utf8');
+    const parsed = JSON.parse(legacyFile) as unknown;
+    if (!isValidStoredAuth(parsed)) {
+      return null;
+    }
+
+    await writeStoredAuth(parsed);
+    return parsed;
   } catch {
     return null;
   }
@@ -122,6 +151,83 @@ function openBrowser(url: string) {
   }
 
   return spawn('xdg-open', [url], { stdio: 'ignore', detached: true });
+}
+
+function browserRequired(message: string): CloudAuthError {
+  return new CloudAuthError('AUTH_BROWSER_REQUIRED', message);
+}
+
+function refreshExpired(message = 'Stored cloud login has expired'): CloudAuthError {
+  return new CloudAuthError('AUTH_REFRESH_EXPIRED', message);
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' || error.name === 'TimeoutError' || /aborted/i.test(error.message))
+  );
+}
+
+function addAbortListener(signal: AbortSignal, listener: () => void): () => void {
+  signal.addEventListener('abort', listener, { once: true });
+  return () => signal.removeEventListener('abort', listener);
+}
+
+async function fetchWithRefreshTimeout(
+  url: URL,
+  init: RequestInit,
+  options: { refreshTimeoutMs?: number; signal?: AbortSignal } = {}
+): Promise<Response> {
+  const refreshTimeoutMs = options.refreshTimeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS;
+  const controller = new AbortController();
+  const removers: Array<() => void> = [];
+  let timedOut = false;
+  let callerAborted = false;
+
+  const abortFromCaller = () => {
+    callerAborted = true;
+    controller.abort();
+  };
+
+  for (const signal of [options.signal, init.signal]) {
+    if (!signal) {
+      continue;
+    }
+
+    if (signal.aborted) {
+      callerAborted = true;
+      controller.abort();
+      break;
+    }
+
+    removers.push(addAbortListener(signal, abortFromCaller));
+  }
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, refreshTimeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (timedOut || (!callerAborted && isAbortLikeError(error))) {
+      throw new CloudAuthError(
+        'AUTH_REFRESH_TIMEOUT',
+        `Cloud auth refresh timed out after ${refreshTimeoutMs}ms`,
+        { cause: error }
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    for (const remove of removers) {
+      remove();
+    }
+  }
 }
 
 function redirectToHostedCliAuthPage(
@@ -262,14 +368,21 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
   });
 }
 
-export async function refreshStoredAuth(auth: StoredAuth): Promise<StoredAuth> {
-  const response = await fetch(buildApiUrl(auth.apiUrl, '/api/v1/auth/token/refresh'), {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
+export async function refreshStoredAuth(
+  auth: StoredAuth,
+  options: { refreshTimeoutMs?: number; signal?: AbortSignal } = {}
+): Promise<StoredAuth> {
+  const response = await fetchWithRefreshTimeout(
+    buildApiUrl(auth.apiUrl, '/api/v1/auth/token/refresh'),
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ refreshToken: auth.refreshToken }),
     },
-    body: JSON.stringify({ refreshToken: auth.refreshToken }),
-  });
+    options
+  );
 
   const payload = (await response.json().catch(() => null)) as {
     accessToken?: string;
@@ -278,7 +391,7 @@ export async function refreshStoredAuth(auth: StoredAuth): Promise<StoredAuth> {
   } | null;
 
   if (!response.ok || !payload?.accessToken || !payload?.refreshToken || !payload?.accessTokenExpiresAt) {
-    throw new Error('Stored cloud login has expired');
+    throw refreshExpired();
   }
 
   const nextAuth: StoredAuth = {
@@ -305,10 +418,24 @@ async function loginWithBrowser(apiUrl: string): Promise<StoredAuth> {
 
 export async function ensureAuthenticated(
   apiUrl: string,
-  options?: { force?: boolean }
+  options?: { force?: boolean; interactive?: boolean; refreshTimeoutMs?: number }
 ): Promise<StoredAuth> {
-  const force = options?.force === true;
-  const stored = !force ? await readStoredAuth() : null;
+  const session = await ensureCloudSession({
+    apiUrl,
+    force: options?.force,
+    interactive: options?.interactive,
+    refreshTimeoutMs: options?.refreshTimeoutMs,
+  });
+  return session.auth;
+}
+
+export async function ensureCloudSession(options: CloudSessionOptions = {}): Promise<CloudSession> {
+  const env = options.env ?? process.env;
+  const apiUrl = options.apiUrl || env.CLOUD_API_URL?.trim() || defaultApiUrl();
+  const force = options.force === true;
+  const interactive = options.interactive !== false;
+  const refreshTimeoutMs = options.refreshTimeoutMs;
+  const stored = !force ? await readStoredAuth(env) : null;
 
   // Stored auth is authoritative on its own host. A host mismatch between
   // `apiUrl` (typically defaultApiUrl()) and `stored.apiUrl` is NOT a reason
@@ -316,22 +443,53 @@ export async function ensureAuthenticated(
   // may have drifted (e.g. CLOUD_API_URL env set/unset between sessions).
   // Only `--force` re-links to a different host.
   if (!stored) {
-    return loginWithBrowser(apiUrl);
+    if (!interactive) {
+      throw browserRequired('Cloud login required. Run `agent-relay login`.');
+    }
+    const auth = await loginWithBrowser(apiUrl);
+    return createCloudSession(auth, { refreshTimeoutMs });
   }
 
   if (!shouldRefresh(stored.accessTokenExpiresAt)) {
-    return stored;
+    return createCloudSession(stored, { refreshTimeoutMs });
   }
 
   try {
-    return await refreshStoredAuth(stored);
+    const auth = await refreshStoredAuth(stored, { refreshTimeoutMs });
+    return createCloudSession(auth, { refreshTimeoutMs });
   } catch (error) {
     if (isEnvBackedAuth(stored)) {
       throw toEnvAuthRefreshError(error);
     }
 
-    return loginWithBrowser(stored.apiUrl);
+    if (!interactive) {
+      throw error;
+    }
+
+    const auth = await loginWithBrowser(stored.apiUrl);
+    return createCloudSession(auth, { refreshTimeoutMs });
   }
+}
+
+function createCloudSession(auth: StoredAuth, options: { refreshTimeoutMs?: number } = {}): CloudSession {
+  const client = new CloudApiClient({
+    ...auth,
+    refreshTimeoutMs: options.refreshTimeoutMs,
+    onRefresh: async (snapshot) => {
+      if (isEnvBackedAuth(auth)) {
+        return;
+      }
+
+      await writeStoredAuth({
+        apiUrl: snapshot.apiUrl,
+        accessToken: snapshot.accessToken,
+        refreshToken: snapshot.refreshToken,
+        accessTokenExpiresAt: snapshot.accessTokenExpiresAt,
+      });
+    },
+  });
+
+  return { auth, client };
 }
 
 function apiFetch(
@@ -356,7 +514,8 @@ function apiFetch(
 export async function authorizedApiFetch(
   auth: StoredAuth,
   requestPath: string,
-  init: RequestInit
+  init: RequestInit,
+  options: { interactive?: boolean; refreshTimeoutMs?: number } = {}
 ): Promise<{ response: Response; auth: StoredAuth }> {
   let activeAuth = auth;
   let response = await apiFetch(activeAuth.apiUrl, activeAuth.accessToken, requestPath, init);
@@ -366,10 +525,17 @@ export async function authorizedApiFetch(
   }
 
   try {
-    activeAuth = await refreshStoredAuth(activeAuth);
+    activeAuth = await refreshStoredAuth(activeAuth, {
+      refreshTimeoutMs: options.refreshTimeoutMs,
+      signal: init.signal ?? undefined,
+    });
   } catch (error) {
     if (isEnvBackedAuth(activeAuth)) {
       throw toEnvAuthRefreshError(error);
+    }
+
+    if (options.interactive === false) {
+      throw error;
     }
 
     activeAuth = await loginWithBrowser(activeAuth.apiUrl);

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -4,6 +4,7 @@ export {
   clearStoredAuth,
   refreshStoredAuth,
   ensureAuthenticated,
+  ensureCloudSession,
   authorizedApiFetch,
 } from './auth.js';
 
@@ -36,7 +37,20 @@ export {
   type ConnectProviderResult,
 } from './connect.js';
 
-export { createWorkspace, issueWorkspaceToken } from './workspaces.js';
+export { createWorkspace, issueWorkspaceToken, resolveActiveWorkspace } from './workspaces.js';
+
+export {
+  activeWorkspaceKey,
+  readWorkspaceStore,
+  resolveActiveWorkspaceKey,
+  setActiveWorkspace,
+  setWorkspaceKey,
+  switchWorkspace,
+  validateWorkspaceName,
+  workspaceStorePath,
+  writeWorkspaceStore,
+  type WorkspaceStore,
+} from './workspace-store.js';
 
 export {
   deployProactiveAgent,
@@ -103,8 +117,14 @@ export { PermissionAuditLog, getDefaultPermissionAuditPath } from './audit.js';
 
 export {
   type StoredAuth,
+  CloudAuthError,
+  type CloudAuthErrorCode,
+  type CloudSession,
+  type CloudSessionOptions,
   type WhoAmIResponse,
   type AuthSessionResponse,
+  type ActiveWorkspaceDescriptor,
+  type ActiveWorkspaceUrls,
   type WorkspaceCreateResponse,
   type WorkspaceTokenIssueResponse,
   type WorkspaceTokenRecord,
@@ -119,7 +139,9 @@ export {
   type SyncPatchResponse,
   SUPPORTED_PROVIDERS,
   REFRESH_WINDOW_MS,
+  DEFAULT_REFRESH_TIMEOUT_MS,
   AUTH_FILE_PATH,
+  LEGACY_AUTH_FILE_PATH,
   defaultApiUrl,
   isSupportedProvider,
 } from './types.js';

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -8,6 +8,36 @@ export type StoredAuth = {
   apiUrl: string;
 };
 
+export type CloudAuthErrorCode =
+  | 'AUTH_REFRESH_TIMEOUT'
+  | 'AUTH_REFRESH_EXPIRED'
+  | 'AUTH_BROWSER_REQUIRED'
+  | 'AUTH_ENV_REPROVISION_REQUIRED';
+
+export class CloudAuthError extends Error {
+  constructor(
+    public readonly code: CloudAuthErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'CloudAuthError';
+  }
+}
+
+export type CloudSession = {
+  auth: StoredAuth;
+  client: import('./api-client.js').CloudApiClient;
+};
+
+export type CloudSessionOptions = {
+  apiUrl?: string;
+  force?: boolean;
+  interactive?: boolean;
+  refreshTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
 export type WhoAmIResponse = {
   authenticated: boolean;
   source: 'session' | 'token';
@@ -71,6 +101,29 @@ export type WorkspaceTokenRecord = {
 export type WorkspaceTokenIssueResponse = {
   key: string;
   workspaceToken?: WorkspaceTokenRecord;
+};
+
+export type ActiveWorkspaceUrls = {
+  relayfileUrl?: string;
+  relaycronUrl?: string;
+  relaycastUrl?: string;
+  relayauthUrl?: string;
+  [key: string]: string | undefined;
+};
+
+export type ActiveWorkspaceDescriptor = {
+  name?: string;
+  key: string;
+  cloudWorkspaceId: string;
+  relaycastWorkspaceId: string;
+  relaycastApiKey?: string;
+  relayfileWorkspaceId: string;
+  relayauthWorkspaceId: string;
+  organizationId?: string;
+  slug?: string;
+  urls: ActiveWorkspaceUrls;
+  apiUrl: string;
+  provisioned?: boolean;
 };
 
 export type ProactiveDeploymentResponse = {
@@ -208,7 +261,9 @@ export type GetPatchesResponse = {
 export const SUPPORTED_PROVIDERS = ['anthropic', 'openai', 'google', 'cursor', 'opencode', 'droid'] as const;
 
 export const REFRESH_WINDOW_MS = 60_000;
+export const DEFAULT_REFRESH_TIMEOUT_MS = 10_000;
 export const AUTH_FILE_PATH = path.join(os.homedir(), '.agentworkforce/relay', 'cloud-auth.json');
+export const LEGACY_AUTH_FILE_PATH = path.join(os.homedir(), '.agent-relay', 'cloud-auth.json');
 
 export function defaultApiUrl(): string {
   return process.env.CLOUD_API_URL?.trim() || 'https://agentrelay.com/cloud';

--- a/packages/cloud/src/workspace-store.test.ts
+++ b/packages/cloud/src/workspace-store.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  readWorkspaceStore,
+  resolveActiveWorkspaceKey,
+  setActiveWorkspace,
+  setWorkspaceKey,
+  workspaceStorePath,
+} from './workspace-store.js';
+
+let dir: string;
+const original = process.env.AGENT_RELAY_HOME;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ws-'));
+  process.env.AGENT_RELAY_HOME = dir;
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.AGENT_RELAY_HOME;
+  else process.env.AGENT_RELAY_HOME = original;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('workspace store', () => {
+  it('stores keys, sets the first as active, and resolves the active key', () => {
+    setWorkspaceKey('ops', 'rk_ops');
+    expect(resolveActiveWorkspaceKey()).toBe('rk_ops');
+
+    setWorkspaceKey('support', 'rk_support');
+    expect(readWorkspaceStore().active).toBe('ops');
+
+    setActiveWorkspace('support');
+    expect(resolveActiveWorkspaceKey()).toBe('rk_support');
+  });
+
+  it('throws when switching to an unknown workspace', () => {
+    expect(() => setActiveWorkspace('nope')).toThrow(/Unknown workspace/);
+  });
+
+  it('writes the store with owner-only permissions', () => {
+    setWorkspaceKey('ops', 'rk_ops');
+    const mode = fs.statSync(workspaceStorePath()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('rejects reserved object-property workspace names', () => {
+    expect(() => setWorkspaceKey('__proto__', 'rk_bad')).toThrow(/Invalid workspace name/);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/packages/cloud/src/workspace-store.ts
+++ b/packages/cloud/src/workspace-store.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Local store of named workspace keys plus which one is active. This is the
+ * canonical Agent Relay workspace pin consumed by cloud, workforce, and
+ * relayfile integrations.
+ */
+export interface WorkspaceStore {
+  active?: string;
+  workspaces: Record<string, { key: string }>;
+}
+
+const RESERVED_WORKSPACE_NAMES = new Set(['__proto__', 'prototype', 'constructor']);
+
+export function workspaceStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  const dir = env.AGENT_RELAY_HOME ?? path.join(os.homedir(), '.agentworkforce/relay');
+  return path.join(dir, 'workspaces.json');
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}
+
+export function validateWorkspaceName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('Workspace name is required.');
+  }
+  if (RESERVED_WORKSPACE_NAMES.has(trimmed)) {
+    throw new Error(`Invalid workspace name "${trimmed}".`);
+  }
+  return trimmed;
+}
+
+export function readWorkspaceStore(env: NodeJS.ProcessEnv = process.env): WorkspaceStore {
+  const file = workspaceStorePath(env);
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as Partial<WorkspaceStore>;
+    return { active: parsed.active, workspaces: parsed.workspaces ?? {} };
+  } catch (err: unknown) {
+    if (isNodeError(err) && err.code === 'ENOENT') {
+      return { workspaces: {} };
+    }
+    throw err;
+  }
+}
+
+export function writeWorkspaceStore(store: WorkspaceStore, env: NodeJS.ProcessEnv = process.env): void {
+  const file = workspaceStorePath(env);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+}
+
+export function setWorkspaceKey(
+  name: string,
+  key: string,
+  env: NodeJS.ProcessEnv = process.env
+): WorkspaceStore {
+  const workspaceName = validateWorkspaceName(name);
+  const store = readWorkspaceStore(env);
+  store.workspaces[workspaceName] = { key };
+  store.active ??= workspaceName;
+  writeWorkspaceStore(store, env);
+  return store;
+}
+
+export function setActiveWorkspace(name: string, env: NodeJS.ProcessEnv = process.env): WorkspaceStore {
+  const workspaceName = validateWorkspaceName(name);
+  const store = readWorkspaceStore(env);
+  if (!store.workspaces[workspaceName]) {
+    throw new Error(
+      `Unknown workspace "${workspaceName}". Add it with \`relay workspace set_key ${workspaceName} <key>\`.`
+    );
+  }
+  store.active = workspaceName;
+  writeWorkspaceStore(store, env);
+  return store;
+}
+
+export const switchWorkspace = setActiveWorkspace;
+
+export function resolveActiveWorkspaceKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const store = readWorkspaceStore(env);
+  return store.active ? store.workspaces[store.active]?.key : undefined;
+}
+
+export const activeWorkspaceKey = resolveActiveWorkspaceKey;

--- a/packages/cloud/src/workspaces.test.ts
+++ b/packages/cloud/src/workspaces.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setWorkspaceKey } from './workspace-store.js';
+import { resolveActiveWorkspace } from './workspaces.js';
+
+let dir: string;
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ws-'));
+  process.env = {
+    ...originalEnv,
+    AGENT_RELAY_HOME: dir,
+    CLOUD_API_URL: 'https://cloud.example.test',
+    CLOUD_API_ACCESS_TOKEN: 'access-token',
+    CLOUD_API_REFRESH_TOKEN: 'refresh-token',
+    CLOUD_API_ACCESS_TOKEN_EXPIRES_AT: '2999-01-01T00:00:00.000Z',
+  };
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveActiveWorkspace', () => {
+  it('resolves the active workspace key into a canonical descriptor', async () => {
+    setWorkspaceKey('ops', 'rk_live_ops');
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            workspace: {
+              name: 'Ops',
+              key: 'rk_live_ops',
+              cloudWorkspaceId: 'rw_ops',
+              relaycastWorkspaceId: 'rc_ops',
+              relaycastApiKey: 'rk_live_ops',
+              relayfileWorkspaceId: 'rw_ops',
+              relayauthWorkspaceId: 'rw_ops',
+              organizationId: 'org_1',
+              slug: 'ops',
+              urls: {
+                relayfileUrl: 'https://relayfile.example.test',
+              },
+              provisioned: true,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(resolveActiveWorkspace()).resolves.toEqual({
+      name: 'Ops',
+      key: 'rk_live_ops',
+      cloudWorkspaceId: 'rw_ops',
+      relaycastWorkspaceId: 'rc_ops',
+      relaycastApiKey: 'rk_live_ops',
+      relayfileWorkspaceId: 'rw_ops',
+      relayauthWorkspaceId: 'rw_ops',
+      organizationId: 'org_1',
+      slug: 'ops',
+      urls: {
+        relayfileUrl: 'https://relayfile.example.test',
+      },
+      apiUrl: 'https://cloud.example.test',
+      provisioned: true,
+    });
+
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(
+      'https://cloud.example.test/api/v1/workspaces/rk_live_ops/resolve'
+    );
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer access-token');
+  });
+});

--- a/packages/cloud/src/workspaces.ts
+++ b/packages/cloud/src/workspaces.ts
@@ -1,10 +1,13 @@
 import { authorizedApiFetch, ensureAuthenticated } from './auth.js';
 import {
+  type ActiveWorkspaceDescriptor,
+  type ActiveWorkspaceUrls,
   defaultApiUrl,
   type WorkspaceCreateResponse,
   type WorkspaceTokenIssueResponse,
   type WorkspaceTokenRecord,
 } from './types.js';
+import { resolveActiveWorkspaceKey } from './workspace-store.js';
 
 type WorkspaceClientOptions = {
   apiUrl?: string;
@@ -12,6 +15,12 @@ type WorkspaceClientOptions = {
 
 type WorkspaceTokenIssueOptions = WorkspaceClientOptions & {
   name?: string;
+};
+
+type ResolveActiveWorkspaceOptions = WorkspaceClientOptions & {
+  interactive?: boolean;
+  refreshTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -31,6 +40,21 @@ async function readJson(response: Response): Promise<unknown> {
 function readString(payload: JsonRecord, key: string): string | undefined {
   const value = payload[key];
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readStringAny(payload: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = readString(payload, key);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readBoolean(payload: JsonRecord, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : undefined;
 }
 
 function buildEndpointError(action: string, endpoint: string, response: Response, payload: unknown): Error {
@@ -113,6 +137,85 @@ function normalizeWorkspaceTokenIssueResponse(
   };
 }
 
+function readUrls(payload: JsonRecord): ActiveWorkspaceUrls {
+  const rawUrls = payload.urls;
+  const urls: ActiveWorkspaceUrls = {};
+
+  if (isObject(rawUrls)) {
+    for (const [key, value] of Object.entries(rawUrls)) {
+      if (typeof value === 'string' && value.trim()) {
+        urls[key] = value.trim();
+      }
+    }
+  }
+
+  for (const key of ['relayfileUrl', 'relaycronUrl', 'relaycastUrl', 'relayauthUrl']) {
+    const value = readString(payload, key);
+    if (value) {
+      urls[key] = value;
+    }
+  }
+
+  return urls;
+}
+
+function normalizeActiveWorkspaceDescriptor(
+  payload: unknown,
+  fallbackKey: string,
+  apiUrl: string
+): ActiveWorkspaceDescriptor {
+  if (!isObject(payload)) {
+    throw new Error('Active workspace response was not valid JSON.');
+  }
+
+  const workspace = isObject(payload.workspace) ? payload.workspace : payload;
+  const key = readStringAny(workspace, ['key', 'workspaceKey', 'relaycastApiKey']) ?? fallbackKey;
+  const cloudWorkspaceId = readStringAny(workspace, ['cloudWorkspaceId', 'workspaceId', 'id']);
+  const relaycastWorkspaceId = readStringAny(workspace, ['relaycastWorkspaceId']);
+  const relayfileWorkspaceId = readStringAny(workspace, ['relayfileWorkspaceId']);
+  const relayauthWorkspaceId = readStringAny(workspace, ['relayauthWorkspaceId']);
+
+  if (!cloudWorkspaceId) {
+    throw new Error('Active workspace response is missing cloudWorkspaceId.');
+  }
+  if (!relaycastWorkspaceId) {
+    throw new Error('Active workspace response is missing relaycastWorkspaceId.');
+  }
+  if (!relayfileWorkspaceId) {
+    throw new Error('Active workspace response is missing relayfileWorkspaceId.');
+  }
+  if (!relayauthWorkspaceId) {
+    throw new Error('Active workspace response is missing relayauthWorkspaceId.');
+  }
+
+  return {
+    ...(readString(workspace, 'name') ? { name: readString(workspace, 'name') } : {}),
+    key,
+    cloudWorkspaceId,
+    relaycastWorkspaceId,
+    ...(readString(workspace, 'relaycastApiKey')
+      ? {
+          relaycastApiKey: readString(workspace, 'relaycastApiKey'),
+        }
+      : {}),
+    relayfileWorkspaceId,
+    relayauthWorkspaceId,
+    ...(readStringAny(workspace, ['organizationId', 'organization_id'])
+      ? {
+          organizationId: readStringAny(workspace, ['organizationId', 'organization_id']),
+        }
+      : {}),
+    ...(readString(workspace, 'slug') ? { slug: readString(workspace, 'slug') } : {}),
+    urls: readUrls(workspace),
+    apiUrl,
+    ...(readBoolean(workspace, 'provisioned') !== undefined
+      ? {
+          provisioned: readBoolean(workspace, 'provisioned'),
+        }
+      : {}),
+  };
+}
+
 async function tryPostJson(
   endpoint: string,
   body: Record<string, unknown>,
@@ -128,6 +231,34 @@ async function tryPostJson(
   return {
     response,
     payload: await readJson(response),
+  };
+}
+
+async function tryGetJson(
+  endpoint: string,
+  options: WorkspaceClientOptions & { refreshTimeoutMs?: number; interactive?: boolean }
+): Promise<{ response: Response; payload: unknown; apiUrl: string }> {
+  const apiUrl = options.apiUrl || defaultApiUrl();
+  const auth = await ensureAuthenticated(apiUrl, {
+    interactive: options.interactive,
+    refreshTimeoutMs: options.refreshTimeoutMs,
+  });
+  const { response } = await authorizedApiFetch(
+    auth,
+    endpoint,
+    {
+      method: 'GET',
+    },
+    {
+      interactive: options.interactive,
+      refreshTimeoutMs: options.refreshTimeoutMs,
+    }
+  );
+
+  return {
+    response,
+    payload: await readJson(response),
+    apiUrl: auth.apiUrl,
   };
 }
 
@@ -206,4 +337,44 @@ export async function issueWorkspaceToken(
   throw (
     lastUnsupported ?? new Error('Workspace token issuance is not supported by the configured cloud API.')
   );
+}
+
+export async function resolveActiveWorkspace(
+  options: ResolveActiveWorkspaceOptions = {}
+): Promise<ActiveWorkspaceDescriptor> {
+  const key = resolveActiveWorkspaceKey(options.env);
+  if (!key) {
+    throw new Error(
+      'No active Agent Relay workspace found. Run `agent-relay workspace set_key <name> <key>` or `agent-relay workspace join <name> <key>`.'
+    );
+  }
+
+  const encodedKey = encodeURIComponent(key);
+  const endpoints = [
+    `/api/v1/workspaces/${encodedKey}/resolve`,
+    `/api/v1/workspaces/resolve?key=${encodedKey}`,
+    `/api/v1/workspaces/active?key=${encodedKey}`,
+  ];
+  let lastUnsupported: Error | null = null;
+
+  for (const endpoint of endpoints) {
+    const { response, payload, apiUrl } = await tryGetJson(endpoint, {
+      apiUrl: options.apiUrl,
+      interactive: options.interactive ?? false,
+      refreshTimeoutMs: options.refreshTimeoutMs,
+    });
+
+    if (response.status === 404 || response.status === 405) {
+      lastUnsupported = buildEndpointError('Workspace resolve', endpoint, response, payload);
+      continue;
+    }
+
+    if (!response.ok) {
+      throw buildEndpointError('Workspace resolve', endpoint, response, payload);
+    }
+
+    return normalizeActiveWorkspaceDescriptor(payload, key, apiUrl);
+  }
+
+  throw lastUnsupported ?? new Error('Workspace resolution is not supported by the configured cloud API.');
 }


### PR DESCRIPTION
## Summary

References AgentWorkforce/cloud#2108 and the agreed design doc `docs/design/auth-unification-2108.md` in the cloud worktree.

This PR makes `@agent-relay/cloud` the canonical token + workspace session contract for downstream cloud/workforce/relayfile work:

- adds `ensureCloudSession({ apiUrl?, force?, interactive?, refreshTimeoutMs?, env? }) -> { auth, client }`
- adds typed `CloudAuthError` codes: `AUTH_REFRESH_TIMEOUT`, `AUTH_REFRESH_EXPIRED`, `AUTH_BROWSER_REQUIRED`, `AUTH_ENV_REPROVISION_REQUIRED`
- adds timeout-bounded refresh via `AbortController` to `refreshStoredAuth` and `CloudApiClient` refresh paths
- migrates legacy `~/.agent-relay/cloud-auth.json` to canonical `~/.agentworkforce/relay/cloud-auth.json` when canonical auth is absent, with no dual-write or automatic legacy deletion
- promotes workspace-store APIs from CLI-private code into `@agent-relay/cloud`
- adds `resolveActiveWorkspace()` returning the canonical cloud/relaycast/relayfile/relayauth descriptor via `GET /api/v1/workspaces/:workspaceId/resolve`
- adds `agent-relay cloud session --json` and `agent-relay workspace active --json` as cross-language surfaces for Go consumers; `cloud session --json` intentionally emits only `apiUrl`, `accessToken`, and `accessTokenExpiresAt`, never the refresh token
- bumps `@agent-relay/cloud` to `8.7.0`

Current PR head after reconstruction: `2ec20962a`.

## Publish plan

Standard publish after review/merge. Consumers should integrate against this branch using a local link/file ref until this PR lands and `@agent-relay/cloud@8.7.0` is published; after publish, consumers can bump to `^8.7.0` and rerun CI.

## Validation

Passing on the reconstructed branch:

```bash
npm --prefix packages/cloud run build
npx vitest run packages/cloud/src/api-client.test.ts packages/cloud/src/auth.test.ts packages/cloud/src/workspace-store.test.ts packages/cloud/src/workspaces.test.ts packages/cli/src/cli/commands/cloud.test.ts packages/cli/src/cli/commands/workspace.test.ts packages/cli/src/cli/lib/workspace-store.test.ts
```

Clean-diff check:

```bash
git diff --name-only origin/main...HEAD
```

contains only auth-unification files under `packages/cloud`, `packages/cli/src/cli/commands`, `packages/cli/src/cli/lib/workspace-store.ts`, plus `CHANGELOG.md`, `package-lock.json`, and `packages/cloud/package.json`.

Known pre-existing blocker, not introduced here:

```bash
npm --prefix packages/cli run build
```

fails in untouched `src/cli/agent-relay-mcp.ts` with:

```text
Object literal may only specify known properties, and 'model' does not exist in type '{ name: string; cli: ... }'
```

This PR does not modify `packages/cli/src/cli/agent-relay-mcp.ts`.
