### PR TITLE
feat(cli): add integration subscribe/unsubscribe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-relay integration subscribe|unsubscribe` manages relayfile integration bindings from the relay CLI, including inline connect remediation, explicit `--spawn` handling, inbound webhook creation, and subscription writeback wiring. `integration subscription create` now accepts `--filter`, `--url`, and `--secret`.
 - `agent-relay integration webhook create-inbound <channel> [--name]` mints an inbound channel webhook (returns a scoped URL + one-time token) so external services can push messages into an agent's channel without the SDK; `list-inbound` and `delete-inbound` manage them. Closes the CLI gap where inbound webhooks were reachable only via the SDK/MCP.
 - `agent-relay` spawn APIs add an optional task-exit mode so spawned CLI agents run the injected task and then cleanly self-terminate with `/exit`.
 - `@agent-relay/harness-driver` adds local fleet sidecar protocol frames for node and handler registration, clean node deregistration, broker handler invocation, handler results, handler-attributed spawns, object-record capability metadata, and sidecar supervision metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `agent-relay integration subscribe|unsubscribe` manages relayfile integration bindings from the relay CLI, including inline connect remediation, explicit `--spawn` handling, inbound webhook creation, and subscription writeback wiring. `integration subscription create` now accepts `--filter`, `--url`, and `--secret`.
+- `agent-relay integration subscribe|unsubscribe` binds any relayfile provider to a relay channel or agent in one command, with inline connect flow when the provider isn't linked yet.
+- `agent-relay integration subscription create` now accepts `--filter`, `--url`, and `--secret` to scope delivery and secure the writeback endpoint.
 - `agent-relay integration webhook create-inbound <channel> [--name]` mints an inbound channel webhook (returns a scoped URL + one-time token) so external services can push messages into an agent's channel without the SDK; `list-inbound` and `delete-inbound` manage them. Closes the CLI gap where inbound webhooks were reachable only via the SDK/MCP.
 - `agent-relay` spawn APIs add an optional task-exit mode so spawned CLI agents run the injected task and then cleanly self-terminate with `/exit`.
 - `@agent-relay/harness-driver` adds local fleet sidecar protocol frames for node and handler registration, clean node deregistration, broker handler invocation, handler results, handler-attributed spawns, object-record capability metadata, and sidecar supervision metadata.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "9.1.3",
+  "version": "9.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1769,7 +1769,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9911,44 +9910,44 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "9.1.3"
+      "version": "9.1.4"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "9.1.3",
-        "@agent-relay/config": "9.1.3",
-        "@agent-relay/fleet": "9.1.3",
-        "@agent-relay/harness-driver": "9.1.3",
-        "@agent-relay/sdk": "9.1.3",
-        "@agent-relay/utils": "9.1.3",
+        "@agent-relay/cloud": "9.1.4",
+        "@agent-relay/config": "9.1.4",
+        "@agent-relay/fleet": "9.1.4",
+        "@agent-relay/harness-driver": "9.1.4",
+        "@agent-relay/sdk": "9.1.4",
+        "@agent-relay/utils": "9.1.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^5.0.5",
         "@relayflows/cli": "^1.0.1",
@@ -10008,9 +10007,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dependencies": {
-        "@agent-relay/config": "9.1.3",
+        "@agent-relay/config": "9.1.4",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -10026,7 +10025,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -10039,60 +10038,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.3",
-        "@agent-relay/integration-prompts": "9.1.3"
+        "@agent-relay/harness-driver": "9.1.4",
+        "@agent-relay/integration-prompts": "9.1.4"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.3",
-        "@agent-relay/harnesses": "9.1.3",
-        "@agent-relay/sdk": "9.1.3",
+        "@agent-relay/harness-driver": "9.1.4",
+        "@agent-relay/harnesses": "9.1.4",
+        "@agent-relay/sdk": "9.1.4",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "9.1.3",
+        "@agent-relay/sdk": "9.1.4",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "9.1.3",
-        "@agent-relay/broker-darwin-x64": "9.1.3",
-        "@agent-relay/broker-linux-arm64": "9.1.3",
-        "@agent-relay/broker-linux-x64": "9.1.3",
-        "@agent-relay/broker-win32-x64": "9.1.3"
+        "@agent-relay/broker-darwin-arm64": "9.1.4",
+        "@agent-relay/broker-darwin-x64": "9.1.4",
+        "@agent-relay/broker-linux-arm64": "9.1.4",
+        "@agent-relay/broker-linux-x64": "9.1.4",
+        "@agent-relay/broker-win32-x64": "9.1.4"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.3",
-        "@agent-relay/sdk": "9.1.3"
+        "@agent-relay/harness-driver": "9.1.4",
+        "@agent-relay/sdk": "9.1.4"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dependencies": {
-        "@agent-relay/config": "9.1.3"
+        "@agent-relay/config": "9.1.4"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -10101,7 +10100,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dependencies": {
         "@relaycast/sdk": "^5.0.5"
       },
@@ -10137,9 +10136,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dependencies": {
-        "@agent-relay/config": "9.1.3",
+        "@agent-relay/config": "9.1.4",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/src/cli/bootstrap.test.ts
+++ b/packages/cli/src/cli/bootstrap.test.ts
@@ -90,6 +90,8 @@ const expectedLeafCommands = [
   'message inbox get_readers',
   'message file upload',
   // integration
+  'integration subscribe',
+  'integration unsubscribe',
   'integration webhook create',
   'integration webhook list',
   'integration webhook delete',

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -1,4 +1,6 @@
 import type { Command } from 'commander';
+import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { getProjectPaths } from '@agent-relay/config';
 import type { AgentRelayAgent } from '@agent-relay/sdk';
 
@@ -18,9 +20,127 @@ export interface LocalRelayOptions {
   baseUrl?: string;
 }
 
+export interface RelayfileBinding {
+  provider: string;
+  resource: string;
+  channel: string;
+  webhookId: string;
+  subscriptionId: string;
+}
+
+export interface RelayfileBridge {
+  isConnected(provider: string): Promise<boolean>;
+  connect(provider: string): Promise<void>;
+  bind(input: {
+    provider: string;
+    resource: string;
+    channel: string;
+    webhookId: string;
+    webhookToken: string;
+    subscriptionId: string;
+  }): Promise<void>;
+  listBindings(): Promise<RelayfileBinding[]>;
+  unbind(provider: string, resource: string): Promise<void>;
+}
+
 export type IntegrationCommandDependencies = SdkCommandDeps & {
   resolveLocalRelayOptions: () => Promise<LocalRelayOptions | undefined>;
+  relayfile: RelayfileBridge;
+  isInteractive: () => boolean;
+  prompt: (question: string) => Promise<string>;
 };
+
+function runRelayfile(args: string[], options: { inherit?: boolean } = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('relayfile', args, {
+      stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(stderr.trim() || `relayfile ${args.join(' ')} exited with code ${code ?? 'unknown'}`));
+    });
+  });
+}
+
+function readProviderConnected(payload: unknown, provider: string): boolean {
+  const normalizedProvider = provider.trim().toLowerCase();
+  const values = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === 'object'
+      ? Object.values(payload as Record<string, unknown>)
+      : [];
+  return values.some((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return false;
+    }
+    const record = entry as Record<string, unknown>;
+    const name = String(record.provider ?? record.name ?? record.id ?? '')
+      .trim()
+      .toLowerCase();
+    const state = String(record.state ?? record.status ?? '')
+      .trim()
+      .toLowerCase();
+    return name === normalizedProvider && ['connected', 'ready', 'active', 'ok'].includes(state);
+  });
+}
+
+function defaultRelayfileBridge(): RelayfileBridge {
+  return {
+    async isConnected(provider) {
+      const output = await runRelayfile(['integration', 'list', '--json']);
+      return readProviderConnected(JSON.parse(output), provider);
+    },
+    async connect(provider) {
+      await runRelayfile(['integration', 'connect', provider], { inherit: true });
+    },
+    async bind(input) {
+      await runRelayfile([
+        'integration',
+        'bind',
+        input.provider,
+        input.resource,
+        '--channel',
+        input.channel,
+        '--webhook',
+        input.webhookId,
+        '--webhook-token',
+        input.webhookToken,
+        '--subscription',
+        input.subscriptionId,
+      ]);
+    },
+    async listBindings() {
+      const output = await runRelayfile(['integration', 'bind', '--list', '--json']);
+      const parsed = JSON.parse(output) as unknown;
+      return Array.isArray(parsed) ? (parsed as RelayfileBinding[]) : [];
+    },
+    async unbind(provider, resource) {
+      await runRelayfile(['integration', 'unbind', provider, resource]);
+    },
+  };
+}
+
+async function promptLine(question: string): Promise<string> {
+  const readline = await import('node:readline/promises');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
 
 async function resolveLocalBrokerRelayOptions(): Promise<LocalRelayOptions | undefined> {
   let client:
@@ -30,8 +150,9 @@ async function resolveLocalBrokerRelayOptions(): Promise<LocalRelayOptions | und
       }
     | undefined;
   try {
-    client = connectProjectBrokerClient(getProjectPaths().projectRoot);
-    const session = await client.getSession();
+    const brokerClient = connectProjectBrokerClient(getProjectPaths().projectRoot);
+    client = brokerClient;
+    const session = await brokerClient.getSession();
     const workspaceKey = session.workspace_key?.trim();
     if (!workspaceKey) {
       return undefined;
@@ -54,6 +175,9 @@ function withIntegrationDefaults(
   return {
     ...withSdkDefaults(overrides),
     resolveLocalRelayOptions: resolveLocalBrokerRelayOptions,
+    relayfile: defaultRelayfileBridge(),
+    isInteractive: () => Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    prompt: promptLine,
     ...overrides,
   };
 }
@@ -79,6 +203,126 @@ function localRetryOptions(options: SdkClientOptions, local: LocalRelayOptions):
   };
 }
 
+function parseFilter(raw: string): Record<string, string> {
+  const [key, ...rest] = raw.split('=');
+  const trimmedKey = key?.trim();
+  if (!trimmedKey || rest.length === 0) {
+    throw new Error('Invalid --filter value. Expected key=value, for example channel=#ops.');
+  }
+  return { [trimmedKey]: rest.join('=').trim() };
+}
+
+function commaList(raw: unknown): string[] {
+  return String(raw ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function defaultBridgeUrl(commandOpts: Record<string, unknown>, local?: LocalRelayOptions): string {
+  const explicit = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
+  if (explicit) {
+    return explicit;
+  }
+  const baseUrl =
+    (typeof commandOpts.baseUrl === 'string' ? commandOpts.baseUrl.trim() : '') ||
+    local?.baseUrl ||
+    process.env.RELAY_BASE_URL?.trim() ||
+    'https://agentrelay.com';
+  return `${baseUrl.replace(/\/+$/, '')}/integrations/relayfile/writeback`;
+}
+
+function bridgeSecret(commandOpts: Record<string, unknown>): string {
+  const explicit = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
+  return explicit || randomBytes(24).toString('hex');
+}
+
+function targetChannel(target: string): string {
+  const trimmed = target.trim();
+  return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
+}
+
+function agentName(target: string): string | undefined {
+  const trimmed = target.trim();
+  return trimmed.startsWith('@') ? trimmed.slice(1).trim() : undefined;
+}
+
+async function ensureProviderConnected(
+  deps: IntegrationCommandDependencies,
+  provider: string,
+  opts: Record<string, unknown>
+): Promise<void> {
+  if (await deps.relayfile.isConnected(provider)) {
+    return;
+  }
+
+  if (opts.input === false || !deps.isInteractive()) {
+    throw new Error(
+      `${provider} isn't connected to this workspace yet.\nRun: relayfile integration connect ${provider} --workspace <ws>, then re-run.`
+    );
+  }
+
+  deps.log(`${provider} isn't connected to this workspace yet.`);
+  deps.log(`Opening browser to connect ${provider}...`);
+  await deps.relayfile.connect(provider);
+  if (!(await deps.relayfile.isConnected(provider))) {
+    throw new Error(
+      `${provider} is still not connected. Run: relayfile integration connect ${provider} --workspace <ws>, then re-run.`
+    );
+  }
+}
+
+async function ensureRecipient(
+  relay: AgentRelayAgent,
+  provider: string,
+  target: string,
+  opts: Record<string, unknown>
+): Promise<void> {
+  const name = agentName(target);
+  if (!name) {
+    return;
+  }
+  const agents = await relay.agents.list();
+  if (agents.some((agent: { name: string }) => agent.name === name)) {
+    return;
+  }
+
+  const spawnCli = typeof opts.spawn === 'string' ? opts.spawn.trim() : '';
+  if (!spawnCli) {
+    throw new Error(
+      `Recipient agent ${target} does not exist. Run: agent-relay integration subscribe ${provider} --to ${target} --spawn <cli>`
+    );
+  }
+
+  await relay.agents.register({
+    name,
+    type: 'agent',
+    metadata: { requestedCli: spawnCli, source: 'integration.subscribe' },
+  });
+}
+
+async function promptSubscribeOptions(
+  deps: IntegrationCommandDependencies,
+  provider: string | undefined,
+  opts: Record<string, unknown>
+): Promise<{ provider: string; resource: string; to: string }> {
+  if (provider && typeof opts.resource === 'string' && typeof opts.to === 'string') {
+    return { provider, resource: opts.resource, to: opts.to };
+  }
+  if (opts.input === false || !deps.isInteractive()) {
+    throw new Error(
+      'Non-interactive subscribe requires <provider>, --resource <value>, and --to <agent|#channel>.'
+    );
+  }
+  const resolvedProvider = provider ?? (await deps.prompt('Integration provider: '));
+  const resource =
+    typeof opts.resource === 'string' && opts.resource.trim()
+      ? opts.resource
+      : await deps.prompt('Provider resource: ');
+  const to = typeof opts.to === 'string' && opts.to.trim() ? opts.to : await deps.prompt('Relay recipient: ');
+  return { provider: resolvedProvider, resource, to };
+}
+
 async function runIntegrationOperation<T>(
   deps: IntegrationCommandDependencies,
   commandOpts: Record<string, unknown>,
@@ -101,12 +345,118 @@ async function runIntegrationOperation<T>(
   }
 }
 
