### PR TITLE
chore(deps): bump relaycast SDKs to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- relaycast SDKs upgraded to latest: `@relaycast/sdk` 5.0.5 (v4→v5 major), `relaycast` crate 5.0.2, `relaycast-sdk` 0.3.0, Swift relaycast 5.0.5. The v5 `agents.release` now returns an action invocation (like `agents.spawn`); the `remove_agent` MCP tool surfaces that invocation.
 - The hosted engine base URL default is owned solely by the relaycast SDK. `agent-relay`, `agent-relay-broker`, and the bundled SDKs no longer hardcode a base URL — they pass `RELAYCAST_BASE_URL`/`RELAY_BASE_URL` through for self-hosting and otherwise inherit the SDK default (`cast.agentrelay.com`). The broker reaches the fleet node-control endpoint via the SDK's `node_control_ws_url` helper and only injects `RELAY_BASE_URL` into spawned agents when an override is set.
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,9 +2001,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relaycast"
-version = "5.0.1"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022fc55041de1c7412d79217aacd09bcf827fe2c401213f5e40e06ac40d674b"
+checksum = "7ebdb019e721d550a15b602e7a47d024ce76bbb57d5c6cea76c82e1ac96183b0"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=5.0.1"
+relaycast = "=5.0.2"
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "9.1.0",
+  "version": "9.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1769,6 +1769,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9910,46 +9911,46 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "9.1.0"
+      "version": "9.1.3"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "9.1.0",
-        "@agent-relay/config": "9.1.0",
-        "@agent-relay/fleet": "9.1.0",
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/sdk": "9.1.0",
-        "@agent-relay/utils": "9.1.0",
+        "@agent-relay/cloud": "9.1.3",
+        "@agent-relay/config": "9.1.3",
+        "@agent-relay/fleet": "9.1.3",
+        "@agent-relay/harness-driver": "9.1.3",
+        "@agent-relay/sdk": "9.1.3",
+        "@agent-relay/utils": "9.1.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@relaycast/sdk": "^4.1.6",
+        "@relaycast/sdk": "^5.0.5",
         "@relayflows/cli": "^1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
@@ -9971,11 +9972,11 @@
       }
     },
     "packages/cli/node_modules/@relaycast/sdk": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
-      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-5.0.5.tgz",
+      "integrity": "sha512-Lgfg7uzKr3ox0b6lNUQ6hfd5ereoID5+QTXsmnGoQ7pjfj9DilAkPQiyDEM7OCUC+SSQiNViLu0CB1DRofpisw==",
       "dependencies": {
-        "@relaycast/types": "4.1.6",
+        "@relaycast/types": "5.0.5",
         "zod": "^4.3.6"
       }
     },
@@ -9989,9 +9990,9 @@
       }
     },
     "packages/cli/node_modules/@relaycast/types": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
-      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-5.0.5.tgz",
+      "integrity": "sha512-He4BR8zyIPsQ4WaVYOFRrOfJq9FlkzCwvB9f3eG6Wj2oXKLD+vxrtVpUG87DmGA+pNgRReW8sgPM4vFoeAo11A==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -10007,9 +10008,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "dependencies": {
-        "@agent-relay/config": "9.1.0",
+        "@agent-relay/config": "9.1.3",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -10025,7 +10026,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -10038,60 +10039,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/integration-prompts": "9.1.0"
+        "@agent-relay/harness-driver": "9.1.3",
+        "@agent-relay/integration-prompts": "9.1.3"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/harnesses": "9.1.0",
-        "@agent-relay/sdk": "9.1.0",
+        "@agent-relay/harness-driver": "9.1.3",
+        "@agent-relay/harnesses": "9.1.3",
+        "@agent-relay/sdk": "9.1.3",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "9.1.0",
+        "@agent-relay/sdk": "9.1.3",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "9.1.0",
-        "@agent-relay/broker-darwin-x64": "9.1.0",
-        "@agent-relay/broker-linux-arm64": "9.1.0",
-        "@agent-relay/broker-linux-x64": "9.1.0",
-        "@agent-relay/broker-win32-x64": "9.1.0"
+        "@agent-relay/broker-darwin-arm64": "9.1.3",
+        "@agent-relay/broker-darwin-x64": "9.1.3",
+        "@agent-relay/broker-linux-arm64": "9.1.3",
+        "@agent-relay/broker-linux-x64": "9.1.3",
+        "@agent-relay/broker-win32-x64": "9.1.3"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.0",
-        "@agent-relay/sdk": "9.1.0"
+        "@agent-relay/harness-driver": "9.1.3",
+        "@agent-relay/sdk": "9.1.3"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "dependencies": {
-        "@agent-relay/config": "9.1.0"
+        "@agent-relay/config": "9.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -10100,27 +10101,27 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "dependencies": {
-        "@relaycast/sdk": "^4.1.6"
+        "@relaycast/sdk": "^5.0.5"
       },
       "devDependencies": {
         "@types/node": "^22.13.10"
       }
     },
     "packages/sdk/node_modules/@relaycast/sdk": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-4.1.6.tgz",
