### PR TITLE
Allow Relayfile SDK 0.10 in agent package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4058,6 +4058,58 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@relayfile/mount-darwin-arm64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.10.1.tgz",
+      "integrity": "sha512-A6pLlYHR5seLHR5BIUFhEEt2WFbOG2FgZ2fCKtB+gMvBZuxNPdnFphMLKUak7JDvE5j1/NPmFM4A2E5X1rkR5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-darwin-x64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.10.1.tgz",
+      "integrity": "sha512-bN5jd8aF8xi9tQ8tCh/TwYg8QlUf4c/KZm+LkAXgZzuGukvuwAJzIfS6gbbfRTi7wkebatbJDTJFYP3cCwMOhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-arm64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.10.1.tgz",
+      "integrity": "sha512-AZN8DyRW7AbeNR2QJJwbM4APkDu5fAFB393Rqh2QL+lF69U8usP9w+SAMKCQPfuekJarMgLmnIpgPMRJWAqXCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-x64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.1.tgz",
+      "integrity": "sha512-Gpa/K6z/cWIGIjnL1hLU/m9c7hbb9XjDPrYJEO2G9TNCd8fboUxFMABMqQJTTBzBm8FaT9/qC0WGeOjedQyMsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@relayfile/sdk": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.6.1.tgz",
@@ -15728,11 +15780,11 @@
     },
     "packages/agent": {
       "name": "@agent-relay/agent",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "dependencies": {
         "@agent-relay/events": "7.1.1",
         "@relaycast/sdk": "1.1.2",
-        "@relayfile/sdk": "^0.7.2"
+        "@relayfile/sdk": "^0.10.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -15819,24 +15871,32 @@
       }
     },
     "packages/agent/node_modules/@relayfile/core": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.7.11.tgz",
-      "integrity": "sha512-4gkBmmsdLGEe2a4ZPO84eYFyiKNpD6GymYBg5Awsr/dnwRnBqhe2W8F6rEjdxRpa0Wi1cARFYcsfV4/B4SifOA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.10.1.tgz",
+      "integrity": "sha512-VsNVlH4QPy9KGQSIiNosXadRJLqwmV+lSWgDB93TwMnIH12TI1ochntlTIK70bOFPe+XLmPB7BFy/5pAKAxJ1A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "packages/agent/node_modules/@relayfile/sdk": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.7.11.tgz",
-      "integrity": "sha512-cOxlp+N7rDEcAhvzX/J97ZTvzMLfBmKDzxzLz4rTnP9n3e3EwZRl02lJWese1caVBVBbHeUa9Ds7AHwg1x8uqA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.1.tgz",
+      "integrity": "sha512-q496hLDQ+R9mVw6Wj3Xw2IoqUBurHYxlZYyCHQW5Hr1qFIebVLgvPbJZk6zSBF8cpxmi258WtEr28+eG+HVzVQ==",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.7.11"
+        "@relayfile/core": "0.10.1",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.1",
+        "@relayfile/mount-darwin-x64": "0.10.1",
+        "@relayfile/mount-linux-arm64": "0.10.1",
+        "@relayfile/mount-linux-x64": "0.10.1"
       }
     },
     "packages/agent/node_modules/@types/node": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-relay/agent",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@agent-relay/events": "7.1.1",
     "@relaycast/sdk": "1.1.2",
-    "@relayfile/sdk": "^0.7.2"
+    "@relayfile/sdk": "^0.10.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary
- bump @agent-relay/agent to 7.1.2
- allow @relayfile/sdk ^0.10.1
- regenerate package-lock.json

## Context
Fast-follow for AgentWorkforce/cloud#2271 Option C. The published @agent-relay/agent package still resolves from packages/agent, but packages/agent was removed from relay main after the package split. This PR targets feature/slack-relay-bridge, the current 7.1.1 package branch that still contains packages/agent and packages/events.

## Validation
- npm --workspace packages/events run build
- npm --workspace packages/agent run typecheck
- npm --workspace packages/agent run build
- git diff --check

Note: npm --workspace packages/agent test exits 1 on this branch because the package has no matching test files; typecheck/build are the meaningful package gates here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

