### PR TITLE
feat(integration): dynamic per-channel writeback secret + ingress URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `agent-relay integration subscribe` now points the writeback subscription at the relayfile-cloud ingress (`{relayfile}/v1/workspaces/{ws}/integrations/relay/writeback`) resolved from the local relayfile config, instead of a relay-server path that returned 404. `--bridge-url` still overrides; `--bridge-secret` falls back to `RELAY_WRITEBACK_SECRET` so the signing secret can match the ingress's `RELAY_WRITEBACK_HMAC_SECRET`.
+- `agent-relay integration subscribe` now points the writeback subscription at the relayfile-cloud ingress and signs it with a per-channel secret fetched from relayfile (`relayfile integration writeback-secret`), instead of a relay-server path that returned 404. The secret is derived server-side and tied to the logged-in account, so there's nothing to provision; `--bridge-url`/`--bridge-secret` still override.
 - relaycast SDKs upgraded to latest: `@relaycast/sdk` 5.0.5 (v4→v5 major), `relaycast` crate 5.0.2, `relaycast-sdk` 0.3.0, Swift relaycast 5.0.5. The v5 `agents.release` now returns an action invocation (like `agents.spawn`); the `remove_agent` MCP tool surfaces that invocation.
 - The hosted engine base URL default is owned solely by the relaycast SDK. `agent-relay`, `agent-relay-broker`, and the bundled SDKs no longer hardcode a base URL — they pass `RELAYCAST_BASE_URL`/`RELAY_BASE_URL` through for self-hosting and otherwise inherit the SDK default (`cast.agentrelay.com`). The broker reaches the fleet node-control endpoint via the SDK's `node_control_ws_url` helper and only injects `RELAY_BASE_URL` into spawned agents when an override is set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `agent-relay integration subscribe` now points the writeback subscription at the relayfile-cloud ingress (`{relayfile}/v1/workspaces/{ws}/integrations/relay/writeback`) resolved from the local relayfile config, instead of a relay-server path that returned 404. `--bridge-url` still overrides; `--bridge-secret` falls back to `RELAY_WRITEBACK_SECRET` so the signing secret can match the ingress's `RELAY_WRITEBACK_HMAC_SECRET`.
 - relaycast SDKs upgraded to latest: `@relaycast/sdk` 5.0.5 (v4→v5 major), `relaycast` crate 5.0.2, `relaycast-sdk` 0.3.0, Swift relaycast 5.0.5. The v5 `agents.release` now returns an action invocation (like `agents.spawn`); the `remove_agent` MCP tool surfaces that invocation.
 - The hosted engine base URL default is owned solely by the relaycast SDK. `agent-relay`, `agent-relay-broker`, and the bundled SDKs no longer hardcode a base URL — they pass `RELAYCAST_BASE_URL`/`RELAY_BASE_URL` through for self-hosting and otherwise inherit the SDK default (`cast.agentrelay.com`). The broker reaches the fleet node-control endpoint via the SDK's `node_control_ws_url` helper and only injects `RELAY_BASE_URL` into spawned agents when an override is set.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "9.1.4",
+  "version": "9.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -9910,44 +9910,44 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "9.1.4"
+      "version": "9.1.5"
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "MIT"
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "MIT"
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "MIT"
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "MIT"
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "9.1.4",
-        "@agent-relay/config": "9.1.4",
-        "@agent-relay/fleet": "9.1.4",
-        "@agent-relay/harness-driver": "9.1.4",
-        "@agent-relay/sdk": "9.1.4",
-        "@agent-relay/utils": "9.1.4",
+        "@agent-relay/cloud": "9.1.5",
+        "@agent-relay/config": "9.1.5",
+        "@agent-relay/fleet": "9.1.5",
+        "@agent-relay/harness-driver": "9.1.5",
+        "@agent-relay/sdk": "9.1.5",
+        "@agent-relay/utils": "9.1.5",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@relaycast/sdk": "^5.0.5",
         "@relayflows/cli": "^1.0.1",
@@ -10007,9 +10007,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "dependencies": {
-        "@agent-relay/config": "9.1.4",
+        "@agent-relay/config": "9.1.5",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -10025,7 +10025,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
@@ -10038,60 +10038,60 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.4",
-        "@agent-relay/integration-prompts": "9.1.4"
+        "@agent-relay/harness-driver": "9.1.5",
+        "@agent-relay/integration-prompts": "9.1.5"
       }
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.4",
-        "@agent-relay/harnesses": "9.1.4",
-        "@agent-relay/sdk": "9.1.4",
+        "@agent-relay/harness-driver": "9.1.5",
+        "@agent-relay/harnesses": "9.1.5",
+        "@agent-relay/sdk": "9.1.5",
         "zod": "^3.23.8"
       }
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "9.1.4",
+        "@agent-relay/sdk": "9.1.5",
         "ws": "^8.18.3",
         "zod": "^3.23.8"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "9.1.4",
