### PR TITLE
chore(release): sync package lock for cloud auth publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.4.0",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -1177,7 +1177,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18703,43 +18702,43 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.4.0"
+      "version": "8.6.0"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.4.0",
-        "@agent-relay/config": "8.4.0",
-        "@agent-relay/harness-driver": "8.4.0",
-        "@agent-relay/sdk": "8.4.0",
-        "@agent-relay/utils": "8.4.0",
+        "@agent-relay/cloud": "8.6.0",
+        "@agent-relay/config": "8.6.0",
+        "@agent-relay/harness-driver": "8.6.0",
+        "@agent-relay/sdk": "8.6.0",
+        "@agent-relay/utils": "8.6.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^3.1.1",
         "@relayflows/cli": "^1.0.1",
@@ -18760,11 +18759,25 @@
         "node": ">=20.9.0"
       }
     },
+    "packages/cli/node_modules/@agent-relay/cloud": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-8.6.0.tgz",
+      "integrity": "sha512-LEjFWAbXIpD/QCWcJp520/cUK+KNgbUqb/HOzVGQz4ps0G9cVkK8vVKhbVlQtiyn4Z5QxBnW9x+Ilv8MZWVzpg==",
+      "dependencies": {
+        "@agent-relay/config": "8.6.0",
+        "@aws-sdk/client-s3": "3.1020.0",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "optionalDependencies": {
+        "ssh2": "^1.17.0"
+      }
+    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
       "version": "8.7.0",
       "dependencies": {
-        "@agent-relay/config": "8.4.0",
+        "@agent-relay/config": "8.6.0",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -18780,7 +18793,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -18793,35 +18806,35 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.4.0",
+        "@agent-relay/sdk": "8.6.0",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.4.0",
-        "@agent-relay/broker-darwin-x64": "8.4.0",
-        "@agent-relay/broker-linux-arm64": "8.4.0",
-        "@agent-relay/broker-linux-x64": "8.4.0",
-        "@agent-relay/broker-win32-x64": "8.4.0"
+        "@agent-relay/broker-darwin-arm64": "8.6.0",
+        "@agent-relay/broker-darwin-x64": "8.6.0",
+        "@agent-relay/broker-linux-arm64": "8.6.0",
+        "@agent-relay/broker-linux-x64": "8.6.0",
+        "@agent-relay/broker-win32-x64": "8.6.0"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.4.0",
-        "@agent-relay/sdk": "8.4.0"
+        "@agent-relay/harness-driver": "8.6.0",
+        "@agent-relay/sdk": "8.6.0"
       }
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "dependencies": {
-        "@agent-relay/config": "8.4.0"
+        "@agent-relay/config": "8.6.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -18830,7 +18843,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "dependencies": {
         "@relaycast/sdk": "^3.1.1"
       },
@@ -18840,14 +18853,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.4.0",
+      "version": "8.6.0",
       "dependencies": {
-        "@agent-relay/config": "8.4.0",
+        "@agent-relay/config": "8.6.0",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary\n- Sync package-lock metadata after @agent-relay/cloud moved to 8.7.0 so npm ci works on main.\n\n## Validation\n- npm ci --ignore-scripts --no-audit --no-fund\n- npm --prefix packages/config run build\n- npm --prefix packages/cloud run build\n\nCo-Authored-By: OpenAI Codex <codex@openai.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