+async function runSubscribe(
+  deps: IntegrationCommandDependencies,
+  providerArg: string | undefined,
+  opts: Record<string, unknown>
+): Promise<void> {
+  if (opts.list) {
+    const local = await deps.resolveLocalRelayOptions();
+    const relayOptions = sdkOptionsFromOpts(opts);
+    const relay = deps.createAgentRelay(
+      local && !explicitWorkspaceKey(opts) ? localRetryOptions(relayOptions, local) : relayOptions
+    );
+    const [bindings, webhooks, subscriptions] = await Promise.all([
+      deps.relayfile.listBindings(),
+      relay.webhooks.list(),
+      relay.webhooks.subscriptions(),
+    ]);
+    printJson(deps, { bindings, webhooks, subscriptions });
+    return;
+  }
+
+  const { provider, resource, to } = await promptSubscribeOptions(deps, providerArg, opts);
+  const local = await deps.resolveLocalRelayOptions();
+  await ensureProviderConnected(deps, provider, opts);
+
+  const relayOptions = sdkOptionsFromOpts(opts);
+  const relay = deps.createAgentRelay(
+    local && !explicitWorkspaceKey(opts) ? localRetryOptions(relayOptions, local) : relayOptions
+  );
+  await ensureRecipient(relay, provider, to, opts);
+  const channel = targetChannel(to);
+  const webhook = await relay.webhooks.createInbound({ channel, name: `relayfile:${provider}` });
+  const events = commaList(opts.events);
+  const subscription = await relay.integrations.subscriptions.create({
+    event: events.length === 1 ? events[0]! : 'message.created',
+    events: events.length ? events : ['message.created', 'thread.reply'],
+    filter: { channel },
+    url: defaultBridgeUrl(opts, local),
+    secret: bridgeSecret(opts),
+  });
+  await deps.relayfile.bind({
+    provider,
+    resource,
+    channel,
+    webhookId: webhook.webhookId,
+    webhookToken: webhook.token,
+    subscriptionId: subscription.id,
+  });
+  deps.log(`✓ ${provider} ${resource} bound -> ${to}`);
+  deps.log('✓ Listening. Replies will post back in-thread.');
+}
+
+async function runUnsubscribe(
+  deps: IntegrationCommandDependencies,
+  provider: string,
+  opts: Record<string, unknown>
+): Promise<void> {
+  const resource = typeof opts.resource === 'string' ? opts.resource.trim() : '';
+  if (!resource) {
+    throw new Error('Missing --resource <value> for unsubscribe.');
+  }
+  const bindings = await deps.relayfile.listBindings();
+  const binding = bindings.find((item) => item.provider === provider && item.resource === resource);
+  if (!binding) {
+    throw new Error(`No binding found for ${provider} ${resource}.`);
+  }
+  const local = await deps.resolveLocalRelayOptions();
+  const relayOptions = sdkOptionsFromOpts(opts);
+  const relay = deps.createAgentRelay(
+    local && !explicitWorkspaceKey(opts) ? localRetryOptions(relayOptions, local) : relayOptions
+  );
+  await relay.webhooks.delete(binding.webhookId);
+  await relay.webhooks.unsubscribe(binding.subscriptionId);
+  await deps.relayfile.unbind(provider, resource);
+  deps.log(`Unsubscribed ${provider} ${resource}.`);
+}
+
 export function registerIntegrationCommands(
   program: Command,
   overrides: Partial<IntegrationCommandDependencies> = {}
 ): void {
   const deps = withIntegrationDefaults(overrides);
   const group = program.command('integration').description('Webhooks and event subscriptions');
+
+  addSdkOptions(
+    group
+      .command('subscribe [provider]')
+      .description('Subscribe a relay recipient to a relayfile integration')
+      .option('--resource <value>', 'Provider-native resource (channel, project, label, etc.)')
+      .option('--to <target>', 'Relay recipient, e.g. @agent or #channel')
+      .option('--spawn <cli>', 'Register the recipient agent when it is absent')
+      .option('--events <list>', 'Comma-separated relay event names', 'message.created,thread.reply')
+      .option('--bridge-url <url>', 'Writeback bridge URL')
+      .option('--bridge-secret <secret>', 'HMAC signing secret for the writeback bridge')
+      .option('--list', 'List active relayfile integration bindings')
+      .option('--no-input', 'Do not prompt or launch browser-based connect flows')
+  ).action(async (provider: string | undefined, o: Record<string, unknown>) => {
+    await runSdk(deps, async () => {
+      await runSubscribe(deps, provider, o);
+    });
+  });
+
+  addSdkOptions(
+    group
+      .command('unsubscribe')
+      .description('Remove a relayfile integration subscription')
+      .argument('<provider>', 'Integration provider')
+      .option('--resource <value>', 'Provider-native resource used when subscribing')
+  ).action(async (provider: string, o: Record<string, unknown>) => {
+    await runSdk(deps, async () => {
+      await runUnsubscribe(deps, provider, o);
+    });
+  });
 
   const webhook = group.command('webhook').description('Webhooks');
 
@@ -214,11 +564,22 @@ export function registerIntegrationCommands(
       .command('create')
       .description('Create a subscription to events')
       .argument('<event>', 'Event name')
+      .option('--filter <filter>', 'Filter expression, e.g. channel=#ops')
+      .option('--url <url>', 'Delivery URL for subscription')
+      .option('--secret <secret>', 'HMAC signing secret')
   ).action(async (event: string, o: Record<string, unknown>) => {
     await runSdk(deps, async () => {
+      const filter = typeof o.filter === 'string' ? parseFilter(o.filter) : undefined;
       printJson(
         deps,
-        await runIntegrationOperation(deps, o, (relay) => relay.integrations.subscriptions.create({ event }))
+        await runIntegrationOperation(deps, o, (relay) =>
+          relay.integrations.subscriptions.create({
+            event,
+            ...(filter ? { filter } : {}),
+            ...(typeof o.url === 'string' ? { url: o.url } : {}),
+            ...(typeof o.secret === 'string' ? { secret: o.secret } : {}),
+          })
+        )
       );
     });
   });

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -76,6 +76,20 @@ function runRelayfile(args: string[], options: { inherit?: boolean } = {}): Prom
 
 function readProviderConnected(payload: unknown, provider: string): boolean {
   const normalizedProvider = provider.trim().toLowerCase();
+  const CONNECTED_STATES = ['connected', 'ready', 'active', 'ok'];
+  // Handle dict-keyed payloads where the provider name is the key
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const record = payload as Record<string, unknown>;
+    const entry = Object.entries(record).find(([key]) => key.trim().toLowerCase() === normalizedProvider)?.[1];
+    if (entry && typeof entry === 'object') {
+      const state = String((entry as Record<string, unknown>).state ?? (entry as Record<string, unknown>).status ?? '')
+        .trim()
+        .toLowerCase();
+      if (CONNECTED_STATES.includes(state)) {
+        return true;
+      }
+    }
+  }
   const values = Array.isArray(payload)
     ? payload
     : payload && typeof payload === 'object'
@@ -92,7 +106,7 @@ function readProviderConnected(payload: unknown, provider: string): boolean {
     const state = String(record.state ?? record.status ?? '')
       .trim()
       .toLowerCase();
-    return name === normalizedProvider && ['connected', 'ready', 'active', 'ok'].includes(state);
+    return name === normalizedProvider && CONNECTED_STATES.includes(state);
   });
 }
 
