### PR TITLE
chore(deps): update @relaycast/sdk to 4.0 in @agent-relay/sdk + cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `@agent-relay/sdk` and `@agent-relay/cli` now depend on `@relaycast/sdk` 4.0 (durable-delivery status model `queued|delivered|acked|failed|dead_lettered`).
+
 - `codex-relay-skill` and `gemini-relay-extension` now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK. Set `RELAY_BASE_URL` to keep using `https://api.relaycast.dev`.
 - `agent-relay local agent message hold|flush|auto <name>` now owns local broker delivery controls; the old top-level `agent-relay agent message ...` path was removed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6461,11 +6461,11 @@
       }
     },
     "node_modules/@relaycast/sdk": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-3.1.1.tgz",
-      "integrity": "sha512-r7hGpbJ4+hgUpJ8LTvup9vVeEKOyG38w9qTeDd4/cmWA1X2zLdznl82j7wVIORk5hnpHCuzddVUwB9BdvtsH5w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.0.0.tgz",
+      "integrity": "sha512-x6aHC0w2tIorE/gtU5iBc6bHUj0vmYySIye8NFg4aC8jbFwELRoy1xKtlYgiwmSK23eZ/zZ9xxMeI33i7OI+7Q==",
       "dependencies": {
-        "@relaycast/types": "3.1.1",
+        "@relaycast/types": "4.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -6479,9 +6479,9 @@
       }
     },
     "node_modules/@relaycast/types": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-3.1.1.tgz",
-      "integrity": "sha512-sfBnWGw4LsxCFgDl51bPJTVYtCUAf0kHXLFfw+HKAZUZkWNK9Sg+fkcPlGynsU/LWFFYuvQcFy14yDx3cgq/HA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-ag9GYFe/1jsWhDpWdUW8gZwdr0wJ9/jj/aq4oNHQVOFmjJERN3gM0BX0o2c/iWnl0VS4lWjEnC04fH9/QbxZQQ==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -6565,41 +6565,6 @@
         "strip-ansi": "^7.2.0",
         "yaml": "^2.7.0",
         "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@relayflows/core/node_modules/@relaycast/sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-1.2.0.tgz",
