### PR TITLE
docs(changelog): record the relay dashboard removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@agent-relay/cloud` preserves operator refresh-token expiry metadata and refreshes canonical cloud sessions before access or refresh tokens reach their renewal windows.
 - `agent-relay-broker` persists pending deliveries on shutdown and on every queue change, redelivers them on restart, reports timeout-fallback verification explicitly, and emits `delivery_dropped` when the per-worker queue cap evicts a message.
 
+### Removed
+
+- The local web dashboard is removed. `agent-relay up` no longer starts a dashboard, the installer no longer fetches the `relay-dashboard-server` binary / UI or installs `@agent-relay/dashboard-server`, and `up` drops the `--no-dashboard`, `--port`, and `--foreground` flags.
+- Telemetry drops the `human_dashboard` `ActionSource` (CLI and `agent-relay-broker`); broker HTTP-API spawns now report `human_cli`.
+
+### Breaking Changes
+
+- `agent-relay up` is broker-only and runs attached by default. The previous `--no-dashboard` (which detached) is gone — use `--background` to run detached. The `--no-dashboard`, `--port`, and `--foreground` flags now error as unknown options.
+- The `AGENT_RELAY_DASHBOARD_PORT` environment variable is replaced by `AGENT_RELAY_BROKER_PORT`, which sets the broker base port (the HTTP API binds the next free port above it).
+
+### Migration Guidance
+
+- Replace `agent-relay up --no-dashboard` with `agent-relay up --background`.
+- Remove `--port`/`--foreground` from `up` invocations; set `AGENT_RELAY_BROKER_PORT` in place of `AGENT_RELAY_DASHBOARD_PORT` to pin the broker port.
+- Dashboard assets are no longer managed by `agent-relay uninstall`; delete any leftover `~/.agentworkforce/relay/dashboard` directory manually.
+
 ## [8.9.2] - 2026-06-19
 
 ### Fixed


### PR DESCRIPTION
Adds the `[Unreleased]` changelog entry for the local web dashboard removal (landed in #1146), kept out of that PR per request.

**Removed**
- Local web dashboard: `agent-relay up` no longer starts one; installer no longer fetches `relay-dashboard-server`/UI or `@agent-relay/dashboard-server`; `up` drops `--no-dashboard`/`--port`/`--foreground`.
- `human_dashboard` `ActionSource` retired (CLI + broker); HTTP-API spawns report `human_cli`.

**Breaking Changes**
- `agent-relay up` is broker-only, attached by default; use `--background` to detach (replaces the old `--no-dashboard` detach behavior). Removed flags now error.
- `AGENT_RELAY_DASHBOARD_PORT` → `AGENT_RELAY_BROKER_PORT`.

**Migration Guidance** included for each.

This is a SemVer-major (breaking) change set; the version bump is intentionally left out for maintainers to decide.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

