### PR TITLE
feat(cli): stream broker startup progress with --verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `agent-relay skills add` installs the `/orchestrate` skill (from `agentrelay.com/skill.md`) into your coding harnesses. An interactive TUI asks whether to install for the current project or globally and which harnesses to target (Claude Code, Codex, Cursor, Gemini, OpenCode); `--global`/`--local`, `--harness <ids>`, and `--all` flags drive it non-interactively.
+- `agent-relay up --verbose` now prints step-by-step startup progress (port resolution, broker process spawn, handshake retries, fleet sidecar, node-delivery wait, agent spawns) and streams the broker's own startup-phase logs and stderr live, instead of only surfacing a terse error if startup fails.
 
 ### Changed
 

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -230,7 +230,9 @@ describe('registerCoreCommands', () => {
       expect.stringMatching(/^\[verbose\] Resolving a free API port starting near/)
     );
     expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/^\[verbose\] API port resolved: 3889/));
-    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/^\[verbose\] Broker status check passed\.$/));
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[verbose\] Broker status check passed\.$/)
+    );
   });
 
   it('up exits early when connection metadata points to a running process', async () => {

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -213,7 +213,24 @@ describe('registerCoreCommands', () => {
     const exitCode = await runCommand(program, ['up', '--broker-name', 'relayfile-dev']);
 
     expect(exitCode).toBeUndefined();
-    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, 'relayfile-dev');
+    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, 'relayfile-dev', undefined);
+  });
+
+  it('up --verbose forwards the flag to createRelay and logs startup step markers', async () => {
+    const relay = createRelayMock({
+      getStatus: vi.fn(async () => ({ agent_count: 1, pending_delivery_count: 0 })),
+    });
+    const { program, deps } = createHarness({ relay });
+
+    const exitCode = await runCommand(program, ['up', '--verbose']);
+
+    expect(exitCode).toBeUndefined();
+    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, undefined, true);
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[verbose\] Resolving a free API port starting near/)
+    );
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/^\[verbose\] API port resolved: 3889/));
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/^\[verbose\] Broker status check passed\.$/));
   });
 
   it('up exits early when connection metadata points to a running process', async () => {
@@ -332,7 +349,7 @@ describe('registerCoreCommands', () => {
     // Port probing happens before createRelay — only one broker is spawned
     expect(deps.createRelay).toHaveBeenCalledTimes(1);
     // API port = base port (3888) + 1 = 3889
-    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, undefined);
+    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, undefined, undefined);
     expect(relay.getStatus).toHaveBeenCalledTimes(1);
   });
 
