### PR TITLE
fix(cloud): serialize auth refresh writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@agent-relay/cloud` now writes cloud auth atomically and serializes file-backed token refreshes across processes, preventing concurrent refreshes from clobbering rotated credentials.
 - `@agent-relay/cloud` refresh now fails with typed, timeout-bounded errors and migrates legacy `~/.agent-relay/cloud-auth.json` credentials into the canonical `~/.agentworkforce/relay/cloud-auth.json` store without dual-writing.
 - `agent-relay-broker` persists pending deliveries on shutdown and on every queue change, redelivers them on restart, reports timeout-fallback verification explicitly, and emits `delivery_dropped` when the per-worker queue cap evicts a message.
 

--- a/packages/cloud/src/api-client.ts
+++ b/packages/cloud/src/api-client.ts
@@ -8,6 +8,10 @@ export type CloudApiClientOptions = {
   accessTokenExpiresAt: string;
   refreshTokenExpiresAt?: string;
   refreshTimeoutMs?: number;
+  refreshAuth?: (
+    snapshot: CloudApiClientSnapshot,
+    options: { force: boolean; signal?: AbortSignal }
+  ) => Promise<CloudApiClientSnapshot>;
   onRefresh?: (snapshot: CloudApiClientSnapshot) => void | Promise<void>;
 };
 
@@ -120,14 +124,25 @@ export class CloudApiClient {
       return;
     }
 
-    this.refreshPromise = this.doRefresh(signal).finally(() => {
+    this.refreshPromise = this.doRefresh(force, signal).finally(() => {
       this.refreshPromise = null;
     });
 
     return this.refreshPromise;
   }
 
-  private async doRefresh(signal?: AbortSignal): Promise<void> {
+  private async doRefresh(force: boolean, signal?: AbortSignal): Promise<void> {
+    if (this.options.refreshAuth) {
+      this.applySnapshot(await this.options.refreshAuth(this.snapshot(), { force, signal }));
+      await this.options.onRefresh?.(this.snapshot());
+      return;
+    }
+
+    this.applySnapshot(await this.requestRefresh(signal));
+    await this.options.onRefresh?.(this.snapshot());
+  }
+
+  private async requestRefresh(signal?: AbortSignal): Promise<CloudApiClientSnapshot> {
     const refreshTimeoutMs = this.options.refreshTimeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS;
     const controller = new AbortController();
     let timedOut = false;
@@ -195,11 +210,20 @@ export class CloudApiClient {
       throw new CloudAuthError('AUTH_REFRESH_EXPIRED', 'Refresh response missing token fields');
     }
 
-    this.accessToken = payload.accessToken;
-    this.accessTokenExpiresAt = payload.accessTokenExpiresAt;
-    this.refreshToken = payload.refreshToken;
-    this.refreshTokenExpiresAt = payload.refreshTokenExpiresAt;
-    await this.options.onRefresh?.(this.snapshot());
+    return {
+      apiUrl: this.options.apiUrl,
+      accessToken: payload.accessToken,
+      accessTokenExpiresAt: payload.accessTokenExpiresAt,
+      refreshToken: payload.refreshToken,
+      ...(payload.refreshTokenExpiresAt ? { refreshTokenExpiresAt: payload.refreshTokenExpiresAt } : {}),
+    };
+  }
+
+  private applySnapshot(snapshot: CloudApiClientSnapshot): void {
+    this.accessToken = snapshot.accessToken;
+    this.accessTokenExpiresAt = snapshot.accessTokenExpiresAt;
+    this.refreshToken = snapshot.refreshToken;
+    this.refreshTokenExpiresAt = snapshot.refreshTokenExpiresAt;
   }
 
   private buildHeaders(headers: HeaderInput | undefined): Headers {

--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const fsMocks = vi.hoisted(() => ({
   readFile: vi.fn(),
   writeFile: vi.fn(),
+  chmod: vi.fn(),
+  rename: vi.fn(),
   mkdir: vi.fn(),
   rm: vi.fn(),
+  stat: vi.fn(),
 }));
 
 const childProcessMocks = vi.hoisted(() => ({
@@ -28,8 +31,11 @@ import {
   ensureCloudSession,
   readStoredAuth,
   refreshStoredAuth,
+  writeStoredAuth,
 } from './auth.js';
 import { AUTH_FILE_PATH, CloudAuthError, LEGACY_AUTH_FILE_PATH, type StoredAuth } from './types.js';
+
+const AUTH_LOCK_PATH = `${AUTH_FILE_PATH}.lock`;
 
 const FILE_AUTH: StoredAuth = {
   apiUrl: 'https://file.example/cloud',
@@ -64,11 +70,51 @@ beforeEach(() => {
   fsMocks.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   fsMocks.writeFile.mockReset();
   fsMocks.writeFile.mockResolvedValue(undefined);
+  fsMocks.chmod.mockReset();
+  fsMocks.chmod.mockResolvedValue(undefined);
+  fsMocks.rename.mockReset();
+  fsMocks.rename.mockResolvedValue(undefined);
   fsMocks.mkdir.mockReset();
   fsMocks.mkdir.mockResolvedValue(undefined);
   fsMocks.rm.mockReset();
   fsMocks.rm.mockResolvedValue(undefined);
+  fsMocks.stat.mockReset();
+  fsMocks.stat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   childProcessMocks.spawn.mockClear();
+});
+
+describe('writeStoredAuth', () => {
+  it('atomically writes auth through a pid-scoped sibling temp file', async () => {
+    await writeStoredAuth(FILE_AUTH);
+
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(expect.stringContaining('.agentworkforce/relay'), {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(fsMocks.writeFile).toHaveBeenCalledOnce();
+    const [temporaryPath, body, writeOptions] = fsMocks.writeFile.mock.calls[0];
+    expect(String(temporaryPath)).toContain('.cloud-auth.json.');
+    expect(temporaryPath).toContain(`.${process.pid}.`);
+    expect(temporaryPath).toMatch(/\.tmp$/);
+    expect(body).toBe(`${JSON.stringify(FILE_AUTH, null, 2)}\n`);
+    expect(writeOptions).toEqual({
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    expect(fsMocks.chmod).toHaveBeenCalledWith(temporaryPath, 0o600);
+    expect(fsMocks.rename).toHaveBeenCalledWith(temporaryPath, AUTH_FILE_PATH);
+    expect(fsMocks.writeFile).not.toHaveBeenCalledWith(AUTH_FILE_PATH, expect.anything(), expect.anything());
+    expect(fsMocks.rm).toHaveBeenCalledWith(temporaryPath, { force: true });
+  });
+
+  it('cleans up the temp file when the atomic rename fails', async () => {
+    fsMocks.rename.mockRejectedValueOnce(new Error('rename failed'));
+
+    await expect(writeStoredAuth(FILE_AUTH)).rejects.toThrow('rename failed');
+
+    const temporaryPath = fsMocks.writeFile.mock.calls[0][0];
+    expect(fsMocks.rm).toHaveBeenCalledWith(temporaryPath, { force: true });
+  });
 });
 
 describe('readStoredAuth', () => {
@@ -135,19 +181,22 @@ describe('readStoredAuth', () => {
       mode: 0o700,
     });
     expect(fsMocks.writeFile).toHaveBeenCalledWith(
-      AUTH_FILE_PATH,
+      expect.stringContaining('.cloud-auth.json.'),
       `${JSON.stringify(FILE_AUTH, null, 2)}\n`,
       {
         encoding: 'utf8',
         mode: 0o600,
       }
     );
+    expect(fsMocks.chmod).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), 0o600);
+    expect(fsMocks.rename).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), AUTH_FILE_PATH);
+    expect(fsMocks.writeFile).not.toHaveBeenCalledWith(AUTH_FILE_PATH, expect.anything(), expect.anything());
     expect(fsMocks.writeFile).not.toHaveBeenCalledWith(
       LEGACY_AUTH_FILE_PATH,
       expect.anything(),
       expect.anything()
     );
-    expect(fsMocks.rm).not.toHaveBeenCalled();
+    expect(fsMocks.rm).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), { force: true });
   });
 });
 
@@ -294,6 +343,54 @@ describe('ensureAuthenticated', () => {
 
     expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
+
+  it('forces 401-triggered client refresh through the file-backed refresh lock', async () => {
+    const storedAuth: StoredAuth = {
+      apiUrl: 'https://origin.example/cloud',
+      accessToken: 'rejected-access',
+      refreshToken: 'stored-refresh',
+      accessTokenExpiresAt: farFutureIso(),
+    };
+    const refreshedAuth: StoredAuth = {
+      apiUrl: storedAuth.apiUrl,
+      accessToken: 'accepted-access',
+      refreshToken: 'rotated-refresh',
+      accessTokenExpiresAt: farFutureIso(),
+    };
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(storedAuth));
+
+    const fetchSpy = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const requestUrl = String(input);
+      if (requestUrl.includes('/api/v1/auth/token/refresh')) {
+        return new Response(JSON.stringify(refreshedAuth), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      const headers = new Headers(init?.headers);
+      if (headers.get('authorization') === 'Bearer rejected-access') {
+        return new Response(JSON.stringify({ error: 'expired' }), { status: 401 });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const session = await ensureCloudSession({ apiUrl: 'https://ignored.example/cloud' });
+    const response = await session.client.fetch('/api/v1/workflows');
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const refreshCall = fetchSpy.mock.calls.find((call) =>
+      String(call[0]).includes('/api/v1/auth/token/refresh')
+    );
+    expect(refreshCall).toBeTruthy();
+    expect(JSON.parse(String((refreshCall?.[1] as RequestInit).body))).toEqual({
+      refreshToken: 'stored-refresh',
+    });
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(AUTH_LOCK_PATH, { mode: 0o700 });
+  });
 });
 
 describe('refreshStoredAuth', () => {
@@ -340,6 +437,7 @@ describe('refreshStoredAuth', () => {
       refreshToken: 'stored-refresh',
       accessTokenExpiresAt: '2026-04-13T12:00:00.000Z',
     };
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(auth));
 
     vi.stubGlobal(
       'fetch',
@@ -361,6 +459,101 @@ describe('refreshStoredAuth', () => {
     expect(error).toMatchObject({ code: 'AUTH_REFRESH_TIMEOUT' });
 
     vi.useRealTimers();
+  });
+
+  it('serializes concurrent file-backed refreshes and reuses the rotated token', async () => {
+    vi.useFakeTimers();
+    const staleAuth: StoredAuth = {
+      apiUrl: 'https://origin.example/cloud',
+      accessToken: 'stale-access',
+      refreshToken: 'stale-refresh',
+      accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
+    };
+    const freshAuth: StoredAuth = {
+      apiUrl: staleAuth.apiUrl,
+      accessToken: 'fresh-access',
+      refreshToken: 'fresh-refresh',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    };
+    let canonicalAuth = staleAuth;
+    let lockHeld = false;
+
+    fsMocks.readFile.mockImplementation(async (file: string) => {
+      if (file === AUTH_FILE_PATH) {
+        return JSON.stringify(canonicalAuth);
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    fsMocks.mkdir.mockImplementation(async (file: string) => {
+      if (file === AUTH_LOCK_PATH) {
+        if (lockHeld) {
+          throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' });
+        }
+        lockHeld = true;
+      }
+      return undefined;
+    });
+    fsMocks.stat.mockImplementation(async (file: string) => {
+      if (file === AUTH_LOCK_PATH && lockHeld) {
+        return { mtimeMs: Date.now() };
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    fsMocks.rename.mockImplementation(async (_temporaryPath: string, file: string) => {
+      if (file === AUTH_FILE_PATH) {
+        canonicalAuth = freshAuth;
+      }
+    });
+    fsMocks.rm.mockImplementation(async (file: string) => {
+      if (file === AUTH_LOCK_PATH) {
+        lockHeld = false;
+      }
+      return undefined;
+    });
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify(freshAuth), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const first = refreshStoredAuth(staleAuth);
+    const second = refreshStoredAuth(staleAuth);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(first).resolves.toEqual(freshAuth);
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(second).resolves.toEqual(freshAuth);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body))).toEqual({
+      refreshToken: 'stale-refresh',
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('releases the file-backed refresh lock when refresh throws', async () => {
+    const auth: StoredAuth = {
+      apiUrl: 'https://origin.example/cloud',
+      accessToken: 'stale-access',
+      refreshToken: 'stored-refresh',
+      accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
+    };
+    fsMocks.readFile.mockResolvedValue(JSON.stringify(auth));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw Object.assign(new Error('socket closed'), { name: 'NetworkError' });
+      })
+    );
+
+    await expect(refreshStoredAuth(auth)).rejects.toThrow('socket closed');
+
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(AUTH_LOCK_PATH, { mode: 0o700 });
+    expect(fsMocks.rm).toHaveBeenCalledWith(AUTH_LOCK_PATH, { recursive: true, force: true });
   });
 });
 

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -4,9 +4,10 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import { buildApiUrl } from './api-client.js';
-import { CloudApiClient } from './api-client.js';
+import { CloudApiClient, type CloudApiClientOptions, type CloudApiClientSnapshot } from './api-client.js';
 import { appendAgentRelayTelemetryHeaders } from './telemetry-headers.js';
 import {
   AUTH_FILE_PATH,
@@ -19,6 +20,12 @@ import {
   type CloudSessionOptions,
   type StoredAuth,
 } from './types.js';
+
+const AUTH_DIR_PATH = path.dirname(AUTH_FILE_PATH);
+const AUTH_LOCK_PATH = `${AUTH_FILE_PATH}.lock`;
+const AUTH_LOCK_RETRY_DELAY_MS = 50;
+const AUTH_LOCK_STALE_MS = 30_000;
+const AUTH_LOCK_TIMEOUT_MS = 30_000;
 
 const envBackedAuth = new WeakSet<StoredAuth>();
 
@@ -87,18 +94,34 @@ function isValidStoredAuth(value: unknown): value is StoredAuth {
   );
 }
 
+function isNodeErrorWithCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === code
+  );
+}
+
+async function readCanonicalStoredAuth(): Promise<StoredAuth | null> {
+  try {
+    const file = await fs.readFile(AUTH_FILE_PATH, 'utf8');
+    const parsed = JSON.parse(file) as unknown;
+    return isValidStoredAuth(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function readStoredAuth(env: NodeJS.ProcessEnv = process.env): Promise<StoredAuth | null> {
   const envAuth = readEnvAuth(env);
   if (envAuth) {
     return envAuth;
   }
 
-  try {
-    const file = await fs.readFile(AUTH_FILE_PATH, 'utf8');
-    const parsed = JSON.parse(file) as unknown;
-    return isValidStoredAuth(parsed) ? parsed : null;
-  } catch {
-    // Fall through to the one-time migration path below.
+  const stored = await readCanonicalStoredAuth();
+  if (stored) {
+    return stored;
   }
 
   try {
@@ -116,18 +139,93 @@ export async function readStoredAuth(env: NodeJS.ProcessEnv = process.env): Prom
 }
 
 export async function writeStoredAuth(auth: StoredAuth): Promise<void> {
-  await fs.mkdir(path.dirname(AUTH_FILE_PATH), {
+  await fs.mkdir(AUTH_DIR_PATH, {
     recursive: true,
     mode: 0o700,
   });
-  await fs.writeFile(AUTH_FILE_PATH, `${JSON.stringify(auth, null, 2)}\n`, {
-    encoding: 'utf8',
-    mode: 0o600,
-  });
+
+  const temporaryPath = path.join(
+    AUTH_DIR_PATH,
+    `.${path.basename(AUTH_FILE_PATH)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`
+  );
+
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(auth, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await fs.chmod(temporaryPath, 0o600);
+    await fs.rename(temporaryPath, AUTH_FILE_PATH);
+  } finally {
+    await fs.rm(temporaryPath, { force: true });
+  }
 }
 
 export async function clearStoredAuth(): Promise<void> {
   await fs.rm(AUTH_FILE_PATH, { force: true });
+}
+
+async function removeStaleStoredAuthLock(): Promise<boolean> {
+  try {
+    const lockStats = await fs.stat(AUTH_LOCK_PATH);
+    if (Date.now() - lockStats.mtimeMs < AUTH_LOCK_STALE_MS) {
+      return false;
+    }
+  } catch (error) {
+    if (isNodeErrorWithCode(error, 'ENOENT')) {
+      return true;
+    }
+    throw error;
+  }
+
+  await fs.rm(AUTH_LOCK_PATH, { recursive: true, force: true });
+  return true;
+}
+
+async function acquireStoredAuthLock(signal?: AbortSignal): Promise<void> {
+  const startedAt = Date.now();
+
+  while (true) {
+    if (signal?.aborted) {
+      throw signal.reason ?? new Error('Cloud auth lock acquisition aborted');
+    }
+
+    try {
+      await fs.mkdir(AUTH_LOCK_PATH, { mode: 0o700 });
+      return;
+    } catch (error) {
+      if (!isNodeErrorWithCode(error, 'EEXIST')) {
+        throw error;
+      }
+    }
+
+    if (await removeStaleStoredAuthLock()) {
+      continue;
+    }
+
+    if (Date.now() - startedAt >= AUTH_LOCK_TIMEOUT_MS) {
+      throw new Error(`Timed out waiting for cloud auth lock at ${AUTH_LOCK_PATH}`);
+    }
+
+    await delay(AUTH_LOCK_RETRY_DELAY_MS, undefined, { signal });
+  }
+}
+
+async function withStoredAuthLock<T>(
+  callback: () => Promise<T>,
+  options: { signal?: AbortSignal } = {}
+): Promise<T> {
+  await fs.mkdir(AUTH_DIR_PATH, {
+    recursive: true,
+    mode: 0o700,
+  });
+  await acquireStoredAuthLock(options.signal);
+
+  try {
+    return await callback();
+  } finally {
+    await fs.rm(AUTH_LOCK_PATH, { recursive: true, force: true });
+  }
 }
 
 function shouldRefresh(accessTokenExpiresAt: string): boolean {
@@ -370,6 +468,32 @@ async function beginBrowserLogin(apiUrl: string): Promise<StoredAuth> {
 
 export async function refreshStoredAuth(
   auth: StoredAuth,
+  options: { force?: boolean; refreshTimeoutMs?: number; signal?: AbortSignal } = {}
+): Promise<StoredAuth> {
+  if (isEnvBackedAuth(auth)) {
+    return markEnvBackedAuth(await requestStoredAuthRefresh(auth, options));
+  }
+
+  return withStoredAuthLock(async () => {
+    const latestAuth = await readCanonicalStoredAuth();
+    const refreshSource = latestAuth?.apiUrl === auth.apiUrl ? latestAuth : auth;
+
+    if (
+      !options.force &&
+      latestAuth?.apiUrl === auth.apiUrl &&
+      !shouldRefresh(latestAuth.accessTokenExpiresAt)
+    ) {
+      return latestAuth;
+    }
+
+    const nextAuth = await requestStoredAuthRefresh(refreshSource, options);
+    await writeStoredAuth(nextAuth);
+    return nextAuth;
+  }, options);
+}
+
+async function requestStoredAuthRefresh(
+  auth: StoredAuth,
   options: { refreshTimeoutMs?: number; signal?: AbortSignal } = {}
 ): Promise<StoredAuth> {
   const response = await fetchWithRefreshTimeout(
@@ -401,11 +525,6 @@ export async function refreshStoredAuth(
     accessTokenExpiresAt: payload.accessTokenExpiresAt,
   };
 
-  if (isEnvBackedAuth(auth)) {
-    return markEnvBackedAuth(nextAuth);
-  }
-
-  await writeStoredAuth(nextAuth);
   return nextAuth;
 }
 
@@ -472,24 +591,38 @@ export async function ensureCloudSession(options: CloudSessionOptions = {}): Pro
 }
 
 function createCloudSession(auth: StoredAuth, options: { refreshTimeoutMs?: number } = {}): CloudSession {
-  const client = new CloudApiClient({
+  const clientOptions: CloudApiClientOptions = {
     ...auth,
     refreshTimeoutMs: options.refreshTimeoutMs,
-    onRefresh: async (snapshot) => {
-      if (isEnvBackedAuth(auth)) {
-        return;
-      }
+  };
 
-      await writeStoredAuth({
-        apiUrl: snapshot.apiUrl,
-        accessToken: snapshot.accessToken,
-        refreshToken: snapshot.refreshToken,
-        accessTokenExpiresAt: snapshot.accessTokenExpiresAt,
-      });
-    },
-  });
+  if (!isEnvBackedAuth(auth)) {
+    clientOptions.refreshAuth = async (snapshot, refreshOptions) =>
+      toCloudApiClientSnapshot(
+        await refreshStoredAuth(toStoredAuth(snapshot), {
+          force: refreshOptions.force,
+          refreshTimeoutMs: options.refreshTimeoutMs,
+          signal: refreshOptions.signal,
+        })
+      );
+  }
+
+  const client = new CloudApiClient(clientOptions);
 
   return { auth, client };
+}
+
+function toStoredAuth(snapshot: CloudApiClientSnapshot): StoredAuth {
+  return {
+    apiUrl: snapshot.apiUrl,
+    accessToken: snapshot.accessToken,
+    refreshToken: snapshot.refreshToken,
+    accessTokenExpiresAt: snapshot.accessTokenExpiresAt,
+  };
+}
+
+function toCloudApiClientSnapshot(auth: StoredAuth): CloudApiClientSnapshot {
+  return auth;
 }
 
 function apiFetch(
@@ -526,6 +659,7 @@ export async function authorizedApiFetch(
 
   try {
     activeAuth = await refreshStoredAuth(activeAuth, {
+      force: true,
       refreshTimeoutMs: options.refreshTimeoutMs,
       signal: init.signal ?? undefined,
     });


### PR DESCRIPTION
## Summary
- write cloud auth through a pid-scoped sibling temp file, chmod 0600, then atomic rename
- serialize file-backed read-refresh-write with a stale-aware cross-process lock and re-read/re-check stored auth under the lock
- route file-backed CloudApiClient refreshes, including 401-forced refreshes, through the locked refresh path

## Tests
- npx vitest run packages/cloud/src
- npm run build:config && npm --prefix packages/cloud run build

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

