### PR TITLE
chore(cloud): drop the legacy ~/.agent-relay auth fallback

### DIFF
--- a/packages/cloud/src/auth.test.ts
+++ b/packages/cloud/src/auth.test.ts
@@ -33,7 +33,7 @@ import {
   refreshStoredAuth,
   writeStoredAuth,
 } from './auth.js';
-import { AUTH_FILE_PATH, CloudAuthError, LEGACY_AUTH_FILE_PATH, type StoredAuth } from './types.js';
+import { AUTH_FILE_PATH, CloudAuthError, type StoredAuth } from './types.js';
 
 const AUTH_LOCK_PATH = `${AUTH_FILE_PATH}.lock`;
 
@@ -175,40 +175,22 @@ describe('readStoredAuth', () => {
     expect(fsMocks.readFile).not.toHaveBeenCalled();
   });
 
-  it('migrates legacy auth to the canonical auth path when canonical auth is absent', async () => {
+  it('returns null when canonical auth is absent and never reads the legacy .agent-relay path', async () => {
     fsMocks.readFile.mockImplementation(async (file: string) => {
       if (file === AUTH_FILE_PATH) {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       }
-      if (file === LEGACY_AUTH_FILE_PATH) {
-        return JSON.stringify(FILE_AUTH);
-      }
       throw new Error(`unexpected file ${file}`);
     });
 
-    await expect(readStoredAuth({})).resolves.toEqual(FILE_AUTH);
+    await expect(readStoredAuth({})).resolves.toBeNull();
 
-    expect(fsMocks.mkdir).toHaveBeenCalledWith(expect.stringContaining('.agentworkforce/relay'), {
-      recursive: true,
-      mode: 0o700,
-    });
-    expect(fsMocks.writeFile).toHaveBeenCalledWith(
-      expect.stringContaining('.cloud-auth.json.'),
-      `${JSON.stringify(FILE_AUTH, null, 2)}\n`,
-      {
-        encoding: 'utf8',
-        mode: 0o600,
-      }
-    );
-    expect(fsMocks.chmod).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), 0o600);
-    expect(fsMocks.rename).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), AUTH_FILE_PATH);
-    expect(fsMocks.writeFile).not.toHaveBeenCalledWith(AUTH_FILE_PATH, expect.anything(), expect.anything());
-    expect(fsMocks.writeFile).not.toHaveBeenCalledWith(
-      LEGACY_AUTH_FILE_PATH,
-      expect.anything(),
-      expect.anything()
-    );
-    expect(fsMocks.rm).toHaveBeenCalledWith(expect.stringContaining('.cloud-auth.json.'), { force: true });
+    // The legacy migrate-on-read shim was removed: no read of a ~/.agent-relay
+    // path, and no write/rename back into the canonical location.
+    const readPaths = fsMocks.readFile.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(readPaths.some((p: string) => p.includes('.agent-relay'))).toBe(false);
+    expect(fsMocks.writeFile).not.toHaveBeenCalled();
+    expect(fsMocks.rename).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cloud/src/auth.ts
+++ b/packages/cloud/src/auth.ts
@@ -12,7 +12,6 @@ import { appendAgentRelayTelemetryHeaders } from './telemetry-headers.js';
 import {
   AUTH_FILE_PATH,
   DEFAULT_REFRESH_TIMEOUT_MS,
-  LEGACY_AUTH_FILE_PATH,
   REFRESH_TOKEN_WINDOW_MS,
   REFRESH_WINDOW_MS,
   CloudAuthError,
@@ -127,23 +126,7 @@ export async function readStoredAuth(env: NodeJS.ProcessEnv = process.env): Prom
     return envAuth;
   }
 
-  const stored = await readCanonicalStoredAuth();
-  if (stored) {
-    return stored;
-  }
-
-  try {
-    const legacyFile = await fs.readFile(LEGACY_AUTH_FILE_PATH, 'utf8');
-    const parsed = JSON.parse(legacyFile) as unknown;
-    if (!isValidStoredAuth(parsed)) {
-      return null;
-    }
-
-    await writeStoredAuth(parsed);
-    return parsed;
-  } catch {
-    return null;
-  }
+  return readCanonicalStoredAuth();
 }
 
 export async function writeStoredAuth(auth: StoredAuth): Promise<void> {

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -172,7 +172,6 @@ export {
   REFRESH_TOKEN_WINDOW_MS,
   DEFAULT_REFRESH_TIMEOUT_MS,
   AUTH_FILE_PATH,
-  LEGACY_AUTH_FILE_PATH,
   defaultApiUrl,
   isSupportedProvider,
 } from './types.js';

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -265,7 +265,6 @@ export const REFRESH_WINDOW_MS = 5 * 60_000;
 export const REFRESH_TOKEN_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_REFRESH_TIMEOUT_MS = 10_000;
 export const AUTH_FILE_PATH = path.join(os.homedir(), '.agentworkforce/relay', 'cloud-auth.json');
-export const LEGACY_AUTH_FILE_PATH = path.join(os.homedir(), '.agent-relay', 'cloud-auth.json');
 
 export function defaultApiUrl(): string {
   return process.env.CLOUD_API_URL?.trim() || 'https://agentrelay.com/cloud';


### PR DESCRIPTION
## What

Removes the last `.agent-relay` reference in the cloud **auth store**. The canonical credential file already moved to `~/.agentworkforce/relay/cloud-auth.json`; `.agent-relay` only lingered as `LEGACY_AUTH_FILE_PATH` + a migrate-on-read shim. This deletes both so the CLI never reads/writes a `~/.agent-relay` directory for auth.

## Changes (`packages/cloud`)
- `types.ts` — delete `LEGACY_AUTH_FILE_PATH`.
- `auth.ts` — drop the legacy import and the legacy read/migrate-on-read branch. `readStoredAuth` now = env auth → canonical file → `null`.
- `index.ts` — stop re-exporting `LEGACY_AUTH_FILE_PATH`.
- `auth.test.ts` — replace the "migrates legacy auth" test with one asserting the `.agent-relay` path is **never read** and no write/rename happens.

## Scope
**Auth store only**, by request. The other, unrelated `~/.agent-relay` directories — sandbox runtime state (`cloud`), telemetry (`relay-broker`, `relay-tui`), binary cache (`relayfile`), workflow run-db (`relayflows`) — are separate concepts and tracked as a follow-up phase.

`agent-relay update`/uninstall still removes the old `.agent-relay` install dir (`core-maintenance.ts` keeps it in `INSTALL_DIR_NAMES` on purpose — that *helps* eliminate it from machines).

## ⚠️ Behavior change (minor)
A machine whose creds exist **only** at `~/.agent-relay/cloud-auth.json` (never re-authed since the canonical move) will no longer be auto-migrated and must re-run `agentworkforce login`. Current 4.x users already have creds at `~/.agentworkforce/relay/` and are unaffected. If you'd rather keep the migrate-on-read shim for one more release before deleting, say so and I'll restore just the read (without the `.agent-relay` constant lingering elsewhere).

## Verified
- `npm --prefix packages/cloud run build` (tsc) clean.
- `vitest run packages/cloud/src/auth.test.ts` → 25/25 pass.
- No residual `LEGACY_AUTH_FILE_PATH` references in source.

## Follow-ups (not in this PR)
- Stale doc comments in `pear`/`pear-mobile` `src/main/auth.ts` still mention the `~/.agent-relay` fallback (separate repos, comment-only).
- Phase 2: the 4 non-auth `.agent-relay` dirs across `cloud`/`relay-broker`/`relay-tui`/`relayfile`/`relayflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

