### PR TITLE
chore: bump relaycast to latest (broker crate 4.1.1 + CLI SDK 4.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `@agent-relay/sdk` and `@agent-relay/cli` now depend on `@relaycast/sdk` 4.0 (durable-delivery status model `queued|delivered|acked|failed|dead_lettered`).
-- `agent-relay-broker` upgrades the bundled `relaycast` crate from 3.0 to 4.1, aligning the broker with the `@relaycast/sdk` 4.x durable-delivery model. This changes the relaycast-backed local delivery store schema.
+- `agent-relay-broker` upgrades the bundled `relaycast` crate from 3.0 to 4.1, changing the relaycast-backed local delivery store schema.
 - `agent-relay` and `@agent-relay/sdk` update `@relaycast/sdk` to the latest `4.1.6` patch.
 
 - `codex-relay-skill` and `gemini-relay-extension` now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK. Set `RELAY_BASE_URL` to keep using `https://api.relaycast.dev`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `@agent-relay/sdk` and `@agent-relay/cli` now depend on `@relaycast/sdk` 4.0 (durable-delivery status model `queued|delivered|acked|failed|dead_lettered`).
+- `agent-relay-broker` upgrades the bundled `relaycast` crate from 3.0 to 4.1, aligning the broker with the `@relaycast/sdk` 4.x durable-delivery model. This changes the relaycast-backed local delivery store schema.
 
 - `codex-relay-skill` and `gemini-relay-extension` now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK. Set `RELAY_BASE_URL` to keep using `https://api.relaycast.dev`.
 - `agent-relay local agent message hold|flush|auto <name>` now owns local broker delivery controls; the old top-level `agent-relay agent message ...` path was removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `@agent-relay/sdk` and `@agent-relay/cli` now depend on `@relaycast/sdk` 4.0 (durable-delivery status model `queued|delivered|acked|failed|dead_lettered`).
 - `agent-relay-broker` upgrades the bundled `relaycast` crate from 3.0 to 4.1, aligning the broker with the `@relaycast/sdk` 4.x durable-delivery model. This changes the relaycast-backed local delivery store schema.
+- `agent-relay` and `@agent-relay/sdk` update `@relaycast/sdk` to the latest `4.1.6` patch.
 
 - `codex-relay-skill` and `gemini-relay-extension` now default to `https://gateway.relaycast.dev`, matching the `agent-relay` CLI and SDK. Set `RELAY_BASE_URL` to keep using `https://api.relaycast.dev`.
 - `agent-relay local agent message hold|flush|auto <name>` now owns local broker delivery controls; the old top-level `agent-relay agent message ...` path was removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,9 +2001,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "3.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9e462ae4dde5c008f65303cc0c9ee3816d0af19591fa50ae58216a25c29e29"
+checksum = "2ded2515766a4ed1b14873704bad35ddc42f3cb5205c002598b0bd2e27ec2462"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=3.0.0"
+relaycast = "=4.1.1"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "8.9.0",
+  "version": "8.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -2104,6 +2104,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19604,46 +19605,46 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "8.9.0"
+      "version": "8.9.2"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "8.9.0",
-        "@agent-relay/config": "8.9.0",
-        "@agent-relay/fleet": "8.9.0",
-        "@agent-relay/harness-driver": "8.9.0",
-        "@agent-relay/sdk": "8.9.0",
-        "@agent-relay/utils": "8.9.0",
+        "@agent-relay/cloud": "8.9.2",
+        "@agent-relay/config": "8.9.2",
+        "@agent-relay/fleet": "8.9.2",
+        "@agent-relay/harness-driver": "8.9.2",
+        "@agent-relay/sdk": "8.9.2",
+        "@agent-relay/utils": "8.9.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^4.1.2",
+        "@relaycast/sdk": "^4.1.6",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -19665,11 +19666,11 @@
       }
     },
     "packages/cli/node_modules/@relaycast/sdk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.2.tgz",
-      "integrity": "sha512-u2+m1ScZGWog+S5AUhmefspcgh8IQ16TdQV+Ru9yniivmY1EqPLP42QqQtCfU8BY/TtSgFihMe9Of+8BJ5JvuQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
+      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
       "dependencies": {
-        "@relaycast/types": "4.1.2",
+        "@relaycast/types": "4.1.6",
         "zod": "^4.3.6"
       }
     },
@@ -19683,9 +19684,9 @@
       }
     },
     "packages/cli/node_modules/@relaycast/types": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.2.tgz",