@@ -228,7 +242,7 @@ function defaultBridgeUrl(commandOpts: Record<string, unknown>, local?: LocalRel
     (typeof commandOpts.baseUrl === 'string' ? commandOpts.baseUrl.trim() : '') ||
     local?.baseUrl ||
     process.env.RELAY_BASE_URL?.trim() ||
-    'https://agentrelay.com';
+    'https://cast.agentrelay.com';
   return `${baseUrl.replace(/\/+$/, '')}/integrations/relayfile/writeback`;
 }
 
@@ -375,23 +389,31 @@ async function runSubscribe(
   );
   await ensureRecipient(relay, provider, to, opts);
   const channel = targetChannel(to);
-  const webhook = await relay.webhooks.createInbound({ channel, name: `relayfile:${provider}` });
   const events = commaList(opts.events);
-  const subscription = await relay.integrations.subscriptions.create({
-    event: events.length === 1 ? events[0]! : 'message.created',
-    events: events.length ? events : ['message.created', 'thread.reply'],
-    filter: { channel },
-    url: defaultBridgeUrl(opts, local),
-    secret: bridgeSecret(opts),
-  });
-  await deps.relayfile.bind({
-    provider,
-    resource,
-    channel,
-    webhookId: webhook.webhookId,
-    webhookToken: webhook.token,
-    subscriptionId: subscription.id,
-  });
+  let webhook: { webhookId: string; token: string } | undefined;
+  let subscription: { id: string } | undefined;
+  try {
+    webhook = await relay.webhooks.createInbound({ channel, name: `relayfile:${provider}` });
+    subscription = await relay.integrations.subscriptions.create({
+      event: events.length === 1 ? events[0]! : 'message.created',
+      events: events.length ? events : ['message.created', 'thread.reply'],
+      filter: { channel },
+      url: defaultBridgeUrl(opts, local),
+      secret: bridgeSecret(opts),
+    });
+    await deps.relayfile.bind({
+      provider,
+      resource,
+      channel,
+      webhookId: webhook.webhookId,
+      webhookToken: webhook.token,
+      subscriptionId: subscription.id,
+    });
+  } catch (err) {
+    if (subscription) await relay.integrations.subscriptions.delete(subscription.id).catch(() => undefined);
+    if (webhook) await relay.webhooks.delete(webhook.webhookId).catch(() => undefined);
+    throw err;
+  }
   deps.log(`✓ ${provider} ${resource} bound -> ${to}`);
   deps.log('✓ Listening. Replies will post back in-thread.');
 }
