### PR TITLE
feat(evals): add mount scoring and onboarding variants to @agent-relay/evals

### DIFF
--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-relay/evals",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "Agent Relay eval harness — scenario runner, broker harness, and scoring utilities for testing relay-connected agents",
   "type": "module",
   "main": "dist/index.js",
@@ -45,6 +45,11 @@
       "types": "./dist/scenarios/onboarding.d.ts",
       "import": "./dist/scenarios/onboarding.js",
       "default": "./dist/scenarios/onboarding.js"
+    },
+    "./scoring/mount": {
+      "types": "./dist/scoring/mount.d.ts",
+      "import": "./dist/scoring/mount.js",
+      "default": "./dist/scoring/mount.js"
     },
     "./scenarios/core": {
       "types": "./dist/scenarios/index.d.ts",

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -22,6 +22,10 @@ export type {
   AgentInfo,
   TranscriptEntry,
   Phantom,
+  // Mount / writeback eval types
+  MountScenario,
+  MountScenarioResult,
+  MountCellMetrics,
 } from './types.js';
 
 export { SCHEMA_VERSION } from './types.js';

--- a/packages/evals/src/scenarios/onboarding.ts
+++ b/packages/evals/src/scenarios/onboarding.ts
@@ -1,0 +1,65 @@
+/**
+ * Onboarding variants for spawn/release reliability evals.
+ *
+ * Ordered from lightest to heaviest. The eval runner tests each variant and
+ * the goal is to find the MINIMUM text that achieves 10/10 reliability, so
+ * variants at the top of the list are preferred if they prove sufficient.
+ *
+ * bare        → zero spawn/release guidance (measures the baseline failure rate)
+ * one-liner   → single sentence naming both tools (minimum viable hint)
+ * brief       → tool names + parameters + when-to-use (compact but complete)
+ * skill       → full reference with examples (maximum clarity, maximum tokens)
+ */
+
+export type OnboardingVariant = 'bare' | 'one-liner' | 'brief' | 'skill';
+
+export const ONBOARDING_VARIANTS: OnboardingVariant[] = ['bare', 'one-liner', 'brief', 'skill'];
+
+/**
+ * Return the onboarding text suffix for a given variant.
+ * Appended to the scenario-specific role description.
+ */
+export function onboardingText(variant: OnboardingVariant): string {
+  switch (variant) {
+    case 'bare':
+      return '';
+
+    case 'one-liner':
+      return '\n\nCall mcp__agent-relay__add_agent to spawn a worker agent for a task, and mcp__agent-relay__remove_agent to release workers when they are done.';
+
+    case 'brief':
+      return `
+
+## Agent management
+- Spawn a relay worker: mcp__agent-relay__add_agent({ name, cli: "claude", task })
+  name = unique identifier, task = full instructions for the worker.
+- Release a relay worker: mcp__agent-relay__remove_agent({ name })
+When the task says to delegate or assign work, call add_agent. Release with remove_agent when the worker reports done.`;
+
+    case 'skill':
+      return `
+
+## Managing Worker Agents
+
+### Spawn a relay worker
+To delegate work, call:
+  mcp__agent-relay__add_agent({ name: "WorkerName", cli: "claude", task: "detailed instructions" })
+
+Required fields: name (unique string), cli ("claude"), task (full instructions for the worker).
+The relay worker will DM you "ACK: <understanding>" when it starts and "DONE: <result>" when complete.
+
+**Important**: When your task asks you to "assign to a worker", "delegate to an agent", or "spawn a relay worker",
+this means calling mcp__agent-relay__add_agent — never your built-in Task capability.
+
+### Release a relay worker
+As soon as a relay worker reports done, call:
+  mcp__agent-relay__remove_agent({ name: "WorkerName" })
+
+Always release relay workers when done — unreleased agents waste resources.
+
+### When to spawn vs do the work yourself
+If the task explicitly asks you to delegate or assign work to a worker, always spawn — do not do it yourself.
+Spawn for anything large, parallel, or that needs specialised focus.
+Only handle it yourself when the task is trivial AND you were not asked to delegate.`;
+  }
+}

--- a/packages/evals/src/scenarios/onboarding.ts
+++ b/packages/evals/src/scenarios/onboarding.ts
@@ -13,7 +13,7 @@
 
 export type OnboardingVariant = 'bare' | 'one-liner' | 'brief' | 'skill';
 
-export const ONBOARDING_VARIANTS: OnboardingVariant[] = ['bare', 'one-liner', 'brief', 'skill'];
+export const ONBOARDING_VARIANTS = ['bare', 'one-liner', 'brief', 'skill'] as const satisfies readonly OnboardingVariant[];
 
 /**
  * Return the onboarding text suffix for a given variant.
@@ -61,5 +61,8 @@ Always release relay workers when done — unreleased agents waste resources.
 If the task explicitly asks you to delegate or assign work to a worker, always spawn — do not do it yourself.
 Spawn for anything large, parallel, or that needs specialised focus.
 Only handle it yourself when the task is trivial AND you were not asked to delegate.`;
+
+    default:
+      throw new Error(`Unknown OnboardingVariant: ${variant as string}`);
   }
 }

--- a/packages/evals/src/scenarios/onboarding.ts
+++ b/packages/evals/src/scenarios/onboarding.ts
@@ -13,7 +13,12 @@
 
 export type OnboardingVariant = 'bare' | 'one-liner' | 'brief' | 'skill';
 
-export const ONBOARDING_VARIANTS = ['bare', 'one-liner', 'brief', 'skill'] as const satisfies readonly OnboardingVariant[];
+export const ONBOARDING_VARIANTS = [
+  'bare',
+  'one-liner',
+  'brief',
+  'skill',
+] as const satisfies readonly OnboardingVariant[];
 
 /**
  * Return the onboarding text suffix for a given variant.

--- a/packages/evals/src/scoring/mount.ts
+++ b/packages/evals/src/scoring/mount.ts
@@ -112,9 +112,7 @@ export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
 
   const relFiles = newFiles.map((f) => relative(mountDir, f));
   const inExpectedPath = relFiles.filter((p) => p.startsWith(expectedPathPrefix));
-  const inDiscovery = relFiles.filter(
-    (p) => p.includes('/discovery/') || p.startsWith('discovery/'),
-  );
+  const inDiscovery = relFiles.filter((p) => p.includes('/discovery/') || p.startsWith('discovery/'));
 
   const jsonValid =
     inExpectedPath.length > 0 &&

--- a/packages/evals/src/scoring/mount.ts
+++ b/packages/evals/src/scoring/mount.ts
@@ -13,7 +13,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 import type { BrokerEvent } from '@agent-relay/harness-driver';
 
@@ -110,9 +110,11 @@ export function newMountFiles(mountDir: string, snapshot: Set<string>): string[]
 export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
   const { mountDir, newFiles, expectedPathPrefix, events, cleanExit = true } = opts;
 
-  const relative = newFiles.map((f) => f.replace(mountDir + '/', ''));
-  const inExpectedPath = relative.filter((p) => p.startsWith(expectedPathPrefix));
-  const inDiscovery = relative.filter((p) => p.includes('/discovery/') || p.startsWith('discovery/'));
+  const relFiles = newFiles.map((f) => relative(mountDir, f));
+  const inExpectedPath = relFiles.filter((p) => p.startsWith(expectedPathPrefix));
+  const inDiscovery = relFiles.filter(
+    (p) => p.includes('/discovery/') || p.startsWith('discovery/'),
+  );
 
   const jsonValid =
     inExpectedPath.length > 0 &&
@@ -128,14 +130,14 @@ export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
   const usedRelayMessaging = events.some((e) => e.kind === 'relay_inbound');
 
   return {
-    wroteSomething: relative.length > 0,
+    wroteSomething: relFiles.length > 0,
     correctPath: inExpectedPath.length > 0,
     jsonValid,
     discoveryViolation: inDiscovery.length > 0,
     usedRelayMessaging,
     cleanExit,
     pass: inExpectedPath.length > 0 && jsonValid && inDiscovery.length === 0,
-    filesWritten: relative,
+    filesWritten: relFiles,
     filesAtCorrectPath: inExpectedPath,
   };
 }

--- a/packages/evals/src/scoring/mount.ts
+++ b/packages/evals/src/scoring/mount.ts
@@ -112,9 +112,7 @@ export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
 
   const relative = newFiles.map((f) => f.replace(mountDir + '/', ''));
   const inExpectedPath = relative.filter((p) => p.startsWith(expectedPathPrefix));
-  const inDiscovery = relative.filter(
-    (p) => p.includes('/discovery/') || p.startsWith('discovery/'),
-  );
+  const inDiscovery = relative.filter((p) => p.includes('/discovery/') || p.startsWith('discovery/'));
 
   const jsonValid =
     inExpectedPath.length > 0 &&
@@ -150,7 +148,16 @@ export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
  */
 export function mountCellStats(scores: MountScore[]): MountCellStats {
   const n = scores.length;
-  if (n === 0) return { runs: 0, passed: 0, passRate: 0, wroteSomethingRate: 0, correctPathRate: 0, discoveryViolationRate: 0, usedRelayMessagingRate: 0 };
+  if (n === 0)
+    return {
+      runs: 0,
+      passed: 0,
+      passRate: 0,
+      wroteSomethingRate: 0,
+      correctPathRate: 0,
+      discoveryViolationRate: 0,
+      usedRelayMessagingRate: 0,
+    };
   const rate = (pred: (s: MountScore) => boolean) => scores.filter(pred).length / n;
   return {
     runs: n,

--- a/packages/evals/src/scoring/mount.ts
+++ b/packages/evals/src/scoring/mount.ts
@@ -1,0 +1,164 @@
+/**
+ * Filesystem scoring utilities for agents that use a relayfile writeback mount.
+ *
+ * The writeback pattern: an agent writes a JSON file to a path under the
+ * .integrations/ mount (e.g. .integrations/slack/channels/<id>/messages/msg.json)
+ * and the relayfile writeback consumer picks it up and dispatches to the provider.
+ *
+ * Usage:
+ *   const snapshot = snapshotMount(fixtureDir)
+ *   // ... spawn agent, wait for exit ...
+ *   const newFiles = newMountFiles(fixtureDir, snapshot)
+ *   const score = scoreMountRun({ mountDir: fixtureDir, newFiles, expectedPathPrefix, events })
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { BrokerEvent } from '@agent-relay/harness-driver';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Per-dimension scoring for one mount writeback eval run. */
+export interface MountScore {
+  /** Agent created at least one file under the mount root. */
+  wroteSomething: boolean;
+  /** File(s) landed under the expected path prefix (correct provider + resource). */
+  correctPath: boolean;
+  /** All files at the expected path are syntactically valid JSON. */
+  jsonValid: boolean;
+  /** Agent wrote under discovery/ — schema-only, must never happen. */
+  discoveryViolation: boolean;
+  /** Agent sent at least one relay_inbound message instead of/in addition to writing a file. */
+  usedRelayMessaging: boolean;
+  /** Agent exited cleanly rather than timing out. */
+  cleanExit: boolean;
+  /** Overall pass: correctPath && jsonValid && !discoveryViolation. */
+  pass: boolean;
+  /** All files created by the agent, relative to mountDir. */
+  filesWritten: string[];
+  /** Subset of filesWritten that match expectedPathPrefix. */
+  filesAtCorrectPath: string[];
+}
+
+/** Options for scoreMountRun(). */
+export interface ScoreMountRunOptions {
+  /** Root of the .integrations/ mount directory (absolute path). */
+  mountDir: string;
+  /** Files created by the agent since spawning (from newMountFiles). */
+  newFiles: string[];
+  /**
+   * Expected path prefix the writeback file must be under (relative to mountDir).
+   * Example: ".integrations/slack/channels/C12345__general/messages/"
+   */
+  expectedPathPrefix: string;
+  /** Broker events captured during the run. */
+  events: BrokerEvent[];
+  /** Whether the agent exited without timing out. Defaults to true. */
+  cleanExit?: boolean;
+}
+
+/** Summary stats across repeated runs of one scenario×variant cell. */
+export interface MountCellStats {
+  runs: number;
+  passed: number;
+  passRate: number;
+  wroteSomethingRate: number;
+  correctPathRate: number;
+  discoveryViolationRate: number;
+  usedRelayMessagingRate: number;
+}
+
+// ── Mount file tracking ───────────────────────────────────────────────────────
+
+function walkDir(dir: string, out: Set<string>): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    entry.isDirectory() ? walkDir(full, out) : out.add(full);
+  }
+}
+
+/**
+ * Snapshot all file paths currently under mountDir.
+ * Call before spawning the agent; diff with newMountFiles after.
+ */
+export function snapshotMount(mountDir: string): Set<string> {
+  const existing = new Set<string>();
+  walkDir(mountDir, existing);
+  return existing;
+}
+
+/**
+ * Return absolute paths of files under mountDir that weren't in the snapshot.
+ * These are the files the agent created during the run.
+ */
+export function newMountFiles(mountDir: string, snapshot: Set<string>): string[] {
+  const current = new Set<string>();
+  walkDir(mountDir, current);
+  return [...current].filter((f) => !snapshot.has(f));
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────────────
+
+/**
+ * Score an agent run against a mount writeback scenario.
+ *
+ * Pass = agent wrote to the correct path, the file is valid JSON, and it did
+ * NOT write under discovery/.
+ */
+export function scoreMountRun(opts: ScoreMountRunOptions): MountScore {
+  const { mountDir, newFiles, expectedPathPrefix, events, cleanExit = true } = opts;
+
+  const relative = newFiles.map((f) => f.replace(mountDir + '/', ''));
+  const inExpectedPath = relative.filter((p) => p.startsWith(expectedPathPrefix));
+  const inDiscovery = relative.filter(
+    (p) => p.includes('/discovery/') || p.startsWith('discovery/'),
+  );
+
+  const jsonValid =
+    inExpectedPath.length > 0 &&
+    inExpectedPath.every((p) => {
+      try {
+        JSON.parse(readFileSync(join(mountDir, p), 'utf8'));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+  const usedRelayMessaging = events.some((e) => e.kind === 'relay_inbound');
+
+  return {
+    wroteSomething: relative.length > 0,
+    correctPath: inExpectedPath.length > 0,
+    jsonValid,
+    discoveryViolation: inDiscovery.length > 0,
+    usedRelayMessaging,
+    cleanExit,
+    pass: inExpectedPath.length > 0 && jsonValid && inDiscovery.length === 0,
+    filesWritten: relative,
+    filesAtCorrectPath: inExpectedPath,
+  };
+}
+
+// ── Aggregate stats ───────────────────────────────────────────────────────────
+
+/**
+ * Roll up repeated MountScore results into pass-rate statistics for one cell
+ * (scenario × variant) in a report matrix.
+ */
+export function mountCellStats(scores: MountScore[]): MountCellStats {
+  const n = scores.length;
+  if (n === 0) return { runs: 0, passed: 0, passRate: 0, wroteSomethingRate: 0, correctPathRate: 0, discoveryViolationRate: 0, usedRelayMessagingRate: 0 };
+  const rate = (pred: (s: MountScore) => boolean) => scores.filter(pred).length / n;
+  return {
+    runs: n,
+    passed: scores.filter((s) => s.pass).length,
+    passRate: rate((s) => s.pass),
+    wroteSomethingRate: rate((s) => s.wroteSomething),
+    correctPathRate: rate((s) => s.correctPath),
+    discoveryViolationRate: rate((s) => s.discoveryViolation),
+    usedRelayMessagingRate: rate((s) => s.usedRelayMessaging),
+  };
+}

--- a/packages/evals/src/types.ts
+++ b/packages/evals/src/types.ts
@@ -169,3 +169,55 @@ export interface MatrixReport {
 }
 
 export const SCHEMA_VERSION = 1;
+
+// ── Mount / writeback eval types ──────────────────────────────────────────────
+// Shared types for evals that test filesystem writeback behavior rather than
+// (or in addition to) relay messaging. Used by pear and any consumer that
+// evaluates agent behavior against a relayfile .integrations/ mount.
+
+/**
+ * A scenario that tests whether an agent correctly writes a writeback file
+ * to the relayfile .integrations/ mount instead of (or alongside) relay messaging.
+ */
+export interface MountScenario {
+  id: string;
+  title: string;
+  /**
+   * Path prefix (relative to the fixture/mount root) the agent must write
+   * under to pass. Example: ".integrations/slack/channels/C12345__general/messages/"
+   */
+  expectedPathPrefix: string;
+  /**
+   * Task text to inject into the agent at spawn.
+   * The eval runner may prepend a variant-specific prefix before this.
+   */
+  task: string;
+}
+
+/** One scored run of a MountScenario. */
+export interface MountScenarioResult {
+  scenarioId: string;
+  scenarioTitle: string;
+  /** Onboarding variant under test (e.g. "bare", "claude-md", "slim-inject", "full-inject"). */
+  variant: string;
+  /** 1-based repetition index within this scenario×variant cell. */
+  run: number;
+  pass: boolean;
+  wroteSomething: boolean;
+  correctPath: boolean;
+  jsonValid: boolean;
+  discoveryViolation: boolean;
+  usedRelayMessaging: boolean;
+  filesWritten: string[];
+  durationMs: number;
+  error?: string;
+}
+
+/** Aggregated metrics for one scenario×variant cell across repeated runs. */
+export interface MountCellMetrics {
+  scenarioId: string;
+  variant: string;
+  runs: number;
+  passed: number;
+  passRate: number;
+}


### PR DESCRIPTION
## Summary

- **`./scoring/mount`** — new export for filesystem-writeback eval scoring: `snapshotMount`, `newMountFiles`, `scoreMountRun` (correctPath / jsonValid / discoveryViolation / usedRelayMessaging / cleanExit / pass), `mountCellStats` for aggregate pass-rate stats across repeated runs
- **`./scenarios/onboarding`** — migrated from `tests/integration/broker/evals/scenarios/onboarding.ts` into the package proper so downstream consumers (pear, agent-assistant) can import it without reaching into relay's test internals
- **New types** in main export: `MountScenario`, `MountScenarioResult`, `MountCellMetrics` — shared types for eval runners that test filesystem writeback behavior rather than relay messaging

## Motivation

Pear's integration mount eval harness (`evals/` in pear-sdk-bump) needs to score whether an agent wrote a valid writeback file to `.integrations/<provider>/...` versus writing to the wrong path, writing invalid JSON, writing inside `discovery/`, or using relay messaging instead. This scoring is generic enough to live in the package.

Tracked in `specs/agent-relay-evals-package.md` — this addresses the "pear scenarios need filesystem scoring" blocker.

## Test plan

- [ ] `npm run build` in `packages/evals` compiles cleanly (verified locally)
- [ ] `@agent-relay/evals/scoring/mount` imports resolve in pear-sdk-bump (`npx tsx evals/runner.ts`)
- [ ] `@agent-relay/evals/scenarios/onboarding` exports `OnboardingVariant` and `onboardingText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