@@ -344,7 +361,7 @@ describe('registerCoreCommands', () => {
 
     expect(exitCode).toBeUndefined();
     expect(deps.createRelay).toHaveBeenCalledTimes(1);
-    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, undefined);
+    expect(deps.createRelay).toHaveBeenCalledWith('/tmp/project', 3889, undefined, undefined);
     expect(relay.getStatus).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cli/src/cli/commands/core.ts
+++ b/packages/cli/src/cli/commands/core.ts
@@ -83,7 +83,12 @@ type UpdateInfo = {
 export interface CoreDependencies {
   getProjectPaths: () => CoreProjectPaths;
   loadTeamsConfig: (projectRoot: string) => CoreTeamsConfig | null;
-  createRelay: (cwd: string, apiPort?: number, brokerName?: string) => CoreRelay | Promise<CoreRelay>;
+  createRelay: (
+    cwd: string,
+    apiPort?: number,
+    brokerName?: string,
+    verbose?: boolean
+  ) => CoreRelay | Promise<CoreRelay>;
   spawnProcess: (command: string, args: string[], options?: Record<string, unknown>) => SpawnedProcess;
   execCommand: (command: string) => Promise<{ stdout: string; stderr: string }>;
   killProcess: (pid: number, signal?: NodeJS.Signals | number) => void;
@@ -137,7 +142,12 @@ function resolveCliVersion(fileSystem: CoreFileSystem): string {
   }
 }
 
-async function createDefaultRelay(cwd: string, apiPort = 0, brokerName?: string): Promise<CoreRelay> {
+async function createDefaultRelay(
+  cwd: string,
+  apiPort = 0,
+  brokerName?: string,
+  verbose = false
+): Promise<CoreRelay> {
   const binaryArgs: BrokerInitArgs = {};
   if (apiPort > 0) {
     binaryArgs.persist = true;
@@ -152,6 +162,12 @@ async function createDefaultRelay(cwd: string, apiPort = 0, brokerName?: string)
     binaryArgs,
     brokerName,
     preferConnect: apiPort > 0,
+    ...(verbose
+      ? {
+          onStep: (message: string) => console.error(`[agent-relay][verbose] ${message}`),
+          onStderr: (line: string) => console.error(`[broker] ${line}`),
+        }
+      : {}),
   });
 
   const relay: CoreRelay = {

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -831,7 +831,11 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       return;
     }
     child.unref?.();
-    vlog(deps, options.verbose, `Spawned detached broker child (pid: ${child.pid ?? 'unknown'}), waiting for readiness...`);
+    vlog(
+      deps,
+      options.verbose,
+      `Spawned detached broker child (pid: ${child.pid ?? 'unknown'}), waiting for readiness...`
+    );
     const readiness = await waitForBrokerReadiness(
       paths,
       deps,

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -123,6 +123,13 @@ function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Emit a `[verbose]`-prefixed step marker via `deps.log` when `--verbose` is set. */
+function vlog(deps: CoreDependencies, verbose: boolean | undefined, message: string): void {
+  if (verbose) {
+    deps.log(`[verbose] ${message}`);
+  }
+}
+
 type ErrorWithCode = { code?: unknown };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -267,17 +274,23 @@ export async function startBrokerWithPortFallback(
   paths: CoreProjectPaths,
   basePort: number,
   deps: CoreDependencies,
-  brokerName?: string
+  brokerName?: string,
+  verbose?: boolean
 ): Promise<{ relay: CoreRelay; apiPort: number }> {
   // Resolve a free API port BEFORE spawning the broker.  This avoids
   // spawning (and flocking) multiple --persist brokers during retry,
   // which caused stale-flock "already running" errors.
   const startApiPort = basePort + 1;
+  vlog(deps, verbose, `Resolving a free API port starting near ${startApiPort}...`);
   const apiPort = await resolveApiPortWithFallback(startApiPort, MAX_API_PORT_ATTEMPTS, deps);
+  vlog(deps, verbose, `API port resolved: ${apiPort}`);
 
-  const candidate = await deps.createRelay(paths.projectRoot, apiPort, brokerName);
+  vlog(deps, verbose, 'Creating broker client (spawns broker process, waits for handshake)...');
+  const candidate = await deps.createRelay(paths.projectRoot, apiPort, brokerName, verbose);
+  vlog(deps, verbose, 'Broker client created. Checking broker status...');
 
   await candidate.getStatus();
+  vlog(deps, verbose, 'Broker status check passed.');
   return { relay: candidate, apiPort };
 }
 
@@ -725,14 +738,20 @@ async function waitForBrokerReadiness(
   paths: CoreProjectPaths,
   deps: CoreDependencies,
   waitMs: number,
-  requireApi: boolean
+  requireApi: boolean,
+  verbose?: boolean
 ): Promise<BrokerReadiness> {
   const deadline = deps.now() + waitMs;
   let latest = await checkBrokerReadiness(paths, deps, requireApi);
+  vlog(deps, verbose, `Broker readiness: ${latest.state}`);
 
   while (latest.state !== 'running' && waitMs > 0 && deps.now() < deadline) {
     await deps.sleep(Math.min(STATUS_POLL_INTERVAL_MS, Math.max(0, deadline - deps.now())));
+    const previousState = latest.state;
     latest = await checkBrokerReadiness(paths, deps, requireApi);
+    if (latest.state !== previousState) {
+      vlog(deps, verbose, `Broker readiness: ${latest.state}`);
+    }
   }
 
   return latest;
@@ -812,7 +831,14 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       return;
     }
     child.unref?.();
-    const readiness = await waitForBrokerReadiness(paths, deps, DETACHED_START_READY_TIMEOUT_MS, true);
+    vlog(deps, options.verbose, `Spawned detached broker child (pid: ${child.pid ?? 'unknown'}), waiting for readiness...`);
+    const readiness = await waitForBrokerReadiness(
+      paths,
+      deps,
+      DETACHED_START_READY_TIMEOUT_MS,
+      true,
+      options.verbose
+    );
     if (readiness.state !== 'running') {
       const pid = readiness.state === 'starting' ? readiness.conn.pid : child.pid;
       deps.error(
@@ -897,9 +923,16 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
 
     // Kill any orphaned broker processes for this project that lost their PID
     // files (e.g. user deleted .agentworkforce/relay/ while broker was running).
+    vlog(deps, options.verbose, 'Checking for orphaned broker processes...');
     await killOrphanedBrokerProcesses(paths.projectRoot, deps);
 
-    const started = await startBrokerWithPortFallback(paths, basePort, deps, options.brokerName);
+    const started = await startBrokerWithPortFallback(
+      paths,
+      basePort,
+      deps,
+      options.brokerName,
+      options.verbose
+    );
     relay = started.relay;
 
     deps.log(`Relay API: http://localhost:${started.apiPort}`);
@@ -908,12 +941,14 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     deps.log(`Workspace Key: ${relay.workspaceKey ?? 'unknown'}`);
     deps.log('Broker started.');
 
+    vlog(deps, options.verbose, 'Loading teams.json and starting implicit fleet sidecar (if any)...');
     const teamsConfig = deps.loadTeamsConfig(paths.projectRoot);
     fleetSidecar = startImplicitLocalFleetSidecar(paths, relay, options, deps, teamsConfig);
     const shouldSpawn =
       options.spawn === true ? true : options.spawn === false ? false : Boolean(teamsConfig?.autoSpawn);
 
     if (shouldSpawn && teamsConfig && teamsConfig.agents.length > 0) {
+      vlog(deps, options.verbose, 'Waiting for broker node delivery (/v1/node/ws) before auto-spawning...');
       const delivery = await waitForNodeDelivery(relay, deps);
       if (!delivery.ready) {
         deps.error('Refusing to auto-spawn agents because broker node delivery is not connected.');
@@ -926,6 +961,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
         return;
       }
       for (const agent of teamsConfig.agents) {
+        vlog(deps, options.verbose, `Spawning agent '${agent.name}' (cli: ${agent.cli})...`);
         await relay.spawn({
           name: agent.name,
           cli: agent.cli,

--- a/packages/cli/src/cli/lib/client-factory.ts
+++ b/packages/cli/src/cli/lib/client-factory.ts
@@ -8,6 +8,10 @@ export interface CreateRuntimeClientOptions {
   brokerName?: string;
   env?: NodeJS.ProcessEnv;
   preferConnect?: boolean;
+  /** Forward broker stderr lines to this callback (e.g. for `--verbose`). */
+  onStderr?: (line: string) => void;
+  /** Forward human-readable startup step markers to this callback (e.g. for `--verbose`). */
+  onStep?: (message: string) => void;
 }
 
 export interface ClientSpawnOptions {
@@ -34,6 +38,8 @@ export async function createRuntimeClient(options: CreateRuntimeClientOptions): 
     brokerName,
     env = process.env,
     preferConnect = false,
+    onStderr,
+    onStep,
   } = options;
 
   if (preferConnect) {
@@ -53,6 +59,8 @@ export async function createRuntimeClient(options: CreateRuntimeClientOptions): 
     channels,
     cwd,
     env: env as Record<string, string>,
+    onStderr,
+    onStep,
   });
 }
 

--- a/packages/harness-driver/src/client.ts
+++ b/packages/harness-driver/src/client.ts
@@ -290,6 +290,7 @@ export class HarnessDriverClient {
    * 6. Starts event stream + lease renewal
    */
   static async spawn(options?: RuntimeSpawnOptions): Promise<HarnessDriverClient> {
+    const onStep = options?.onStep;
     let binaryPath = options?.binaryPath;
     if (!binaryPath) {
       const resolved = getBrokerBinaryPath();
@@ -298,11 +299,13 @@ export class HarnessDriverClient {
       }
       binaryPath = resolved;
     }
+    onStep?.(`Resolved broker binary: ${binaryPath}`);
     const apiKey = `br_${randomBytes(16).toString('hex')}`;
     const { cwd, timeoutMs, args, env } = buildBrokerSpawnConfig(options, apiKey);
     const stderrLines: string[] = [];
     const stdoutLines: string[] = [];
 
+    onStep?.(`Spawning broker process: ${binaryPath} ${args.join(' ')}`);
     const child = spawn(binaryPath, args, {
       cwd,
       env,
@@ -326,6 +329,7 @@ export class HarnessDriverClient {
       stdoutLines,
       stderrLines,
     });
+    onStep?.(`Broker API listening at ${baseUrl}`);
     drainBrokerStdioAfterStartup(child);
 
     const client = new HarnessDriverClient({
@@ -368,6 +372,7 @@ export class HarnessDriverClient {
     // the broker exits later (e.g. on normal shutdown).
     brokerExited.catch(() => {});
 
+    onStep?.('Waiting for broker session handshake...');
     let session: SessionInfo | undefined;
     for (let attempt = 0; attempt < 10; attempt++) {
       try {
@@ -377,12 +382,15 @@ export class HarnessDriverClient {
         const message = err instanceof Error ? err.message : String(err);
         const is503 = message.includes('503') || message.includes('Service Unavailable');
         if (!is503 || attempt >= 9) throw err;
+        onStep?.(`Broker still starting (handshake attempt ${attempt + 1}/10), retrying in 1s...`);
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
     }
+    onStep?.(`Broker handshake complete (workspace: ${session?.workspace_key ?? 'unknown'})`);
 
     if (!client.brokerExitInfo) {
       client.connectEvents();
+      onStep?.('Event stream connected.');
 
       // Renew the owner lease so the broker doesn't auto-shutdown
       client.leaseTimer = setInterval(() => {

--- a/packages/harness-driver/src/spawn-config.ts
+++ b/packages/harness-driver/src/spawn-config.ts
@@ -31,6 +31,8 @@ export interface RuntimeSpawnOptions {
   env?: NodeJS.ProcessEnv;
   /** Forward broker stderr to this callback. */
   onStderr?: (line: string) => void;
+  /** Forward human-readable startup step markers to this callback (e.g. for `--verbose`). */
+  onStep?: (message: string) => void;
   /** Timeout in ms to wait for broker to become ready. Default: 45000. */
   startupTimeoutMs?: number;
   /** Timeout in ms for HTTP requests to the broker. Default: 30000. */


### PR DESCRIPTION
## Summary
- `agent-relay up --verbose` now logs CLI-side step markers as it starts the broker: API port resolution, orphan-process cleanup, broker process spawn, handshake retry attempts, status checks, fleet sidecar startup, node-delivery wait, and per-agent spawns.
- Wires the broker child process's own stderr (its existing `[agent-relay][startup +Nms] ...` phase logs, gated by `AGENT_RELAY_STARTUP_DEBUG`, already on by default) to live console output when `--verbose` is set — previously those lines were only buffered for crash reports and invisible on a successful-but-slow or transient-503 startup.
- Adds an `onStep` callback to `HarnessDriverClient.spawn()` / `RuntimeSpawnOptions` so consumers can observe binary resolution, process spawn, API bind, and handshake retry progress.

This came out of debugging a `relay local up` failure that surfaced only as `Failed to start broker: Service Unavailable` with no indication of which startup phase had stalled.

## Test plan
- [x] `npx vitest run packages/cli/src/cli/commands/core.test.ts packages/cli/src/cli/lib/broker-lifecycle.test.ts packages/cli/src/cli/lib/client-factory.test.ts packages/harness-driver/src` — all passing, including a new `up --verbose forwards the flag to createRelay and logs startup step markers` test.
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` — no new errors (pre-existing unrelated `@relayfile/client` errors persist on `main`).
- [x] `npm --prefix packages/cli run lint` — no new warnings/errors.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