-      "integrity": "sha512-/tBN0Up1X+MMQzyyUq9jNSkoTuPtRWcfno3t5iO8PBCJkE9+b89RY+6SxcmII9+8EjlEgMb3xqYey414wDuwTQ==",
-      "dependencies": {
-        "@relaycast/types": "1.2.0",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@relayflows/core/node_modules/@relaycast/sdk/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@relayflows/core/node_modules/@relaycast/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-ZgnK3VN6RkE2/P+eDRmcr6f4N66yTELT3PHk4ZjIKlmZBL0vgwCZCKC4ZxJrEkcaOPWP4bx3LpajSIKWke6kYA==",
-      "dependencies": {
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@relayflows/core/node_modules/@relaycast/types/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@relayflows/core/node_modules/ansi-regex": {
@@ -19675,7 +19640,7 @@
         "@agent-relay/sdk": "8.7.2",
         "@agent-relay/utils": "8.7.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^3.1.1",
+        "@relaycast/sdk": "^4.0.0",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -19732,98 +19697,7 @@
       "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.6.0"
-      }
-    },
-    "packages/evals/node_modules/@agent-relay/broker-darwin-arm64": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-8.6.0.tgz",
-      "integrity": "sha512-UYtgASeiTaznHwh6epYj6UcR0N756MgUz4PSiUQDReKbv504t7VCsEY/oIV7tB77qVGTaniwvBfEtSeUw38M2Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/evals/node_modules/@agent-relay/broker-darwin-x64": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-8.6.0.tgz",
-      "integrity": "sha512-JwCjAiWKtzRKONM5uMyxEa1Fe2xIMQAiHBwOSPZCztInZF+yGUXGvU44xd4OX59ocFTylWxvsKgBGcLDphX88Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/evals/node_modules/@agent-relay/broker-linux-arm64": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-8.6.0.tgz",
-      "integrity": "sha512-AKdsnk/juFCLy1/ecm7OesqSvUg+AQ4V9VXWxeu2cQy7ZM69JFvIF3RNrUHmntB0qlub6kraDnj9Dk802Toz2Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/evals/node_modules/@agent-relay/broker-linux-x64": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-8.6.0.tgz",
-      "integrity": "sha512-XEwftmuPX9EPm87B67qNNr0c2DadP8dq0vpGuidZk/Il9I+jRZf1juQDb53SnjqpeEEZSBpkzk6u2Vr8MPEnbw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/evals/node_modules/@agent-relay/broker-win32-x64": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-8.6.0.tgz",
-      "integrity": "sha512-8Bn9ZzTWt7nnitUAVsIlCxaoTa4WVdfnHEmIJ1Bez+bcEyM8Ur+xKbk9D8+SCBi6Fv9g3B71GIPKKV/1VSB4iA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/evals/node_modules/@agent-relay/harness-driver": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/harness-driver/-/harness-driver-8.6.0.tgz",
-      "integrity": "sha512-MWTjkqK3o/1u8KUp6+/7RsMlXHERmiVTIStXhBlZEFGoT6Z5mPSzgVOBT3wSdZg9/iYFbH8vcVLL9jhk649ywQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@agent-relay/sdk": "8.6.0",
-        "ws": "^8.18.3",
-        "zod": "^3.23.8"
-      },
-      "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.6.0",
-        "@agent-relay/broker-darwin-x64": "8.6.0",
-        "@agent-relay/broker-linux-arm64": "8.6.0",
-        "@agent-relay/broker-linux-x64": "8.6.0",
-        "@agent-relay/broker-win32-x64": "8.6.0"
-      }
-    },
-    "packages/evals/node_modules/@agent-relay/sdk": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-8.6.0.tgz",
-      "integrity": "sha512-1ngoap4oGuA6iDMZvUSl4lHfOSuyLJlXdiFmc6hnDAYIMo89xvkAFN9r7ENNg5v7mcg0R7EuIAD+e7D0vdMg8A==",
-      "dependencies": {
-        "@relaycast/sdk": "^3.1.1"
+        "@agent-relay/harness-driver": "8.7.2"
       }
     },
     "packages/fleet": {
@@ -19878,7 +19752,7 @@
       "name": "@agent-relay/sdk",
       "version": "8.7.2",
       "dependencies": {
-        "@relaycast/sdk": "^3.1.1"
+        "@relaycast/sdk": "^4.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.10"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@agent-relay/sdk": "8.7.2",
     "@agent-relay/utils": "8.7.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^3.1.1",
+    "@relaycast/sdk": "^4.0.0",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -63,7 +63,7 @@
     "check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@agent-relay/harness-driver": "8.6.0"
+    "@agent-relay/harness-driver": "8.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,6 +59,6 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^3.1.1"
+    "@relaycast/sdk": "^4.0.0"
   }
 }


### PR DESCRIPTION
## What
Bumps `@relaycast/sdk` `^3.1.1` → `^4.0.0` in **`@agent-relay/sdk`** and **`@agent-relay/cli`** (relay's two consumers).

## The real root cause (no override needed)
The naive bump broke one test because of a **version skew**: `packages/evals` pinned `@agent-relay/harness-driver: "8.6.0"` — an exact **published** version, while the workspace is `8.7.2`. The repo convention is to pin siblings at the exact workspace version so npm **symlinks the local package**; `8.6.0 ≠ 8.7.2` made npm fetch the *published* `8.6.0` from the registry, dragging in `@agent-relay/sdk@8.6.0 → @relaycast/sdk@3.1.1` and preventing a single `@relaycast/sdk` from hoisting. That left relay's own SDK on a *nested* `4.0.0` the MCP-startup test's mock couldn't intercept.

**Fix:** repin `evals` to `8.7.2` (matching every other workspace cross-dep) so it uses the local `harness-driver` — which pulls no `@relaycast/sdk`. `@relaycast/sdk@4.0.0` then hoists cleanly. **No override.**

## Safety
relay's SDK only uses `RelayCast`/`RelayError`/options from `@relaycast/sdk` — none touched by 4.0's breaking changes. `build:core` clean, **full suite 924 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)