@@ -415,8 +437,16 @@ async function runUnsubscribe(
   const relay = deps.createAgentRelay(
     local && !explicitWorkspaceKey(opts) ? localRetryOptions(relayOptions, local) : relayOptions
   );
-  await relay.webhooks.delete(binding.webhookId);
-  await relay.webhooks.unsubscribe(binding.subscriptionId);
+  try {
+    await relay.webhooks.delete(binding.webhookId);
+  } catch (err) {
+    deps.log(`Warning: failed to delete webhook ${binding.webhookId}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    await relay.webhooks.unsubscribe(binding.subscriptionId);
+  } catch (err) {
+    deps.log(`Warning: failed to remove subscription ${binding.subscriptionId}: ${err instanceof Error ? err.message : String(err)}`);
+  }
   await deps.relayfile.unbind(provider, resource);
   deps.log(`Unsubscribed ${provider} ${resource}.`);
 }

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -80,9 +80,13 @@ function readProviderConnected(payload: unknown, provider: string): boolean {
   // Handle dict-keyed payloads where the provider name is the key
   if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
     const record = payload as Record<string, unknown>;
-    const entry = Object.entries(record).find(([key]) => key.trim().toLowerCase() === normalizedProvider)?.[1];
+    const entry = Object.entries(record).find(
+      ([key]) => key.trim().toLowerCase() === normalizedProvider
+    )?.[1];
     if (entry && typeof entry === 'object') {
-      const state = String((entry as Record<string, unknown>).state ?? (entry as Record<string, unknown>).status ?? '')
+      const state = String(
+        (entry as Record<string, unknown>).state ?? (entry as Record<string, unknown>).status ?? ''
+      )
         .trim()
         .toLowerCase();
       if (CONNECTED_STATES.includes(state)) {
@@ -440,12 +444,16 @@ async function runUnsubscribe(
   try {
     await relay.webhooks.delete(binding.webhookId);
   } catch (err) {
-    deps.log(`Warning: failed to delete webhook ${binding.webhookId}: ${err instanceof Error ? err.message : String(err)}`);
+    deps.log(
+      `Warning: failed to delete webhook ${binding.webhookId}: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
   try {
     await relay.webhooks.unsubscribe(binding.subscriptionId);
   } catch (err) {
-    deps.log(`Warning: failed to remove subscription ${binding.subscriptionId}: ${err instanceof Error ? err.message : String(err)}`);
+    deps.log(
+      `Warning: failed to remove subscription ${binding.subscriptionId}: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
   await deps.relayfile.unbind(provider, resource);
   deps.log(`Unsubscribed ${provider} ${resource}.`);

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -57,6 +57,8 @@ function createRelayMock() {
       })),
       list: vi.fn(async () => []),
       delete: vi.fn(async () => undefined),
+      subscriptions: vi.fn(async () => []),
+      unsubscribe: vi.fn(async () => undefined),
     },
     capabilities: {
       register: vi.fn(async (i: unknown) => ({ ...(i as object) })),
@@ -251,6 +253,273 @@ describe('SDK-backed CLI groups', () => {
     const { program, relay } = harness(registerIntegrationCommands);
     await program.parseAsync(['integration', 'webhook', 'delete-inbound', 'in1'], { from: 'user' });
     expect(relay.webhooks.delete).toHaveBeenCalledWith('in1');
+  });
+
+  it('integration subscription create passes filter url and secret to subscriptions.create', async () => {
+    const { program, relay } = harness(registerIntegrationCommands);
+    await program.parseAsync(
+      [
+        'integration',
+        'subscription',
+        'create',
+        'message.created',
+        '--filter',
+        'channel=#ops',
+        '--url',
+        'https://bridge.test/writeback',
+        '--secret',
+        's3cr3t',
+      ],
+      { from: 'user' }
+    );
+    expect(relay.integrations.subscriptions.create).toHaveBeenCalledWith({
+      event: 'message.created',
+      filter: { channel: '#ops' },
+      url: 'https://bridge.test/writeback',
+      secret: 's3cr3t',
+    });
+  });
+
+  it('integration subscription create keeps optional subscription fields absent by default', async () => {
+    const { program, relay } = harness(registerIntegrationCommands);
+    await program.parseAsync(['integration', 'subscription', 'create', 'message.created'], { from: 'user' });
+    expect(relay.integrations.subscriptions.create).toHaveBeenCalledWith({ event: 'message.created' });
+  });
+
+  it('integration subscribe exits with remediation when provider is not connected and no-input is set', async () => {
+    const relay = createRelayMock();
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log,
+      error,
+      exit: exit as never,
+      resolveLocalRelayOptions: vi.fn(async () => ({ workspaceKey: 'rk_live_local' })),
+      isInteractive: () => false,
+      relayfile: {
+        isConnected: vi.fn(async () => false),
+        connect: vi.fn(async () => undefined),
+        bind: vi.fn(async () => undefined),
+        listBindings: vi.fn(async () => []),
+        unbind: vi.fn(async () => undefined),
+      },
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(
+      ['integration', 'subscribe', 'slack', '--resource', '#acme', '--to', '@slackbot', '--no-input'],
+      { from: 'user' }
+    );
+
+    expect(error).toHaveBeenCalledWith(
+      "slack isn't connected to this workspace yet.\nRun: relayfile integration connect slack --workspace <ws>, then re-run."
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(relay.webhooks.createInbound).not.toHaveBeenCalled();
+  });
+
+  it('integration subscribe creates inbound webhook, subscription, and relayfile binding', async () => {
+    const relay = createRelayMock();
+    relay.agents.list.mockResolvedValueOnce([{ id: 'a1', name: 'slackbot' }]);
+    const relayfile = {
+      isConnected: vi.fn(async () => true),
+      connect: vi.fn(async () => undefined),
+      bind: vi.fn(async () => undefined),
+      listBindings: vi.fn(async () => []),
+      unbind: vi.fn(async () => undefined),
+    };
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log,
+      error,
+      exit: exit as never,
+      resolveLocalRelayOptions: vi.fn(async () => ({
+        workspaceKey: 'rk_live_local',
+        baseUrl: 'https://relay.local',
+      })),
+      isInteractive: () => false,
+      relayfile,
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(
+      [
+        'integration',
+        'subscribe',
+        'slack',
+        '--resource',
+        '#acme',
+        '--to',
+        '@slackbot',
+        '--bridge-url',
+        'https://bridge.test/writeback',
+        '--bridge-secret',
+        'secret',
+      ],
+      { from: 'user' }
+    );
+
+    expect(relay.webhooks.createInbound).toHaveBeenCalledWith({
+      channel: 'slackbot',
+      name: 'relayfile:slack',
+    });
+    expect(relay.integrations.subscriptions.create).toHaveBeenCalledWith({
+      event: 'message.created',
+      events: ['message.created', 'thread.reply'],
+      filter: { channel: 'slackbot' },
+      url: 'https://bridge.test/writeback',
+      secret: 'secret',
+    });
+    expect(relayfile.bind).toHaveBeenCalledWith({
+      provider: 'slack',
+      resource: '#acme',
+      channel: 'slackbot',
+      webhookId: 'in1',
+      webhookToken: 'tok_once',
+      subscriptionId: 'sub1',
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('integration subscribe --list prints relayfile bindings', async () => {
+    const relay = createRelayMock();
+    const relayfile = {
+      isConnected: vi.fn(async () => true),
+      connect: vi.fn(async () => undefined),
+      bind: vi.fn(async () => undefined),
+      listBindings: vi.fn(async () => [
+        {
+          provider: 'slack',
+          resource: '#acme',
+          channel: 'slackbot',
+          webhookId: 'in1',
+          subscriptionId: 'sub1',
+        },
+      ]),
+      unbind: vi.fn(async () => undefined),
+    };
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log,
+      error,
+      exit: exit as never,
+      resolveLocalRelayOptions: vi.fn(async () => ({ workspaceKey: 'rk_live_local' })),
+      relayfile,
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(['integration', 'subscribe', '--list'], { from: 'user' });
+
+    expect(relayfile.listBindings).toHaveBeenCalled();
+    expect(relay.webhooks.list).toHaveBeenCalled();
+    expect(relay.webhooks.subscriptions).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          bindings: [
+            {
+              provider: 'slack',
+              resource: '#acme',
+              channel: 'slackbot',
+              webhookId: 'in1',
+              subscriptionId: 'sub1',
+            },
+          ],
+          webhooks: [],
+          subscriptions: [],
+        },
+        null,
+        2
+      )
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('integration subscribe requires explicit spawn when a target agent is absent', async () => {
+    const relay = createRelayMock();
+    relay.agents.list.mockResolvedValueOnce([]);
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log,
+      error,
+      exit: exit as never,
+      resolveLocalRelayOptions: vi.fn(async () => ({ workspaceKey: 'rk_live_local' })),
+      isInteractive: () => false,
+      relayfile: {
+        isConnected: vi.fn(async () => true),
+        connect: vi.fn(async () => undefined),
+        bind: vi.fn(async () => undefined),
+        listBindings: vi.fn(async () => []),
+        unbind: vi.fn(async () => undefined),
+      },
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(['integration', 'subscribe', 'slack', '--resource', '#acme', '--to', '@ghost'], {
+      from: 'user',
+    });
+
+    expect(error).toHaveBeenCalledWith(
+      'Recipient agent @ghost does not exist. Run: agent-relay integration subscribe slack --to @ghost --spawn <cli>'
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(relay.webhooks.createInbound).not.toHaveBeenCalled();
+  });
+
+  it('integration unsubscribe removes webhook, subscription, and relayfile binding', async () => {
+    const relay = createRelayMock();
+    const relayfile = {
+      isConnected: vi.fn(async () => true),
+      connect: vi.fn(async () => undefined),
+      bind: vi.fn(async () => undefined),
+      listBindings: vi.fn(async () => [
+        {
+          provider: 'slack',
+          resource: '#acme',
+          channel: 'slackbot',
+          webhookId: 'in1',
+          subscriptionId: 'sub1',
+        },
+      ]),
+      unbind: vi.fn(async () => undefined),
+    };
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log,
+      error,
+      exit: exit as never,
+      resolveLocalRelayOptions: vi.fn(async () => ({ workspaceKey: 'rk_live_local' })),
+      relayfile,
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(['integration', 'unsubscribe', 'slack', '--resource', '#acme'], {
+      from: 'user',
+    });
+
+    expect(relay.webhooks.delete).toHaveBeenCalledWith('in1');
+    expect(relay.webhooks.unsubscribe).toHaveBeenCalledWith('sub1');
+    expect(relayfile.unbind).toHaveBeenCalledWith('slack', '#acme');
+    expect(error).not.toHaveBeenCalled();
   });
 
   it('capabilities register routes to capabilities.register', async () => {


### PR DESCRIPTION
## Summary

- Adds `agent-relay integration subscribe [provider]` — one-shot wizard that connects a relayfile provider to a relay channel: checks connection, creates inbound webhook, creates outbound subscription, and calls `relayfile integration bind`
- Adds `agent-relay integration unsubscribe <provider> --resource <value>` — tears down webhook + subscription + binding atomically
- Adds `--list` flag to `subscribe` to show active bindings
- Surfaces `--filter`, `--url`, and `--secret` on `integration subscription create` (engine already supported these; only the CLI wrapper was missing them)
- Inline `relayfile integration connect` flow when the provider isn't connected; respects `--no-input` for CI

## Context

Part of the **integration-bridge** feature. This is the user-facing orchestration layer (C1–C4) — the single command that makes provider→agent wiring frictionless. Spec: `relaycast/docs/integration-bridge.md` §12.

## Test plan

- [ ] `packages/cli/src/cli/commands/integration.ts` subscribe/unsubscribe unit tests
- [ ] `integration subscription create --filter channel=#ops --url https://… --secret …` flags work
- [ ] `subscribe --list` returns active bindings
- [ ] `subscribe` without `--resource`/`--to` drops into interactive wizard
- [ ] `subscribe` with unconnected provider triggers connect flow then resumes
- [ ] `unsubscribe` with unknown provider/resource exits with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

