### PR TITLE
fix(cli): refresh lockfile for cloud workspace version

### DIFF
--- a/.agentworkforce/trajectories/active/traj_b1jrutolckfb/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_b1jrutolckfb/trajectory.json
@@ -145,20 +145,11 @@
           "type": "reflection",
           "content": "PR 1123 review complete: no code edits needed; lockfile-only change validated locally and GitHub Actions are green",
           "raw": {
-            "focalPoints": [
-              "lockfile",
-              "ci",
-              "scope"
-            ],
+            "focalPoints": ["lockfile", "ci", "scope"],
             "confidence": 0.9
           },
           "significance": "high",
-          "tags": [
-            "focal:lockfile",
-            "focal:ci",
-            "focal:scope",
-            "confidence:0.9"
-          ]
+          "tags": ["focal:lockfile", "focal:ci", "focal:scope", "confidence:0.9"]
         }
       ]
     }

--- a/.agentworkforce/trajectories/active/traj_b1jrutolckfb/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_b1jrutolckfb/trajectory.json
@@ -127,6 +127,38 @@
             "reasoning": "Only commits after v8.4.0 should remain in [Unreleased]; recent released sections should be curated from the commits between adjacent release tags."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1781355941523,
+          "type": "decision",
+          "content": "PR 1123 lockfile is reproducible from current manifests: PR 1123 lockfile is reproducible from current manifests",
+          "raw": {
+            "question": "PR 1123 lockfile is reproducible from current manifests",
+            "chosen": "PR 1123 lockfile is reproducible from current manifests",
+            "alternatives": [],
+            "reasoning": "package-lock.json is the sole changed file; npm install --package-lock-only, npm ci, npm test, typecheck, lint, and targeted prettier all validate the lockfile change. Broader syncpack/format issues are outside this lockfile PR."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1781356028983,
+          "type": "reflection",
+          "content": "PR 1123 review complete: no code edits needed; lockfile-only change validated locally and GitHub Actions are green",
+          "raw": {
+            "focalPoints": [
+              "lockfile",
+              "ci",
+              "scope"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:lockfile",
+            "focal:ci",
+            "focal:scope",
+            "confidence:0.9"
+          ]
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -18702,43 +18702,43 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.6.0"
+      "version": "8.7.0"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.6.0",
-        "@agent-relay/config": "8.6.0",
-        "@agent-relay/harness-driver": "8.6.0",
-        "@agent-relay/sdk": "8.6.0",
-        "@agent-relay/utils": "8.6.0",
+        "@agent-relay/cloud": "8.7.0",
+        "@agent-relay/config": "8.7.0",
+        "@agent-relay/harness-driver": "8.7.0",
+        "@agent-relay/sdk": "8.7.0",
+        "@agent-relay/utils": "8.7.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^3.1.1",
         "@relayflows/cli": "^1.0.1",
@@ -18759,25 +18759,11 @@
         "node": ">=20.9.0"
       }
     },
-    "packages/cli/node_modules/@agent-relay/cloud": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-8.6.0.tgz",
-      "integrity": "sha512-LEjFWAbXIpD/QCWcJp520/cUK+KNgbUqb/HOzVGQz4ps0G9cVkK8vVKhbVlQtiyn4Z5QxBnW9x+Ilv8MZWVzpg==",
-      "dependencies": {
-        "@agent-relay/config": "8.6.0",
-        "@aws-sdk/client-s3": "3.1020.0",
-        "ignore": "^7.0.5",
-        "tar": "^7.5.10"
-      },
-      "optionalDependencies": {
-        "ssh2": "^1.17.0"
-      }
-    },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
       "version": "8.7.0",
       "dependencies": {
-        "@agent-relay/config": "8.6.0",
+        "@agent-relay/config": "8.7.0",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -18793,7 +18779,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -18806,35 +18792,35 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.6.0",
+        "@agent-relay/sdk": "8.7.0",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.6.0",
-        "@agent-relay/broker-darwin-x64": "8.6.0",
-        "@agent-relay/broker-linux-arm64": "8.6.0",
-        "@agent-relay/broker-linux-x64": "8.6.0",
-        "@agent-relay/broker-win32-x64": "8.6.0"
+        "@agent-relay/broker-darwin-arm64": "8.7.0",
+        "@agent-relay/broker-darwin-x64": "8.7.0",
+        "@agent-relay/broker-linux-arm64": "8.7.0",
+        "@agent-relay/broker-linux-x64": "8.7.0",
+        "@agent-relay/broker-win32-x64": "8.7.0"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.6.0",
-        "@agent-relay/sdk": "8.6.0"
+        "@agent-relay/harness-driver": "8.7.0",
+        "@agent-relay/sdk": "8.7.0"
       }
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "dependencies": {
-        "@agent-relay/config": "8.6.0"
+        "@agent-relay/config": "8.7.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -18843,7 +18829,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "dependencies": {
         "@relaycast/sdk": "^3.1.1"
       },
@@ -18853,14 +18839,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "dependencies": {
-        "@agent-relay/config": "8.6.0",
+        "@agent-relay/config": "8.7.0",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- refresh package-lock workspace metadata from 8.6.0 to 8.7.0
- remove the stale nested `packages/cli/node_modules/@agent-relay/cloud@8.6.0` lock entry that shadowed the workspace package at packaged CLI runtime
- keep the fix lockfile-only; no syncpack/version-policy cleanup included

## Validation
- `npm ci`
- `npm run build:core`
- `node packages/cli/dist/cli/index.js --version` -> `8.7.0`
- `(cd packages/cli && node dist/cli/index.js --version)` -> `8.7.0`
- `npm run pack:validate`

## Notes
This forward-fixes the packaged CLI crash after #1119 where `ensureCloudSession` existed in source/workspace `@agent-relay/cloud@8.7.0`, but the stale lock installed a nested `@agent-relay/cloud@8.6.0` under `packages/cli/node_modules`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

