### PR TITLE
docs(fleets): add Fleets setup page

### DIFF
--- a/web/content/docs/fleets.mdx
+++ b/web/content/docs/fleets.mdx
@@ -1,0 +1,108 @@
+---
+title: 'Fleets'
+description: 'Run agents on dedicated machines — like a Mac mini with Claude Code and Codex — instead of your laptop.'
+---
+
+Agents have to run *somewhere*. By default that's your laptop — which means they die when you close
+it. A **fleet node** is a long-lived process on a dedicated machine that the workspace can spawn
+agents onto. Put a Mac mini in the corner running Claude Code and Codex, point the workspace at it,
+and anyone can `spawn` an agent that boots there, joins your channels, and keeps working after you
+walk away.
+
+One `fleet serve` = one node. A node advertises which harnesses it can run; the workspace spawns onto
+nodes that have the harness you asked for.
+
+<Note>
+  Fleets are behind a per-workspace flag (`fleet_nodes_enabled`), **off by default**. Ask your
+  operator to enable it before serving a node.
+</Note>
+
+## Set up a node
+
+On the machine (the Mac mini), install the harness CLIs (`claude`, `codex`) on `PATH`, then:
+
+```bash
+npm install @agent-relay/fleet @agent-relay/harnesses zod
+```
+
+Describe the node — what it's named and which harnesses it offers:
+
+```ts file="macmini.node.ts"
+import { claude, codex } from '@agent-relay/harnesses';
+import { defineNode, spawn } from '@agent-relay/fleet';
+
+export default defineNode({
+  name: 'macmini-1',
+  maxAgents: 8,
+  capabilities: {
+    'spawn:claude': spawn(claude),
+    'spawn:codex': spawn(codex),
+  },
+});
+```
+
+Serve it — this process *is* the node, so keep it running:
+
+```bash
+RELAY_WORKSPACE_KEY=rk_live_... agent-relay fleet serve ./macmini.node.ts
+```
+
+Confirm it registered:
+
+```bash
+agent-relay fleet nodes     # macmini-1, with spawn:claude / spawn:codex
+agent-relay fleet status    # handlers_live: true when ready
+```
+
+## Spawn onto it
+
+Agents reach the fleet through their MCP tools — no extra wiring:
+
+- **`query_nodes`** — find nodes by capability (`which node can spawn:codex?`).
+- **`spawn`** — launch an agent on a node by name, or let the workspace pick one with the capability.
+
+So "spawn a Claude Code agent on the Mac mini to fix this bug" boots an agent on `macmini-1` that
+joins the channel and reports back — no SSH. Run a second machine the same way (its own node file,
+different `name`) and work spreads across both.
+
+## Add actions and triggers
+
+A node can also expose typed [actions](/docs/actions) and react to messages:
+
+```ts file="macmini.node.ts"
+import { z } from 'zod';
+import { claude, codex } from '@agent-relay/harnesses';
+import { action, defineNode, onMessage, spawn } from '@agent-relay/fleet';
+
+export default defineNode({
+  name: 'macmini-1',
+  capabilities: {
+    'spawn:claude': spawn(claude),
+    'spawn:codex': spawn(codex),
+    echo: action({ input: z.object({ text: z.string() }) }, async (input, ctx) => {
+      await ctx.relay.sendMessage({ to: 'general', text: input.text });
+      return { echoed: input.text };
+    }),
+  },
+  triggers: [onMessage({ channel: '#general', match: /echo:/ }, 'echo')],
+});
+```
+
+<Note>
+  Trigger regexes must be flag-free — `defineNode` rejects `/ship/i`; use `/[Ss]hip/` instead.
+</Note>
+
+<CardGroup cols={2}>
+  <Card title="Harnesses" href="/docs/harnesses">
+    The agents a node can spawn.
+  </Card>
+  <Card title="Actions" href="/docs/actions">
+    Typed capabilities a node exposes.
+  </Card>
+  <Card title="Workspaces" href="/docs/workspaces">
+    Where the workspace key lives.
+  </Card>
+  <Card title="Agent Relay MCP" href="/docs/agent-relay-mcp">
+    The query_nodes and spawn tools.
+  </Card>
+</CardGroup>

--- a/web/lib/docs-nav.ts
+++ b/web/lib/docs-nav.ts
@@ -48,6 +48,10 @@ export const docsNav: NavGroup[] = [
     ],
   },
   {
+    title: 'Fleets',
+    items: [{ title: 'Fleets', slug: 'fleets' }],
+  },
+  {
     title: 'Interfaces',
     items: [
       { title: 'TypeScript SDK', slug: 'typescript-sdk' },


### PR DESCRIPTION
Adds a concise, example-driven **Fleets** docs page and a "Fleets" nav group.

Explains *why* nodes exist (agents need a host that outlives your laptop) and walks through the most common setup — a Mac mini in the workspace running Claude Code and Codex as harnesses:

- **Set up a node** — `defineNode` with `spawn:claude` / `spawn:codex`, then `fleet serve`; verify with `fleet nodes` / `fleet status`.
- **Spawn onto it** — `query_nodes` and `spawn` from an agent.
- **Add actions and triggers** — `action(...)` + `onMessage(...)`.
- A `Note` on the off-by-default `fleet_nodes_enabled` flag.

496 words, high signal-to-noise per review feedback. Only `web/content/docs/fleets.mdx` and `web/lib/docs-nav.ts` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

