### PR TITLE
Address fleet serve review follow-up

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_upshg9a9y5tx/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_upshg9a9y5tx/summary.md
@@ -2,8 +2,8 @@
 
 > **Status:** ✅ Completed
 > **Confidence:** 90%
-> **Started:** June 19, 2026 at 01:41 PM
-> **Completed:** June 19, 2026 at 01:42 PM
+> **Started:** June 19, 2026, at 01:41 PM
+> **Completed:** June 19, 2026, at 01:42 PM
 
 ---
 
@@ -30,4 +30,4 @@ Addressed PR 1170 automated review feedback by adding marker-aware default unwra
 
 _Agent: default_
 
-- Preserve Node.js JS interop while keeping Bun standalone off the jiti fallback: Preserve Node.js JS interop while keeping Bun standalone off the jiti fallback
+- Updated the loader to preserve Node.js interop for CommonJS default wrappers and ESM-syntax `.js` files while keeping the Bun standalone path on native import unless a TypeScript-like extension requires `jiti`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.8.5",
+  "version": "8.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -2104,7 +2104,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19605,44 +19604,44 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.8.5"
+      "version": "8.9.0"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.8.5",
-        "@agent-relay/config": "8.8.5",
-        "@agent-relay/fleet": "8.8.5",
-        "@agent-relay/harness-driver": "8.8.5",
-        "@agent-relay/sdk": "8.8.5",
-        "@agent-relay/utils": "8.8.5",
+        "@agent-relay/cloud": "8.9.0",
+        "@agent-relay/config": "8.9.0",
+        "@agent-relay/fleet": "8.9.0",
+        "@agent-relay/harness-driver": "8.9.0",
+        "@agent-relay/sdk": "8.9.0",
+        "@agent-relay/utils": "8.9.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^4.1.1",
         "@relayflows/cli": "^1.0.1",
@@ -19702,9 +19701,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "dependencies": {
-        "@agent-relay/config": "8.8.5",
+        "@agent-relay/config": "8.9.0",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -19720,7 +19719,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -19733,60 +19732,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.8.5",
-        "@agent-relay/integration-prompts": "8.8.5"
+        "@agent-relay/harness-driver": "8.9.0",
+        "@agent-relay/integration-prompts": "8.9.0"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.8.5",
-        "@agent-relay/harnesses": "8.8.5",
-        "@agent-relay/sdk": "8.8.5",
+        "@agent-relay/harness-driver": "8.9.0",
+        "@agent-relay/harnesses": "8.9.0",
+        "@agent-relay/sdk": "8.9.0",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.8.5",
+        "@agent-relay/sdk": "8.9.0",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.8.5",
-        "@agent-relay/broker-darwin-x64": "8.8.5",
-        "@agent-relay/broker-linux-arm64": "8.8.5",
-        "@agent-relay/broker-linux-x64": "8.8.5",
-        "@agent-relay/broker-win32-x64": "8.8.5"
+        "@agent-relay/broker-darwin-arm64": "8.9.0",
+        "@agent-relay/broker-darwin-x64": "8.9.0",
+        "@agent-relay/broker-linux-arm64": "8.9.0",
+        "@agent-relay/broker-linux-x64": "8.9.0",
+        "@agent-relay/broker-win32-x64": "8.9.0"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.8.5",
-        "@agent-relay/sdk": "8.8.5"
+        "@agent-relay/harness-driver": "8.9.0",
+        "@agent-relay/sdk": "8.9.0"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "dependencies": {
-        "@agent-relay/config": "8.8.5"
+        "@agent-relay/config": "8.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -19795,7 +19794,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "dependencies": {
         "@relaycast/sdk": "^4.1.1"
       },
@@ -19831,14 +19830,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.8.5",
+      "version": "8.9.0",
       "dependencies": {
-        "@agent-relay/config": "8.8.5",
+        "@agent-relay/config": "8.9.0",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -100,6 +100,7 @@ describe('fleet command support', () => {
   it('loads CommonJS compiled JS node files that export default wrappers', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'relay-node-def-'));
     try {
+      await writeFile(path.join(dir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
       const file = path.join(dir, 'node-def.js');
       await writeFile(
         file,


### PR DESCRIPTION
## Summary
- explicitly mark the CommonJS compiled JS node-definition test fixture as `type: commonjs`
- clean up the PR feedback trajectory summary wording and timestamp punctuation

Follow-up to #1170 after it merged while these CodeRabbit items were being addressed.

## Validation
- `npx vitest run packages/cli/src/cli/commands/fleet.test.ts`
- `npx prettier --check packages/cli/src/cli/commands/fleet.test.ts .agentworkforce/trajectories/completed/2026-06/traj_upshg9a9y5tx/summary.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

