### PR TITLE
chore(deps): bump bundled relaycast SDKs to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped the bundled relaycast SDKs to v5: `agent-relay-broker` builds against the `relaycast` crate 5.0.0, `agent-relay`/`@agent-relay/sdk` use `@relaycast/sdk` ^5.0.0, the Python `communicate` client uses `relaycast-sdk` 0.3.0, and the Swift SDK tracks relaycast 5.0.0. Node delivery is unconditional in v5, so the broker no longer toggles the per-workspace stream (the removed `workspace_stream_set` API).
 - The hosted engine base URL default is owned solely by the relaycast SDK. `agent-relay`, `agent-relay-broker`, and the bundled SDKs no longer hardcode a base URL — they pass `RELAYCAST_BASE_URL`/`RELAY_BASE_URL` through for self-hosting and otherwise inherit the SDK default (`cast.agentrelay.com`). The broker reaches the fleet node-control endpoint via the SDK's `node_control_ws_url` helper and only injects `RELAY_BASE_URL` into spawned agents when an override is set.
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,9 +2001,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "4.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e9e8c4627560572999940ccf4d1638f48b5bb8844848a7fb88c85d46a296b"
+checksum = "c781a790fe6aaf9d159fbc07d7f78d523718be24bedb8622af3424a8564c3833"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=4.2.0"
+relaycast = "=5.0.0"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -64,14 +64,6 @@ impl RelaycastWsClient {
         let mut has_connected = false;
 
         loop {
-            if let Err(error) = self.workspace_http.ensure_workspace_stream_enabled().await {
-                tracing::warn!(
-                    target = "relay_broker::ws",
-                    error = %error,
-                    "failed to enable workspace stream before websocket connect"
-                );
-            }
-
             // Attribute the broker's own relaycast traffic (the workspace
             // stream) to the agent-relay CLI as the origin actor — forwarded as
             // the `origin_actor` query param (WS upgrades can't set headers).
@@ -567,26 +559,6 @@ impl RelaycastHttpClient {
             .send(channel, text, None, None, None)
             .await
             .map_err(|e| anyhow::anyhow!("relaycast send_to_channel failed: {e}"))?;
-        Ok(())
-    }
-
-    /// Ensure workspace-wide WebSocket fanout is enabled for this workspace.
-    pub async fn ensure_workspace_stream_enabled(&self) -> Result<()> {
-        let Some(relay) = (*self.relay).as_ref() else {
-            tracing::warn!("SDK relay client not initialized; cannot enable workspace stream");
-            return Ok(());
-        };
-
-        let config = relay
-            .workspace_stream_set(true)
-            .await
-            .map_err(|error| anyhow::anyhow!("relaycast workspace_stream_set failed: {error}"))?;
-        tracing::debug!(
-            enabled = config.enabled,
-            default_enabled = config.default_enabled,
-            override = ?config.override_value,
-            "ensured workspace stream enabled"
-        );
         Ok(())
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "9.1.0",
+  "version": "9.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1769,6 +1769,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9910,46 +9911,46 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "9.1.0"
+      "version": "9.1.2"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "9.1.0",
-        "@agent-relay/config": "9.1.0",
-        "@agent-relay/fleet": "9.1.0",
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/sdk": "9.1.0",
-        "@agent-relay/utils": "9.1.0",
+        "@agent-relay/cloud": "9.1.2",
+        "@agent-relay/config": "9.1.2",
+        "@agent-relay/fleet": "9.1.2",
+        "@agent-relay/harness-driver": "9.1.2",
+        "@agent-relay/sdk": "9.1.2",
+        "@agent-relay/utils": "9.1.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^4.1.6",
+        "@relaycast/sdk": "^5.0.0",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -9971,11 +9972,11 @@
       }
     },
     "packages/cli/node_modules/@relaycast/sdk": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
-      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-5.0.0.tgz",
+      "integrity": "sha512-1f6P8sqwAtntEv8aKk5aF/+4g+ewX8xXz6p7SfvFHTNX5qgMpZKqQAomAE+RygoW8Iqr6wvBDwi71oWe6l0P8w==",
       "dependencies": {
-        "@relaycast/types": "4.1.6",
+        "@relaycast/types": "5.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -9989,9 +9990,9 @@
       }
     },
     "packages/cli/node_modules/@relaycast/types": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
-      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-5.0.0.tgz",
+      "integrity": "sha512-Ov6J+qRIX4JJe32tXebck+TBKW3wfswtdUKH+Ey/T8XXTXesRPDJeS7E2i2M3ELicmAn78GCzPzgZ7lKAtrNOA==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -10007,9 +10008,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "dependencies": {
-        "@agent-relay/config": "9.1.0",
+        "@agent-relay/config": "9.1.2",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -10025,7 +10026,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -10038,60 +10039,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/integration-prompts": "9.1.0"
+        "@agent-relay/harness-driver": "9.1.2",
+        "@agent-relay/integration-prompts": "9.1.2"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/harnesses": "9.1.0",
-        "@agent-relay/sdk": "9.1.0",
+        "@agent-relay/harness-driver": "9.1.2",
+        "@agent-relay/harnesses": "9.1.2",
+        "@agent-relay/sdk": "9.1.2",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "9.1.0",
+        "@agent-relay/sdk": "9.1.2",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "9.1.0",
-        "@agent-relay/broker-darwin-x64": "9.1.0",
-        "@agent-relay/broker-linux-arm64": "9.1.0",
-        "@agent-relay/broker-linux-x64": "9.1.0",
-        "@agent-relay/broker-win32-x64": "9.1.0"
+        "@agent-relay/broker-darwin-arm64": "9.1.2",
+        "@agent-relay/broker-darwin-x64": "9.1.2",
+        "@agent-relay/broker-linux-arm64": "9.1.2",
+        "@agent-relay/broker-linux-x64": "9.1.2",
+        "@agent-relay/broker-win32-x64": "9.1.2"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/sdk": "9.1.0"
+        "@agent-relay/harness-driver": "9.1.2",
+        "@agent-relay/sdk": "9.1.2"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "dependencies": {
-        "@agent-relay/config": "9.1.0"
+        "@agent-relay/config": "9.1.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -10100,27 +10101,27 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "dependencies": {
-        "@relaycast/sdk": "^4.1.6"
+        "@relaycast/sdk": "^5.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.10"
       }
     },
     "packages/sdk/node_modules/@relaycast/sdk": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
