### PR TITLE
refactor(cli): drop redundant gateway.relaycast.dev default in MCP server

### DIFF
--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -296,6 +296,9 @@ describe('agent-relay-mcp startup helpers', () => {
     vi.stubEnv('RELAY_SKIP_BOOTSTRAP', '1');
 
     expect(mod.normalizeBaseUrl('https://api.relaycast.dev///')).toBe('https://api.relaycast.dev');
+    expect(mod.normalizeBaseUrl(`https://api.relaycast.dev${'/'.repeat(1000)}`)).toBe(
+      'https://api.relaycast.dev',
+    );
     expect(mod.envFlagEnabled(' on ')).toBe(true);
     expect(mod.envFlagEnabled('0')).toBe(false);
     expect(mod.normalizeAgentType('agent')).toBe('agent');

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -295,6 +295,7 @@ describe('agent-relay-mcp startup helpers', () => {
     vi.stubEnv('RELAY_STRICT_AGENT_NAME', ' yes ');
     vi.stubEnv('RELAY_SKIP_BOOTSTRAP', '1');
 
+    expect(mod.normalizeBaseUrl('https://api.relaycast.dev///')).toBe('https://api.relaycast.dev');
     expect(mod.envFlagEnabled(' on ')).toBe(true);
     expect(mod.envFlagEnabled('0')).toBe(false);
     expect(mod.normalizeAgentType('agent')).toBe('agent');

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -297,7 +297,7 @@ describe('agent-relay-mcp startup helpers', () => {
 
     expect(mod.normalizeBaseUrl('https://api.relaycast.dev///')).toBe('https://api.relaycast.dev');
     expect(mod.normalizeBaseUrl(`https://api.relaycast.dev${'/'.repeat(1000)}`)).toBe(
-      'https://api.relaycast.dev',
+      'https://api.relaycast.dev'
     );
     expect(mod.envFlagEnabled(' on ')).toBe(true);
     expect(mod.envFlagEnabled('0')).toBe(false);

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -295,7 +295,6 @@ describe('agent-relay-mcp startup helpers', () => {
     vi.stubEnv('RELAY_STRICT_AGENT_NAME', ' yes ');
     vi.stubEnv('RELAY_SKIP_BOOTSTRAP', '1');
 
-    expect(mod.normalizeBaseUrl('https://api.relaycast.dev///')).toBe('https://api.relaycast.dev');
     expect(mod.envFlagEnabled(' on ')).toBe(true);
     expect(mod.envFlagEnabled('0')).toBe(false);
     expect(mod.normalizeAgentType('agent')).toBe('agent');

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -115,7 +115,13 @@ function resolveEnv(key: string): string | undefined {
  * the public `agent-relay/mcp` export surface stable for downstream importers.
  */
 export function normalizeBaseUrl(baseUrl?: string): string {
-  return (baseUrl ?? 'https://gateway.relaycast.dev').replace(/\/+$/, '');
+  // Strip trailing slashes with a linear loop rather than a regex. A pattern
+  // like `/\/+$/` triggers CodeQL's polynomial-backtracking (ReDoS) warning on
+  // uncontrolled input with many repeated '/'; `endsWith`/`slice` is O(n) and
+  // has no backtracking.
+  let url = baseUrl ?? 'https://gateway.relaycast.dev';
+  while (url.endsWith('/')) url = url.slice(0, -1);
+  return url;
 }
 
 function isEntrypoint(): boolean {

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -105,6 +105,19 @@ function resolveEnv(key: string): string | undefined {
   return v;
 }
 
+/**
+ * Normalize a base URL by stripping trailing slashes, falling back to the
+ * gateway default when none is provided.
+ *
+ * @deprecated No longer used internally — the base URL default is now owned by
+ * `@relaycast/sdk` (`RelayCast`/`WsClient`/`AgentRelay` all default
+ * `options.baseUrl` to `https://gateway.relaycast.dev`). Retained only to keep
+ * the public `agent-relay/mcp` export surface stable for downstream importers.
+ */
+export function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl ?? 'https://gateway.relaycast.dev').replace(/\/+$/, '');
+}
+
 function isEntrypoint(): boolean {
   const invocationPath = process.argv[1];
   if (!invocationPath) return false;

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -40,7 +40,6 @@ import type {
 } from './mcp/types.js';
 export type { AgentRelayMcpServerOptions } from './mcp/types.js';
 
-const DEFAULT_BASE_URL = 'https://gateway.relaycast.dev';
 export const AGENT_RELAY_MCP_VERSION = process.env.AGENT_RELAY_CLI_VERSION ?? SDK_VERSION ?? 'unknown';
 let mcpTelemetryExitHookInstalled = false;
 
@@ -104,10 +103,6 @@ function resolveEnv(key: string): string | undefined {
   const v = process.env[key];
   if (!v || /^\$\{.+\}$/.test(v)) return undefined;
   return v;
-}
-
-export function normalizeBaseUrl(baseUrl?: string): string {
-  return (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
 }
 
 function isEntrypoint(): boolean {


### PR DESCRIPTION
## Summary

Two small base-URL cleanups were investigated. Only one was safe to change.

### Task 1 — CLI MCP server (changed)
`packages/cli/src/cli/agent-relay-mcp.ts` declared a local `DEFAULT_BASE_URL = 'https://gateway.relaycast.dev'` consumed only by `normalizeBaseUrl()`. This duplicated the default already applied by `@relaycast/sdk` (`RelayCast`/`WsClient`/`AgentRelay` all do `options.baseUrl ?? 'https://gateway.relaycast.dev'`).

Verified the runtime path: the MCP server constructs every client with `baseUrl: options.baseUrl`, where `options.baseUrl` comes from `RELAY_BASE_URL` (possibly `undefined`). When unset, `undefined` flows straight through to the SDK and the SDK's `gateway.relaycast.dev` default applies — **behavior is unchanged**. `normalizeBaseUrl` was never called in the runtime path (only by a test), so it and its single test assertion are removed, leaving the SDK as the single source of truth.

- Removed `DEFAULT_BASE_URL` const
- Removed dead `normalizeBaseUrl()` export
- Dropped the one test assertion that exercised it

### Task 2 — opencode plugin (intentionally NOT changed)
`plugins/opencode-relay-plugin/src/index.ts` defaults to `https://www.relaycast.dev/api/v1`. Investigation shows this is **not** a stale wrong-host for the gateway engine:

- The plugin issues bespoke RPC-style POST calls: `/register`, `/dm/send`, `/inbox/check`, `/agent/list`, `/message/post`, `/agent/add`, `/agent/remove` (see `src/tools.ts`, `src/hooks.ts`).
- The gateway engine (`@relaycast/sdk`) uses a different surface entirely: `POST /v1/agents`, `POST /v1/dm`, `GET /v1/inbox`, `GET /v1/agents`, `POST /v1/agents/spawn`, `POST /v1/agents/release`, etc. — different HTTP methods and path shapes.
- The plugin README explicitly documents this divergence: *"Unlike Claude Code and Gemini CLI plugins which use MCP servers, this plugin uses OpenCode's native `tool()` API with direct HTTP calls to the Relaycast API."*
- These RPC paths and `www.relaycast.dev/api/v1` appear nowhere else in the repo except the plugin and its own test (`tests/polling.test.ts` hard-codes the full URL).

Repointing it to `gateway.relaycast.dev/v1` would break the calls (no matching routes) and contradict the plugin's documented architecture. Left untouched.

## Verification
- `tsc --noEmit` on `packages/cli`: passes (exit 0)
- `vitest` on `agent-relay-mcp.startup.test.ts`: 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

