### PR TITLE
fix(changelog): escape glob in @agent-relay/* to satisfy prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin verify-standalone-macos to macos-15 and add smoke wait timeout
 - Record workspace_id from agent registration response
 - Use @relaycast/sdk instead of dead bespoke RPC API
-- Drop redundant @agent-relay/* tsconfig paths so the compiled CLI keeps workspace exports
+- Drop redundant @agent-relay/\* tsconfig paths so the compiled CLI keeps workspace exports
 
 ## [9.0.1] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin verify-standalone-macos to macos-15 and add smoke wait timeout
 - Record workspace_id from agent registration response
 - Use @relaycast/sdk instead of dead bespoke RPC API
-- Drop redundant @agent-relay/\* tsconfig paths so the compiled CLI keeps workspace exports
+- Drop redundant `@agent-relay/*` tsconfig paths so the compiled CLI keeps workspace exports
 
 ## [9.0.1] - 2026-06-21
 


### PR DESCRIPTION
## Problem

The `lint` job on `main` is failing. ESLint passes, but the **Check formatting** step (`prettier --check .`) exits non-zero.

The `chore(release): v9.1.0` commit introduced this CHANGELOG line with an unescaped `*`, which prettier parses as markdown emphasis:

```
- Drop redundant @agent-relay/* tsconfig paths so the compiled CLI keeps workspace exports
```

## Fix

Ran `prettier --write CHANGELOG.md` — the only change is escaping the glob (`@agent-relay/\*`). `prettier --check CHANGELOG.md` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

