### PR TITLE
fix(build): drop redundant @agent-relay/* tsconfig paths so the compiled CLI keeps workspace exports

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/summary.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Fixed bun-compiled CLI dropping @agent-relay/* workspace exports to undefined (Fleet local node skipped / 'is not a function' on local up). Root cause: bun & esbuild honor tsconfig paths that map workspace packages to their .d.ts (no runtime exports); paths resolve per nearest tsconfig to the importing file, so transitive imports broke too. Final fix (after a fresh-eyes review pivoted away from an earlier build-script workaround): removed the redundant @agent-relay/* paths from the root and packages/cli tsconfig.json — they duplicated the npm workspace node_modules symlinks, so tsc still resolves .d.ts (via package exports.types) and bundlers resolve .js (via exports.import). Also reverted the now-obsolete namespace-import workarounds in fleet-sidecar.ts and fleet/src/index.ts to plain named imports. tsc type-checking untouched. Verified: build:core green (0 type errors), built binary, local up starts implicit fleet node with fleet-node.json connected:true + spawn:claude/codex/gemini.
+Fixed bun-compiled CLI dropping @agent-relay/_ workspace exports to undefined (Fleet local node skipped / 'is not a function' on local up). Root cause: bun & esbuild honor tsconfig paths that map workspace packages to their .d.ts (no runtime exports); paths resolve per nearest tsconfig to the importing file, so transitive imports broke too. Final fix (after a fresh-eyes review pivoted away from an earlier build-script workaround): removed the redundant @agent-relay/_ paths from the root and packages/cli tsconfig.json — they duplicated the npm workspace node_modules symlinks, so tsc still resolves .d.ts (via package exports.types) and bundlers resolve .js (via exports.import). Also reverted the now-obsolete namespace-import workarounds in fleet-sidecar.ts and fleet/src/index.ts to plain named imports. tsc type-checking untouched. Verified: build:core green (0 type errors), built binary, local up starts implicit fleet node with fleet-node.json connected:true + spawn:claude/codex/gemini.
 
 **Approach:** Standard approach
 
@@ -18,15 +18,17 @@ Fixed bun-compiled CLI dropping @agent-relay/* workspace exports to undefined (F
 ## Key Decisions
 
 ### Fix at the bundler layer via empty-paths tsconfig next to the build entry
+
 - **Chose:** Fix at the bundler layer via empty-paths tsconfig next to the build entry
-- **Reasoning:** Root cause: packages/cli/tsconfig.json paths map @agent-relay/* to dist/index.d.ts; bun/esbuild honor tsconfig paths and bundle the declaration files (no runtime exports) -> undefined. fleet breaks because it is only ever namespace-imported. Build-script override is surgical and leaves tsc type-checking untouched, vs changing shared root paths.
+- **Reasoning:** Root cause: packages/cli/tsconfig.json paths map @agent-relay/\* to dist/index.d.ts; bun/esbuild honor tsconfig paths and bundle the declaration files (no runtime exports) -> undefined. fleet breaks because it is only ever namespace-imported. Build-script override is surgical and leaves tsc type-checking untouched, vs changing shared root paths.
 
 ---
 
 ## Chapters
 
 ### 1. Work
-*Agent: default*
+
+_Agent: default_
 
 - Fix at the bundler layer via empty-paths tsconfig next to the build entry: Fix at the bundler layer via empty-paths tsconfig next to the build entry
 - Root cause is bun/esbuild honoring tsconfig paths (->.d.ts, no runtime exports) per-importing-file; fix needs empty-paths tsconfig in EVERY bundled package dist, not just the entry, to cover transitive workspace imports. Verified end-to-end: fleet-node.json connected:true with all spawn handlers.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Fix @agent-relay/fleet exports dropped to undefined in bun --compile standalone binary (local up Fleet local node skipped)
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 22, 2026 at 09:44 AM
+> **Completed:** June 22, 2026 at 10:06 AM
+
+---
+
+## Summary
+
+Fixed bun-compiled CLI dropping @agent-relay/* workspace exports to undefined (Fleet local node skipped / 'is not a function' on local up). Root cause: bun & esbuild honor tsconfig paths that map workspace packages to their .d.ts (no runtime exports); paths resolve per nearest tsconfig to the importing file, so transitive imports broke too. Final fix (after a fresh-eyes review pivoted away from an earlier build-script workaround): removed the redundant @agent-relay/* paths from the root and packages/cli tsconfig.json — they duplicated the npm workspace node_modules symlinks, so tsc still resolves .d.ts (via package exports.types) and bundlers resolve .js (via exports.import). Also reverted the now-obsolete namespace-import workarounds in fleet-sidecar.ts and fleet/src/index.ts to plain named imports. tsc type-checking untouched. Verified: build:core green (0 type errors), built binary, local up starts implicit fleet node with fleet-node.json connected:true + spawn:claude/codex/gemini.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Fix at the bundler layer via empty-paths tsconfig next to the build entry
+- **Chose:** Fix at the bundler layer via empty-paths tsconfig next to the build entry
+- **Reasoning:** Root cause: packages/cli/tsconfig.json paths map @agent-relay/* to dist/index.d.ts; bun/esbuild honor tsconfig paths and bundle the declaration files (no runtime exports) -> undefined. fleet breaks because it is only ever namespace-imported. Build-script override is surgical and leaves tsc type-checking untouched, vs changing shared root paths.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Fix at the bundler layer via empty-paths tsconfig next to the build entry: Fix at the bundler layer via empty-paths tsconfig next to the build entry
+- Root cause is bun/esbuild honoring tsconfig paths (->.d.ts, no runtime exports) per-importing-file; fix needs empty-paths tsconfig in EVERY bundled package dist, not just the entry, to cover transitive workspace imports. Verified end-to-end: fleet-node.json connected:true with all spawn handlers.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/trajectory.json
@@ -42,9 +42,7 @@
             "confidence": 0.9
           },
           "significance": "high",
-          "tags": [
-            "confidence:0.9"
-          ]
+          "tags": ["confidence:0.9"]
         }
       ]
     }

--- a/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_d88jruejk2zk/trajectory.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_d88jruejk2zk",
+  "version": 1,
+  "task": {
+    "title": "Fix @agent-relay/fleet exports dropped to undefined in bun --compile standalone binary (local up Fleet local node skipped)"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-22T07:44:17.272Z",
+  "completedAt": "2026-06-22T08:06:29.530Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-22T07:53:58.239Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_fmr96gta9rp3",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-22T07:53:58.239Z",
+      "endedAt": "2026-06-22T08:06:29.530Z",
+      "events": [
+        {
+          "ts": 1782114838239,
+          "type": "decision",
+          "content": "Fix at the bundler layer via empty-paths tsconfig next to the build entry: Fix at the bundler layer via empty-paths tsconfig next to the build entry",
+          "raw": {
+            "question": "Fix at the bundler layer via empty-paths tsconfig next to the build entry",
+            "chosen": "Fix at the bundler layer via empty-paths tsconfig next to the build entry",
+            "alternatives": [],
+            "reasoning": "Root cause: packages/cli/tsconfig.json paths map @agent-relay/* to dist/index.d.ts; bun/esbuild honor tsconfig paths and bundle the declaration files (no runtime exports) -> undefined. fleet breaks because it is only ever namespace-imported. Build-script override is surgical and leaves tsc type-checking untouched, vs changing shared root paths."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1782115588773,
+          "type": "reflection",
+          "content": "Root cause is bun/esbuild honoring tsconfig paths (->.d.ts, no runtime exports) per-importing-file; fix needs empty-paths tsconfig in EVERY bundled package dist, not just the entry, to cover transitive workspace imports. Verified end-to-end: fleet-node.json connected:true with all spawn handlers.",
+          "raw": {
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed bun-compiled CLI dropping @agent-relay/* workspace exports to undefined (Fleet local node skipped / 'is not a function' on local up). Root cause: bun & esbuild honor tsconfig paths that map workspace packages to their .d.ts (no runtime exports); paths resolve per nearest tsconfig to the importing file, so transitive imports broke too. Fix: build-bun.sh & build-standalone.sh write an empty-paths tsconfig into every packages/*/dist before bundling, forcing node_modules (.js) resolution. tsc type-checking untouched. Verified: rebuilt core from source, built binary, local up starts implicit fleet node with fleet-node.json connected:true + spawn:claude/codex/gemini.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "c7380efd69238db002f4cba087cebef593bf9fcd",
+    "endRef": "c7380efd69238db002f4cba087cebef593bf9fcd"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Bun-compiled `agent-relay` standalone binary now bundles workspace packages from their compiled JS instead of their `.d.ts`, so `local up` starts the implicit Fleet local node instead of failing with `Fleet local node skipped: … is not a function`. The `tsconfig` `paths` that mapped `@agent-relay/*` to declaration files (no runtime exports) were redundant with the npm workspace symlinks and have been removed.
 - `agent-relay` and `@agent-relay/sdk` require `@relaycast/sdk` `^4.1.2`, whose matching `@relaycast/types` package is now published, so publish installs resolve cleanly without pinning.
 - `agent-relay fleet serve <node-def>` loads plain JavaScript node definitions without `jiti`, so the published Bun-compiled CLI can serve compiled JS node files.
 - Spawned opencode worker agents no longer pause for interactive tool-approval prompts; the broker injects a wildcard allow-all permission block into every generated `opencode.json`, augmenting existing partial permission objects rather than replacing them.

