### PR TITLE
ci(publish): publish @agent-relay/fleet in the release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1021,6 +1021,55 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+  # Publish @agent-relay/fleet after @agent-relay/harnesses lands on the
+  # registry. fleet pins @agent-relay/{harnesses,harness-driver,sdk} by exact
+  # version, so publishing it before harnesses exists would leave a window where
+  # `npm install @agent-relay/fleet@<v>` cannot resolve its dependencies — the
+  # same install race the broker/sdk/harnesses ordering above is built to avoid.
+  # The root CLI depends on @agent-relay/fleet, so this must finish before
+  # publish-main (wired via publish-main's needs).
+  publish-fleet:
+    name: Publish fleet
+    needs: [build, publish-harnesses]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'all'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: .
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Dry run check
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/fleet
+        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Publish to NPM
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/fleet
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
+            exit 0
+          fi
+          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
   # package=main publishes only the root `agent-relay` tarball, but that
   # tarball pins several @agent-relay/* runtime dependencies to the freshly
   # bumped version. Publish those direct deps first so a main-only release
@@ -1443,7 +1492,7 @@ jobs:
   # Publish main package
   publish-main:
     name: Publish Main Package
-    needs: [build, verify-binaries, publish-packages, publish-main-runtime-deps]
+    needs: [build, verify-binaries, publish-packages, publish-fleet, publish-main-runtime-deps]
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.publish_root.outputs.published }}
@@ -1453,6 +1502,7 @@ jobs:
       needs.build.result == 'success' &&
       (needs.verify-binaries.result == 'success' || (needs.verify-binaries.result == 'skipped' && github.event.inputs.package == 'cli-prerelease')) &&
       (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') &&
+      (needs.publish-fleet.result == 'success' || needs.publish-fleet.result == 'skipped') &&
       (needs.publish-main-runtime-deps.result == 'success' || needs.publish-main-runtime-deps.result == 'skipped')
 
     steps:


### PR DESCRIPTION
## Problem

The **Publish Package** workflow ([run 27600505024](https://github.com/AgentWorkforce/relay/actions/runs/27600505024/job/81604501986)) failed twice in **Publish Main Package**:

```
Waiting for npm registry propagation: @agent-relay/fleet@8.8.0
...
Timed out waiting for CLI @agent-relay/* dependencies:
  - @agent-relay/fleet@8.8.0
```

The root `agent-relay` CLI now depends on **`@agent-relay/fleet`**, so `publish-main`'s "Wait for CLI internal dependencies" step (which derives its list from `packages/cli/package.json`'s `@agent-relay/*` deps) blocks on `@agent-relay/fleet@<bumped version>`. But `fleet` was never added to the publish workflow, so on the all-package release nothing publishes it → the wait loop (12×10s) times out.

> Note: the `Build & Version` job (which runs the test suite) **passed** this time — the earlier mock fix (#1135) is working. This is a separate, downstream gap.

## Fix

Add a `publish-fleet` job that:
- runs after `publish-harnesses` — `fleet` pins `@agent-relay/{harnesses,harness-driver,sdk}` by exact version, so it must land **after** `harnesses` to avoid the same install-resolution race the broker/sdk/harnesses ordering already guards against;
- is gated `if: package == 'all'` (mirrors `publish-harnesses`);
- skips if the version already exists, and publishes with `--provenance` like every other package.

Wire it into `publish-main`'s `needs` + `if` so the root tarball is only published once `fleet` is on the registry.

## ⚠️ Manual step required before the next release

`@agent-relay/fleet@8.7.2` was a **manual token publish** (no provenance attestations), so the package has **no npm Trusted Publisher** configured. This workflow publishes via OIDC (`id-token: write` + `--provenance`, no `NODE_AUTH_TOKEN` anywhere), so the new `publish-fleet` job will fail auth until the Trusted Publisher for `@agent-relay/fleet` is added on npmjs.com → Package settings → Trusted Publishing → GitHub Actions → repo `AgentWorkforce/relay`, workflow `publish.yml`.

## Validation

- `actionlint` clean (no new findings).
- Job graph verified: `publish-fleet` defined, referenced in `publish-main` `needs` + `if`.
- `npm publish --dry-run` for `packages/fleet` packs cleanly (6 files: `dist/` + README + package.json).

## Follow-up (not in this PR)

The `main` / `cli-prerelease` release path (`publish-main-runtime-deps`) also doesn't publish `fleet` (or its `harnesses` dep). It's a less-common path and was already incomplete for fleet; worth covering separately if those paths are used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