-      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-5.0.0.tgz",
+      "integrity": "sha512-1f6P8sqwAtntEv8aKk5aF/+4g+ewX8xXz6p7SfvFHTNX5qgMpZKqQAomAE+RygoW8Iqr6wvBDwi71oWe6l0P8w==",
       "dependencies": {
-        "@relaycast/types": "4.1.6",
+        "@relaycast/types": "5.0.0",
         "zod": "^4.3.6"
       }
     },
     "packages/sdk/node_modules/@relaycast/types": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
-      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-5.0.0.tgz",
+      "integrity": "sha512-Ov6J+qRIX4JJe32tXebck+TBKW3wfswtdUKH+Ey/T8XXTXesRPDJeS7E2i2M3ELicmAn78GCzPzgZ7lKAtrNOA==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -10136,9 +10137,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "dependencies": {
-        "@agent-relay/config": "9.1.0",
+        "@agent-relay/config": "9.1.2",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@agent-relay/sdk": "9.1.2",
     "@agent-relay/utils": "9.1.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^4.1.6",
+    "@relaycast/sdk": "^5.0.0",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 
 [project.optional-dependencies]
 communicate = [
-    "relaycast-sdk>=0.2.0",
+    "relaycast-sdk>=0.3.0",
     "aiohttp>=3.9",
 ]
 openai-agents = ["openai-agents>=0.1"]
@@ -24,7 +24,7 @@ google-adk = ["google-adk>=0.1"]
 agno = ["agno>=0.1"]
 crewai = ["crewai>=0.1"]
 dev = [
-    "relaycast-sdk>=0.2.0",
+    "relaycast-sdk>=0.3.0",
     "aiohttp>=3.9",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/packages/sdk-swift/Package.resolved
+++ b/packages/sdk-swift/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AgentWorkforce/relaycast.git",
       "state" : {
-        "revision" : "21830a01a62defcff261d2de59843b6afff7f534",
-        "version" : "4.2.0"
+        "revision" : "4d59f19308d01d9ab6db42fc2770179bc4cdbebd",
+        "version" : "5.0.0"
       }
     }
   ],

--- a/packages/sdk-swift/Package.swift
+++ b/packages/sdk-swift/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AgentWorkforce/relaycast.git",
-            from: "4.2.0"
+            from: "5.0.0"
         )
     ],
     targets: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,6 +59,6 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^4.1.6"
+    "@relaycast/sdk": "^5.0.0"
   }
 }


### PR DESCRIPTION
## What

Updates the broker and all bundled SDKs to **relaycast v5** (PR AgentWorkforce/relaycast#212 → v5.0.0, which makes node delivery unconditional).

| Surface | Bump |
|---|---|
| `agent-relay-broker` (Rust) | `relaycast` crate `=4.2.0` → `=5.0.0` |
| `agent-relay` / `@agent-relay/sdk` (npm) | `@relaycast/sdk` `^4.1.6` → `^5.0.0` |
| `sdk-py` `communicate` | `relaycast-sdk` `>=0.2.0` → `>=0.3.0` |
| `sdk-swift` | relaycast Swift `from: 4.2.0` → `5.0.0` |

## Only code change

The broker dropped `ensure_workspace_stream_enabled()` / `RelayCast::workspace_stream_set` — **removed in v5** (node delivery is unconditional; the per-workspace stream is no longer a client-toggled setting). Everything else was a clean dep bump; nothing in relay referenced the removed `workspace_stream_*` API.

## Verification (all green against v5)
- **broker**: `cargo build` + `cargo test -p agent-relay-broker` → 774 pass.
- **npm**: `@relaycast/sdk@5.0.0` resolves; sdk + cli `tsc` clean; `turbo build` 8/8; vitest 19/19; sdk suite 110/110; type tests 5/5.
- **sdk-py**: `relaycast-sdk 0.3.0`; communicate wrap unchanged; 53 tests pass.
- **sdk-swift**: re-resolved to relaycast `5.0.0`; `swift build` clean; 70 tests pass.

## ⚠️ Follow-up: runtime delivery against a v5 engine
This PR is "compiles + unit-tests green against v5." Because v5 removed the workspace-stream toggle in favor of **unconditional node delivery**, there's an open runtime question: does a v5 engine still serve the workspace stream (①) to broker keys, or are broker-hosted agents now delivered only via node delivery (②)? If the latter, the broker needs the **node-delivery migration** (always-a-node, bind agents, take delivery+context from `/v1/node/ws`, delete `fleet_mode`) for messages to actually inject. Recommend an end-to-end delivery check against the v5 engine before relying on this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

