### PR TITLE
fix(mcp): accept grok and opencode in the spawn tool cli enum

### DIFF
--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -612,7 +612,9 @@ function registerAgentRelayTools(
       description: 'Invoke the fleet spawn action. Optionally target a specific node.',
       inputSchema: {
         name: z.string().describe('Agent name'),
-        cli: z.enum(['claude', 'codex', 'gemini', 'aider', 'goose']).describe('AI CLI to launch'),
+        cli: z
+          .enum(['claude', 'codex', 'gemini', 'aider', 'goose', 'grok', 'opencode'])
+          .describe('AI CLI to launch'),
         task: z.string().optional().describe('Initial task instructions'),
         channel: z.string().optional().describe('Channel to join'),
         channels: z.array(z.string()).optional().describe('Channels to join'),


### PR DESCRIPTION
## What

The `spawn` MCP tool's `cli` enum listed only the original five (`claude/codex/gemini/aider/goose`), while the sibling `add_agent` tool already accepts `grok` and `opencode`. This one-line inconsistency made **grok unselectable via `spawn`** even though the rest of the stack already supports it:

- Rust broker: `is_grok`, `--always-approve` permission bypass (`worker.rs`)
- MCP injection: `configure_grok_mcp` / `grok mcp add agent-relay …` (`snippets.rs`)
- CLI registry + harness definition (`cli-registry.yaml`, `harnesses/src/index.ts`)

This PR aligns the `spawn` enum with `add_agent`.

## Why it's safe

The `spawn` handler forwards `cli` verbatim into the loosely-typed `actions.invoke('spawn', actionInput)` — no narrow `CliType` is required at that call site, so no cast is needed and `tsc --noEmit -p packages/cli` stays green. (Contrast `add_agent`, whose handler must down-cast `cli` to the five-member `SpawnAgentRequest.cli` type before calling `agents.spawn`; that cast is intentionally left untouched.)

## Known remaining gap (out of this repo)

End-to-end grok spawning via the **`add_agent`** path is still gated **server-side**: `getRelay().agents.spawn()` POSTs to the hosted gateway (`POST /v1/agents/spawn`), which validates `cli` against `[claude, codex, opencode, gemini, aider, goose]` and **rejects `grok`** at runtime (observed: `cli must be one of: claude, codex, opencode, gemini, aider, goose`). The local `@relaycast/types` `CliTypeSchema` is even narrower (the five, no `opencode`). Fully unblocking grok requires updating the gateway / `@relaycast/types` `CliTypeSchema` to include `grok` — that lives outside this repo.

The `spawn` (fleet-action) path builds a PTY harness from a free-form `cli` string and may bypass the gateway enum; verifying that end-to-end requires the rebuilt `agent-relay` package + a deployed gateway that doesn't re-validate.

## Test

- `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

