### PR TITLE
openclaw: default Codex runtime to gpt-5.4

### DIFF
--- a/packages/openclaw/bridge/bridge.mjs
+++ b/packages/openclaw/bridge/bridge.mjs
@@ -43,7 +43,7 @@ const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_ATTEMPTS = 15;
 const OPENCLAW_NAME = process.env.OPENCLAW_NAME ?? process.env.AGENT_NAME ?? 'agent';
 const OPENCLAW_WORKSPACE_ID = process.env.OPENCLAW_WORKSPACE_ID ?? 'unknown';
-const OPENCLAW_MODEL = process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.3-codex';
+const OPENCLAW_MODEL = process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.4';
 
 let ws = null;
 let connected = false; // gateway handshake complete

--- a/packages/openclaw/src/identity/model.ts
+++ b/packages/openclaw/src/identity/model.ts
@@ -1,13 +1,13 @@
-const DEFAULT_MODEL = 'openai-codex/gpt-5.3-codex';
+const DEFAULT_MODEL = 'openai-codex/gpt-5.4';
 
 /**
  * Normalize a raw model string into a fully-qualified "provider/model" reference.
  *
  * Examples:
- *   normalizeModelRef('gpt-5.3-codex', 'openai-codex') → 'openai-codex/gpt-5.3-codex'
+ *   normalizeModelRef('gpt-5.4', 'openai-codex') → 'openai-codex/gpt-5.4'
  *   normalizeModelRef('claude-opus-4-6')                → 'anthropic/claude-opus-4-6'
- *   normalizeModelRef('openai-codex/gpt-5.3-codex')     → 'openai-codex/gpt-5.3-codex'
- *   normalizeModelRef(undefined)                         → 'openai-codex/gpt-5.3-codex'
+ *   normalizeModelRef('openai-codex/gpt-5.4')           → 'openai-codex/gpt-5.4'
+ *   normalizeModelRef(undefined)                         → 'openai-codex/gpt-5.4'
  */
 export function normalizeModelRef(rawModel?: string, providerHint?: string): string {
   const model = (rawModel ?? '').trim().toLowerCase();

--- a/packages/openclaw/src/mcp/tools.ts
+++ b/packages/openclaw/src/mcp/tools.ts
@@ -31,7 +31,7 @@ export function getToolDefinitions(): McpToolDefinition[] {
           },
           model: {
             type: 'string',
-            description: 'Model reference (e.g. "openai-codex/gpt-5.3-codex"). Defaults to parent model.',
+            description: 'Model reference (e.g. "openai-codex/gpt-5.4"). Defaults to parent model.',
           },
           channels: {
             type: 'array',

--- a/packages/openclaw/src/runtime/openclaw-config.ts
+++ b/packages/openclaw/src/runtime/openclaw-config.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 export interface OpenClawConfigOptions {
-  /** Fully-qualified model ref, e.g. "openai-codex/gpt-5.3-codex". */
+  /** Fully-qualified model ref, e.g. "openai-codex/gpt-5.4". */
   modelRef: string;
   /** Path to ~/.openclaw/ (default: $HOME/.openclaw). */
   openclawHome?: string;

--- a/packages/openclaw/src/runtime/patch.ts
+++ b/packages/openclaw/src/runtime/patch.ts
@@ -17,7 +17,7 @@ import { existsSync } from 'node:fs';
  *   - "Claude Code" branding
  *
  * @param distDir - Path to OpenClaw's dist directory (e.g. /usr/lib/node_modules/openclaw/dist)
- * @param modelRef - Full model reference (e.g. "openai-codex/gpt-5.3-codex")
+ * @param modelRef - Full model reference (e.g. "openai-codex/gpt-5.4")
  * @returns Number of files patched, or 0 if dist not found or patching skipped
  */
 export async function patchOpenClawDist(distDir: string, modelRef: string): Promise<number> {
@@ -26,7 +26,7 @@ export async function patchOpenClawDist(distDir: string, modelRef: string): Prom
     return 0;
   }
 
-  // Extract bare model ID (e.g. "gpt-5.3-codex" from "openai-codex/gpt-5.3-codex")
+  // Extract bare model ID (e.g. "gpt-5.4" from "openai-codex/gpt-5.4")
   const modelId = modelRef.includes('/') ? modelRef.split('/').pop()! : modelRef;
 
   // Order matters: replace fully-qualified patterns before bare model IDs,

--- a/packages/openclaw/src/runtime/setup.ts
+++ b/packages/openclaw/src/runtime/setup.ts
@@ -13,7 +13,7 @@ import {
 } from '../identity/files.js';
 
 export interface RuntimeSetupOptions {
-  /** Raw model string (e.g. "gpt-5.3-codex"). Defaults to env OPENCLAW_MODEL. */
+  /** Raw model string (e.g. "gpt-5.4"). Defaults to env OPENCLAW_MODEL. */
   model?: string;
   /** Agent name. Defaults to env OPENCLAW_NAME or AGENT_NAME. */
   name?: string;
@@ -39,7 +39,7 @@ export async function runtimeSetup(options: RuntimeSetupOptions = {}): Promise<{
   workspaceId: string;
 }> {
   const home = options.homeDir ?? process.env.HOME ?? '/home/node';
-  const model = options.model ?? process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.3-codex';
+  const model = options.model ?? process.env.OPENCLAW_MODEL ?? 'openai-codex/gpt-5.4';
   const name = options.name ?? process.env.OPENCLAW_NAME ?? process.env.AGENT_NAME ?? 'agent';
   const workspaceId = options.workspaceId ?? process.env.OPENCLAW_WORKSPACE_ID ?? 'unknown';
   const role = options.role ?? process.env.OPENCLAW_ROLE ?? 'general';

--- a/packages/openclaw/src/spawn/types.ts
+++ b/packages/openclaw/src/spawn/types.ts
@@ -7,7 +7,7 @@ export interface SpawnOptions {
   channels?: string[];
   /** Agent role description. */
   role?: string;
-  /** Model reference (e.g. "openai-codex/gpt-5.3-codex"). */
+  /** Model reference (e.g. "openai-codex/gpt-5.4"). */
   model?: string;
   /** System prompt / task description. */
   systemPrompt?: string;


### PR DESCRIPTION
## Summary

- update OpenClaw Codex runtime defaults from `gpt-5` to `gpt-5.4`
- keep bridge, setup, config, patch, MCP tool, and spawn type defaults aligned

## Validation

- `git diff --check origin/main..HEAD`
- `npm ci`
- `npm run build`

Note: local Rust toolchain was unavailable, so the build used the repository's prebuilt broker binary path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