-        "@agent-relay/broker-darwin-x64": "9.1.4",
-        "@agent-relay/broker-linux-arm64": "9.1.4",
-        "@agent-relay/broker-linux-x64": "9.1.4",
-        "@agent-relay/broker-win32-x64": "9.1.4"
+        "@agent-relay/broker-darwin-arm64": "9.1.5",
+        "@agent-relay/broker-darwin-x64": "9.1.5",
+        "@agent-relay/broker-linux-arm64": "9.1.5",
+        "@agent-relay/broker-linux-x64": "9.1.5",
+        "@agent-relay/broker-win32-x64": "9.1.5"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "9.1.4",
-        "@agent-relay/sdk": "9.1.4"
+        "@agent-relay/harness-driver": "9.1.5",
+        "@agent-relay/sdk": "9.1.5"
       }
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "Apache-2.0"
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "dependencies": {
-        "@agent-relay/config": "9.1.4"
+        "@agent-relay/config": "9.1.5"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -10100,7 +10100,7 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "dependencies": {
         "@relaycast/sdk": "^5.0.5"
       },
@@ -10136,9 +10136,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "9.1.4",
+      "version": "9.1.5",
       "dependencies": {
-        "@agent-relay/config": "9.1.4",
+        "@agent-relay/config": "9.1.5",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -1,6 +1,5 @@
 import type { Command } from 'commander';
 import { spawn } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
 import { getProjectPaths } from '@agent-relay/config';
 import type { AgentRelayAgent } from '@agent-relay/sdk';
 
@@ -28,11 +27,11 @@ export interface RelayfileBinding {
   subscriptionId: string;
 }
 
-export interface RelayfileWritebackTarget {
-  /** relayfile-cloud base URL that hosts the writeback ingress. */
-  baseUrl: string;
-  /** relayfile workspace id used to scope the ingress route. */
-  workspaceId: string;
+export interface RelayfileWritebackBinding {
+  /** relayfile-cloud writeback ingress URL the subscription delivers to. */
+  url: string;
+  /** Per-channel HMAC secret the subscription signs deliveries with. */
+  secret: string;
 }
 
 export interface RelayfileBridge {
@@ -49,11 +48,13 @@ export interface RelayfileBridge {
   listBindings(): Promise<RelayfileBinding[]>;
   unbind(provider: string, resource: string): Promise<void>;
   /**
-   * Resolve where agent replies should be written back to: the relayfile-cloud
-   * base URL + the workspace id that scopes the writeback ingress route. Returns
-   * undefined when it can't be determined (caller falls back to --bridge-url).
+   * Resolve the writeback ingress URL + per-channel signing secret for a relay
+   * channel, fetched from relayfile-cloud over the authenticated relayfile
+   * session. Returns undefined when it can't be determined (caller falls back to
+   * --bridge-url / --bridge-secret). The secret is derived server-side, so the
+   * subscription and the ingress agree on it without any static shared secret.
    */
-  resolveWritebackTarget(): Promise<RelayfileWritebackTarget | undefined>;
+  resolveWritebackBinding(channel: string): Promise<RelayfileWritebackBinding | undefined>;
 }
 
 export type IntegrationCommandDependencies = SdkCommandDeps & {
@@ -160,53 +161,27 @@ function defaultRelayfileBridge(): RelayfileBridge {
     async unbind(provider, resource) {
       await runRelayfile(['integration', 'unbind', provider, resource]);
     },
-    async resolveWritebackTarget() {
-      return readRelayfileWritebackTarget();
+    async resolveWritebackBinding(channel) {
+      try {
+        const output = await runRelayfile([
+          'integration',
+          'writeback-secret',
+          '--channel',
+          channel,
+          '--json',
+        ]);
+        const parsed = JSON.parse(output) as { url?: unknown; secret?: unknown };
+        const url = typeof parsed.url === 'string' ? parsed.url.trim() : '';
+        const secret = typeof parsed.secret === 'string' ? parsed.secret.trim() : '';
+        if (!url || !secret) {
+          return undefined;
+        }
+        return { url, secret };
+      } catch {
+        return undefined;
+      }
     },
   };
-}
-
-const DEFAULT_RELAYFILE_BASE_URL = 'https://file.agentrelay.com';
-
-interface RelayfileWorkspaceConfig {
-  name?: string;
-  id?: string;
-  relayWorkspaceId?: string;
-  server?: string;
-}
-
-/**
- * Resolve the writeback ingress target from the local relayfile config
- * (`~/.relayfile/workspaces.json`): the default workspace's server (base URL)
- * and its runtime workspace id (`relayWorkspaceId`, the id the relayfile-cloud
- * fs/ingress routes are keyed by).
- */
-async function readRelayfileWritebackTarget(): Promise<RelayfileWritebackTarget | undefined> {
-  try {
-    const { readFile } = await import('node:fs/promises');
-    const os = await import('node:os');
-    const path = await import('node:path');
-    const configPath = path.join(os.homedir(), '.relayfile', 'workspaces.json');
-    const raw = await readFile(configPath, 'utf-8');
-    const parsed = JSON.parse(raw) as {
-      default?: string;
-      workspaces?: RelayfileWorkspaceConfig[];
-    };
-    const workspaces = Array.isArray(parsed.workspaces) ? parsed.workspaces : [];
-    const defaultKey = typeof parsed.default === 'string' ? parsed.default : '';
-    const match =
-      workspaces.find(
-        (w) => w.relayWorkspaceId === defaultKey || w.id === defaultKey || w.name === defaultKey
-      ) ?? workspaces[0];
-    const workspaceId = match?.relayWorkspaceId?.trim() || match?.id?.trim();
-    if (!workspaceId) {
-      return undefined;
-    }
-    const baseUrl = match?.server?.trim() || DEFAULT_RELAYFILE_BASE_URL;
-    return { baseUrl, workspaceId };
-  } catch {
-    return undefined;
-  }
 }
 
 async function promptLine(question: string): Promise<string> {
@@ -297,44 +272,47 @@ function commaList(raw: unknown): string[] {
 }
 
 /**
- * Resolve the writeback bridge URL the relay subscription should deliver to.
+ * Resolve the writeback delivery URL + signing secret for the relay
+ * subscription. Both come from relayfile-cloud (workspace-scoped ingress URL +
+ * the per-channel derived secret), fetched over the authenticated relayfile
+ * session — so the subscription and the ingress agree on the secret with
+ * nothing to provision.
  *
- * The ingress is hosted by relayfile-cloud and is workspace-scoped, so the URL
- * carries the relayfile workspace id:
- *   {relayfileBaseUrl}/v1/workspaces/{workspaceId}/integrations/relay/writeback
- *
- * Precedence: explicit --bridge-url > resolved relayfile target. Throws with a
- * clear remediation when neither is available (so we never silently create a
- * subscription pointed at a dead URL).
+ * Precedence: explicit --bridge-url/--bridge-secret override each field; the
+ * fetched binding fills the rest. Throws with remediation when a field can't be
+ * resolved, so we never create a subscription with a dead URL or an
+ * unverifiable secret.
  */
-async function resolveBridgeUrl(
+async function resolveWriteback(
   deps: IntegrationCommandDependencies,
-  commandOpts: Record<string, unknown>
-): Promise<string> {
-  const explicit = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
-  if (explicit) {
-    return explicit;
-  }
-  const target = await deps.relayfile.resolveWritebackTarget();
-  if (!target) {
+  commandOpts: Record<string, unknown>,
+  channel: string
+): Promise<{ url: string; secret: string }> {
+  const explicitUrl = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
+  const explicitSecret =
+    typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
+
+  const binding =
+    explicitUrl && explicitSecret
+      ? undefined
+      : await deps.relayfile.resolveWritebackBinding(channel);
+
+  const url = explicitUrl || binding?.url;
+  const secret = explicitSecret || binding?.secret;
+
+  if (!url) {
     throw new Error(
-      'Could not resolve the relayfile writeback ingress URL. Pass --bridge-url ' +
-        '<https://file.agentrelay.com/v1/workspaces/<ws>/integrations/relay/writeback>.'
+      'Could not resolve the relayfile writeback ingress URL. Ensure relayfile is ' +
+        'logged in (relayfile login), or pass --bridge-url.'
     );
   }
-  const base = target.baseUrl.replace(/\/+$/, '');
-  return `${base}/v1/workspaces/${encodeURIComponent(target.workspaceId)}/integrations/relay/writeback`;
-}
-
-/**
- * The HMAC secret the subscription signs deliveries with. Must match the
- * relayfile-cloud ingress's RELAY_WRITEBACK_HMAC_SECRET for signatures to
- * verify. Precedence: --bridge-secret > RELAY_WRITEBACK_SECRET env > a random
- * value (unsigned-by-mismatch; only useful when the ingress has no secret set).
- */
-function bridgeSecret(commandOpts: Record<string, unknown>): string {
-  const explicit = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
-  return explicit || process.env.RELAY_WRITEBACK_SECRET?.trim() || randomBytes(24).toString('hex');
+  if (!secret) {
+    throw new Error(
+      'Could not resolve the writeback signing secret. Ensure relayfile is logged ' +
+        'in (relayfile login) and supports `integration writeback-secret`, or pass --bridge-secret.'
+    );
+  }
+  return { url, secret };
 }
 
 function targetChannel(target: string): string {
@@ -476,6 +454,7 @@ async function runSubscribe(
   await ensureRecipient(relay, provider, to, opts);
   const channel = targetChannel(to);
   const events = commaList(opts.events);
+  const writeback = await resolveWriteback(deps, opts, channel);
   let webhook: { webhookId: string; token: string } | undefined;
   let subscription: { id: string } | undefined;
   try {
@@ -484,8 +463,8 @@ async function runSubscribe(
       event: events.length === 1 ? events[0]! : 'message.created',
       events: events.length ? events : ['message.created', 'thread.reply'],
       filter: { channel },
-      url: await resolveBridgeUrl(deps, opts),
-      secret: bridgeSecret(opts),
+      url: writeback.url,
+      secret: writeback.secret,
     });
     await deps.relayfile.bind({
       provider,

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -196,10 +196,7 @@ async function readRelayfileWritebackTarget(): Promise<RelayfileWritebackTarget 
     const defaultKey = typeof parsed.default === 'string' ? parsed.default : '';
     const match =
       workspaces.find(
-        (w) =>
-          w.relayWorkspaceId === defaultKey ||
-          w.id === defaultKey ||
-          w.name === defaultKey
+        (w) => w.relayWorkspaceId === defaultKey || w.id === defaultKey || w.name === defaultKey
       ) ?? workspaces[0];
     const workspaceId = match?.relayWorkspaceId?.trim() || match?.id?.trim();
     if (!workspaceId) {

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -28,6 +28,13 @@ export interface RelayfileBinding {
   subscriptionId: string;
 }
 
+export interface RelayfileWritebackTarget {
+  /** relayfile-cloud base URL that hosts the writeback ingress. */
+  baseUrl: string;
+  /** relayfile workspace id used to scope the ingress route. */
+  workspaceId: string;
+}
+
 export interface RelayfileBridge {
   isConnected(provider: string): Promise<boolean>;
   connect(provider: string): Promise<void>;
@@ -41,6 +48,12 @@ export interface RelayfileBridge {
   }): Promise<void>;
   listBindings(): Promise<RelayfileBinding[]>;
   unbind(provider: string, resource: string): Promise<void>;
+  /**
+   * Resolve where agent replies should be written back to: the relayfile-cloud
+   * base URL + the workspace id that scopes the writeback ingress route. Returns
+   * undefined when it can't be determined (caller falls back to --bridge-url).
+   */
+  resolveWritebackTarget(): Promise<RelayfileWritebackTarget | undefined>;
 }
 
 export type IntegrationCommandDependencies = SdkCommandDeps & {
@@ -147,7 +160,56 @@ function defaultRelayfileBridge(): RelayfileBridge {
     async unbind(provider, resource) {
       await runRelayfile(['integration', 'unbind', provider, resource]);
     },
+    async resolveWritebackTarget() {
+      return readRelayfileWritebackTarget();
+    },
   };
+}
+
+const DEFAULT_RELAYFILE_BASE_URL = 'https://file.agentrelay.com';
+
+interface RelayfileWorkspaceConfig {
+  name?: string;
+  id?: string;
+  relayWorkspaceId?: string;
+  server?: string;
+}
+
+/**
+ * Resolve the writeback ingress target from the local relayfile config
+ * (`~/.relayfile/workspaces.json`): the default workspace's server (base URL)
+ * and its runtime workspace id (`relayWorkspaceId`, the id the relayfile-cloud
+ * fs/ingress routes are keyed by).
+ */
+async function readRelayfileWritebackTarget(): Promise<RelayfileWritebackTarget | undefined> {
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const configPath = path.join(os.homedir(), '.relayfile', 'workspaces.json');
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as {
+      default?: string;
+      workspaces?: RelayfileWorkspaceConfig[];
+    };
+    const workspaces = Array.isArray(parsed.workspaces) ? parsed.workspaces : [];
+    const defaultKey = typeof parsed.default === 'string' ? parsed.default : '';
+    const match =
+      workspaces.find(
+        (w) =>
+          w.relayWorkspaceId === defaultKey ||
+          w.id === defaultKey ||
+          w.name === defaultKey
+      ) ?? workspaces[0];
+    const workspaceId = match?.relayWorkspaceId?.trim() || match?.id?.trim();
+    if (!workspaceId) {
+      return undefined;
+    }
+    const baseUrl = match?.server?.trim() || DEFAULT_RELAYFILE_BASE_URL;
+    return { baseUrl, workspaceId };
+  } catch {
+    return undefined;
+  }
 }
 
 async function promptLine(question: string): Promise<string> {
@@ -237,22 +299,45 @@ function commaList(raw: unknown): string[] {
     .filter(Boolean);
 }
 
-function defaultBridgeUrl(commandOpts: Record<string, unknown>, local?: LocalRelayOptions): string {
+/**
+ * Resolve the writeback bridge URL the relay subscription should deliver to.
+ *
+ * The ingress is hosted by relayfile-cloud and is workspace-scoped, so the URL
+ * carries the relayfile workspace id:
+ *   {relayfileBaseUrl}/v1/workspaces/{workspaceId}/integrations/relay/writeback
+ *
+ * Precedence: explicit --bridge-url > resolved relayfile target. Throws with a
+ * clear remediation when neither is available (so we never silently create a
+ * subscription pointed at a dead URL).
+ */
+async function resolveBridgeUrl(
+  deps: IntegrationCommandDependencies,
+  commandOpts: Record<string, unknown>
+): Promise<string> {
   const explicit = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
   if (explicit) {
     return explicit;
   }
-  const baseUrl =
-    (typeof commandOpts.baseUrl === 'string' ? commandOpts.baseUrl.trim() : '') ||
-    local?.baseUrl ||
-    process.env.RELAY_BASE_URL?.trim() ||
-    'https://cast.agentrelay.com';
-  return `${baseUrl.replace(/\/+$/, '')}/integrations/relayfile/writeback`;
+  const target = await deps.relayfile.resolveWritebackTarget();
+  if (!target) {
+    throw new Error(
+      'Could not resolve the relayfile writeback ingress URL. Pass --bridge-url ' +
+        '<https://file.agentrelay.com/v1/workspaces/<ws>/integrations/relay/writeback>.'
+    );
+  }
+  const base = target.baseUrl.replace(/\/+$/, '');
+  return `${base}/v1/workspaces/${encodeURIComponent(target.workspaceId)}/integrations/relay/writeback`;
 }
 
+/**
+ * The HMAC secret the subscription signs deliveries with. Must match the
+ * relayfile-cloud ingress's RELAY_WRITEBACK_HMAC_SECRET for signatures to
+ * verify. Precedence: --bridge-secret > RELAY_WRITEBACK_SECRET env > a random
+ * value (unsigned-by-mismatch; only useful when the ingress has no secret set).
+ */
 function bridgeSecret(commandOpts: Record<string, unknown>): string {
   const explicit = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
-  return explicit || randomBytes(24).toString('hex');
+  return explicit || process.env.RELAY_WRITEBACK_SECRET?.trim() || randomBytes(24).toString('hex');
 }
 
 function targetChannel(target: string): string {
@@ -402,7 +487,7 @@ async function runSubscribe(
       event: events.length === 1 ? events[0]! : 'message.created',
       events: events.length ? events : ['message.created', 'thread.reply'],
       filter: { channel },
-      url: defaultBridgeUrl(opts, local),
+      url: await resolveBridgeUrl(deps, opts),
       secret: bridgeSecret(opts),
     });
     await deps.relayfile.bind({

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -291,25 +291,28 @@ async function resolveWriteback(
   const explicitUrl = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
   const explicitSecret = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
 
-  const binding =
-    explicitUrl && explicitSecret ? undefined : await deps.relayfile.resolveWritebackBinding(channel);
+  if ((explicitUrl && !explicitSecret) || (!explicitUrl && explicitSecret)) {
+    throw new Error('--bridge-url and --bridge-secret must be provided together; providing only one is not supported.');
+  }
 
-  const url = explicitUrl || binding?.url;
-  const secret = explicitSecret || binding?.secret;
+  if (explicitUrl && explicitSecret) {
+    return { url: explicitUrl, secret: explicitSecret };
+  }
 
-  if (!url) {
+  const binding = await deps.relayfile.resolveWritebackBinding(channel);
+  if (!binding?.url) {
     throw new Error(
       'Could not resolve the relayfile writeback ingress URL. Ensure relayfile is ' +
-        'logged in (relayfile login), or pass --bridge-url.'
+        'logged in (relayfile login), or pass --bridge-url and --bridge-secret.'
     );
   }
-  if (!secret) {
+  if (!binding?.secret) {
     throw new Error(
       'Could not resolve the writeback signing secret. Ensure relayfile is logged ' +
-        'in (relayfile login) and supports `integration writeback-secret`, or pass --bridge-secret.'
+        'in (relayfile login) and supports `integration writeback-secret`, or pass --bridge-url and --bridge-secret.'
     );
   }
-  return { url, secret };
+  return { url: binding.url, secret: binding.secret };
 }
 
 function targetChannel(target: string): string {

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -289,13 +289,10 @@ async function resolveWriteback(
   channel: string
 ): Promise<{ url: string; secret: string }> {
   const explicitUrl = typeof commandOpts.bridgeUrl === 'string' ? commandOpts.bridgeUrl.trim() : '';
-  const explicitSecret =
-    typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
+  const explicitSecret = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
 
   const binding =
-    explicitUrl && explicitSecret
-      ? undefined
-      : await deps.relayfile.resolveWritebackBinding(channel);
+    explicitUrl && explicitSecret ? undefined : await deps.relayfile.resolveWritebackBinding(channel);
 
   const url = explicitUrl || binding?.url;
   const secret = explicitSecret || binding?.secret;

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -292,7 +292,9 @@ async function resolveWriteback(
   const explicitSecret = typeof commandOpts.bridgeSecret === 'string' ? commandOpts.bridgeSecret.trim() : '';
 
   if ((explicitUrl && !explicitSecret) || (!explicitUrl && explicitSecret)) {
-    throw new Error('--bridge-url and --bridge-secret must be provided together; providing only one is not supported.');
+    throw new Error(
+      '--bridge-url and --bridge-secret must be provided together; providing only one is not supported.'
+    );
   }
 
   if (explicitUrl && explicitSecret) {

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -306,6 +306,10 @@ describe('SDK-backed CLI groups', () => {
         bind: vi.fn(async () => undefined),
         listBindings: vi.fn(async () => []),
         unbind: vi.fn(async () => undefined),
+        resolveWritebackTarget: vi.fn(async () => ({
+          baseUrl: 'https://file.test',
+          workspaceId: 'rw_test',
+        })),
       },
     } satisfies Partial<IntegrationCommandDependencies>);
 
@@ -330,6 +334,10 @@ describe('SDK-backed CLI groups', () => {
       bind: vi.fn(async () => undefined),
       listBindings: vi.fn(async () => []),
       unbind: vi.fn(async () => undefined),
+      resolveWritebackTarget: vi.fn(async () => ({
+        baseUrl: 'https://file.test',
+        workspaceId: 'rw_test',
+      })),
     };
     const log = vi.fn();
     const error = vi.fn();
@@ -388,6 +396,46 @@ describe('SDK-backed CLI groups', () => {
     expect(error).not.toHaveBeenCalled();
   });
 
+  it('integration subscribe defaults the bridge URL to the workspace-scoped relayfile ingress', async () => {
+    const relay = createRelayMock();
+    relay.agents.list.mockResolvedValueOnce([{ id: 'a1', name: 'slackbot' }]);
+    const relayfile = {
+      isConnected: vi.fn(async () => true),
+      connect: vi.fn(async () => undefined),
+      bind: vi.fn(async () => undefined),
+      listBindings: vi.fn(async () => []),
+      unbind: vi.fn(async () => undefined),
+      resolveWritebackTarget: vi.fn(async () => ({
+        baseUrl: 'https://file.agentrelay.com',
+        workspaceId: 'rw_7ccfea89',
+      })),
+    };
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program, {
+      createAgentRelay: () => relay as never,
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn() as never,
+      resolveLocalRelayOptions: vi.fn(async () => undefined),
+      isInteractive: () => false,
+      relayfile,
+    } satisfies Partial<IntegrationCommandDependencies>);
+
+    await program.parseAsync(
+      ['integration', 'subscribe', 'slack', '--resource', '#acme', '--to', '@slackbot', '--bridge-secret', 'shared'],
+      { from: 'user' }
+    );
+
+    expect(relayfile.resolveWritebackTarget).toHaveBeenCalled();
+    expect(relay.integrations.subscriptions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://file.agentrelay.com/v1/workspaces/rw_7ccfea89/integrations/relay/writeback',
+        secret: 'shared',
+      })
+    );
+  });
+
   it('integration subscribe --list prints relayfile bindings', async () => {
     const relay = createRelayMock();
     const relayfile = {
@@ -404,6 +452,10 @@ describe('SDK-backed CLI groups', () => {
         },
       ]),
       unbind: vi.fn(async () => undefined),
+      resolveWritebackTarget: vi.fn(async () => ({
+        baseUrl: 'https://file.test',
+        workspaceId: 'rw_test',
+      })),
     };
     const log = vi.fn();
     const error = vi.fn();
@@ -467,6 +519,10 @@ describe('SDK-backed CLI groups', () => {
         bind: vi.fn(async () => undefined),
         listBindings: vi.fn(async () => []),
         unbind: vi.fn(async () => undefined),
+        resolveWritebackTarget: vi.fn(async () => ({
+          baseUrl: 'https://file.test',
+          workspaceId: 'rw_test',
+        })),
       },
     } satisfies Partial<IntegrationCommandDependencies>);
 
@@ -497,6 +553,10 @@ describe('SDK-backed CLI groups', () => {
         },
       ]),
       unbind: vi.fn(async () => undefined),
+      resolveWritebackTarget: vi.fn(async () => ({
+        baseUrl: 'https://file.test',
+        workspaceId: 'rw_test',
+      })),
     };
     const log = vi.fn();
     const error = vi.fn();

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -306,9 +306,9 @@ describe('SDK-backed CLI groups', () => {
         bind: vi.fn(async () => undefined),
         listBindings: vi.fn(async () => []),
         unbind: vi.fn(async () => undefined),
-        resolveWritebackTarget: vi.fn(async () => ({
-          baseUrl: 'https://file.test',
-          workspaceId: 'rw_test',
+        resolveWritebackBinding: vi.fn(async () => ({
+          url: 'https://file.test/v1/workspaces/rw_test/integrations/relay/writeback',
+          secret: 'test-secret',
         })),
       },
     } satisfies Partial<IntegrationCommandDependencies>);
@@ -334,9 +334,9 @@ describe('SDK-backed CLI groups', () => {
       bind: vi.fn(async () => undefined),
       listBindings: vi.fn(async () => []),
       unbind: vi.fn(async () => undefined),
-      resolveWritebackTarget: vi.fn(async () => ({
-        baseUrl: 'https://file.test',
-        workspaceId: 'rw_test',
+      resolveWritebackBinding: vi.fn(async () => ({
+        url: 'https://file.test/v1/workspaces/rw_test/integrations/relay/writeback',
+        secret: 'test-secret',
       })),
     };
     const log = vi.fn();
@@ -396,7 +396,7 @@ describe('SDK-backed CLI groups', () => {
     expect(error).not.toHaveBeenCalled();
   });
 
-  it('integration subscribe defaults the bridge URL to the workspace-scoped relayfile ingress', async () => {
+  it('integration subscribe fetches the writeback URL + secret from relayfile', async () => {
     const relay = createRelayMock();
     relay.agents.list.mockResolvedValueOnce([{ id: 'a1', name: 'slackbot' }]);
     const relayfile = {
@@ -405,9 +405,9 @@ describe('SDK-backed CLI groups', () => {
       bind: vi.fn(async () => undefined),
       listBindings: vi.fn(async () => []),
       unbind: vi.fn(async () => undefined),
-      resolveWritebackTarget: vi.fn(async () => ({
-        baseUrl: 'https://file.agentrelay.com',
-        workspaceId: 'rw_7ccfea89',
+      resolveWritebackBinding: vi.fn(async () => ({
+        url: 'https://file.agentrelay.com/v1/workspaces/rw_7ccfea89/integrations/relay/writeback',
+        secret: 'derived-secret-hex',
       })),
     };
     const program = new Command();
@@ -423,25 +423,15 @@ describe('SDK-backed CLI groups', () => {
     } satisfies Partial<IntegrationCommandDependencies>);
 
     await program.parseAsync(
-      [
-        'integration',
-        'subscribe',
-        'slack',
-        '--resource',
-        '#acme',
-        '--to',
-        '@slackbot',
-        '--bridge-secret',
-        'shared',
-      ],
+      ['integration', 'subscribe', 'slack', '--resource', '#acme', '--to', '@slackbot'],
       { from: 'user' }
     );
 
-    expect(relayfile.resolveWritebackTarget).toHaveBeenCalled();
+    expect(relayfile.resolveWritebackBinding).toHaveBeenCalledWith('slackbot');
     expect(relay.integrations.subscriptions.create).toHaveBeenCalledWith(
       expect.objectContaining({
         url: 'https://file.agentrelay.com/v1/workspaces/rw_7ccfea89/integrations/relay/writeback',
-        secret: 'shared',
+        secret: 'derived-secret-hex',
       })
     );
   });
@@ -462,9 +452,9 @@ describe('SDK-backed CLI groups', () => {
         },
       ]),
       unbind: vi.fn(async () => undefined),
-      resolveWritebackTarget: vi.fn(async () => ({
-        baseUrl: 'https://file.test',
-        workspaceId: 'rw_test',
+      resolveWritebackBinding: vi.fn(async () => ({
+        url: 'https://file.test/v1/workspaces/rw_test/integrations/relay/writeback',
+        secret: 'test-secret',
       })),
     };
     const log = vi.fn();
@@ -529,9 +519,9 @@ describe('SDK-backed CLI groups', () => {
         bind: vi.fn(async () => undefined),
         listBindings: vi.fn(async () => []),
         unbind: vi.fn(async () => undefined),
-        resolveWritebackTarget: vi.fn(async () => ({
-          baseUrl: 'https://file.test',
-          workspaceId: 'rw_test',
+        resolveWritebackBinding: vi.fn(async () => ({
+          url: 'https://file.test/v1/workspaces/rw_test/integrations/relay/writeback',
+          secret: 'test-secret',
         })),
       },
     } satisfies Partial<IntegrationCommandDependencies>);
@@ -563,9 +553,9 @@ describe('SDK-backed CLI groups', () => {
         },
       ]),
       unbind: vi.fn(async () => undefined),
-      resolveWritebackTarget: vi.fn(async () => ({
-        baseUrl: 'https://file.test',
-        workspaceId: 'rw_test',
+      resolveWritebackBinding: vi.fn(async () => ({
+        url: 'https://file.test/v1/workspaces/rw_test/integrations/relay/writeback',
+        secret: 'test-secret',
       })),
     };
     const log = vi.fn();

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -423,7 +423,17 @@ describe('SDK-backed CLI groups', () => {
     } satisfies Partial<IntegrationCommandDependencies>);
 
     await program.parseAsync(
-      ['integration', 'subscribe', 'slack', '--resource', '#acme', '--to', '@slackbot', '--bridge-secret', 'shared'],
+      [
+        'integration',
+        'subscribe',
+        'slack',
+        '--resource',
+        '#acme',
+        '--to',
+        '@slackbot',
+        '--bridge-secret',
+        'shared',
+      ],
       { from: 'user' }
     );
 


### PR DESCRIPTION
## Summary

Wires `agent-relay integration subscribe` to the relayfile-cloud writeback ingress and signs the subscription with a **dynamic per-channel secret** — no static secret to provision. Companion to relayfile-cloud#96 (ingress + derive endpoint) and relayfile#342 (the `writeback-secret` CLI command).

## Problem

The subscribe command created the writeback subscription pointed at a relay-server path that 404s, and used a *random* signing secret the ingress could never match.

## Changes

- `RelayfileBridge.resolveWritebackBinding(channel)` shells `relayfile integration writeback-secret --channel X --json`, which fetches `{ url, secret }` from relayfile-cloud over the authenticated relayfile session. The secret is **derived server-side** (`HMAC(INTERNAL_HMAC_SECRET, "relay-writeback:v1:{ws}:{channel}")`), so the subscription and the ingress agree on it with nothing to set up.
- `resolveWriteback()` fills the subscription `url` + `secret` from that binding; `--bridge-url` / `--bridge-secret` still override each field. Errors with remediation when a field can't be resolved — never a dead URL or an unverifiable secret.
- Drops the `RELAY_WRITEBACK_SECRET` env + random-secret fallback.

## Test plan

- `vitest run relaycast-groups.test.ts` → 20 passed (the subscribe test now asserts the URL + secret come from `resolveWritebackBinding`) ✅
- CLI typecheck ✅

## Ordering

Live once relaycast-cloud#17 (engine 5.0.6) + relayfile-cloud#96 (ingress + secret endpoint) are deployed and relayfile#342 (the CLI command) ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)