-      "integrity": "sha512-GB+uom7/e1Ei5m0ysKc+6VFDnNVIuf/GDmg6okwpWi25FGESsBVaBE62v5z5/YJumbgO0LYeT0lrYuvQnx8SZg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-5.0.5.tgz",
+      "integrity": "sha512-Lgfg7uzKr3ox0b6lNUQ6hfd5ereoID5+QTXsmnGoQ7pjfj9DilAkPQiyDEM7OCUC+SSQiNViLu0CB1DRofpisw==",
       "dependencies": {
-        "@relaycast/types": "4.1.6",
+        "@relaycast/types": "5.0.5",
         "zod": "^4.3.6"
       }
     },
     "packages/sdk/node_modules/@relaycast/types": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-4.1.6.tgz",
-      "integrity": "sha512-ppFkCVqa8HXVekIK1cTWRLssVl1OvZDfjVGLaUzFjNBkK88v7gR/ZSvMveyRFWLw4GORTTb96YmV1UPIwveY7g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-5.0.5.tgz",
+      "integrity": "sha512-He4BR8zyIPsQ4WaVYOFRrOfJq9FlkzCwvB9f3eG6Wj2oXKLD+vxrtVpUG87DmGA+pNgRReW8sgPM4vFoeAo11A==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -10136,9 +10137,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "9.1.0",
+      "version": "9.1.3",
       "dependencies": {
-        "@agent-relay/config": "9.1.0",
+        "@agent-relay/config": "9.1.3",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@agent-relay/sdk": "9.1.3",
     "@agent-relay/utils": "9.1.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@relaycast/sdk": "^4.1.6",
+    "@relaycast/sdk": "^5.0.5",
     "@relayflows/cli": "^1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -674,22 +674,12 @@ function registerAgentRelayTools(
         reason: z.string().optional().describe('Removal reason'),
         delete_agent: z.boolean().optional().describe('Permanently delete the agent'),
       },
-      outputSchema: {
-        name: z.string().describe('Removed agent name'),
-        removed: z.boolean().describe('Whether the agent was removed'),
-        deleted: z.boolean().describe('Whether the agent was deleted'),
-        reason: z.string().nullable().describe('Removal reason'),
-      },
+      outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
     async ({ name, reason, delete_agent }) => {
-      const released = await getRelay().agents.release({ name, reason, deleteAgent: delete_agent });
-      return jsonContent({
-        name: released.name,
-        removed: released.released,
-        deleted: released.deleted,
-        reason: released.reason,
-      });
+      const invocation = await getRelay().agents.release({ name, reason, deleteAgent: delete_agent });
+      return jsonContent({ invocation });
     }
   );
 }

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 
 [project.optional-dependencies]
 communicate = [
-    "relaycast-sdk>=0.2.0",
+    "relaycast-sdk>=0.3.0",
     "aiohttp>=3.9",
 ]
 openai-agents = ["openai-agents>=0.1"]
@@ -24,7 +24,7 @@ google-adk = ["google-adk>=0.1"]
 agno = ["agno>=0.1"]
 crewai = ["crewai>=0.1"]
 dev = [
-    "relaycast-sdk>=0.2.0",
+    "relaycast-sdk>=0.3.0",
     "aiohttp>=3.9",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/packages/sdk-swift/Package.resolved
+++ b/packages/sdk-swift/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AgentWorkforce/relaycast.git",
       "state" : {
-        "revision" : "21830a01a62defcff261d2de59843b6afff7f534",
-        "version" : "4.2.0"
+        "revision" : "2bd03f54fa35a6bfa50cbba5feb353267aba642c",
+        "version" : "5.0.5"
       }
     }
   ],