-      "integrity": "sha512-+vZUOzk86LfiadrjzVT1+sM5VRbNFk4qP/tClvk1Sab6TYNlryMvZfJaDios9Jv/8/FbhEqd2gIhB1arPNHuyg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
+      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -19701,9 +19702,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "dependencies": {
-        "@agent-relay/config": "8.9.0",
+        "@agent-relay/config": "8.9.2",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -19719,7 +19720,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -19732,60 +19733,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.9.0",
-        "@agent-relay/integration-prompts": "8.9.0"
+        "@agent-relay/harness-driver": "8.9.2",
+        "@agent-relay/integration-prompts": "8.9.2"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.9.0",
-        "@agent-relay/harnesses": "8.9.0",
-        "@agent-relay/sdk": "8.9.0",
+        "@agent-relay/harness-driver": "8.9.2",
+        "@agent-relay/harnesses": "8.9.2",
+        "@agent-relay/sdk": "8.9.2",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "8.9.0",
+        "@agent-relay/sdk": "8.9.2",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "8.9.0",
-        "@agent-relay/broker-darwin-x64": "8.9.0",
-        "@agent-relay/broker-linux-arm64": "8.9.0",
-        "@agent-relay/broker-linux-x64": "8.9.0",
-        "@agent-relay/broker-win32-x64": "8.9.0"
+        "@agent-relay/broker-darwin-arm64": "8.9.2",
+        "@agent-relay/broker-darwin-x64": "8.9.2",
+        "@agent-relay/broker-linux-arm64": "8.9.2",
+        "@agent-relay/broker-linux-x64": "8.9.2",
+        "@agent-relay/broker-win32-x64": "8.9.2"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "8.9.0",
-        "@agent-relay/sdk": "8.9.0"
+        "@agent-relay/harness-driver": "8.9.2",
+        "@agent-relay/sdk": "8.9.2"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "dependencies": {
-        "@agent-relay/config": "8.9.0"
+        "@agent-relay/config": "8.9.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -19794,27 +19795,27 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "dependencies": {
-        "@relaycast/sdk": "^4.1.2"
+        "@relaycast/sdk": "^4.1.6"
       },
       "devDependencies": {
         "@types/node": "^22.13.10"
       }
     },
     "packages/sdk/node_modules/@relaycast/sdk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.2.tgz",
-      "integrity": "sha512-u2+m1ScZGWog+S5AUhmefspcgh8IQ16TdQV+Ru9yniivmY1EqPLP42QqQtCfU8BY/TtSgFihMe9Of+8BJ5JvuQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
+      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
       "dependencies": {
-        "@relaycast/types": "4.1.2",
+        "@relaycast/types": "4.1.6",
         "zod": "^4.3.6"
       }
     },
     "packages/sdk/node_modules/@relaycast/types": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.2.tgz",
-      "integrity": "sha512-+vZUOzk86LfiadrjzVT1+sM5VRbNFk4qP/tClvk1Sab6TYNlryMvZfJaDios9Jv/8/FbhEqd2gIhB1arPNHuyg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
+      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -19830,14 +19831,14 @@
     },
     "packages/telemetry": {
       "name": "@agent-relay/telemetry",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "deprecated": "@agent-relay/telemetry is deprecated. Telemetry is now internal to the agent-relay CLI."
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "8.9.0",
+      "version": "8.9.2",
       "dependencies": {
-        "@agent-relay/config": "8.9.0",
+        "@agent-relay/config": "8.9.2",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@agent-relay/sdk": "8.9.2",
     "@agent-relay/utils": "8.9.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^4.1.2",
+    "@relaycast/sdk": "^4.1.6",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,6 +59,6 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^4.1.2"
+    "@relaycast/sdk": "^4.1.6"
   }
 }


### PR DESCRIPTION
Aligns the relaycast dependency to the latest across the broker and the CLI/SDK.

### Rust broker crate: `relaycast` `=3.0.0` → `=4.1.1`
Matches the `@relaycast/sdk` 4.x line. relaycast 4.x adopts the new durable-delivery model and **changes its underlying delivery-store DB schema** (internal to the crate — no in-repo schema/migrations).
- No broker code changes needed; the 3→4 API surface the broker consumes is unchanged.
- `cargo build` / `cargo clippy` clean; `cargo test -p agent-relay-broker --lib` → 775 passed, 0 failed.

### JS SDK: `@relaycast/sdk` `^4.1.2` → `^4.1.6` (latest patch)
Bumped in `agent-relay` (CLI) and `@agent-relay/sdk` so the CLI resolves a single current 4.1.6 across its direct and workspace-transitive paths.
- `build:sdk` / `build:cli` clean, CLI `tsc --noEmit` clean.
- SDK suite 110 passed, CLI suite 374 passed.

**Note (runtime):** because relaycast 4.x changes its delivery-store schema, existing local broker state written by 3.x may not be forward-compatible. No in-repo migration was added — flagging for a clear-state/migration decision if needed.