### PR TITLE
fix(ci): pin verify-standalone-macos to macos-15, add smoke wait timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1411,7 +1411,7 @@ jobs:
   verify-standalone-macos:
     name: Verify Standalone (macOS)
     needs: [build-standalone, build-broker]
-    runs-on: macos-latest
+    runs-on: macos-15
     if: github.event.inputs.package == 'all' || github.event.inputs.package == 'main'
     strategy:
       fail-fast: false

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -127,7 +127,11 @@ sleep 8
 UP_EXIT=""
 if kill -0 "$UP_PID" 2>/dev/null; then
   run_cli local down --force --timeout 5000 >/dev/null 2>&1 || true
+  # Hard-kill after 15s if down --force didn't terminate the process (e.g. macOS 26 hang)
+  ( sleep 15 && kill -9 "$UP_PID" 2>/dev/null || true ) &
+  KILLER_PID=$!
   wait "$UP_PID" || true
+  kill "$KILLER_PID" 2>/dev/null || true
 else
   if wait "$UP_PID"; then
     UP_EXIT=0


### PR DESCRIPTION
## Summary

- `macos-latest` migrated to macOS 26 on June 15 2026; the arm64 broker process stopped terminating cleanly on the new runner, causing the verify-standalone-macos arm64 job to hang for hours (blocking `publish-main`)
- Pin `verify-standalone-macos` to `macos-15` to restore stable behavior
- Add a 15s hard-kill fallback in `ci-standalone-smoke.sh` so the job can never hang indefinitely even if `down --force` fails to exit the process

## Test plan

- [ ] Merge and re-trigger the publish workflow — verify-standalone-macos arm64 should complete in ~1 min instead of hanging
- [ ] Confirm `agent-relay` CLI publishes at the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

