### PR TITLE
fix(cli): unblock Publish Package — mock @agent-relay/sdk boundary in MCP startup test

### DIFF
--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -199,6 +199,27 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
   }) as any;
   RelayCast.createWorkspace = vi.fn((name: string) => behavior.createWorkspaceImpl(name));
 
+  // The query_nodes tool constructs `new AgentRelay(...)` from @agent-relay/sdk
+  // and calls `.nodes.list()`. AgentRelay wraps @relaycast/sdk internally, so
+  // mocking only @relaycast/sdk leaves this path dependent on the two packages
+  // resolving the SAME physical @relaycast/sdk copy. A fresh publish-time
+  // `npm install` can nest a duplicate @relaycast/sdk under packages/sdk, at
+  // which point AgentRelay's internal client is the real (unmocked) one and the
+  // call escapes to a live HTTP request. Mock the direct boundary so the test is
+  // independent of node_modules hoisting.
+  const agentRelayNodesList = vi.fn(async (_query?: { capability?: string; name?: string }) => [
+    {
+      name: 'node-a',
+      status: 'online',
+      capabilities: [{ name: 'spawn:codex' }],
+    },
+  ]);
+  const AgentRelayMock = vi.fn(function (this: unknown) {
+    return {
+      nodes: { list: agentRelayNodesList },
+    };
+  }) as any;
+
   vi.doMock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
     McpServer: FakeMcpServer,
     ResourceTemplate: class ResourceTemplate {
@@ -218,6 +239,10 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
     RelayCast,
     SDK_VERSION: 'test-sdk-version',
   }));
+  vi.doMock('@agent-relay/sdk', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('@agent-relay/sdk');
+    return { ...actual, AgentRelay: AgentRelayMock };
+  });
   vi.doMock('./telemetry/index.js', () => ({
     initTelemetry: telemetryInit,
     shutdown: telemetryShutdown,


### PR DESCRIPTION
## Problem

The **Publish Package** workflow ([run 27598076243](https://github.com/AgentWorkforce/relay/actions/runs/27598076243/job/81592508122)) fails its `Run tests` step with a single failure:

```
RelayError: Route not found
 ❯ relayErrorFromApi packages/sdk/node_modules/@relaycast/sdk/src/errors.ts:101:9
 ❯ Object.list           packages/sdk/src/messaging/relaycast.ts:984:8
 ❯ agent-relay-mcp.ts:1237  (query_nodes handler)
 ❯ agent-relay-mcp.startup.test.ts:352
```

This is release-blocking: `npm test` runs in the publish job, so the failure aborts the release.

## Root cause

The `query_nodes` MCP tool constructs `new AgentRelay(...)` from **`@agent-relay/sdk`** and calls `.nodes.list()`. `AgentRelay` wraps **`@relaycast/sdk`** internally, but the test only mocks `@relaycast/sdk` — so the path works *only* when `packages/cli` and `packages/sdk` resolve the **same physical `@relaycast/sdk` copy**.

- On `main`, `@relaycast/sdk@4.0.0` hoists to a single root copy → the mock applies → green.
- The publish job regenerates the lockfile (`rm -rf package-lock.json && npm install`) at the freshly-bumped version. The tree's pre-existing `@relaycast/sdk` skew (a stray transitive `1.2.0`, plus `@relayflows/core` pinning `^1.1.0`) tips the resolver into nesting a **duplicate** `@relaycast/sdk` under `packages/sdk`. `AgentRelay`'s internal client is then the **real, unmocked** copy → live HTTP request → `Route not found`.

The stack confirms it: the unmocked client resolves from `packages/sdk/node_modules/@relaycast/sdk`, not the hoisted root copy.

This is a **monorepo publish-time artifact, not a production bug** — a real end-user install dedupes `@relaycast/sdk@^4.0.0` to one copy, so `AgentRelay` works fine. Production code is therefore untouched.

## Fix

Mock the **direct boundary** the handler uses (`@agent-relay/sdk`'s `AgentRelay`) instead of the transitive `@relaycast/sdk`, via `importActual` + override so the real token-helper exports stay intact. The `query_nodes` path is now independent of `node_modules` hoisting — aligning with the repo convention to "mock the boundary, not internal modules".

## Verification

Forced the nested-duplicate scenario locally (`cp` the root `@relaycast/sdk` into `packages/sdk/node_modules`):

| | nested duplicate present |
|---|---|
| **pre-fix** | ❌ reproduces `RelayError: Route not found` |
| **post-fix** | ✅ 16/16 pass |

- Full `packages/cli` suite: **362 passed, 5 skipped**.
- No production code changed.

## Follow-up (not in this PR)

The underlying dep skew (`@relaycast/sdk@1.2.0` / `@relayflows/core@^1.1.0`) is the same version-hygiene fragility tracked in #1134. This PR makes the test resilient; tightening the dep tree is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