--- a/packages/sdk-swift/Package.swift
+++ b/packages/sdk-swift/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AgentWorkforce/relaycast.git",
-            from: "4.2.0"
+            from: "5.0.5"
         )
     ],
     targets: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,6 +59,6 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^4.1.6"
+    "@relaycast/sdk": "^5.0.5"
   }
 }


### PR DESCRIPTION
Upgrades every relaycast SDK dependency to its latest published version.

## Version bumps
| Ecosystem | Package | From | To |
|---|---|---|---|
| npm | `@relaycast/sdk` (`packages/sdk`, `packages/cli`) | `^4.1.6` | `^5.0.5` (v4→v5 **major**) |
| Rust | `relaycast` crate (`crates/broker`) | `=5.0.1` | `=5.0.2` |
| PyPI | `relaycast-sdk` (`packages/sdk-py`, communicate + dev) | `>=0.2.0` | `>=0.3.0` |
| Swift | `relaycast` git dep (`packages/sdk-swift`) | `4.2.0` | `5.0.5` |

Lockfiles: `package-lock.json` regenerated (`npm install`); `Cargo.lock` bumped relaycast 5.0.1→5.0.2; `packages/sdk-swift/Package.resolved` resolved to tag 5.0.5. `packages/sdk-py/uv.lock` intentionally **not** touched — `main`'s lock is already stale against its own `pyproject` (re-resolving pulls ~32 unrelated transitive bumps), so that drift is left to a dedicated lock-refresh; `relaycast-sdk 0.3.0` resolves cleanly against the bumped constraint.

## v4→v5 code adaptation (TS)
The v5 `@relaycast/sdk` reworked agent release to flow through the action-invocation pipeline (consistent with the node-only delivery migration #1201):

- **Before (v4):** `relay.agents.release(...)` returned a synchronous result `{ name, removed, deleted, reason }`.
- **After (v5):** `relay.agents.release(...)` returns an **action invocation** — same shape as `agents.spawn` (`{ invocationId, actionName, handlerAgentId, handlerNodeId, dispatchedNodeId?, input, status, createdAt }`).

`packages/cli/src/cli/agent-relay-mcp.ts` — the `remove_agent` MCP tool read the removed `name`/`released`/`deleted`/`reason` fields, breaking `tsc`. Updated to surface the invocation (`{ invocation }` with the permissive `jsonResult` output schema), mirroring the existing `spawn` tool.

All other relay imports (`RelayCast`, `RelayError`, `RelayErrorCode`, `AgentClientOptions`, `RelayCastOptions`, `SDK_VERSION`, `WsClient`, `AgentClient`) are unchanged in v5. The Rust 5.0.1→5.0.2 patch and the Swift 5.0.5 API needed no code changes.

## Per-ecosystem verification (local)
- **Broker (Rust):** `cargo build -p agent-relay-broker` ✅ · `cargo test -p agent-relay-broker` ✅ **791 + 12 + 1 passed, 0 failed** · `cargo clippy -p agent-relay-broker` ✅ clean.
- **TS sdk:** build/typecheck ✅ · node-test-runner vitest ✅ **110/110**.
- **TS cli + all packages:** `tsc` build ✅ (fixed the v5 breakage above) · broker integration tests typecheck ✅ · `vitest run` ✅ **969 passed, 5 skipped, 0 failed** (79 files). *(The repo-wide `npm test` glob also sweeps the Swift `.build/checkouts/relaycast` vendored checkout's own tests; excluding that path — which CI does, since the Swift checkout isn't populated on Linux CI — relay's own suite is fully green.)*
- **sdk-py:** `relaycast-sdk 0.3.0` resolves; `pytest` ✅ **279 passed** (incl. all communicate/relaycast transport tests). 4 pre-existing failures (`test_dry_run`, `test_relay_lifecycle_hooks`) are a relay-source `sessionId` payload mismatch on `main` — reproduced identically with relaycast-sdk **0.2.0**, so unrelated to this bump.
- **sdk-swift:** `swift build` ✅ against tag 5.0.5 · `swift test` ✅ **70 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)