### PR TITLE
fix(opencode-plugin): use @relaycast/sdk instead of dead bespoke RPC API

### DIFF
--- a/plugins/opencode-relay-plugin/package.json
+++ b/plugins/opencode-relay-plugin/package.json
@@ -24,11 +24,14 @@
     "dist",
     "README.md"
   ],
+  "dependencies": {
+    "@relaycast/sdk": "^4.1.6"
+  },
   "peerDependencies": {
     "opencode": ">=0.1.0"
   },
   "scripts": {
     "build": "npx tsc -p tsconfig.json",
-    "test": "npx vitest run tests/tools.test.ts tests/spawn.test.ts tests/polling.test.ts tests/integration.test.ts"
+    "test": "npx vitest run --config vitest.config.ts tests/tools.test.ts tests/spawn.test.ts tests/polling.test.ts tests/integration.test.ts"
   }
 }

--- a/plugins/opencode-relay-plugin/src/hooks.ts
+++ b/plugins/opencode-relay-plugin/src/hooks.ts
@@ -1,5 +1,5 @@
 import type { RelayState } from './index.js';
-import { inboxToMessages } from './tools.js';
+import { collectInboxMessages } from './tools.js';
 
 interface HookContext {
   hook(name: string, handler: HookHandler): void;
@@ -103,7 +103,7 @@ async function pollInbox(state: RelayState): Promise<RelayMessage[]> {
   }
 
   const inbox = await state.agent.inbox();
-  return inboxToMessages(inbox);
+  return collectInboxMessages(state.agent, inbox, state.seenMessageIds);
 }
 
 function formatInjectedMessages(messages: RelayMessage[]): string {

--- a/plugins/opencode-relay-plugin/src/hooks.ts
+++ b/plugins/opencode-relay-plugin/src/hooks.ts
@@ -1,4 +1,5 @@
 import type { RelayState } from './index.js';
+import { inboxToMessages } from './tools.js';
 
 interface HookContext {
   hook(name: string, handler: HookHandler): void;
@@ -28,10 +29,6 @@ interface RelayMessage {
   ts: string;
 }
 
-interface InboxCheckResponse {
-  messages?: RelayMessage[];
-}
-
 export function registerHooks(ctx: HookContext, state: RelayState): void {
   // These OpenCode hook names are provisional per specs/cli-native-plugins.md section 5.
   ctx.hook('session.idle', async () => handleSessionIdle(state));
@@ -40,7 +37,7 @@ export function registerHooks(ctx: HookContext, state: RelayState): void {
 }
 
 async function handleSessionIdle(state: RelayState): Promise<SessionIdleResult | void> {
-  if (!state.connected || !state.token) {
+  if (!state.connected || !state.agent) {
     return;
   }
 
@@ -101,27 +98,12 @@ async function handleSessionEnd(state: RelayState): Promise<void> {
 }
 
 async function pollInbox(state: RelayState): Promise<RelayMessage[]> {
-  const response = await fetch(`${normalizeBaseUrl(state.apiBaseUrl)}/inbox/check`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${state.token}`,
-    },
-    body: JSON.stringify({}),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Relay API error: ${response.status} ${await response.text()}`);
+  if (!state.agent) {
+    return [];
   }
 
-  const payload = (await response.json()) as InboxCheckResponse;
-  return Array.isArray(payload.messages) ? payload.messages : [];
-}
-
-function normalizeBaseUrl(baseUrl: string): string {
-  let end = baseUrl.length;
-  while (end > 0 && baseUrl[end - 1] === '/') end--;
-  return end === baseUrl.length ? baseUrl : baseUrl.slice(0, end);
+  const inbox = await state.agent.inbox();
+  return inboxToMessages(inbox);
 }
 
 function formatInjectedMessages(messages: RelayMessage[]): string {

--- a/plugins/opencode-relay-plugin/src/index.ts
+++ b/plugins/opencode-relay-plugin/src/index.ts
@@ -1,7 +1,9 @@
+import type { AgentClient, RelayCast } from '@relaycast/sdk';
+
 import { registerHooks } from './hooks.js';
 import { registerTools, type ToolContext } from './tools.js';
 
-export const DEFAULT_RELAYCAST_API_BASE_URL = 'https://www.relaycast.dev/api/v1';
+export const DEFAULT_RELAYCAST_API_BASE_URL = 'https://cast.agentrelay.com';
 export const DEFAULT_IDLE_POLL_INTERVAL_MS = 3_000;
 
 export interface SessionIdleResult {
@@ -54,6 +56,10 @@ export class RelayState {
   lastIdlePollAt = 0;
   spawned = new Map<string, SpawnedAgent>();
   connected = false;
+  /** Workspace-scoped client (apiKey = workspace key). Owns agent registry calls. */
+  relay: RelayCast | null = null;
+  /** Agent-scoped client (token = registered agent token). Owns messaging calls. */
+  agent: AgentClient | null = null;
 }
 export default async function relayPlugin(ctx: PluginContext): Promise<RelayState> {
   const state = new RelayState();
@@ -80,18 +86,18 @@ export {
   createRelaySendTool,
   createRelaySpawnTool,
   createRelayTools,
+  inboxToMessages,
   registerTools,
-  relaycastAPI,
 } from './tools.js';
 export type {
   EmptyInput,
   Message,
-  RelayAPIResponse,
   RelayConnectInput,
   RelayDismissInput,
   RelayPostInput,
   RelaySendInput,
   RelaySpawnInput,
+  RelayCastFactory,
   SpawnLike,
   ToolDefinition,
   ToolDependencies,

--- a/plugins/opencode-relay-plugin/src/index.ts
+++ b/plugins/opencode-relay-plugin/src/index.ts
@@ -57,9 +57,11 @@ export class RelayState {
   spawned = new Map<string, SpawnedAgent>();
   /**
    * IDs of messages already surfaced to the agent. The engine `inbox()` is
-   * read-only, so we drain via `markRead` and also keep this local watermark as
-   * a backstop so the same message is never re-injected even if a read-receipt
-   * write lags or fails.
+   * read-only, so the durable drain happens on the delivery ledger
+   * (`ackDelivery`); this local watermark is the in-session backstop that keeps
+   * the same message from being re-injected even if a ledger ack lags or fails.
+   * Bounded via FIFO eviction (see `MAX_SEEN_MESSAGE_IDS` / `rememberSeen`) so
+   * it cannot grow unboundedly over a long session.
    */
   seenMessageIds = new Set<string>();
   connected = false;
@@ -95,7 +97,9 @@ export {
   createRelayTools,
   collectInboxMessages,
   inboxToMessages,
+  rememberSeen,
   registerTools,
+  MAX_SEEN_MESSAGE_IDS,
 } from './tools.js';
 export type {
   EmptyInput,

--- a/plugins/opencode-relay-plugin/src/index.ts
+++ b/plugins/opencode-relay-plugin/src/index.ts
@@ -55,6 +55,13 @@ export class RelayState {
   idlePollIntervalMs = DEFAULT_IDLE_POLL_INTERVAL_MS;
   lastIdlePollAt = 0;
   spawned = new Map<string, SpawnedAgent>();
+  /**
+   * IDs of messages already surfaced to the agent. The engine `inbox()` is
+   * read-only, so we drain via `markRead` and also keep this local watermark as
+   * a backstop so the same message is never re-injected even if a read-receipt
+   * write lags or fails.
+   */
+  seenMessageIds = new Set<string>();
   connected = false;
   /** Workspace-scoped client (apiKey = workspace key). Owns agent registry calls. */
   relay: RelayCast | null = null;
@@ -86,6 +93,7 @@ export {
   createRelaySendTool,
   createRelaySpawnTool,
   createRelayTools,
+  collectInboxMessages,
   inboxToMessages,
   registerTools,
 } from './tools.js';

--- a/plugins/opencode-relay-plugin/src/tools.ts
+++ b/plugins/opencode-relay-plugin/src/tools.ts
@@ -4,6 +4,7 @@ import {
   RelayCast,
   RelayError,
   type AgentClient,
+  type DeliveryItem,
   type DmMessage,
   type InboxResponse,
   type MessageWithMeta,
@@ -110,6 +111,79 @@ export function assertConnected(state: RelayState): asserts state is RelayState 
  * summary reports more than one unread item. Keeps a single idle poll bounded.
  */
 const MAX_UNREAD_FETCH = 50;
+
+/**
+ * Upper bound on how many delivery-ledger items we scan per drain when matching
+ * surfaced messages to their durable delivery rows. The engine returns the
+ * non-terminal queue (queued + delivered) which is naturally small, but cap it
+ * so a single poll never fans out unboundedly.
+ */
+const MAX_DELIVERY_SCAN = 200;
+
+/**
+ * Hard cap on {@link RelayState.seenMessageIds}. The watermark only needs to
+ * cover messages the engine might still re-surface; older ids are safe to evict
+ * because the delivery ledger has already acked them server-side. Keeping the
+ * most-recent N ids bounds memory over a long-lived session.
+ */
+export const MAX_SEEN_MESSAGE_IDS = 2_000;
+
+/**
+ * Record `id` as seen, bounding the set with FIFO eviction so it cannot grow
+ * unboundedly. `Set` preserves insertion order, so the first entries are the
+ * oldest; we evict from the front once over the cap.
+ */
+export function rememberSeen(seen: Set<string>, id: string, max = MAX_SEEN_MESSAGE_IDS): void {
+  if (seen.has(id)) {
+    return;
+  }
+  seen.add(id);
+  while (seen.size > max) {
+    const oldest = seen.values().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    seen.delete(oldest);
+  }
+}
+
+/**
+ * Drain surfaced messages from the durable delivery ledger so they stop being
+ * replayed across restarts. The engine models inbox delivery as a per-agent
+ * ledger keyed by `deliveryId`; each row carries the underlying `messageId`.
+ * We list the non-terminal queue, match it to the message ids we just surfaced,
+ * and `ackDelivery` each match (transitioning it to `acked` server-side).
+ *
+ * This is the real server-side drain (it survives restarts), unlike a read
+ * receipt which does not change delivery state. Best-effort: any failure leaves
+ * the local `seenMessageIds` watermark as the backstop against re-injection.
+ */
+async function ackSurfacedDeliveries(agent: AgentClient, messageIds: Set<string>): Promise<void> {
+  if (messageIds.size === 0) {
+    return;
+  }
+  let deliveries: DeliveryItem[];
+  try {
+    deliveries = await agent.deliveries({ limit: MAX_DELIVERY_SCAN });
+  } catch {
+    return;
+  }
+  if (!Array.isArray(deliveries)) {
+    return;
+  }
+  const toAck = deliveries.filter(
+    (delivery) => delivery?.id && delivery?.messageId && messageIds.has(delivery.messageId)
+  );
+  await Promise.all(
+    toAck.map(async (delivery) => {
+      try {
+        await agent.ackDelivery(delivery.id);
+      } catch {
+        // Best-effort: the local watermark already prevents re-injection.
+      }
+    })
+  );
+}
 
 /**
  * Flatten an engine inbox *summary* payload into the flat message list the
@@ -224,8 +298,9 @@ async function fetchUnreadChannelMessages(
  *    that did not mention us are hydrated from the DM / channel message APIs so
  *    earlier instructions and non-mention channel traffic are not dropped.
  *  - Every surfaced message is drained: recorded in `state.seenMessageIds`
- *    (so it is never re-injected) and `markRead`-acked on the engine
- *    (best-effort) so the summary stops reporting it as unread.
+ *    (so it is never re-injected within this session) and acked on the durable
+ *    delivery ledger (best-effort) so it stops being replayed server-side,
+ *    including across restarts.
  */
 export async function collectInboxMessages(
   agent: AgentClient,
@@ -286,20 +361,13 @@ export async function collectInboxMessages(
     }
   }
 
-  // Drain: drop anything already surfaced, then watermark + ack the rest.
+  // Drain: drop anything already surfaced, then watermark + ack the rest on the
+  // durable delivery ledger so it survives restarts.
   const fresh = collected.filter((message) => !seen.has(message.id));
   for (const message of fresh) {
-    seen.add(message.id);
+    rememberSeen(seen, message.id);
   }
-  await Promise.all(
-    fresh.map(async (message) => {
-      try {
-        await agent.markRead(message.id);
-      } catch {
-        // Best-effort: the local watermark already prevents re-injection.
-      }
-    })
-  );
+  await ackSurfacedDeliveries(agent, new Set(fresh.map((message) => message.id)));
 
   return fresh;
 }

--- a/plugins/opencode-relay-plugin/src/tools.ts
+++ b/plugins/opencode-relay-plugin/src/tools.ts
@@ -1,5 +1,13 @@
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 
+import {
+  RelayCast,
+  RelayError,
+  type AgentClient,
+  type InboxResponse,
+  type RelayCastOptions,
+} from '@relaycast/sdk';
+
 import type { RelayMessage, RelayState } from './index.js';
 
 export interface ToolSchemaProperty {
@@ -52,20 +60,34 @@ export interface RelayDismissInput {
 
 export type EmptyInput = Record<string, never>;
 export type Message = RelayMessage;
-export type RelayAPIResponse = Record<string, unknown>;
 export type SpawnLike = (command: string, args?: readonly string[], options?: SpawnOptions) => ChildProcess;
+
+/** Constructs the workspace-scoped SDK client. Overridable in tests. */
+export type RelayCastFactory = (options: RelayCastOptions) => RelayCast;
 
 export interface ToolDependencies {
   spawn?: SpawnLike;
+  createRelayCast?: RelayCastFactory;
 }
+
+const defaultCreateRelayCast: RelayCastFactory = (options) => new RelayCast(options);
 
 function isConnected(state: RelayState): state is RelayState & {
   agentName: string;
   workspace: string;
   token: string;
   connected: true;
+  relay: RelayCast;
+  agent: AgentClient;
 } {
-  return state.connected && state.agentName !== null && state.workspace !== null && state.token !== null;
+  return (
+    state.connected &&
+    state.agentName !== null &&
+    state.workspace !== null &&
+    state.token !== null &&
+    state.relay !== null &&
+    state.agent !== null
+  );
 }
 
 export function assertConnected(state: RelayState): asserts state is RelayState & {
@@ -73,36 +95,53 @@ export function assertConnected(state: RelayState): asserts state is RelayState 
   workspace: string;
   token: string;
   connected: true;
+  relay: RelayCast;
+  agent: AgentClient;
 } {
   if (!isConnected(state)) {
     throw new Error('Not connected to Relay. Call relay_connect first.');
   }
 }
 
-export async function relaycastAPI(
-  state: RelayState,
-  endpoint: string,
-  body: Record<string, unknown>
-): Promise<RelayAPIResponse> {
-  const res = await fetch(`${normalizeBaseUrl(state.apiBaseUrl)}/${endpoint}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${state.token}`,
-    },
-    body: JSON.stringify(body),
-  });
+/**
+ * Flatten an engine inbox payload into the flat message list the plugin's UX
+ * (inbox tool + idle hook) is built around. /v1/inbox has no `messages` array;
+ * the message-like items are channel `mentions` and `unread_dms`.
+ */
+export function inboxToMessages(inbox: InboxResponse): RelayMessage[] {
+  const messages: RelayMessage[] = [];
 
-  if (!res.ok) {
-    throw new Error(`Relay API error: ${res.status} ${await res.text()}`);
+  for (const mention of inbox.mentions) {
+    messages.push({
+      id: mention.id,
+      from: mention.agentName,
+      text: mention.text,
+      channel: mention.channelName,
+      ts: mention.createdAt,
+    });
   }
 
-  return (await res.json()) as RelayAPIResponse;
+  for (const dm of inbox.unreadDms) {
+    if (!dm.lastMessage) {
+      continue;
+    }
+    messages.push({
+      id: dm.lastMessage.id,
+      from: dm.from,
+      text: dm.lastMessage.text,
+      ts: dm.lastMessage.createdAt,
+    });
+  }
+
+  return messages;
 }
 
 export function createRelayConnectTool(
-  state: RelayState
+  state: RelayState,
+  dependencies: ToolDependencies = {}
 ): ToolDefinition<RelayConnectInput, { ok: true; name: string; workspace: string }> {
+  const createRelayCast = dependencies.createRelayCast ?? defaultCreateRelayCast;
+
   return {
     name: 'relay_connect',
     description: 'Connect to an Agent Relay workspace. Call this first.',
@@ -125,28 +164,30 @@ export function createRelayConnectTool(
         throw new Error('Invalid workspace key. Get one at relaycast.dev');
       }
 
-      const res = await fetch(`${normalizeBaseUrl(state.apiBaseUrl)}/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workspace, name, cli: 'opencode' }),
-      });
+      const relay = createRelayCast({ apiKey: workspace, baseUrl: state.apiBaseUrl });
 
-      if (!res.ok) {
-        if (res.status === 401 || res.status === 403) {
+      let token: string;
+      try {
+        // Register (or rotate) this agent identity in the workspace and obtain
+        // its agent token; this is the SDK equivalent of the old /register call.
+        const registration = await relay.registerOrRotate({ name });
+        token = registration.token;
+      } catch (error) {
+        if (isAuthError(error)) {
           throw new Error('Invalid workspace key. Get one at relaycast.dev');
         }
-
-        throw new Error(`Relay API error: ${res.status} ${await res.text()}`);
+        throw error;
       }
 
-      const data = (await res.json()) as { token?: unknown };
-      if (typeof data.token !== 'string' || data.token.length === 0) {
+      if (typeof token !== 'string' || token.length === 0) {
         throw new Error('Relay API error: register response missing token');
       }
 
       state.workspace = workspace;
       state.agentName = name;
-      state.token = data.token;
+      state.token = token;
+      state.relay = relay;
+      state.agent = relay.as(token);
       state.connected = true;
 
       return {
@@ -174,7 +215,7 @@ export function createRelaySendTool(
     },
     async handler({ to, text }) {
       assertConnected(state);
-      await relaycastAPI(state, 'dm/send', { to, text });
+      await state.agent.dm(to, text);
       return { sent: true, to };
     },
   };
@@ -189,8 +230,8 @@ export function createRelayInboxTool(
     schema: { type: 'object', properties: {} },
     async handler() {
       assertConnected(state);
-      const data = await relaycastAPI(state, 'inbox/check', {});
-      const messages = Array.isArray(data.messages) ? (data.messages as Message[]) : [];
+      const inbox = await state.agent.inbox();
+      const messages = inboxToMessages(inbox);
       return { count: messages.length, messages };
     },
   };
@@ -203,8 +244,8 @@ export function createRelayAgentsTool(state: RelayState): ToolDefinition<EmptyIn
     schema: { type: 'object', properties: {} },
     async handler() {
       assertConnected(state);
-      const data = await relaycastAPI(state, 'agent/list', {});
-      return { agents: Array.isArray(data.agents) ? data.agents : [] };
+      const agents = await state.relay.agents.list();
+      return { agents };
     },
   };
 }
@@ -225,7 +266,7 @@ export function createRelayPostTool(
     },
     async handler({ channel, text }) {
       assertConnected(state);
-      await relaycastAPI(state, 'message/post', { channel, text });
+      await state.agent.post(channel, text);
       return { posted: true, channel };
     },
   };
@@ -261,10 +302,13 @@ export function createRelaySpawnTool(
     async handler({ name, task, dir, model }) {
       assertConnected(state);
 
-      await relaycastAPI(state, 'agent/add', {
+      // Register the worker identity in the workspace so it shows up on the
+      // relay before the local OpenCode process bootstraps and connects.
+      // (The engine's agents.spawn requires a fixed cli enum that excludes
+      // "opencode", so we register the identity and spawn the process locally.)
+      await state.relay.agents.registerOrGet({
         name,
-        cli: 'opencode',
-        task,
+        metadata: { cli: 'opencode', task },
       });
 
       const systemPrompt = [
@@ -343,7 +387,7 @@ export function createRelayDismissTool(
         agent.process.kill('SIGTERM');
       }
 
-      await relaycastAPI(state, 'agent/remove', { name });
+      await state.relay.agents.delete(name);
       state.spawned.delete(name);
       return { dismissed: true, name };
     },
@@ -363,7 +407,7 @@ export function createRelayTools(
   ToolDefinition<RelayDismissInput, { dismissed: true; name: string }>,
 ] {
   return [
-    createRelayConnectTool(state),
+    createRelayConnectTool(state, dependencies),
     createRelaySendTool(state),
     createRelayInboxTool(state),
     createRelayAgentsTool(state),
@@ -383,8 +427,15 @@ export function registerTools(
   }
 }
 
-function normalizeBaseUrl(baseUrl: string): string {
-  let end = baseUrl.length;
-  while (end > 0 && baseUrl[end - 1] === '/') end--;
-  return end === baseUrl.length ? baseUrl : baseUrl.slice(0, end);
+function isAuthError(error: unknown): boolean {
+  if (error instanceof RelayError) {
+    return (
+      error.status === 401 ||
+      error.status === 403 ||
+      error.code === 'unauthorized' ||
+      error.code === 'agent_token_invalid' ||
+      error.code === 'workspace_mismatch'
+    );
+  }
+  return false;
 }

--- a/plugins/opencode-relay-plugin/src/tools.ts
+++ b/plugins/opencode-relay-plugin/src/tools.ts
@@ -4,7 +4,9 @@ import {
   RelayCast,
   RelayError,
   type AgentClient,
+  type DmMessage,
   type InboxResponse,
+  type MessageWithMeta,
   type RelayCastOptions,
 } from '@relaycast/sdk';
 
@@ -104,14 +106,30 @@ export function assertConnected(state: RelayState): asserts state is RelayState 
 }
 
 /**
- * Flatten an engine inbox payload into the flat message list the plugin's UX
- * (inbox tool + idle hook) is built around. /v1/inbox has no `messages` array;
- * the message-like items are channel `mentions` and `unread_dms`.
+ * Per-conversation/channel cap on how many unread messages we hydrate when the
+ * summary reports more than one unread item. Keeps a single idle poll bounded.
  */
-export function inboxToMessages(inbox: InboxResponse): RelayMessage[] {
+const MAX_UNREAD_FETCH = 50;
+
+/**
+ * Flatten an engine inbox *summary* payload into the flat message list the
+ * plugin's UX is built around. `/v1/inbox` has no `messages` array; the
+ * message-like items are channel `mentions` and the `lastMessage` of each
+ * unread DM conversation.
+ *
+ * This is summary-only: it cannot recover earlier unread DMs (when
+ * `unreadCount > 1`) or unread channel posts that did not mention us. Use
+ * {@link collectInboxMessages} to hydrate those from the messages APIs.
+ *
+ * Defensive against a null/partial payload: the engine contract guarantees the
+ * arrays, but treat anything missing or non-array as empty rather than throwing
+ * inside an idle poll.
+ */
+export function inboxToMessages(inbox: InboxResponse | null | undefined): RelayMessage[] {
   const messages: RelayMessage[] = [];
 
-  for (const mention of inbox.mentions) {
+  const mentions = Array.isArray(inbox?.mentions) ? inbox.mentions : [];
+  for (const mention of mentions) {
     messages.push({
       id: mention.id,
       from: mention.agentName,
@@ -121,7 +139,8 @@ export function inboxToMessages(inbox: InboxResponse): RelayMessage[] {
     });
   }
 
-  for (const dm of inbox.unreadDms) {
+  const unreadDms = Array.isArray(inbox?.unreadDms) ? inbox.unreadDms : [];
+  for (const dm of unreadDms) {
     if (!dm.lastMessage) {
       continue;
     }
@@ -134,6 +153,155 @@ export function inboxToMessages(inbox: InboxResponse): RelayMessage[] {
   }
 
   return messages;
+}
+
+/** Best-effort hydration of a multi-message DM conversation's unread tail. */
+async function fetchUnreadDmMessages(
+  agent: AgentClient,
+  conversationId: string,
+  from: string,
+  unreadCount: number
+): Promise<RelayMessage[]> {
+  const limit = Math.min(unreadCount, MAX_UNREAD_FETCH);
+  let dmMessages: DmMessage[];
+  try {
+    dmMessages = await agent.dms.messages(conversationId, { limit });
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(dmMessages)) {
+    return [];
+  }
+  // `dms.messages` returns newest-first; take the unread tail and restore
+  // chronological order so multi-message instructions read top-to-bottom.
+  return dmMessages
+    .slice(0, limit)
+    .reverse()
+    .map((message) => ({
+      id: message.id,
+      from: message.agentName ?? from,
+      text: message.text,
+      ts: message.createdAt,
+    }));
+}
+
+/** Best-effort hydration of unread posts in a channel we are not mentioned in. */
+async function fetchUnreadChannelMessages(
+  agent: AgentClient,
+  channelName: string,
+  unreadCount: number
+): Promise<RelayMessage[]> {
+  const limit = Math.min(unreadCount, MAX_UNREAD_FETCH);
+  let channelMessages: MessageWithMeta[];
+  try {
+    channelMessages = await agent.messages(channelName, { limit });
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(channelMessages)) {
+    return [];
+  }
+  return channelMessages
+    .slice(0, limit)
+    .reverse()
+    .map((message) => ({
+      id: message.id,
+      from: message.agentName,
+      text: message.text,
+      channel: channelName,
+      ts: message.createdAt,
+    }));
+}
+
+/**
+ * Build the flat, ordered list of *new* inbox messages and drain them, faithfully
+ * replicating the old `/inbox/check` queue behavior on top of the read-only
+ * engine inbox summary:
+ *
+ *  - Channel `mentions` and unread-DM `lastMessage`s come straight from the
+ *    summary (as in {@link inboxToMessages}).
+ *  - Multi-message DM conversations (`unreadCount > 1`) and unread channel posts
+ *    that did not mention us are hydrated from the DM / channel message APIs so
+ *    earlier instructions and non-mention channel traffic are not dropped.
+ *  - Every surfaced message is drained: recorded in `state.seenMessageIds`
+ *    (so it is never re-injected) and `markRead`-acked on the engine
+ *    (best-effort) so the summary stops reporting it as unread.
+ */
+export async function collectInboxMessages(
+  agent: AgentClient,
+  inbox: InboxResponse | null | undefined,
+  seen: Set<string>
+): Promise<RelayMessage[]> {
+  const collected: RelayMessage[] = [];
+  const seenInBatch = new Set<string>();
+
+  const push = (message: RelayMessage): void => {
+    if (!message.id || seenInBatch.has(message.id)) {
+      return;
+    }
+    seenInBatch.add(message.id);
+    collected.push(message);
+  };
+
+  const mentions = Array.isArray(inbox?.mentions) ? inbox.mentions : [];
+  for (const mention of mentions) {
+    push({
+      id: mention.id,
+      from: mention.agentName,
+      text: mention.text,
+      channel: mention.channelName,
+      ts: mention.createdAt,
+    });
+  }
+
+  const unreadDms = Array.isArray(inbox?.unreadDms) ? inbox.unreadDms : [];
+  for (const dm of unreadDms) {
+    if ((dm.unreadCount ?? 0) > 1 && dm.conversationId) {
+      const hydrated = await fetchUnreadDmMessages(agent, dm.conversationId, dm.from, dm.unreadCount);
+      if (hydrated.length > 0) {
+        for (const message of hydrated) {
+          push(message);
+        }
+        continue;
+      }
+    }
+    if (dm.lastMessage) {
+      push({
+        id: dm.lastMessage.id,
+        from: dm.from,
+        text: dm.lastMessage.text,
+        ts: dm.lastMessage.createdAt,
+      });
+    }
+  }
+
+  const unreadChannels = Array.isArray(inbox?.unreadChannels) ? inbox.unreadChannels : [];
+  for (const channel of unreadChannels) {
+    if (!channel.channelName || (channel.unreadCount ?? 0) <= 0) {
+      continue;
+    }
+    const hydrated = await fetchUnreadChannelMessages(agent, channel.channelName, channel.unreadCount);
+    for (const message of hydrated) {
+      push(message);
+    }
+  }
+
+  // Drain: drop anything already surfaced, then watermark + ack the rest.
+  const fresh = collected.filter((message) => !seen.has(message.id));
+  for (const message of fresh) {
+    seen.add(message.id);
+  }
+  await Promise.all(
+    fresh.map(async (message) => {
+      try {
+        await agent.markRead(message.id);
+      } catch {
+        // Best-effort: the local watermark already prevents re-injection.
+      }
+    })
+  );
+
+  return fresh;
 }
 
 export function createRelayConnectTool(
@@ -166,12 +334,12 @@ export function createRelayConnectTool(
 
       const relay = createRelayCast({ apiKey: workspace, baseUrl: state.apiBaseUrl });
 
-      let token: string;
+      let token: string | undefined;
       try {
         // Register (or rotate) this agent identity in the workspace and obtain
         // its agent token; this is the SDK equivalent of the old /register call.
         const registration = await relay.registerOrRotate({ name });
-        token = registration.token;
+        token = registration?.token;
       } catch (error) {
         if (isAuthError(error)) {
           throw new Error('Invalid workspace key. Get one at relaycast.dev');
@@ -231,7 +399,7 @@ export function createRelayInboxTool(
     async handler() {
       assertConnected(state);
       const inbox = await state.agent.inbox();
-      const messages = inboxToMessages(inbox);
+      const messages = await collectInboxMessages(state.agent, inbox, state.seenMessageIds);
       return { count: messages.length, messages };
     },
   };

--- a/plugins/opencode-relay-plugin/tests/integration.test.ts
+++ b/plugins/opencode-relay-plugin/tests/integration.test.ts
@@ -3,7 +3,7 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import relayPlugin, {
+import {
   RelayState,
   type SpawnLike,
   createRelayConnectTool,
@@ -14,8 +14,7 @@ import relayPlugin, {
 import {
   MockRelayServer,
   connectRelayState,
-  createMockFetch,
-  createPluginContext,
+  createMockRelayCastFactory,
 } from './mock-relay-server.js';
 
 class FakeChildProcess extends EventEmitter implements Pick<ChildProcess, 'kill' | 'pid'> {
@@ -36,11 +35,9 @@ describe('Integration tests', () => {
 
   beforeEach(() => {
     server = new MockRelayServer();
-    vi.stubGlobal('fetch', createMockFetch(server) as typeof fetch);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -48,7 +45,9 @@ describe('Integration tests', () => {
     const state = new RelayState();
 
     // Connect
-    await createRelayConnectTool(state).handler({
+    await createRelayConnectTool(state, {
+      createRelayCast: createMockRelayCastFactory(server),
+    }).handler({
       workspace: 'rk_live_test_workspace',
       name: 'Alice',
     });
@@ -77,7 +76,7 @@ describe('Integration tests', () => {
   });
 
   it('spawn-ack-flow: spawn worker, worker ACKs, worker sends DONE, dismiss', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     const proc = new FakeChildProcess(9999);
     const spawnMock = vi.fn<SpawnLike>(() => proc as unknown as ChildProcess);
 

--- a/plugins/opencode-relay-plugin/tests/integration.test.ts
+++ b/plugins/opencode-relay-plugin/tests/integration.test.ts
@@ -11,11 +11,7 @@ import {
   createRelaySendTool,
   createRelaySpawnTool,
 } from '../src/index.js';
-import {
-  MockRelayServer,
-  connectRelayState,
-  createMockRelayCastFactory,
-} from './mock-relay-server.js';
+import { MockRelayServer, connectRelayState, createMockRelayCastFactory } from './mock-relay-server.js';
 
 class FakeChildProcess extends EventEmitter implements Pick<ChildProcess, 'kill' | 'pid'> {
   pid: number;

--- a/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
+++ b/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
@@ -17,6 +17,8 @@ interface QueuedDm {
   from: string;
   text: string;
   ts: string;
+  channel?: string;
+  conversationId?: string;
 }
 
 /**
@@ -30,43 +32,112 @@ export class MockRelayServer {
   requests: MockRequest[] = [];
   registerShouldFail = false;
 
-  /** Pending DMs that the next `inbox()` call should surface, then drain. */
-  private inboxDms: QueuedDm[] = [];
+  /**
+   * Unread items the engine inbox reports. The engine inbox is *read-only*: it
+   * keeps reporting these until the agent acks each one via `markRead`. We model
+   * that here so tests exercise the plugin's drain (markRead + watermark) path.
+   */
+  private inboxItems: QueuedDm[] = [];
+  /** Message IDs the agent has acked via markRead. */
+  readMessageIds = new Set<string>();
 
   injectMessage(from: string, text: string, extra: Partial<Message> = {}): void {
     const id = crypto.randomUUID();
     const ts = new Date().toISOString();
     this.messages.push({ id, from, text, ts, ...extra });
     // The engine inbox exposes DMs (and channel mentions); model these as DMs.
-    this.inboxDms.push({ id, from, text, ts });
+    this.inboxItems.push({ id, from, text, ts, conversationId: `conv-${from}` });
+  }
+
+  /** Inject a channel mention (surfaces under inbox `mentions`). */
+  injectMention(from: string, channel: string, text: string): string {
+    const id = crypto.randomUUID();
+    const ts = new Date().toISOString();
+    this.inboxItems.push({ id, from, text, ts, channel });
+    return id;
+  }
+
+  /** Inject a DM into an explicit conversation (for multi-message DM tests). */
+  injectDm(from: string, conversationId: string, text: string): string {
+    const id = crypto.randomUUID();
+    const ts = new Date().toISOString();
+    this.inboxItems.push({ id, from, text, ts, conversationId });
+    return id;
+  }
+
+  /** Inject an unread channel post that does NOT mention the reader. */
+  injectChannelPost(from: string, channel: string, text: string): string {
+    const id = crypto.randomUUID();
+    const ts = new Date().toISOString();
+    // No `mention` flag: lands under unread_channels, not mentions.
+    this.inboxItems.push({ id, from, text, ts, channel, conversationId: undefined });
+    // Tag as a non-mention channel post via a sentinel on the object.
+    (this.inboxItems[this.inboxItems.length - 1] as QueuedDm & { channelPost?: boolean }).channelPost =
+      true;
+    return id;
   }
 
   record(endpoint: string, body: Record<string, unknown>): void {
     this.requests.push({ endpoint, body });
   }
 
-  drainInbox() {
-    const mentions = this.inboxDms
-      .filter((m) => 'channel' in m)
+  /** All unacked items for a given conversation, oldest-first. */
+  conversationMessages(conversationId: string): QueuedDm[] {
+    return this.inboxItems.filter(
+      (m) => m.conversationId === conversationId && !this.readMessageIds.has(m.id)
+    );
+  }
+
+  /** All unacked posts for a given channel, oldest-first. */
+  channelMessages(channel: string): QueuedDm[] {
+    return this.inboxItems.filter((m) => m.channel === channel && !this.readMessageIds.has(m.id));
+  }
+
+  markRead(messageId: string): void {
+    this.readMessageIds.add(messageId);
+  }
+
+  /** Build the engine inbox *summary* from current unacked items (read-only). */
+  buildInbox() {
+    const unread = this.inboxItems.filter((m) => !this.readMessageIds.has(m.id));
+
+    const mentions = unread
+      .filter((m) => m.channel && !(m as QueuedDm & { channelPost?: boolean }).channelPost)
       .map((m) => ({
         id: m.id,
-        channelName: '',
+        channelName: m.channel ?? '',
         agentName: m.from,
         text: m.text,
         createdAt: m.ts,
       }));
 
-    const unreadDms = this.inboxDms.map((m) => ({
-      conversationId: `conv-${m.from}`,
-      from: m.from,
-      unreadCount: 1,
-      lastMessage: { id: m.id, text: m.text, createdAt: m.ts },
+    // Group DM items by conversation; summary carries only the last message.
+    const dmConvIds = [
+      ...new Set(unread.filter((m) => m.conversationId).map((m) => m.conversationId as string)),
+    ];
+    const unreadDms = dmConvIds.map((conversationId) => {
+      const items = unread.filter((m) => m.conversationId === conversationId);
+      const last = items[items.length - 1];
+      return {
+        conversationId,
+        from: last.from,
+        unreadCount: items.length,
+        lastMessage: { id: last.id, text: last.text, createdAt: last.ts },
+      };
+    });
+
+    // Channel posts (non-mentions) only surface as an unread count in summary.
+    const channelPosts = unread.filter(
+      (m) => m.channel && (m as QueuedDm & { channelPost?: boolean }).channelPost
+    );
+    const channelNames = [...new Set(channelPosts.map((m) => m.channel as string))];
+    const unreadChannels = channelNames.map((channelName) => ({
+      channelName,
+      unreadCount: channelPosts.filter((m) => m.channel === channelName).length,
     }));
 
-    this.inboxDms = [];
-
     return {
-      unreadChannels: [],
+      unreadChannels,
       mentions,
       unreadDms,
       recentReactions: [],
@@ -75,7 +146,27 @@ export class MockRelayServer {
 }
 
 class MockAgentClient {
-  constructor(private readonly server: MockRelayServer) {}
+  dms: {
+    messages: (conversationId: string, opts?: { limit?: number }) => Promise<unknown[]>;
+  };
+
+  constructor(private readonly server: MockRelayServer) {
+    this.dms = {
+      // Returns newest-first, mirroring the engine contract.
+      messages: async (conversationId, opts) => {
+        this.server.record('dm/messages', { conversationId, limit: opts?.limit ?? null });
+        const items = this.server.conversationMessages(conversationId).slice().reverse();
+        const limit = opts?.limit ?? items.length;
+        return items.slice(0, limit).map((m) => ({
+          id: m.id,
+          agentId: m.from,
+          agentName: m.from,
+          text: m.text,
+          createdAt: m.ts,
+        }));
+      },
+    };
+  }
 
   async dm(agent: string, text: string) {
     this.server.record('dm/send', { to: agent, text });
@@ -91,9 +182,30 @@ class MockAgentClient {
     return { id: crypto.randomUUID(), channel, text };
   }
 
+  // Channel message listing, newest-first.
+  async messages(channel: string, opts?: { limit?: number }) {
+    this.server.record('message/list', { channel, limit: opts?.limit ?? null });
+    const items = this.server.channelMessages(channel).slice().reverse();
+    const limit = opts?.limit ?? items.length;
+    return items.slice(0, limit).map((m) => ({
+      id: m.id,
+      channelId: channel,
+      agentId: m.from,
+      agentName: m.from,
+      text: m.text,
+      createdAt: m.ts,
+    }));
+  }
+
   async inbox() {
     this.server.record('inbox/check', {});
-    return this.server.drainInbox();
+    return this.server.buildInbox();
+  }
+
+  async markRead(messageId: string) {
+    this.server.record('message/read', { messageId });
+    this.server.markRead(messageId);
+    return { messageId, readAt: new Date().toISOString() };
   }
 }
 

--- a/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
+++ b/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
@@ -34,12 +34,22 @@ export class MockRelayServer {
 
   /**
    * Unread items the engine inbox reports. The engine inbox is *read-only*: it
-   * keeps reporting these until the agent acks each one via `markRead`. We model
-   * that here so tests exercise the plugin's drain (markRead + watermark) path.
+   * keeps reporting these until the agent drains each one on the durable
+   * delivery ledger via `ackDelivery`. We model that here so tests exercise the
+   * plugin's drain (delivery ack + watermark) path.
    */
   private inboxItems: QueuedDm[] = [];
-  /** Message IDs the agent has acked via markRead. */
+  /**
+   * Durable delivery ledger keyed by deliveryId. Each row points at the
+   * underlying messageId. An item is "unread" until its delivery is acked.
+   */
+  private deliveryRows: { deliveryId: string; messageId: string; acked: boolean }[] = [];
+  /** Message IDs whose durable delivery has been acked. */
   readMessageIds = new Set<string>();
+
+  private enqueueDelivery(messageId: string): void {
+    this.deliveryRows.push({ deliveryId: `dlv-${messageId}`, messageId, acked: false });
+  }
 
   injectMessage(from: string, text: string, extra: Partial<Message> = {}): void {
     const id = crypto.randomUUID();
@@ -47,6 +57,7 @@ export class MockRelayServer {
     this.messages.push({ id, from, text, ts, ...extra });
     // The engine inbox exposes DMs (and channel mentions); model these as DMs.
     this.inboxItems.push({ id, from, text, ts, conversationId: `conv-${from}` });
+    this.enqueueDelivery(id);
   }
 
   /** Inject a channel mention (surfaces under inbox `mentions`). */
@@ -54,6 +65,7 @@ export class MockRelayServer {
     const id = crypto.randomUUID();
     const ts = new Date().toISOString();
     this.inboxItems.push({ id, from, text, ts, channel });
+    this.enqueueDelivery(id);
     return id;
   }
 
@@ -62,6 +74,7 @@ export class MockRelayServer {
     const id = crypto.randomUUID();
     const ts = new Date().toISOString();
     this.inboxItems.push({ id, from, text, ts, conversationId });
+    this.enqueueDelivery(id);
     return id;
   }
 
@@ -73,6 +86,7 @@ export class MockRelayServer {
     this.inboxItems.push({ id, from, text, ts, channel, conversationId: undefined });
     // Tag as a non-mention channel post via a sentinel on the object.
     (this.inboxItems[this.inboxItems.length - 1] as QueuedDm & { channelPost?: boolean }).channelPost = true;
+    this.enqueueDelivery(id);
     return id;
   }
 
@@ -92,8 +106,20 @@ export class MockRelayServer {
     return this.inboxItems.filter((m) => m.channel === channel && !this.readMessageIds.has(m.id));
   }
 
-  markRead(messageId: string): void {
-    this.readMessageIds.add(messageId);
+  /** Non-terminal (unacked) delivery rows, each carrying its messageId. */
+  deliveries(): { deliveryId: string; messageId: string }[] {
+    return this.deliveryRows
+      .filter((row) => !row.acked)
+      .map((row) => ({ deliveryId: row.deliveryId, messageId: row.messageId }));
+  }
+
+  /** Ack a delivery by deliveryId; marks its message read so the inbox drains. */
+  ackDelivery(deliveryId: string): void {
+    const row = this.deliveryRows.find((r) => r.deliveryId === deliveryId);
+    if (row) {
+      row.acked = true;
+      this.readMessageIds.add(row.messageId);
+    }
   }
 
   /** Build the engine inbox *summary* from current unacked items (read-only). */
@@ -201,10 +227,19 @@ class MockAgentClient {
     return this.server.buildInbox();
   }
 
-  async markRead(messageId: string) {
-    this.server.record('message/read', { messageId });
-    this.server.markRead(messageId);
-    return { messageId, readAt: new Date().toISOString() };
+  async deliveries(opts?: { status?: string; limit?: number }) {
+    this.server.record('deliveries/list', { status: opts?.status ?? null, limit: opts?.limit ?? null });
+    return this.server.deliveries().map((row) => ({
+      id: row.deliveryId,
+      messageId: row.messageId,
+      status: 'delivered',
+    }));
+  }
+
+  async ackDelivery(deliveryId: string) {
+    this.server.record('deliveries/ack', { deliveryId });
+    this.server.ackDelivery(deliveryId);
+    return { id: deliveryId, status: 'acked' };
   }
 }
 

--- a/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
+++ b/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
@@ -1,12 +1,6 @@
 import { vi } from 'vitest';
 
-import type {
-  Message,
-  PluginContext,
-  RelayCastFactory,
-  RelayState,
-  ToolDefinition,
-} from '../src/index.js';
+import type { Message, PluginContext, RelayCastFactory, RelayState, ToolDefinition } from '../src/index.js';
 
 /**
  * Records every call the plugin makes through the SDK, keyed by a stable

--- a/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
+++ b/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
@@ -1,102 +1,165 @@
 import { vi } from 'vitest';
 
-import type { Message, PluginContext, RelayState, ToolDefinition } from '../src/index.js';
+import type {
+  Message,
+  PluginContext,
+  RelayCastFactory,
+  RelayState,
+  ToolDefinition,
+} from '../src/index.js';
 
-interface MockResponse {
-  status: number;
-  body: unknown;
-}
-
+/**
+ * Records every call the plugin makes through the SDK, keyed by a stable
+ * `endpoint` label so tests can assert on transport behavior the same way they
+ * did against the old bespoke HTTP server.
+ */
 export interface MockRequest {
   endpoint: string;
   body: Record<string, unknown>;
-  headers: HeadersInit | undefined;
 }
 
+interface QueuedDm {
+  id: string;
+  from: string;
+  text: string;
+  ts: string;
+}
+
+/**
+ * In-memory stand-in for the relaycast engine. It models just enough of the
+ * RelayCast (workspace) + AgentClient (agent) surface that the plugin touches,
+ * and exposes the recorded request log + an inbox queue for assertions.
+ */
 export class MockRelayServer {
   messages: Message[] = [];
   agents: string[] = [];
   requests: MockRequest[] = [];
-  responses = new Map<string, MockResponse>();
+  registerShouldFail = false;
+
+  /** Pending DMs that the next `inbox()` call should surface, then drain. */
+  private inboxDms: QueuedDm[] = [];
 
   injectMessage(from: string, text: string, extra: Partial<Message> = {}): void {
-    this.messages.push({
-      id: crypto.randomUUID(),
-      from,
-      text,
-      ts: new Date().toISOString(),
-      ...extra,
-    });
+    const id = crypto.randomUUID();
+    const ts = new Date().toISOString();
+    this.messages.push({ id, from, text, ts, ...extra });
+    // The engine inbox exposes DMs (and channel mentions); model these as DMs.
+    this.inboxDms.push({ id, from, text, ts });
   }
 
-  setResponse(endpoint: string, status: number, body: unknown): void {
-    this.responses.set(endpoint, { status, body });
+  record(endpoint: string, body: Record<string, unknown>): void {
+    this.requests.push({ endpoint, body });
   }
 
-  async handle(endpoint: string, body: Record<string, unknown>): Promise<unknown> {
-    switch (endpoint) {
-      case 'dm/send':
-        this.messages.push({
-          id: crypto.randomUUID(),
-          from: 'self',
-          text: String(body.text ?? ''),
-          ts: new Date().toISOString(),
-        });
-        return { ok: true };
-      case 'message/post':
-        return { ok: true };
-      case 'inbox/check': {
-        const queued = [...this.messages];
-        this.messages = [];
-        return { messages: queued };
-      }
-      case 'agent/list':
-        return { agents: this.agents };
-      case 'register':
-        return { token: 'test-token-123' };
-      case 'agent/add': {
-        const name = body.name;
-        if (typeof name === 'string' && !this.agents.includes(name)) {
-          this.agents.push(name);
-        }
-        return { ok: true };
-      }
-      case 'agent/remove': {
-        const name = body.name;
-        if (typeof name === 'string') {
-          this.agents = this.agents.filter((agent) => agent !== name);
-        }
-        return { ok: true };
-      }
-      default:
-        return { ok: true };
-    }
+  drainInbox() {
+    const mentions = this.inboxDms
+      .filter((m) => 'channel' in m)
+      .map((m) => ({
+        id: m.id,
+        channelName: '',
+        agentName: m.from,
+        text: m.text,
+        createdAt: m.ts,
+      }));
+
+    const unreadDms = this.inboxDms.map((m) => ({
+      conversationId: `conv-${m.from}`,
+      from: m.from,
+      unreadCount: 1,
+      lastMessage: { id: m.id, text: m.text, createdAt: m.ts },
+    }));
+
+    this.inboxDms = [];
+
+    return {
+      unreadChannels: [],
+      mentions,
+      unreadDms,
+      recentReactions: [],
+    };
   }
 }
 
-export function createMockFetch(server: MockRelayServer) {
-  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-    const url =
-      typeof input === 'string' || input instanceof URL ? new URL(String(input)) : new URL(input.url);
-    const endpoint = url.pathname.replace(/^\/api\/v1\//, '');
-    const body =
-      typeof init?.body === 'string' && init.body.length > 0
-        ? (JSON.parse(init.body) as Record<string, unknown>)
-        : {};
+class MockAgentClient {
+  constructor(private readonly server: MockRelayServer) {}
 
-    server.requests.push({
-      endpoint,
-      body,
-      headers: init?.headers,
-    });
+  async dm(agent: string, text: string) {
+    this.server.record('dm/send', { to: agent, text });
+    return {
+      conversationId: `conv-${agent}`,
+      message: { id: crypto.randomUUID(), agentId: 'self', agentName: 'self', text },
+      createdAt: new Date().toISOString(),
+    };
+  }
 
-    const override = server.responses.get(endpoint);
-    if (override) {
-      return createResponse(override.body, override.status);
+  async post(channel: string, text: string) {
+    this.server.record('message/post', { channel, text });
+    return { id: crypto.randomUUID(), channel, text };
+  }
+
+  async inbox() {
+    this.server.record('inbox/check', {});
+    return this.server.drainInbox();
+  }
+}
+
+class MockRelayCast {
+  agents: {
+    list: () => Promise<unknown[]>;
+    registerOrGet: (data: { name: string; metadata?: Record<string, unknown> }) => Promise<unknown>;
+    delete: (name: string) => Promise<void>;
+  };
+
+  private agentClient: MockAgentClient;
+
+  constructor(private readonly server: MockRelayServer) {
+    this.agentClient = new MockAgentClient(server);
+    this.agents = {
+      list: async () => {
+        server.record('agent/list', {});
+        return server.agents;
+      },
+      registerOrGet: async (data) => {
+        server.record('agent/add', { name: data.name, ...(data.metadata ?? {}) });
+        if (typeof data.name === 'string' && !server.agents.includes(data.name)) {
+          server.agents.push(data.name);
+        }
+        return { id: crypto.randomUUID(), name: data.name, token: 'worker-token', status: 'online' };
+      },
+      delete: async (name) => {
+        server.record('agent/remove', { name });
+        server.agents = server.agents.filter((a) => a !== name);
+      },
+    };
+  }
+
+  async registerOrRotate(data: { name: string }) {
+    this.server.record('register', { name: data.name, workspace: this.apiKey, cli: 'opencode' });
+    if (this.server.registerShouldFail) {
+      throw new Error('register failed');
     }
+    return {
+      id: crypto.randomUUID(),
+      name: data.name,
+      token: 'test-token-123',
+      status: 'online',
+      createdAt: new Date().toISOString(),
+    };
+  }
 
-    return createResponse(await server.handle(endpoint, body), 200);
-  });
+  apiKey = '';
+
+  as(_token: string) {
+    return this.agentClient;
+  }
+}
+
+export function createMockRelayCastFactory(server: MockRelayServer): RelayCastFactory {
+  return vi.fn((options: { apiKey: string }) => {
+    const relay = new MockRelayCast(server);
+    relay.apiKey = options.apiKey;
+    return relay as unknown as ReturnType<RelayCastFactory>;
+  }) as unknown as RelayCastFactory;
 }
 
 export function createPluginContext() {
@@ -110,18 +173,18 @@ export function createPluginContext() {
   return { ctx, tools };
 }
 
-export function connectRelayState(state: RelayState): RelayState {
+/**
+ * Connect a RelayState directly against the mock SDK (skips the real connect
+ * handler) for tests that start from an already-connected state.
+ */
+export function connectRelayState(state: RelayState, server: MockRelayServer): RelayState {
+  const relay = new MockRelayCast(server);
+  relay.apiKey = 'rk_live_test_workspace';
   state.agentName = 'Lead';
   state.workspace = 'rk_live_test_workspace';
   state.token = 'test-token-123';
+  state.relay = relay as unknown as RelayState['relay'];
+  state.agent = relay.as('test-token-123') as unknown as RelayState['agent'];
   state.connected = true;
   return state;
-}
-
-function createResponse(body: unknown, status: number): Response {
-  const payload = typeof body === 'string' ? body : JSON.stringify(body);
-  return new Response(payload, {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
 }

--- a/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
+++ b/plugins/opencode-relay-plugin/tests/mock-relay-server.ts
@@ -72,8 +72,7 @@ export class MockRelayServer {
     // No `mention` flag: lands under unread_channels, not mentions.
     this.inboxItems.push({ id, from, text, ts, channel, conversationId: undefined });
     // Tag as a non-mention channel post via a sentinel on the object.
-    (this.inboxItems[this.inboxItems.length - 1] as QueuedDm & { channelPost?: boolean }).channelPost =
-      true;
+    (this.inboxItems[this.inboxItems.length - 1] as QueuedDm & { channelPost?: boolean }).channelPost = true;
     return id;
   }
 

--- a/plugins/opencode-relay-plugin/tests/polling.test.ts
+++ b/plugins/opencode-relay-plugin/tests/polling.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RelayState, type HookHandler } from '../src/index.js';
 import { registerHooks } from '../src/hooks.js';
+import type { InboxResponse } from '@relaycast/sdk';
 
 type HookRegistry = Record<string, HookHandler>;
 type HookRegistrationContext = {
@@ -20,44 +21,43 @@ function createContext(): { ctx: HookRegistrationContext; hooks: HookRegistry } 
   };
 }
 
-function createConnectedState(): RelayState {
+function emptyInbox(): InboxResponse {
+  return {
+    unreadChannels: [],
+    mentions: [],
+    unreadDms: [],
+    recentReactions: [],
+  } as unknown as InboxResponse;
+}
+
+function createConnectedState(inbox: () => Promise<InboxResponse>): {
+  state: RelayState;
+  inboxMock: ReturnType<typeof vi.fn>;
+} {
   const state = new RelayState();
   state.connected = true;
   state.agentName = 'Lead';
   state.workspace = 'rk_live_1234567890abcdef';
   state.token = 'tok_test';
-  return state;
-}
-
-function jsonResponse(body: unknown) {
-  return {
-    ok: true,
-    status: 200,
-    json: vi.fn().mockResolvedValue(body),
-    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
-  };
+  const inboxMock = vi.fn(inbox);
+  state.agent = { inbox: inboxMock } as unknown as RelayState['agent'];
+  return { state, inboxMock };
 }
 
 describe('OpenCode relay hooks', () => {
-  const fetchMock = vi.fn();
-
   beforeEach(() => {
-    fetchMock.mockReset();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-13T15:00:00Z'));
-    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('idle-no-messages', async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ messages: [] }));
-
     const { ctx, hooks } = createContext();
-    const state = createConnectedState();
+    const { state, inboxMock } = createConnectedState(async () => emptyInbox());
     registerHooks(ctx, state);
 
     const firstResult = await hooks['session.idle']();
@@ -68,53 +68,62 @@ describe('OpenCode relay hooks', () => {
     expect(firstResult).toBeUndefined();
     expect(secondResult).toBeUndefined();
     expect(thirdResult).toBeUndefined();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://www.relaycast.dev/api/v1/inbox/check', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer tok_test',
-      },
-      body: '{}',
-    });
+    // Second call is throttled by the watermark; only the 1st and 3rd poll.
+    expect(inboxMock).toHaveBeenCalledTimes(2);
   });
 
   it('idle-surfaces-messages', async () => {
-    fetchMock.mockResolvedValue(
-      jsonResponse({
-        messages: [
-          {
+    const inbox: InboxResponse = {
+      unreadChannels: [],
+      mentions: [
+        {
+          id: 'msg-2',
+          channelName: 'general',
+          agentName: 'bob',
+          text: 'Standup in five minutes.',
+          createdAt: '2026-03-13T15:00:01Z',
+        },
+      ],
+      unreadDms: [
+        {
+          conversationId: 'conv-alice',
+          from: 'alice',
+          unreadCount: 1,
+          lastMessage: {
             id: 'msg-1',
-            from: 'alice',
             text: 'Please review auth middleware.',
-            ts: '2026-03-13T15:00:00Z',
+            createdAt: '2026-03-13T15:00:00Z',
           },
-          {
-            id: 'msg-2',
-            from: 'bob',
-            channel: 'general',
-            text: 'Standup in five minutes.',
-            ts: '2026-03-13T15:00:01Z',
-          },
-        ],
-      })
-    );
+        },
+      ],
+      recentReactions: [],
+    } as unknown as InboxResponse;
 
     const { ctx, hooks } = createContext();
-    const state = createConnectedState();
+    const { state } = createConnectedState(async () => inbox);
     registerHooks(ctx, state);
 
     await expect(hooks['session.idle']()).resolves.toEqual({
       inject:
-        'Relay message from alice: Please review auth middleware.\n\n' +
-        'Relay message from bob [#general]: Standup in five minutes.',
+        'Relay message from bob [#general]: Standup in five minutes.\n\n' +
+        'Relay message from alice: Please review auth middleware.',
       continue: true,
     });
   });
 
+  it('idle-swallows-errors', async () => {
+    const { ctx, hooks } = createContext();
+    const { state } = createConnectedState(async () => {
+      throw new Error('boom');
+    });
+    registerHooks(ctx, state);
+
+    await expect(hooks['session.idle']()).resolves.toBeUndefined();
+  });
+
   it('compacting-preserves', async () => {
     const { ctx, hooks } = createContext();
-    const state = createConnectedState();
+    const { state } = createConnectedState(async () => emptyInbox());
     state.spawned.set('worker-a', {
       name: 'worker-a',
       process: { kill: vi.fn().mockReturnValue(true) },
@@ -146,7 +155,7 @@ describe('OpenCode relay hooks', () => {
     const doneKill = vi.fn().mockReturnValue(true);
 
     const { ctx, hooks } = createContext();
-    const state = createConnectedState();
+    const { state } = createConnectedState(async () => emptyInbox());
     state.spawned.set('worker-a', {
       name: 'worker-a',
       process: { kill: runningKill },

--- a/plugins/opencode-relay-plugin/tests/polling.test.ts
+++ b/plugins/opencode-relay-plugin/tests/polling.test.ts
@@ -148,9 +148,7 @@ describe('OpenCode relay hooks', () => {
       recentReactions: [],
     } as unknown as InboxResponse;
 
-    const deliveriesMock = vi.fn(async () => [
-      { id: 'dlv-1', messageId: 'msg-1', status: 'delivered' },
-    ]);
+    const deliveriesMock = vi.fn(async () => [{ id: 'dlv-1', messageId: 'msg-1', status: 'delivered' }]);
     const ackDeliveryMock = vi.fn(async () => ({ id: 'dlv-1', status: 'acked' }));
     const { ctx, hooks } = createContext();
     const { state } = createConnectedState(async () => inbox, {

--- a/plugins/opencode-relay-plugin/tests/polling.test.ts
+++ b/plugins/opencode-relay-plugin/tests/polling.test.ts
@@ -30,9 +30,15 @@ function emptyInbox(): InboxResponse {
   } as unknown as InboxResponse;
 }
 
-function createConnectedState(inbox: () => Promise<InboxResponse>): {
+function createConnectedState(
+  inbox: () => Promise<InboxResponse>,
+  overrides: Partial<Record<'markRead' | 'messages', ReturnType<typeof vi.fn>>> & {
+    dms?: { messages: ReturnType<typeof vi.fn> };
+  } = {}
+): {
   state: RelayState;
   inboxMock: ReturnType<typeof vi.fn>;
+  markReadMock: ReturnType<typeof vi.fn>;
 } {
   const state = new RelayState();
   state.connected = true;
@@ -40,8 +46,14 @@ function createConnectedState(inbox: () => Promise<InboxResponse>): {
   state.workspace = 'rk_live_1234567890abcdef';
   state.token = 'tok_test';
   const inboxMock = vi.fn(inbox);
-  state.agent = { inbox: inboxMock } as unknown as RelayState['agent'];
-  return { state, inboxMock };
+  const markReadMock = overrides.markRead ?? vi.fn(async () => ({ messageId: 'x' }));
+  state.agent = {
+    inbox: inboxMock,
+    markRead: markReadMock,
+    messages: overrides.messages ?? vi.fn(async () => []),
+    dms: overrides.dms ?? { messages: vi.fn(async () => []) },
+  } as unknown as RelayState['agent'];
+  return { state, inboxMock, markReadMock };
 }
 
 describe('OpenCode relay hooks', () => {
@@ -109,6 +121,47 @@ describe('OpenCode relay hooks', () => {
         'Relay message from alice: Please review auth middleware.',
       continue: true,
     });
+  });
+
+  it('idle-drains-and-does-not-reinject', async () => {
+    // The read-only engine inbox keeps reporting the same DM until acked, so the
+    // plugin must markRead + watermark to avoid re-injecting it every poll.
+    const inbox: InboxResponse = {
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [
+        {
+          conversationId: 'conv-alice',
+          from: 'alice',
+          unreadCount: 1,
+          lastMessage: {
+            id: 'msg-1',
+            text: 'Please review auth middleware.',
+            createdAt: '2026-03-13T15:00:00Z',
+          },
+        },
+      ],
+      recentReactions: [],
+    } as unknown as InboxResponse;
+
+    const markReadMock = vi.fn(async () => ({ messageId: 'msg-1' }));
+    const { ctx, hooks } = createContext();
+    const { state } = createConnectedState(async () => inbox, { markRead: markReadMock });
+    registerHooks(ctx, state);
+
+    const first = await hooks['session.idle']();
+    expect(first).toEqual({
+      inject: 'Relay message from alice: Please review auth middleware.',
+      continue: true,
+    });
+    expect(markReadMock).toHaveBeenCalledWith('msg-1');
+
+    // Next poll (past the throttle window) returns the same read-only inbox, but
+    // the watermark suppresses re-injection.
+    vi.advanceTimersByTime(3_000);
+    const second = await hooks['session.idle']();
+    expect(second).toBeUndefined();
+    expect(markReadMock).toHaveBeenCalledTimes(1);
   });
 
   it('idle-swallows-errors', async () => {

--- a/plugins/opencode-relay-plugin/tests/polling.test.ts
+++ b/plugins/opencode-relay-plugin/tests/polling.test.ts
@@ -32,13 +32,14 @@ function emptyInbox(): InboxResponse {
 
 function createConnectedState(
   inbox: () => Promise<InboxResponse>,
-  overrides: Partial<Record<'markRead' | 'messages', ReturnType<typeof vi.fn>>> & {
+  overrides: Partial<Record<'deliveries' | 'ackDelivery' | 'messages', ReturnType<typeof vi.fn>>> & {
     dms?: { messages: ReturnType<typeof vi.fn> };
   } = {}
 ): {
   state: RelayState;
   inboxMock: ReturnType<typeof vi.fn>;
-  markReadMock: ReturnType<typeof vi.fn>;
+  deliveriesMock: ReturnType<typeof vi.fn>;
+  ackDeliveryMock: ReturnType<typeof vi.fn>;
 } {
   const state = new RelayState();
   state.connected = true;
@@ -46,14 +47,16 @@ function createConnectedState(
   state.workspace = 'rk_live_1234567890abcdef';
   state.token = 'tok_test';
   const inboxMock = vi.fn(inbox);
-  const markReadMock = overrides.markRead ?? vi.fn(async () => ({ messageId: 'x' }));
+  const deliveriesMock = overrides.deliveries ?? vi.fn(async () => []);
+  const ackDeliveryMock = overrides.ackDelivery ?? vi.fn(async () => ({ id: 'x', status: 'acked' }));
   state.agent = {
     inbox: inboxMock,
-    markRead: markReadMock,
+    deliveries: deliveriesMock,
+    ackDelivery: ackDeliveryMock,
     messages: overrides.messages ?? vi.fn(async () => []),
     dms: overrides.dms ?? { messages: vi.fn(async () => []) },
   } as unknown as RelayState['agent'];
-  return { state, inboxMock, markReadMock };
+  return { state, inboxMock, deliveriesMock, ackDeliveryMock };
 }
 
 describe('OpenCode relay hooks', () => {
@@ -124,8 +127,9 @@ describe('OpenCode relay hooks', () => {
   });
 
   it('idle-drains-and-does-not-reinject', async () => {
-    // The read-only engine inbox keeps reporting the same DM until acked, so the
-    // plugin must markRead + watermark to avoid re-injecting it every poll.
+    // The read-only engine inbox keeps reporting the same DM until its durable
+    // delivery is acked, so the plugin must ackDelivery + watermark to avoid
+    // re-injecting it every poll.
     const inbox: InboxResponse = {
       unreadChannels: [],
       mentions: [],
@@ -144,9 +148,15 @@ describe('OpenCode relay hooks', () => {
       recentReactions: [],
     } as unknown as InboxResponse;
 
-    const markReadMock = vi.fn(async () => ({ messageId: 'msg-1' }));
+    const deliveriesMock = vi.fn(async () => [
+      { id: 'dlv-1', messageId: 'msg-1', status: 'delivered' },
+    ]);
+    const ackDeliveryMock = vi.fn(async () => ({ id: 'dlv-1', status: 'acked' }));
     const { ctx, hooks } = createContext();
-    const { state } = createConnectedState(async () => inbox, { markRead: markReadMock });
+    const { state } = createConnectedState(async () => inbox, {
+      deliveries: deliveriesMock,
+      ackDelivery: ackDeliveryMock,
+    });
     registerHooks(ctx, state);
 
     const first = await hooks['session.idle']();
@@ -154,14 +164,15 @@ describe('OpenCode relay hooks', () => {
       inject: 'Relay message from alice: Please review auth middleware.',
       continue: true,
     });
-    expect(markReadMock).toHaveBeenCalledWith('msg-1');
+    // Drains the surfaced message on the durable delivery ledger (survives restarts).
+    expect(ackDeliveryMock).toHaveBeenCalledWith('dlv-1');
 
     // Next poll (past the throttle window) returns the same read-only inbox, but
     // the watermark suppresses re-injection.
     vi.advanceTimersByTime(3_000);
     const second = await hooks['session.idle']();
     expect(second).toBeUndefined();
-    expect(markReadMock).toHaveBeenCalledTimes(1);
+    expect(ackDeliveryMock).toHaveBeenCalledTimes(1);
   });
 
   it('idle-swallows-errors', async () => {

--- a/plugins/opencode-relay-plugin/tests/spawn.test.ts
+++ b/plugins/opencode-relay-plugin/tests/spawn.test.ts
@@ -4,7 +4,7 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RelayState, type SpawnLike, createRelayDismissTool, createRelaySpawnTool } from '../src/index.js';
-import { MockRelayServer, connectRelayState, createMockFetch } from './mock-relay-server.js';
+import { MockRelayServer, connectRelayState } from './mock-relay-server.js';
 
 class FakeChildProcess extends EventEmitter implements Pick<ChildProcess, 'kill' | 'pid'> {
   pid: number;
@@ -26,16 +26,14 @@ describe('OpenCode relay spawn and dismiss tools', () => {
 
   beforeEach(() => {
     server = new MockRelayServer();
-    vi.stubGlobal('fetch', createMockFetch(server) as typeof fetch);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it('spawns an OpenCode worker with the relay bootstrap prompt and env vars', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     const proc = new FakeChildProcess(4242);
     const spawnMock = vi.fn<SpawnLike>(
       (command: string, args?: readonly string[], options?: SpawnOptions) => {
@@ -103,7 +101,7 @@ describe('OpenCode relay spawn and dismiss tools', () => {
   });
 
   it('marks a spawned worker as errored when the process exits non-zero', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     const proc = new FakeChildProcess(5050);
     const spawnMock = vi.fn<SpawnLike>(() => proc as unknown as ChildProcess);
 
@@ -118,7 +116,7 @@ describe('OpenCode relay spawn and dismiss tools', () => {
   });
 
   it('dismisses a running worker by killing the process and removing it from relay state', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     const proc = new FakeChildProcess(6060);
 
     state.spawned.set('Researcher', {
@@ -142,7 +140,7 @@ describe('OpenCode relay spawn and dismiss tools', () => {
   });
 
   it('dismisses an already-finished worker without killing it again', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     const proc = new FakeChildProcess(7070);
 
     state.spawned.set('Researcher', {

--- a/plugins/opencode-relay-plugin/tests/tools.test.ts
+++ b/plugins/opencode-relay-plugin/tests/tools.test.ts
@@ -8,6 +8,8 @@ import relayPlugin, {
   createRelayPostTool,
   createRelaySendTool,
   inboxToMessages,
+  rememberSeen,
+  MAX_SEEN_MESSAGE_IDS,
 } from '../src/index.js';
 import type { InboxResponse } from '@relaycast/sdk';
 import {
@@ -138,18 +140,21 @@ describe('OpenCode relay core tools', () => {
     expect(secondCheck).toEqual({ count: 0, messages: [] });
   });
 
-  it('drains surfaced inbox messages via markRead so the read-only inbox stops re-surfacing them', async () => {
+  it('drains surfaced inbox messages via the delivery ledger so the read-only inbox stops re-surfacing them', async () => {
     const state = connectRelayState(new RelayState(), server);
     server.injectMessage('Researcher', 'ACK: Looking into auth.');
 
     const firstCheck = await createRelayInboxTool(state).handler({});
     expect(firstCheck.count).toBe(1);
 
-    // The plugin must ack the surfaced message; the mock inbox is read-only and
-    // only stops reporting an item once it has been markRead'd.
-    const readReqs = server.requests.filter((r) => r.endpoint === 'message/read');
-    expect(readReqs).toHaveLength(1);
-    expect(readReqs[0].body.messageId).toBe(firstCheck.messages[0].id);
+    // The plugin must durably ack the surfaced message on the delivery ledger;
+    // the mock inbox is read-only and only stops reporting an item once its
+    // delivery is acked (which survives restarts, unlike a read receipt).
+    const ackReqs = server.requests.filter((r) => r.endpoint === 'deliveries/ack');
+    expect(ackReqs).toHaveLength(1);
+    expect(ackReqs[0].body.deliveryId).toBe(`dlv-${firstCheck.messages[0].id}`);
+    // No read-receipt drain is attempted (markRead is a no-op on delivery state).
+    expect(server.requests.some((r) => r.endpoint === 'message/read')).toBe(false);
 
     // A subsequent poll sees nothing new even though inbox() is read-only.
     const secondCheck = await createRelayInboxTool(state).handler({});
@@ -173,8 +178,8 @@ describe('OpenCode relay core tools', () => {
     ]);
     // Hydration goes through the DM messages API.
     expect(server.requests.some((r) => r.endpoint === 'dm/messages')).toBe(true);
-    // All three are drained.
-    expect(server.requests.filter((r) => r.endpoint === 'message/read')).toHaveLength(3);
+    // All three are drained on the delivery ledger.
+    expect(server.requests.filter((r) => r.endpoint === 'deliveries/ack')).toHaveLength(3);
   });
 
   it('surfaces unread channel posts that did not mention the reader', async () => {
@@ -223,6 +228,33 @@ describe('OpenCode relay core tools', () => {
         text: 'DONE: Phase 1 complete.',
       },
     });
+  });
+});
+
+describe('rememberSeen watermark bounding', () => {
+  it('is a no-op for an already-seen id', () => {
+    const seen = new Set<string>(['a']);
+    rememberSeen(seen, 'a', 5);
+    expect([...seen]).toEqual(['a']);
+  });
+
+  it('evicts the oldest ids via FIFO once over the cap', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      rememberSeen(seen, `id-${i}`, 4);
+    }
+    // Only the last 4 ids survive; older ones are evicted oldest-first.
+    expect(seen.size).toBe(4);
+    expect([...seen]).toEqual(['id-6', 'id-7', 'id-8', 'id-9']);
+  });
+
+  it('exposes a sane default cap', () => {
+    expect(MAX_SEEN_MESSAGE_IDS).toBeGreaterThan(0);
+    const seen = new Set<string>();
+    for (let i = 0; i < MAX_SEEN_MESSAGE_IDS + 50; i++) {
+      rememberSeen(seen, `id-${i}`);
+    }
+    expect(seen.size).toBe(MAX_SEEN_MESSAGE_IDS);
   });
 });
 

--- a/plugins/opencode-relay-plugin/tests/tools.test.ts
+++ b/plugins/opencode-relay-plugin/tests/tools.test.ts
@@ -11,7 +11,7 @@ import relayPlugin, {
 import {
   MockRelayServer,
   connectRelayState,
-  createMockFetch,
+  createMockRelayCastFactory,
   createPluginContext,
 } from './mock-relay-server.js';
 
@@ -20,11 +20,9 @@ describe('OpenCode relay core tools', () => {
 
   beforeEach(() => {
     server = new MockRelayServer();
-    vi.stubGlobal('fetch', createMockFetch(server) as typeof fetch);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -47,7 +45,9 @@ describe('OpenCode relay core tools', () => {
   it('connects successfully and stores the relay token', async () => {
     const state = new RelayState();
 
-    const result = await createRelayConnectTool(state).handler({
+    const result = await createRelayConnectTool(state, {
+      createRelayCast: createMockRelayCastFactory(server),
+    }).handler({
       workspace: 'rk_live_test_fake_workspace_key',
       name: 'Lead',
     });
@@ -75,7 +75,9 @@ describe('OpenCode relay core tools', () => {
     const state = new RelayState();
 
     await expect(
-      createRelayConnectTool(state).handler({
+      createRelayConnectTool(state, {
+        createRelayCast: createMockRelayCastFactory(server),
+      }).handler({
         workspace: 'workspace-test',
         name: 'Lead',
       })
@@ -86,7 +88,7 @@ describe('OpenCode relay core tools', () => {
   });
 
   it('sends a DM through relay_send', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
 
     const result = await createRelaySendTool(state).handler({
       to: 'Researcher',
@@ -113,9 +115,9 @@ describe('OpenCode relay core tools', () => {
   });
 
   it('returns inbox messages and clears the queue', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     server.injectMessage('Researcher', 'ACK: Looking into auth.');
-    server.injectMessage('Reviewer', 'DONE: Reviewed the patch.', { channel: 'wave1-opencode' });
+    server.injectMessage('Reviewer', 'DONE: Reviewed the patch.');
 
     const firstCheck = await createRelayInboxTool(state).handler({});
     const secondCheck = await createRelayInboxTool(state).handler({});
@@ -129,14 +131,13 @@ describe('OpenCode relay core tools', () => {
       expect.objectContaining({
         from: 'Reviewer',
         text: 'DONE: Reviewed the patch.',
-        channel: 'wave1-opencode',
       }),
     ]);
     expect(secondCheck).toEqual({ count: 0, messages: [] });
   });
 
   it('lists agents through relay_agents', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
     server.agents = ['Lead', 'Researcher', 'Reviewer'];
 
     const result = await createRelayAgentsTool(state).handler({});
@@ -148,7 +149,7 @@ describe('OpenCode relay core tools', () => {
   });
 
   it('posts a channel message through relay_post', async () => {
-    const state = connectRelayState(new RelayState());
+    const state = connectRelayState(new RelayState(), server);
 
     const result = await createRelayPostTool(state).handler({
       channel: 'wave1-opencode',

--- a/plugins/opencode-relay-plugin/tests/tools.test.ts
+++ b/plugins/opencode-relay-plugin/tests/tools.test.ts
@@ -7,7 +7,9 @@ import relayPlugin, {
   createRelayInboxTool,
   createRelayPostTool,
   createRelaySendTool,
+  inboxToMessages,
 } from '../src/index.js';
+import type { InboxResponse } from '@relaycast/sdk';
 import {
   MockRelayServer,
   connectRelayState,
@@ -136,6 +138,60 @@ describe('OpenCode relay core tools', () => {
     expect(secondCheck).toEqual({ count: 0, messages: [] });
   });
 
+  it('drains surfaced inbox messages via markRead so the read-only inbox stops re-surfacing them', async () => {
+    const state = connectRelayState(new RelayState(), server);
+    server.injectMessage('Researcher', 'ACK: Looking into auth.');
+
+    const firstCheck = await createRelayInboxTool(state).handler({});
+    expect(firstCheck.count).toBe(1);
+
+    // The plugin must ack the surfaced message; the mock inbox is read-only and
+    // only stops reporting an item once it has been markRead'd.
+    const readReqs = server.requests.filter((r) => r.endpoint === 'message/read');
+    expect(readReqs).toHaveLength(1);
+    expect(readReqs[0].body.messageId).toBe(firstCheck.messages[0].id);
+
+    // A subsequent poll sees nothing new even though inbox() is read-only.
+    const secondCheck = await createRelayInboxTool(state).handler({});
+    expect(secondCheck).toEqual({ count: 0, messages: [] });
+  });
+
+  it('hydrates earlier messages of a multi-message DM conversation', async () => {
+    const state = connectRelayState(new RelayState(), server);
+    // Three unread DMs in one conversation; the summary would only carry the last.
+    server.injectDm('alice', 'conv-alice', 'Step 1: pull the branch.');
+    server.injectDm('alice', 'conv-alice', 'Step 2: run migrations.');
+    server.injectDm('alice', 'conv-alice', 'Step 3: deploy.');
+
+    const result = await createRelayInboxTool(state).handler({});
+
+    expect(result.count).toBe(3);
+    expect(result.messages.map((m) => m.text)).toEqual([
+      'Step 1: pull the branch.',
+      'Step 2: run migrations.',
+      'Step 3: deploy.',
+    ]);
+    // Hydration goes through the DM messages API.
+    expect(server.requests.some((r) => r.endpoint === 'dm/messages')).toBe(true);
+    // All three are drained.
+    expect(server.requests.filter((r) => r.endpoint === 'message/read')).toHaveLength(3);
+  });
+
+  it('surfaces unread channel posts that did not mention the reader', async () => {
+    const state = connectRelayState(new RelayState(), server);
+    server.injectChannelPost('Bob', 'wave1', 'Build is green.');
+    server.injectChannelPost('Bob', 'wave1', 'Shipping now.');
+
+    const result = await createRelayInboxTool(state).handler({});
+
+    expect(result.count).toBe(2);
+    expect(result.messages).toEqual([
+      expect.objectContaining({ from: 'Bob', channel: 'wave1', text: 'Build is green.' }),
+      expect.objectContaining({ from: 'Bob', channel: 'wave1', text: 'Shipping now.' }),
+    ]);
+    expect(server.requests.some((r) => r.endpoint === 'message/list')).toBe(true);
+  });
+
   it('lists agents through relay_agents', async () => {
     const state = connectRelayState(new RelayState(), server);
     server.agents = ['Lead', 'Researcher', 'Reviewer'];
@@ -167,5 +223,22 @@ describe('OpenCode relay core tools', () => {
         text: 'DONE: Phase 1 complete.',
       },
     });
+  });
+});
+
+describe('inboxToMessages defensive handling', () => {
+  it('returns [] for null/undefined inbox', () => {
+    expect(inboxToMessages(null)).toEqual([]);
+    expect(inboxToMessages(undefined)).toEqual([]);
+  });
+
+  it('tolerates missing / non-array mentions and unreadDms', () => {
+    expect(inboxToMessages({} as unknown as InboxResponse)).toEqual([]);
+    expect(
+      inboxToMessages({
+        mentions: 'nope',
+        unreadDms: null,
+      } as unknown as InboxResponse)
+    ).toEqual([]);
   });
 });

--- a/plugins/opencode-relay-plugin/vitest.config.ts
+++ b/plugins/opencode-relay-plugin/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone config so the plugin's tests resolve against this package's own
+// dependencies rather than climbing to the monorepo root config (the plugin is
+// not part of the npm workspaces and is installed/tested in isolation).
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    root: __dirname,
+  },
+});


### PR DESCRIPTION
## Problem

The OpenCode Relay plugin (`plugins/opencode-relay-plugin`) talked to a bespoke RPC API at `https://www.relaycast.dev/api/v1` (`/register`, `/dm/send`, `/inbox/check`, `/agent/list`, `/message/post`, `/agent/add`, `/agent/remove`). **That host is dead** (returns HTTP 522), so the plugin is fully broken.

## Change

Transport swap only — same tool names, arguments, return shapes, and idle inbox-polling behavior. The plugin now uses the published `@relaycast/sdk` (`^4.1.6`) pointed at the current engine.

- **Default base URL → `https://cast.agentrelay.com`** (old `www` host is dead; no data continuity). Still configurable via the existing `RelayState.apiBaseUrl`, now routed into the SDK as `baseUrl`.
- Removed the bespoke `fetch` / `normalizeBaseUrl` plumbing.
- Tests now mock the SDK (`RelayCast` / `AgentClient`) instead of the dead HTTP URLs, with equivalent coverage (19 tests).

## Endpoint → SDK mapping

| Bespoke endpoint | SDK call |
|---|---|
| `/register` | `new RelayCast({ apiKey: workspace, baseUrl }).registerOrRotate({ name })` → then `relay.as(token)` for the agent client |
| `/dm/send` | `AgentClient.dm(to, text)` |
| `/inbox/check` | `AgentClient.inbox()` flattened by `inboxToMessages()` |
| `/agent/list` | `RelayCast.agents.list()` |
| `/message/post` | `AgentClient.post(channel, text)` |
| `/agent/add` | `RelayCast.agents.registerOrGet({ name, metadata: { cli, task } })` |
| `/agent/remove` | `RelayCast.agents.delete(name)` |

## Things that didn't map cleanly

- **Inbox shape.** `/v1/inbox` returns `{ unread_channels, mentions, unread_dms, recent_reactions }` — no `messages[]`. `inboxToMessages()` flattens channel `mentions[]` and `unread_dms[]` (using each conversation's `lastMessage`) into the flat `RelayMessage[]` the inbox tool and idle hook expect. `unread_channels` and `recent_reactions` are not message-like and are ignored.
- **`/agent/add` (worker registration).** The SDK's `agents.spawn` requires a `cli` enum (`claude|codex|gemini|aider|goose`) that **excludes `opencode`**, and it is meant to spawn a remote process. The plugin instead spawns a *local* OpenCode process, so the relay-side step is just registering the worker identity — implemented with `agents.registerOrGet({ name, metadata: { cli: 'opencode', task } })`. The local `spawn(...)` behavior, bootstrap prompt, and env vars are unchanged.
- **`relay_agents` return type.** Previously passed through whatever the bespoke API returned; now returns the SDK's `Agent[]` objects. Shape (`{ agents: [...] }`) is preserved.

## Build / test

- `npm run build` (tsc): passes
- `npm test` (vitest): 19/19 passing
- Validated against `@relaycast/sdk@4.1.6`.

A standalone `vitest.config.ts` was added to the plugin so its tests run in isolation (the plugin is not part of the monorepo npm workspaces; without it vitest climbs to the root config which can't resolve in a fresh plugin install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

