### PR TITLE
Default Agent Relay clients to cast.agentrelay.com

### DIFF
--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -63,7 +63,7 @@ use crate::{broker, listen_api, routing, worker_request};
 
 const DEFAULT_DELIVERY_RETRY_MS: u64 = 1_000;
 const MAX_DELIVERY_RETRIES: u32 = 10;
-const DEFAULT_RELAYCAST_BASE_URL: &str = "https://gateway.relaycast.dev";
+const DEFAULT_RELAYCAST_BASE_URL: &str = "https://cast.agentrelay.com";
 const THREAD_HISTORY_LIMIT: usize = 1_000;
 const DEFAULT_HTTP_API_LOCAL_DELIVERY_TIMEOUT_MS: u64 = 3_000;
 const DEFAULT_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: u64 = 20_000;

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -695,8 +695,8 @@ fn exit_after_task_instruction_appends_clean_exit_contract() {
 #[test]
 fn ws_base_derivation() {
     assert_eq!(
-        derive_ws_base_url_from_http("https://api.relaycast.dev"),
-        "wss://api.relaycast.dev"
+        derive_ws_base_url_from_http("https://cast.agentrelay.com"),
+        "wss://cast.agentrelay.com"
     );
     assert_eq!(
         derive_ws_base_url_from_http("http://localhost:8787"),

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -1581,7 +1581,7 @@ mod tests {
         .expect("write existing mcp file");
 
         let report =
-            ensure_agent_relay_mcp_config(root, None, Some("https://api.relaycast.dev"), None)
+            ensure_agent_relay_mcp_config(root, None, Some("https://cast.agentrelay.com"), None)
                 .expect("update mcp config");
         assert_eq!(report.created, 0);
         assert_eq!(report.updated, 1);
@@ -1646,7 +1646,7 @@ mod tests {
             "codex",
             "Lead",
             Some("rk_live_test"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -1677,7 +1677,7 @@ mod tests {
             "claude",
             "Worker",
             Some("rk_live_abc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -1715,7 +1715,7 @@ mod tests {
             "claude",
             "Worker",
             Some("rk_live_secret"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -1778,7 +1778,7 @@ mod tests {
             "claude",
             "Worker",
             Some("rk_live_abc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &existing,
             temp.path(),
         )
@@ -1802,7 +1802,7 @@ mod tests {
             "claude",
             "Worker",
             Some("rk_live_abc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &existing,
             temp.path(),
         )
@@ -1875,7 +1875,7 @@ mod tests {
     fn grok_mcp_add_args_use_command_and_args_flags() {
         let args = super::grok_mcp_add_args(
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("GrokWorker"),
             Some("tok_grok_123"),
             None,
@@ -1908,7 +1908,7 @@ mod tests {
     fn droid_mcp_add_args_include_option_separator() {
         let args = super::gemini_droid_mcp_add_args(
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             None,
             None,
             false,
@@ -1931,7 +1931,7 @@ mod tests {
     fn gemini_mcp_add_args_do_not_include_option_separator() {
         let args = super::gemini_droid_mcp_add_args(
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("GeminiWorker"),
             Some("tok_gem_123"),
             true,
@@ -1941,7 +1941,7 @@ mod tests {
 
         assert!(args.contains(&"-e".to_string()));
         assert!(args.contains(&"RELAY_API_KEY=rk_live_xyz".to_string()));
-        assert!(args.contains(&"RELAY_BASE_URL=https://api.relaycast.dev".to_string()));
+        assert!(args.contains(&"RELAY_BASE_URL=https://cast.agentrelay.com".to_string()));
         assert!(args.contains(&"RELAY_AGENT_NAME=GeminiWorker".to_string()));
         assert!(args.contains(&"RELAY_AGENT_TYPE=agent".to_string()));
         assert!(args.contains(&"RELAY_STRICT_AGENT_NAME=1".to_string()));
@@ -1972,7 +1972,7 @@ mod tests {
     fn droid_mcp_add_args_include_env_flags_and_token() {
         let args = super::gemini_droid_mcp_add_args(
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("DroidWorker"),
             Some("tok_droid_123"),
             false,
@@ -1982,7 +1982,7 @@ mod tests {
 
         assert!(args.contains(&"--env".to_string()));
         assert!(args.contains(&"RELAY_API_KEY=rk_live_xyz".to_string()));
-        assert!(args.contains(&"RELAY_BASE_URL=https://api.relaycast.dev".to_string()));
+        assert!(args.contains(&"RELAY_BASE_URL=https://cast.agentrelay.com".to_string()));
         assert!(args.contains(&"RELAY_AGENT_NAME=DroidWorker".to_string()));
         assert!(args.contains(&"RELAY_AGENT_TYPE=agent".to_string()));
         assert!(args.contains(&"RELAY_STRICT_AGENT_NAME=1".to_string()));
@@ -1994,7 +1994,7 @@ mod tests {
         let config = test_agent_result_config();
         let args = super::gemini_droid_mcp_add_args_with_result(
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("GeminiWorker"),
             Some("tok_gem_123"),
             true,
@@ -2020,7 +2020,7 @@ mod tests {
             "codex",
             "CodexAgent",
             Some("rk_live_xyz"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -2040,7 +2040,7 @@ mod tests {
             args.contains(&"mcp_servers.agent-relay.env.RELAY_API_KEY=\"rk_live_xyz\"".to_string())
         );
         assert!(args.contains(
-            &"mcp_servers.agent-relay.env.RELAY_BASE_URL=\"https://api.relaycast.dev\"".to_string()
+            &"mcp_servers.agent-relay.env.RELAY_BASE_URL=\"https://cast.agentrelay.com\"".to_string()
         ));
         assert!(args
             .contains(&"mcp_servers.agent-relay.env.RELAY_AGENT_NAME=\"CodexAgent\"".to_string()));
@@ -2207,7 +2207,7 @@ mod tests {
             "opencode",
             "OcAgent",
             Some("rk_live_oc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -2241,7 +2241,7 @@ mod tests {
         );
         assert_eq!(
             oc_env["RELAY_BASE_URL"].as_str(),
-            Some("https://api.relaycast.dev")
+            Some("https://cast.agentrelay.com")
         );
         assert_eq!(oc_env["RELAY_AGENT_NAME"].as_str(), Some("OcAgent"));
         assert_eq!(oc_env["RELAY_AGENT_TYPE"].as_str(), Some("agent"));
@@ -2264,7 +2264,7 @@ mod tests {
             "opencode",
             "OcAgent",
             Some("rk_live_oc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
             None,
@@ -2354,7 +2354,7 @@ mod tests {
             "cursor",
             "CursorAgent",
             Some("rk_live_cursor"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -2381,7 +2381,7 @@ mod tests {
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_BASE_URL"].as_str(),
-            Some("https://api.relaycast.dev")
+            Some("https://cast.agentrelay.com")
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_AGENT_NAME"].as_str(),
@@ -2405,7 +2405,7 @@ mod tests {
             "cursor",
             "CursorAgent",
             Some("rk_live_cursor"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
             None,
@@ -2470,7 +2470,7 @@ mod tests {
             "aider",
             "Agent",
             Some("rk_live_abc"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
         )
@@ -2501,7 +2501,7 @@ mod tests {
     fn mcp_config_json_produces_valid_structure() {
         let json_str = super::agent_relay_mcp_config_json(
             Some("rk_live_test"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("TestAgent"),
         );
         let json: Value = serde_json::from_str(&json_str).expect("parse JSON");
@@ -2583,7 +2583,7 @@ mod tests {
     fn mcp_config_json_trims_whitespace_values() {
         let json_str = super::agent_relay_mcp_config_json(
             Some("  rk_live_test  "),
-            Some("  https://api.relaycast.dev  "),
+            Some("  https://cast.agentrelay.com  "),
             Some("  Agent  "),
         );
         let json: Value = serde_json::from_str(&json_str).expect("parse JSON");
@@ -2591,7 +2591,7 @@ mod tests {
         // base_url and agent_name are trimmed
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_BASE_URL"].as_str(),
-            Some("https://api.relaycast.dev")
+            Some("https://cast.agentrelay.com")
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_AGENT_NAME"].as_str(),
@@ -2667,7 +2667,7 @@ mod tests {
         super::ensure_opencode_config(
             temp.path(),
             Some("rk_live_test"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("Agent"),
             None,
             None,
@@ -3134,7 +3134,7 @@ mod tests {
             "claude",
             "TestWorker",
             Some("rk_live_test"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
             Some("tok_abc"),
@@ -3431,7 +3431,7 @@ mod tests {
 
         let merged = super::merge_agent_relay_with_project_mcp_inner(
             Some("rk_key"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             Some("agent"),
             Some("tok_test"),
             temp.path(),
@@ -3632,7 +3632,7 @@ mod tests {
             "opencode",
             "headless-worker",
             Some("rk_live_hl"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
             Some("tok_hl_123"),
@@ -3665,7 +3665,7 @@ mod tests {
             "claude",
             "headless-worker",
             Some("rk_live_hl"),
-            Some("https://api.relaycast.dev"),
+            Some("https://cast.agentrelay.com"),
             &[],
             temp.path(),
             Some("tok_hl_123"),

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -2040,7 +2040,8 @@ mod tests {
             args.contains(&"mcp_servers.agent-relay.env.RELAY_API_KEY=\"rk_live_xyz\"".to_string())
         );
         assert!(args.contains(
-            &"mcp_servers.agent-relay.env.RELAY_BASE_URL=\"https://cast.agentrelay.com\"".to_string()
+            &"mcp_servers.agent-relay.env.RELAY_BASE_URL=\"https://cast.agentrelay.com\""
+                .to_string()
         ));
         assert!(args
             .contains(&"mcp_servers.agent-relay.env.RELAY_AGENT_NAME=\"CodexAgent\"".to_string()));

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -119,7 +119,7 @@ export function normalizeBaseUrl(baseUrl?: string): string {
   // like `/\/+$/` triggers CodeQL's polynomial-backtracking (ReDoS) warning on
   // uncontrolled input with many repeated '/'; `endsWith`/`slice` is O(n) and
   // has no backtracking.
-  let url = baseUrl ?? 'https://gateway.relaycast.dev';
+  let url = baseUrl ?? 'https://cast.agentrelay.com';
   while (url.endsWith('/')) url = url.slice(0, -1);
   return url;
 }

--- a/plugins/codex-relay-skill/README.md
+++ b/plugins/codex-relay-skill/README.md
@@ -121,12 +121,12 @@ Use Relaycast when workers need to message each other directly, not only the lea
 
 ## Environment variables
 
-| Variable           | Required | Default                         | Description                                                          |
-| ------------------ | -------- | ------------------------------- | -------------------------------------------------------------------- |
-| `RELAY_API_KEY`    | No       | `""` in the template config     | Relaycast workspace key                                              |
+| Variable           | Required | Default                       | Description                                                          |
+| ------------------ | -------- | ----------------------------- | -------------------------------------------------------------------- |
+| `RELAY_API_KEY`    | No       | `""` in the template config   | Relaycast workspace key                                              |
 | `RELAY_BASE_URL`   | No       | `https://cast.agentrelay.com` | Relaycast API base URL                                               |
-| `RELAY_AGENT_TYPE` | No       | `agent`                         | Default Relaycast agent type                                         |
-| `RELAY_AGENT_NAME` | No       | unset                           | Optional stable relay identity when your workflow wants a fixed name |
+| `RELAY_AGENT_TYPE` | No       | `agent`                       | Default Relaycast agent type                                         |
+| `RELAY_AGENT_NAME` | No       | unset                         | Optional stable relay identity when your workflow wants a fixed name |
 
 ## Plugin structure
 

--- a/plugins/codex-relay-skill/README.md
+++ b/plugins/codex-relay-skill/README.md
@@ -63,7 +63,7 @@ features.codex_hooks = true
 [mcp_servers.agent-relay]
 command = "npx"
 args = ["-y", "agent-relay", "mcp"]
-env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://gateway.relaycast.dev", RELAY_AGENT_TYPE = "agent" }
+env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://cast.agentrelay.com", RELAY_AGENT_TYPE = "agent" }
 ```
 
 2. Copy hooks config:
@@ -124,7 +124,7 @@ Use Relaycast when workers need to message each other directly, not only the lea
 | Variable           | Required | Default                         | Description                                                          |
 | ------------------ | -------- | ------------------------------- | -------------------------------------------------------------------- |
 | `RELAY_API_KEY`    | No       | `""` in the template config     | Relaycast workspace key                                              |
-| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | Relaycast API base URL                                               |
+| `RELAY_BASE_URL`   | No       | `https://cast.agentrelay.com` | Relaycast API base URL                                               |
 | `RELAY_AGENT_TYPE` | No       | `agent`                         | Default Relaycast agent type                                         |
 | `RELAY_AGENT_NAME` | No       | unset                           | Optional stable relay identity when your workflow wants a fixed name |
 

--- a/plugins/codex-relay-skill/codex-config/config.toml
+++ b/plugins/codex-relay-skill/codex-config/config.toml
@@ -6,4 +6,4 @@ features.codex_hooks = true
 [mcp_servers.agent-relay]
 command = "npx"
 args = ["-y", "agent-relay", "mcp"]
-env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://gateway.relaycast.dev", RELAY_AGENT_TYPE = "agent" }
+env = { RELAY_API_KEY = "", RELAY_BASE_URL = "https://cast.agentrelay.com", RELAY_AGENT_TYPE = "agent" }

--- a/plugins/codex-relay-skill/hooks/prompt-inbox.sh
+++ b/plugins/codex-relay-skill/hooks/prompt-inbox.sh
@@ -17,7 +17,7 @@ fi
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
 LAST_POLL_FILE="${RELAY_DIR}/last-poll"
-DEFAULT_BASE_URL="https://gateway.relaycast.dev"
+DEFAULT_BASE_URL="https://cast.agentrelay.com"
 EMPTY_OUTPUT='{}'
 MAX_RENDERED_MESSAGES=20
 MIN_POLL_INTERVAL=3

--- a/plugins/codex-relay-skill/hooks/session-start.sh
+++ b/plugins/codex-relay-skill/hooks/session-start.sh
@@ -17,7 +17,7 @@ fi
 KEY_FILE="${RELAY_DIR}/workspace-key"
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
-DEFAULT_BASE_URL="https://gateway.relaycast.dev"
+DEFAULT_BASE_URL="https://cast.agentrelay.com"
 
 load_env() {
   if [ -f "$ENV_FILE" ]; then

--- a/plugins/codex-relay-skill/hooks/stop-inbox.sh
+++ b/plugins/codex-relay-skill/hooks/stop-inbox.sh
@@ -16,7 +16,7 @@ else
 fi
 TOKEN_FILE="${RELAY_DIR}/token"
 STATE_FILE="${RELAY_DIR}/codex-session.json"
-DEFAULT_BASE_URL="https://gateway.relaycast.dev"
+DEFAULT_BASE_URL="https://cast.agentrelay.com"
 EMPTY_OUTPUT='{}'
 MAX_RENDERED_MESSAGES=20
 

--- a/plugins/codex-relay-skill/scripts/setup.sh
+++ b/plugins/codex-relay-skill/scripts/setup.sh
@@ -155,7 +155,7 @@ ensure_agent_relay_mcp_block() {
       env_seen = 0
       command_line = "command = \"npx\""
       args_line = "args = [\"-y\", \"agent-relay\", \"mcp\"]"
-      env_line = "env = { RELAY_API_KEY = \"\", RELAY_BASE_URL = \"https://gateway.relaycast.dev\", RELAY_AGENT_TYPE = \"agent\" }"
+      env_line = "env = { RELAY_API_KEY = \"\", RELAY_BASE_URL = \"https://cast.agentrelay.com\", RELAY_AGENT_TYPE = \"agent\" }"
     }
     function write_missing_keys() {
       if (!command_seen) {

--- a/plugins/gemini-relay-extension/README.md
+++ b/plugins/gemini-relay-extension/README.md
@@ -96,10 +96,10 @@ Each agent registers with the relay and can message the others.
 
 ## Environment variables
 
-| Variable           | Required | Default                         | Description                   |
-| ------------------ | -------- | ------------------------------- | ----------------------------- |
-| `RELAY_API_KEY`    | Yes      | —                               | Workspace key (`rk_live_...`) |
-| `RELAY_AGENT_NAME` | No       | auto-generated                  | Stable agent identity         |
+| Variable           | Required | Default                       | Description                   |
+| ------------------ | -------- | ----------------------------- | ----------------------------- |
+| `RELAY_API_KEY`    | Yes      | —                             | Workspace key (`rk_live_...`) |
+| `RELAY_AGENT_NAME` | No       | auto-generated                | Stable agent identity         |
 | `RELAY_BASE_URL`   | No       | `https://cast.agentrelay.com` | API base URL override         |
 
 ## Extension structure

--- a/plugins/gemini-relay-extension/README.md
+++ b/plugins/gemini-relay-extension/README.md
@@ -100,7 +100,7 @@ Each agent registers with the relay and can message the others.
 | ------------------ | -------- | ------------------------------- | ----------------------------- |
 | `RELAY_API_KEY`    | Yes      | —                               | Workspace key (`rk_live_...`) |
 | `RELAY_AGENT_NAME` | No       | auto-generated                  | Stable agent identity         |
-| `RELAY_BASE_URL`   | No       | `https://gateway.relaycast.dev` | API base URL override         |
+| `RELAY_BASE_URL`   | No       | `https://cast.agentrelay.com` | API base URL override         |
 
 ## Extension structure
 

--- a/plugins/gemini-relay-extension/hooks/after-agent-inbox.sh
+++ b/plugins/gemini-relay-extension/hooks/after-agent-inbox.sh
@@ -4,7 +4,7 @@ set -eu
 
 ALLOW_OUTPUT='{"decision":"allow"}'
 TOKEN_FILE="${HOME}/.relay/token"
-BASE_URL="${RELAY_BASE_URL:-https://gateway.relaycast.dev}"
+BASE_URL="${RELAY_BASE_URL:-https://cast.agentrelay.com}"
 INBOX_URL="${BASE_URL}/v1/inbox/check"
 GUARD_DIR="${TMPDIR:-/tmp}/relay-afteragent"
 

--- a/plugins/gemini-relay-extension/hooks/after-tool-inbox.sh
+++ b/plugins/gemini-relay-extension/hooks/after-tool-inbox.sh
@@ -4,7 +4,7 @@ set -eu
 
 EMPTY_OUTPUT='{}'
 TOKEN_FILE="${HOME}/.relay/token"
-BASE_URL="${RELAY_BASE_URL:-https://gateway.relaycast.dev}"
+BASE_URL="${RELAY_BASE_URL:-https://cast.agentrelay.com}"
 INBOX_URL="${BASE_URL}/v1/inbox/check"
 
 if ! command -v jq >/dev/null 2>&1; then

--- a/plugins/gemini-relay-extension/hooks/before-model-inject.sh
+++ b/plugins/gemini-relay-extension/hooks/before-model-inject.sh
@@ -49,7 +49,7 @@ MESSAGES=$(curl -fsS -X POST \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  "${RELAY_BASE_URL:-https://gateway.relaycast.dev}/v1/inbox/check" 2>/dev/null || true)
+  "${RELAY_BASE_URL:-https://cast.agentrelay.com}/v1/inbox/check" 2>/dev/null || true)
 
 if [ -z "${MESSAGES:-}" ]; then
   printf '%s\n' "$EMPTY_OUTPUT"

--- a/plugins/gemini-relay-extension/hooks/session-end.sh
+++ b/plugins/gemini-relay-extension/hooks/session-end.sh
@@ -10,7 +10,7 @@ KEY_FILE="${HOME}/.relay/workspace-key"
 TOKEN_FILE="${HOME}/.relay/token"
 STATE_FILE="${HOME}/.relay/gemini-session.json"
 WORKERS_FILE="${HOME}/.relay/gemini-workers.json"
-BASE_URL="https://gateway.relaycast.dev"
+BASE_URL="https://cast.agentrelay.com"
 AFTER_AGENT_DIR="${TMPDIR:-/tmp}/relay-afteragent"
 BEFORE_MODEL_DIR="${TMPDIR:-/tmp}/relay-beforemodel"
 

--- a/plugins/gemini-relay-extension/relay-server.js
+++ b/plugins/gemini-relay-extension/relay-server.js
@@ -12,7 +12,7 @@ const RELAY_DIR = path.join(os.homedir(), '.relay');
 const KEY_FILE = path.join(RELAY_DIR, 'workspace-key');
 const TOKEN_FILE = path.join(RELAY_DIR, 'token');
 const STATE_FILE = path.join(RELAY_DIR, 'gemini-session.json');
-const DEFAULT_BASE_URL = 'https://gateway.relaycast.dev';
+const DEFAULT_BASE_URL = 'https://cast.agentrelay.com';
 
 loadDotEnv(ENV_FILE);
 fs.mkdirSync(RELAY_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Flips the remaining client default base URLs from the legacy hosts (`gateway.relaycast.dev` / `api.relaycast.dev`) to the canonical host `https://cast.agentrelay.com`.

These are the components NOT covered by the other open PRs. `gateway`/`api.relaycast.dev` now only persist in already-shipped/frozen versions, which are served by the legacy-router strangler.

> Existing pre-cutover users with old-DB workspaces who rely on the default should set `RELAY_BASE_URL` or migrate.

## Changes

**Rust broker**
- `crates/broker/src/runtime/mod.rs` — `DEFAULT_RELAYCAST_BASE_URL` default → cast.
- `crates/broker/src/runtime/tests.rs` — ws-base derivation test input → cast.
- `crates/broker/src/snippets.rs` — 30 test/fixture base-URL literals (`api.relaycast.dev`) and embedded `RELAY_BASE_URL=...` assertions → cast.

**gemini plugin** (`plugins/gemini-relay-extension/`)
- `relay-server.js` (`DEFAULT_BASE_URL`)
- `hooks/before-model-inject.sh`, `hooks/after-agent-inbox.sh`, `hooks/after-tool-inbox.sh`, `hooks/session-end.sh` (default fallbacks)
- `README.md` default mention

**codex plugin** (`plugins/codex-relay-skill/`)
- `hooks/session-start.sh`, `hooks/prompt-inbox.sh`, `hooks/stop-inbox.sh`
- `codex-config/config.toml`, `scripts/setup.sh`, `README.md`

## Verification
- `cargo test -p agent-relay-broker`: 775 unit + integration tests pass, 0 failed.
- `node --check` on the JS, `bash -n` on all 8 touched shell scripts: all OK.
- `grep -rnE "gateway\.relaycast\.dev|api\.relaycast\.dev"` over the touched dirs: no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

