### PR TITLE
perf(web): GPU-composite the "Works with Every Agent" message dots

### DIFF
--- a/web/app/landing.module.css
+++ b/web/app/landing.module.css
@@ -4039,6 +4039,11 @@
   inset: 0;
   z-index: 1;
   pointer-events: none;
+  /* Size container so the dots can be positioned with container-query units
+     (cqw/cqh) driven through GPU-composited transforms instead of animating
+     left/top. The box is sized by `inset: 0` (not its contents), so size
+     containment is safe here. */
+  container-type: size;
 }
 
 .howMsg {
@@ -4054,7 +4059,16 @@
     0 0 0 1px color-mix(in srgb, var(--c) 35%, transparent),
     0 0 14px 2px var(--c);
   opacity: 0;
-  will-change: left, top, transform, opacity;
+  /* Position is driven by the individual `translate` property and the size is
+     driven by the individual `scale` property; both composite on the GPU and
+     interpolate independently, mirroring the old left/top vs transform split. */
+  will-change: translate, scale, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .howMsg {
+    animation: none;
+  }
 }
 
 /* Three messages, each its own colour, routed up to the relay and back down. */
@@ -4073,67 +4087,56 @@
 
 @keyframes howMsg_m1 {
   0% {
-    left: 25%;
-    top: 100%;
+    translate: 25cqw 100cqh;
     opacity: 0;
-    transform: scale(1);
+    scale: 1;
   }
   4% {
     opacity: 1;
   }
   9% {
-    left: 25%;
-    top: 75%;
+    translate: 25cqw 75cqh;
   }
   22% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
     animation-timing-function: cubic-bezier(0.6, 0, 0.9, 0.2);
   }
   37% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(0.5);
+    scale: 0.5;
   }
   43% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   49% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   50% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(1.55);
+    scale: 1.55;
     animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1);
   }
   56% {
-    left: 50%;
-    top: 57%;
-    transform: scale(1);
+    translate: 50cqw 57cqh;
+    scale: 1;
   }
   66% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
   }
   82% {
-    left: 75%;
-    top: 75%;
+    translate: 75cqw 75cqh;
   }
   86% {
     opacity: 1;
   }
   91% {
-    left: 75%;
-    top: 100%;
+    translate: 75cqw 100cqh;
     opacity: 0;
   }
   100% {
@@ -4143,67 +4146,56 @@
 
 @keyframes howMsg_m2 {
   0% {
-    left: 75%;
-    top: 100%;
+    translate: 75cqw 100cqh;
     opacity: 0;
-    transform: scale(1);
+    scale: 1;
   }
   4% {
     opacity: 1;
   }
   9% {
-    left: 75%;
-    top: 75%;
+    translate: 75cqw 75cqh;
   }
   22% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
     animation-timing-function: cubic-bezier(0.6, 0, 0.9, 0.2);
   }
   37% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(0.5);
+    scale: 0.5;
   }
   43% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   49% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   50% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(1.55);
+    scale: 1.55;
     animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1);
   }
   56% {
-    left: 50%;
-    top: 57%;
-    transform: scale(1);
+    translate: 50cqw 57cqh;
+    scale: 1;
   }
   66% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
   }
   82% {
-    left: 25%;
-    top: 75%;
+    translate: 25cqw 75cqh;
   }
   86% {
     opacity: 1;
   }
   91% {
-    left: 25%;
-    top: 100%;
+    translate: 25cqw 100cqh;
     opacity: 0;
   }
   100% {
@@ -4213,67 +4205,56 @@
 
 @keyframes howMsg_m3 {
   0% {
-    left: 25%;
-    top: 100%;
+    translate: 25cqw 100cqh;
     opacity: 0;
-    transform: scale(1);
+    scale: 1;
   }
   4% {
     opacity: 1;
   }
   9% {
-    left: 25%;
-    top: 75%;
+    translate: 25cqw 75cqh;
   }
   22% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
     animation-timing-function: cubic-bezier(0.6, 0, 0.9, 0.2);
   }
   37% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(0.5);
+    scale: 0.5;
   }
   43% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   49% {
-    left: 50%;
-    top: 40%;
+    translate: 50cqw 40cqh;
     opacity: 0;
-    transform: scale(0.25);
+    scale: 0.25;
   }
   50% {
-    left: 50%;
-    top: 50%;
+    translate: 50cqw 50cqh;
     opacity: 1;
-    transform: scale(1.55);
+    scale: 1.55;
     animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1);
   }
   56% {
-    left: 50%;
-    top: 57%;
-    transform: scale(1);
+    translate: 50cqw 57cqh;
+    scale: 1;
   }
   66% {
-    left: 50%;
-    top: 75%;
+    translate: 50cqw 75cqh;
   }
   82% {
-    left: 25%;
-    top: 75%;
+    translate: 25cqw 75cqh;
   }
   86% {
     opacity: 1;
   }
   91% {
-    left: 25%;
-    top: 100%;
+    translate: 25cqw 100cqh;
     opacity: 0;
   }
   100% {


### PR DESCRIPTION
## What

The three routed message dots in the home page **HowItWorks** ("Works with Every Agent") pyramid previously animated `left`/`top` on an infinite loop. Animating layout properties runs on the main thread and forces layout + paint every frame. This moves the motion onto the GPU compositor while keeping the path **pixel-identical**.

## How

- Make `.howMsgs` a **size container** (`container-type: size`) so the dots can be positioned with container-query units. Its box is sized by `inset: 0` (not its contents), so size containment is safe and the reference box is unchanged.
- Drive position with the individual **`translate`** property using `cqw`/`cqh` units (e.g. `left: 25%; top: 75%` → `translate: 25cqw 75cqh`), and size with the individual **`scale`** property (`transform: scale(s)` → `scale: s`).
  - Using the *individual* `translate` and `scale` properties (rather than the combined `transform`) preserves the original behavior where position and scale interpolate **independently** across keyframes — a faithful 1:1 mapping.
- Add a `prefers-reduced-motion: reduce` rule that pauses the dot loop (previously the dots animated regardless).

## Why a separate PR

This is an isolated performance refactor of one component, branched off `main` and independent of the button/hero motion-polish work in #1167.

## Notes / risk

- `cqw`/`cqh` and individual `translate`/`scale` transform properties are broadly supported (all evergreen browsers since early 2023); the site already relies on modern CSS like `color-mix`.
- Geometry is unchanged: with `.howMsg` anchored at the container origin via `margin: -5px 0 0 -5px`, `translate: Xcqw Ycqh` places the dot center at `(X%, Y%)` of `.howMsgs` — exactly where `left: X%; top: Y%` did.
- I could not run a full `next build` in this environment (no `node_modules`); validated via brace-balance and a keyframe-by-keyframe audit (33 `translate` + 18 `scale` declarations across the 3 blocks, no residual `left`/`top`/`transform: scale`). Worth a quick visual check that the dots still travel up to the relay and pop back down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULmKZfLCcC3whjY4yGqUx4)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