--- a/packages/cli/src/cli/lib/fleet-sidecar.ts
+++ b/packages/cli/src/cli/lib/fleet-sidecar.ts
@@ -8,11 +8,13 @@ import type {
   FleetRelaySendMessageInput,
   FleetSpawnAgentInput,
 } from '@agent-relay/fleet';
-// bun's standalone `--compile` bundler mis-validates named value imports from
-// this workspace package against its generated .d.ts ("No matching export").
-// A namespace import + destructure sidesteps it while keeping call sites unchanged.
-import * as fleetSdk from '@agent-relay/fleet';
-const { defineDefaultLocalNode, invokeNodeHandler, nodeInfo, nodeManifest, triggerSyncInputs } = fleetSdk;
+import {
+  defineDefaultLocalNode,
+  invokeNodeHandler,
+  nodeInfo,
+  nodeManifest,
+  triggerSyncInputs,
+} from '@agent-relay/fleet';
 import {
   PROTOCOL_VERSION,
   type BrokerToSdk,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,26 +14,12 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "baseUrl": ".",
-    "paths": {
-      "@agent-relay/config": ["../config/dist/index.d.ts"],
-      "@agent-relay/config/*": ["../config/dist/*"],
-      "@agent-relay/policy": ["../policy/dist/index.d.ts"],
-      "@agent-relay/policy/*": ["../policy/dist/*"],
-      "@agent-relay/sdk": ["../sdk/dist/index.d.ts"],
-      "@agent-relay/sdk/*": ["../sdk/dist/*"],
-      "@agent-relay/harness-driver": ["../harness-driver/dist/index.d.ts"],
-      "@agent-relay/harness-driver/*": ["../harness-driver/dist/*"],
-      "@agent-relay/harnesses": ["../harnesses/dist/index.d.ts"],
-      "@agent-relay/harnesses/*": ["../harnesses/dist/*"],
-      "@agent-relay/fleet": ["../fleet/dist/index.d.ts"],
-      "@agent-relay/fleet/*": ["../fleet/dist/*"],
-      "@agent-relay/utils": ["../utils/dist/index.d.ts"],
-      "@agent-relay/utils/*": ["../utils/dist/*"],
-      "@agent-relay/cloud": ["../cloud/dist/index.d.ts"],
-      "@agent-relay/cloud/*": ["../cloud/dist/*"]
-    }
+    "sourceMap": true
+    // No `paths` for @agent-relay/* on purpose: the npm workspace symlinks them
+    // into node_modules, so tsc resolves their `.d.ts` and bundlers (bun,
+    // esbuild) resolve their `.js`. Mapping them to `dist/index.d.ts` here made
+    // the compiled CLI inline the declaration files and lose every workspace
+    // export at runtime (e.g. `local up` → "Fleet local node skipped").
   },
   "include": ["src/index.ts", "src/cli/index.ts", "src/cli/bootstrap.ts", "src/cli/agent-relay-mcp.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]

--- a/packages/fleet/src/index.ts
+++ b/packages/fleet/src/index.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod';
-import type { PtyHarness } from '@agent-relay/harnesses';
-// Namespace import sidesteps bun --compile's named-import validation against the
-// package .d.ts (see packages/cli .../fleet-sidecar.ts).
-import * as harnessDefs from '@agent-relay/harnesses';
-const { claude, codex, definePtyHarness, gemini } = harnessDefs;
+import { claude, codex, definePtyHarness, gemini, type PtyHarness } from '@agent-relay/harnesses';
 import { resolveStaticHarnessConfig, type StaticPtyHarnessDefinition } from '@agent-relay/harness-driver';
 import type {
   AgentSpec,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,28 +12,12 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "baseUrl": ".",
-    "paths": {
-      "@agent-relay/config": ["packages/config/dist/index.d.ts"],
-      "@agent-relay/config/*": ["packages/config/dist/*"],
-      "@agent-relay/policy": ["packages/policy/dist/index.d.ts"],
-      "@agent-relay/policy/*": ["packages/policy/dist/*"],
-      "@agent-relay/sdk": ["packages/sdk/dist/index.d.ts"],
-      "@agent-relay/sdk/*": ["packages/sdk/dist/*"],
-      "@agent-relay/harness-driver": ["packages/harness-driver/dist/index.d.ts"],
-      "@agent-relay/harness-driver/*": ["packages/harness-driver/dist/*"],
-      "@agent-relay/harnesses": ["packages/harnesses/dist/index.d.ts"],
-      "@agent-relay/harnesses/*": ["packages/harnesses/dist/*"],
-      "@agent-relay/integration-prompts": ["packages/integration-prompts/dist/index.d.ts"],
-      "@agent-relay/integration-prompts/*": ["packages/integration-prompts/dist/*"],
-      "@agent-relay/fleet": ["packages/fleet/dist/index.d.ts"],
-      "@agent-relay/fleet/*": ["packages/fleet/dist/*"],
-      "@agent-relay/utils": ["packages/utils/dist/index.d.ts"],
-      "@agent-relay/utils/*": ["packages/utils/dist/*"],
-      "@agent-relay/cloud": ["packages/cloud/dist/index.d.ts"],
-      "@agent-relay/cloud/*": ["packages/cloud/dist/*"]
-    }
+    "sourceMap": true
+    // No `paths` for @agent-relay/* on purpose: the npm workspace symlinks them
+    // into node_modules, so tsc resolves their `.d.ts` and bundlers (bun,
+    // esbuild) resolve their `.js`. Mapping them to `dist/index.d.ts` here made
+    // bundlers inline the declaration files (no runtime exports), so the
+    // compiled CLI lost every workspace export at runtime.
   },
   "files": [],
   "include": []


### PR DESCRIPTION
## Problem

The Bun-compiled `agent-relay` standalone binary dropped **every** `@agent-relay/*` workspace export to `undefined` at runtime. `agent-relay local up` failed with:

```
Fleet local node skipped: C90 is not a function. (... 'C90' is undefined)
```

`C90` was the minified `defineDefaultLocalNode` from `@agent-relay/fleet`. The whole `@agent-relay/fleet` namespace bundled empty. (The broker still started — the implicit Fleet local node is best-effort and the failure is caught — but the node never came up.)

## Root cause

The root `tsconfig.json` and `packages/cli/tsconfig.json` mapped every `@agent-relay/*` import to a sibling package's **`dist/index.d.ts`** via `compilerOptions.paths`. Bun and esbuild honor tsconfig `paths` when bundling, so they inlined the **declaration files** — which have only `export declare` (no runtime values) — leaving the bundled namespace `{}`.

Two details that made it specific and multi-layered:
- Bun resolves `paths` from the tsconfig nearest the **importing file** (and follows `extends`). Packages `fleet`/`harnesses`/`integration-prompts` extend root and inherited the paths → broke; `sdk`/`harness-driver` don't → resolved via `node_modules` → worked. That's why only some packages failed.
- Fixing only the entry left the transitive import (`fleet` → `harnesses`) broken, surfacing as a deeper `spawn requires a PTY harness definition`.

## Fix

Remove the `@agent-relay/*` `paths` (and the now-orphaned `baseUrl`) from `tsconfig.json` and `packages/cli/tsconfig.json`. They were **redundant** with the npm workspace `node_modules` symlinks:
- `tsc` resolves `@agent-relay/*` → `.d.ts` via each package's `exports`/`types`.
- bundlers (bun, esbuild) resolve → `.js` via `import`/`default`.

With the source defect gone, the namespace-import workarounds in `fleet-sidecar.ts` and `fleet/src/index.ts` (added to dodge the same `.d.ts` mis-resolution) revert to plain named imports.

## Scope / safety

- Type-check unaffected: `npm run build:core` → **0 type errors** (incl. the 3 packages that inherit root paths).
- Subpath imports (`@agent-relay/harness-driver/protocol`, `@agent-relay/sdk/actions`, …) still resolve via package `exports`.
- `web/`, and the `tests/`/`evals` tsconfigs that still carry these paths, are independent — only ever consumed by `tsc`, never by a bun/esbuild bundle — so they're intentionally untouched.
- JSONC comments in the tsconfigs are safe (only `tsc`/`bun`/`esbuild` read these files).

## Verification

A freshly compiled binary runs `local up` with the implicit fleet node fully up:

```json
// .agentworkforce/relay/fleet-node.json
{ "connected": true, "handlers": ["spawn:claude", "spawn:codex", "spawn:gemini"] }
```

No "Fleet local node skipped", no "is not a function".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

