### PR TITLE
feat(broker): add POST /api/observer-token to mint scoped read-only tokens

### DIFF
--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -191,6 +191,17 @@ pub enum ListenApiRequest {
         metadata: Option<Value>,
         reply: tokio::sync::oneshot::Sender<Result<Value, AgentResultRouteError>>,
     },
+    /// `POST /api/observer-token` — mint a scoped, read-only Relaycast
+    /// observer token (`ot_live_...`) for the resolved workspace. Used by
+    /// local dashboard clients (e.g. Pear's "Join as observer" link) so they
+    /// stop embedding the full `rk_live_...` workspace key, which grants
+    /// full read/write/spawn access, in shareable links.
+    CreateObserverToken {
+        workspace_id: Option<WorkspaceId>,
+        workspace_alias: Option<WorkspaceAlias>,
+        name: Option<String>,
+        reply: tokio::sync::oneshot::Sender<Result<Value, String>>,
+    },
     FleetSidecarConnect {
         outbound: mpsc::Sender<ProtocolEnvelope<Value>>,
         reply: tokio::sync::oneshot::Sender<Result<Value, String>>,
@@ -412,6 +423,10 @@ fn listen_api_router_with_auth(
             routing::post(listen_api_interrupt),
         )
         .route("/api/send", routing::post(listen_api_send))
+        .route(
+            "/api/observer-token",
+            routing::post(listen_api_create_observer_token),
+        )
         .route("/api/input/{name}", routing::post(listen_api_send_input))
         .route(
             "/api/input/{name}/stream",
@@ -1282,6 +1297,85 @@ async fn listen_api_send(
                 })),
             )
         }
+    }
+}
+
+/// `POST /api/observer-token` — mint a scoped, read-only observer token for
+/// the resolved workspace so local dashboard clients (e.g. Pear's "Join as
+/// observer" link) never have to embed the full workspace API key.
+async fn listen_api_create_observer_token(
+    axum::extract::State(state): axum::extract::State<ListenApiState>,
+    body: Option<axum::Json<Value>>,
+) -> (axum::http::StatusCode, axum::Json<Value>) {
+    let body = body.map(|axum::Json(value)| value).unwrap_or(Value::Null);
+    let workspace_id = body
+        .get("workspaceId")
+        .or_else(|| body.get("workspace_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let workspace_alias = body
+        .get("workspaceAlias")
+        .or_else(|| body.get("workspace_alias"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let name = body
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    if state
+        .tx
+        .send(ListenApiRequest::CreateObserverToken {
+            workspace_id: workspace_id.map(WorkspaceId::from),
+            workspace_alias: workspace_alias.map(WorkspaceAlias::from),
+            name,
+            reply: reply_tx,
+        })
+        .await
+        .is_err()
+    {
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({ "success": false, "error": "internal channel closed" })),
+        );
+    }
+
+    match timeout(LISTEN_API_SEND_TIMEOUT, reply_rx).await {
+        Ok(Ok(Ok(val))) => (axum::http::StatusCode::OK, axum::Json(val)),
+        Ok(Ok(Err(err))) => {
+            let raw_error = err.to_string();
+            let status = if raw_error.starts_with("ambiguous_workspace:")
+                || raw_error.starts_with("workspace_not_found:")
+            {
+                axum::http::StatusCode::BAD_REQUEST
+            } else {
+                axum::http::StatusCode::BAD_GATEWAY
+            };
+            let error = raw_error
+                .strip_prefix("ambiguous_workspace:")
+                .or_else(|| raw_error.strip_prefix("workspace_not_found:"))
+                .unwrap_or(&raw_error)
+                .to_string();
+            (
+                status,
+                axum::Json(json!({ "success": false, "error": error })),
+            )
+        }
+        Ok(Err(_)) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({ "success": false, "error": "internal reply dropped" })),
+        ),
+        Err(_) => (
+            axum::http::StatusCode::GATEWAY_TIMEOUT,
+            axum::Json(json!({ "success": false, "error": "broker request timed out" })),
+        ),
     }
 }
 

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -1305,29 +1305,68 @@ async fn listen_api_send(
 /// observer" link) never have to embed the full workspace API key.
 async fn listen_api_create_observer_token(
     axum::extract::State(state): axum::extract::State<ListenApiState>,
-    body: Option<axum::Json<Value>>,
+    body: axum::body::Bytes,
 ) -> (axum::http::StatusCode, axum::Json<Value>) {
-    let body = body.map(|axum::Json(value)| value).unwrap_or(Value::Null);
-    let workspace_id = body
-        .get("workspaceId")
-        .or_else(|| body.get("workspace_id"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-    let workspace_alias = body
-        .get("workspaceAlias")
-        .or_else(|| body.get("workspace_alias"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-    let name = body
-        .get("name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
+    // Parse raw bytes instead of using the `Json`/`Option<Json<_>>` extractor:
+    // dashboard clients may send `Content-Type: application/json` with an
+    // empty body (every field here is optional), and axum still attempts to
+    // parse that body and rejects the request before this handler runs.
+    let body: Value = if body.is_empty() {
+        Value::Null
+    } else {
+        match serde_json::from_slice::<Value>(&body) {
+            Ok(value) => value,
+            Err(err) => {
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    axum::Json(json!({
+                        "success": false,
+                        "error": format!("invalid JSON body: {err}"),
+                    })),
+                );
+            }
+        }
+    };
+
+    // Extract an optional string field, rejecting the request with 400 if a
+    // field is present but not a string, rather than silently treating a
+    // malformed selector as absent (which could mint a token for the wrong
+    // workspace on this credential-minting endpoint).
+    let string_field =
+        |keys: &[&str]| -> Result<Option<String>, (axum::http::StatusCode, axum::Json<Value>)> {
+            for key in keys {
+                let Some(raw) = body.get(*key) else {
+                    continue;
+                };
+                if raw.is_null() {
+                    continue;
+                }
+                let Some(value) = raw.as_str() else {
+                    return Err((
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(json!({
+                            "success": false,
+                            "error": format!("field '{key}' must be a string"),
+                        })),
+                    ));
+                };
+                let value = value.trim();
+                return Ok((!value.is_empty()).then(|| value.to_string()));
+            }
+            Ok(None)
+        };
+    let workspace_id = match string_field(&["workspaceId", "workspace_id"]) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let workspace_alias = match string_field(&["workspaceAlias", "workspace_alias"]) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let name = match string_field(&["name"]) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     if state
@@ -3162,6 +3201,156 @@ mod auth_tests {
         assert!(
             rx.try_recv().is_err(),
             "invalid mode should not enqueue request"
+        );
+    }
+
+    #[tokio::test]
+    async fn observer_token_route_accepts_empty_body_with_json_content_type() {
+        // Dashboard clients may send `Content-Type: application/json` with an
+        // empty body since every field on this endpoint is optional; it must
+        // not be rejected before the handler runs (regression test for the
+        // `Json`/`Option<Json<_>>` extractor pitfall).
+        let (router, mut rx) = test_router(Some("secret"));
+        let replier = tokio::spawn(async move {
+            match rx.recv().await {
+                Some(ListenApiRequest::CreateObserverToken {
+                    workspace_id,
+                    workspace_alias,
+                    name,
+                    reply,
+                }) => {
+                    assert_eq!(workspace_id, None);
+                    assert_eq!(workspace_alias, None);
+                    assert_eq!(name, None);
+                    let _ = reply.send(Ok(json!({
+                        "success": true,
+                        "id": "ot_1",
+                        "token": "ot_live_abc",
+                        "name": "pear-dashboard-observer",
+                        "scopes": ["stream:read"],
+                        "workspace_id": "ws_1",
+                        "workspace_alias": null,
+                    })));
+                }
+                other => panic!("unexpected request: {:?}", other.map(|_| "other")),
+            }
+        });
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/observer-token")
+                    .method("POST")
+                    .header("x-api-key", "secret")
+                    .header("content-type", "application/json")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        replier.await.expect("replier should complete");
+    }
+
+    #[tokio::test]
+    async fn observer_token_route_accepts_missing_body_entirely() {
+        let (router, mut rx) = test_router(Some("secret"));
+        let replier = tokio::spawn(async move {
+            if let Some(ListenApiRequest::CreateObserverToken { reply, .. }) = rx.recv().await {
+                let _ = reply.send(Ok(json!({ "success": true, "id": "ot_1" })));
+            }
+        });
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/observer-token")
+                    .method("POST")
+                    .header("x-api-key", "secret")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        replier.await.expect("replier should complete");
+    }
+
+    #[tokio::test]
+    async fn observer_token_route_rejects_non_string_workspace_id() {
+        let (router, mut rx) = test_router(Some("secret"));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/observer-token")
+                    .method("POST")
+                    .header("x-api-key", "secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "workspaceId": 123 }).to_string()))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["success"], json!(false));
+        assert!(
+            rx.try_recv().is_err(),
+            "malformed workspaceId should not enqueue a request"
+        );
+    }
+
+    #[tokio::test]
+    async fn observer_token_route_rejects_non_string_name() {
+        let (router, mut rx) = test_router(Some("secret"));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/observer-token")
+                    .method("POST")
+                    .header("x-api-key", "secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "name": ["not", "a", "string"] }).to_string(),
+                    ))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            rx.try_recv().is_err(),
+            "malformed name should not enqueue a request"
+        );
+    }
+
+    #[tokio::test]
+    async fn observer_token_route_rejects_malformed_json_body() {
+        let (router, mut rx) = test_router(Some("secret"));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/observer-token")
+                    .method("POST")
+                    .header("x-api-key", "secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{not json"))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            rx.try_recv().is_err(),
+            "unparseable body should not enqueue a request"
         );
     }
 

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -5,8 +5,8 @@ use relaycast::{
     agent::DmOptions, format_registration_error,
     retry_agent_registration as sdk_retry_agent_registration, ActionDefinition, ActionInvocation,
     AgentClient, AgentRegistrationClient, AgentRegistrationError, AgentRegistrationRetryOutcome,
-    CompleteInvocationRequest, MessageListQuery, RegisterActionRequest, RelayCast,
-    RelayCastOptions, ReleaseAgentRequest,
+    CompleteInvocationRequest, CreateObserverTokenRequest, MessageListQuery, ObserverToken,
+    RegisterActionRequest, RelayCast, RelayCastOptions, ReleaseAgentRequest,
 };
 use serde_json::Value;
 
@@ -187,6 +187,25 @@ impl RelaycastHttpClient {
             .context("SDK relay client not initialized")?;
         relay
             .register_action(request)
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))
+    }
+
+    /// Mint a scoped, read-only observer token for this workspace. Used by
+    /// the local HTTP API so callers (e.g. Pear's "Join as observer" link)
+    /// can hand out a narrow `ot_live_...` credential instead of the raw
+    /// `rk_live_...` workspace key, which grants full read/write/spawn
+    /// access. The raw token material is only present on this response (and
+    /// on `rotate_observer_token`'s), never on subsequent reads.
+    pub async fn create_observer_token(
+        &self,
+        request: CreateObserverTokenRequest,
+    ) -> Result<ObserverToken> {
+        let relay = self
+            .relay_client()
+            .context("SDK relay client not initialized")?;
+        relay
+            .create_observer_token(request)
             .await
             .map_err(|error| anyhow::anyhow!("{error}"))
     }

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -926,18 +926,27 @@ impl BrokerRuntime {
                     .filter(|value| !value.trim().is_empty())
                     .unwrap_or_else(|| DEFAULT_OBSERVER_TOKEN_NAME.to_string());
 
-                match selected_workspace
-                    .http_client
-                    .create_observer_token(CreateObserverTokenRequest {
-                        name: token_name,
-                        scopes: default_observer_token_scopes(),
-                        description: None,
-                        filters: None,
-                        expires_at: None,
-                    })
-                    .await
+                // Bounded the same way `Send`'s relaycast publish is: if the
+                // SDK call hangs, this broker task must not block
+                // indefinitely on it (the HTTP layer already gives up after
+                // `LISTEN_API_SEND_TIMEOUT`, but that alone wouldn't free
+                // this runtime task).
+                let relaycast_timeout = http_api_relaycast_send_timeout();
+                match timeout(
+                    relaycast_timeout,
+                    selected_workspace.http_client.create_observer_token(
+                        CreateObserverTokenRequest {
+                            name: token_name,
+                            scopes: default_observer_token_scopes(),
+                            description: None,
+                            filters: None,
+                            expires_at: None,
+                        },
+                    ),
+                )
+                .await
                 {
-                    Ok(observer_token) => {
+                    Ok(Ok(observer_token)) => {
                         tracing::info!(
                             target = "relay_broker::http_api",
                             workspace_id = %selected_workspace_id,
@@ -954,7 +963,7 @@ impl BrokerRuntime {
                             "workspace_alias": selected_workspace_alias,
                         })));
                     }
-                    Err(error) => {
+                    Ok(Err(error)) => {
                         tracing::warn!(
                             target = "relay_broker::http_api",
                             workspace_id = %selected_workspace_id,
@@ -963,6 +972,18 @@ impl BrokerRuntime {
                         );
                         let _ =
                             reply.send(Err(format!("Failed to create observer token: {error}")));
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            target = "relay_broker::http_api",
+                            workspace_id = %selected_workspace_id,
+                            timeout_ms = %relaycast_timeout.as_millis(),
+                            "timed out minting observer token via HTTP API"
+                        );
+                        let _ = reply.send(Err(format!(
+                            "Failed to create observer token: timed out after {}ms",
+                            relaycast_timeout.as_millis()
+                        )));
                     }
                 }
             }

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -930,8 +930,10 @@ impl BrokerRuntime {
                 // SDK call hangs, this broker task must not block
                 // indefinitely on it (the HTTP layer already gives up after
                 // `LISTEN_API_SEND_TIMEOUT`, but that alone wouldn't free
-                // this runtime task).
-                let relaycast_timeout = http_api_relaycast_send_timeout();
+                // this runtime task). Uses its own timeout (distinct from
+                // `http_api_relaycast_send_timeout`) so tuning the `/api/send`
+                // path can't unintentionally break token minting.
+                let relaycast_timeout = http_api_observer_token_timeout();
                 match timeout(
                     relaycast_timeout,
                     selected_workspace.http_client.create_observer_token(

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1,4 +1,27 @@
 use super::*;
+use relaycast::{CreateObserverTokenRequest, ObserverScope};
+
+/// Default name recorded on observer tokens minted via `/api/observer-token`
+/// when the caller doesn't supply one.
+const DEFAULT_OBSERVER_TOKEN_NAME: &str = "pear-dashboard-observer";
+
+/// Scopes granted to observer tokens minted via `/api/observer-token`: broad
+/// read access to workspace activity, deliberately excluding anything
+/// write/spawn-capable (unlike the raw `rk_live_...` workspace key this
+/// replaces) and `search:read`/`nodes:read`/`deliveries:read`/
+/// `files:read`/`reactions:read`, which aren't needed by the observer
+/// dashboard use case this unblocks.
+pub(crate) fn default_observer_token_scopes() -> Vec<ObserverScope> {
+    vec![
+        ObserverScope::StreamRead,
+        ObserverScope::MessagesRead,
+        ObserverScope::ThreadsRead,
+        ObserverScope::DmsRead,
+        ObserverScope::ChannelsRead,
+        ObserverScope::ActivityRead,
+        ObserverScope::AgentsRead,
+    ]
+}
 
 impl BrokerRuntime {
     pub(super) async fn handle_api_request(&mut self, req: ListenApiRequest) {
@@ -621,44 +644,13 @@ impl BrokerRuntime {
                 reply,
             } => {
                 let normalized_to = to.trim().to_string();
-                let selected_workspace = if let Some(workspace_id) = workspace_id.as_deref() {
-                    workspace_lookup.get(workspace_id).cloned().ok_or_else(|| {
-                        format!(
-                            "workspace_not_found:workspace '{}' is not attached",
-                            workspace_id
-                        )
-                    })
-                } else if let Some(workspace_alias) = workspace_alias.as_deref() {
-                    workspaces
-                        .iter()
-                        .find(|workspace| {
-                            workspace
-                                .workspace_alias
-                                .as_deref()
-                                .is_some_and(|alias| alias.eq_ignore_ascii_case(workspace_alias))
-                        })
-                        .cloned()
-                        .ok_or_else(|| {
-                            format!(
-                                "workspace_not_found:workspace alias '{}' is not attached",
-                                workspace_alias
-                            )
-                        })
-                } else if workspaces.len() == 1 {
-                    Ok(workspaces[0].clone())
-                } else if let Some(default_workspace_id) = default_workspace_id.as_deref() {
-                    workspace_lookup
-                        .get(default_workspace_id)
-                        .cloned()
-                        .ok_or_else(|| {
-                            format!(
-                                "workspace_not_found: default workspace '{}' not found",
-                                default_workspace_id
-                            )
-                        })
-                } else {
-                    Err("ambiguous_workspace:workspaceId or workspaceAlias is required when multiple workspaces are attached".to_string())
-                };
+                let selected_workspace = resolve_workspace(
+                    workspace_id.as_deref(),
+                    workspace_alias.as_deref(),
+                    workspaces,
+                    workspace_lookup,
+                    default_workspace_id.as_deref(),
+                );
                 let selected_workspace = match selected_workspace {
                     Ok(workspace) => workspace,
                     Err(error) => {
@@ -907,6 +899,72 @@ impl BrokerRuntime {
                 }
                 let threads = build_thread_infos(&messages, self_names);
                 let _ = reply.send(Ok(json!({ "threads": threads })));
+            }
+            ListenApiRequest::CreateObserverToken {
+                workspace_id,
+                workspace_alias,
+                name,
+                reply,
+            } => {
+                let selected_workspace = resolve_workspace(
+                    workspace_id.as_deref(),
+                    workspace_alias.as_deref(),
+                    workspaces,
+                    workspace_lookup,
+                    default_workspace_id.as_deref(),
+                );
+                let selected_workspace = match selected_workspace {
+                    Ok(workspace) => workspace,
+                    Err(error) => {
+                        let _ = reply.send(Err(error));
+                        return;
+                    }
+                };
+                let selected_workspace_id = selected_workspace.workspace_id.clone();
+                let selected_workspace_alias = selected_workspace.workspace_alias.clone();
+                let token_name = name
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|| DEFAULT_OBSERVER_TOKEN_NAME.to_string());
+
+                match selected_workspace
+                    .http_client
+                    .create_observer_token(CreateObserverTokenRequest {
+                        name: token_name,
+                        scopes: default_observer_token_scopes(),
+                        description: None,
+                        filters: None,
+                        expires_at: None,
+                    })
+                    .await
+                {
+                    Ok(observer_token) => {
+                        tracing::info!(
+                            target = "relay_broker::http_api",
+                            workspace_id = %selected_workspace_id,
+                            observer_token_id = %observer_token.id,
+                            "minted observer token via HTTP API"
+                        );
+                        let _ = reply.send(Ok(json!({
+                            "success": true,
+                            "id": observer_token.id,
+                            "token": observer_token.token,
+                            "name": observer_token.name,
+                            "scopes": observer_token.scopes,
+                            "workspace_id": selected_workspace_id,
+                            "workspace_alias": selected_workspace_alias,
+                        })));
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target = "relay_broker::http_api",
+                            workspace_id = %selected_workspace_id,
+                            error = %error,
+                            "failed to mint observer token via HTTP API"
+                        );
+                        let _ =
+                            reply.send(Err(format!("Failed to create observer token: {error}")));
+                    }
+                }
             }
             ListenApiRequest::SendInput { name, data, reply } => {
                 match workers
@@ -1484,6 +1542,61 @@ impl BrokerRuntime {
                 unreachable!("fleet sidecar API requests are handled before runtime borrows")
             }
         }
+    }
+}
+
+/// Resolve which attached workspace an HTTP API request targets. Shared by
+/// every route that accepts optional `workspaceId`/`workspaceAlias` fields
+/// (`/api/send`, `/api/observer-token`, ...): explicit id, explicit alias,
+/// the sole attached workspace, the configured default, or — with more than
+/// one workspace attached and no default — an `ambiguous_workspace:` error
+/// the caller must resolve by supplying one of the two fields. A
+/// `workspace_not_found:` error is returned when an explicit id/alias/default
+/// doesn't match any attached workspace.
+pub(crate) fn resolve_workspace(
+    workspace_id: Option<&str>,
+    workspace_alias: Option<&str>,
+    workspaces: &[RelayWorkspace],
+    workspace_lookup: &HashMap<WorkspaceId, RelayWorkspace>,
+    default_workspace_id: Option<&str>,
+) -> Result<RelayWorkspace, String> {
+    if let Some(workspace_id) = workspace_id {
+        workspace_lookup.get(workspace_id).cloned().ok_or_else(|| {
+            format!(
+                "workspace_not_found:workspace '{}' is not attached",
+                workspace_id
+            )
+        })
+    } else if let Some(workspace_alias) = workspace_alias {
+        workspaces
+            .iter()
+            .find(|workspace| {
+                workspace
+                    .workspace_alias
+                    .as_deref()
+                    .is_some_and(|alias| alias.eq_ignore_ascii_case(workspace_alias))
+            })
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "workspace_not_found:workspace alias '{}' is not attached",
+                    workspace_alias
+                )
+            })
+    } else if workspaces.len() == 1 {
+        Ok(workspaces[0].clone())
+    } else if let Some(default_workspace_id) = default_workspace_id {
+        workspace_lookup
+            .get(default_workspace_id)
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "workspace_not_found: default workspace '{}' not found",
+                    default_workspace_id
+                )
+            })
+    } else {
+        Err("ambiguous_workspace:workspaceId or workspaceAlias is required when multiple workspaces are attached".to_string())
     }
 }
 

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -88,6 +88,8 @@ mod tests;
 mod util;
 mod worker_events;
 
+#[cfg(test)]
+pub(crate) use api::{default_observer_token_scopes, resolve_workspace};
 pub(crate) use app_server::*;
 pub(crate) use connection::*;
 pub(crate) use delivery::*;

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -64,6 +64,7 @@ const THREAD_HISTORY_LIMIT: usize = 1_000;
 #[allow(dead_code)] // only http_api_local_delivery_timeout's default; see its own allow
 const DEFAULT_HTTP_API_LOCAL_DELIVERY_TIMEOUT_MS: u64 = 3_000;
 const DEFAULT_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: u64 = 20_000;
+const DEFAULT_HTTP_API_OBSERVER_TOKEN_TIMEOUT_MS: u64 = 20_000;
 const DEFAULT_HTTP_API_EVENT_EMIT_TIMEOUT_MS: u64 = 200;
 static TRACING_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -2780,7 +2780,12 @@ fn resolve_workspace_reports_not_found_for_unknown_alias() {
 fn default_observer_token_scopes_are_read_only_and_exclude_unneeded_scopes() {
     let scopes = default_observer_token_scopes();
 
-    for expected in [
+    // Assert the *exact* set (not just "contains these 7"), so an
+    // accidentally-added extra scope -- including a write scope -- fails this
+    // test instead of silently widening the grant on a credential-minting
+    // endpoint.
+    let actual: HashSet<ObserverScope> = scopes.iter().copied().collect();
+    let expected: HashSet<ObserverScope> = [
         ObserverScope::StreamRead,
         ObserverScope::MessagesRead,
         ObserverScope::ThreadsRead,
@@ -2788,25 +2793,17 @@ fn default_observer_token_scopes_are_read_only_and_exclude_unneeded_scopes() {
         ObserverScope::ChannelsRead,
         ObserverScope::ActivityRead,
         ObserverScope::AgentsRead,
-    ] {
-        assert!(
-            scopes.contains(&expected),
-            "expected default observer token scopes to include {expected:?}"
-        );
-    }
+    ]
+    .into_iter()
+    .collect();
 
-    // Scopes the observer-dashboard use case this unblocks doesn't need;
-    // keeping the grant minimal.
-    for unexpected in [
-        ObserverScope::SearchRead,
-        ObserverScope::NodesRead,
-        ObserverScope::DeliveriesRead,
-        ObserverScope::FilesRead,
-        ObserverScope::ReactionsRead,
-    ] {
-        assert!(
-            !scopes.contains(&unexpected),
-            "expected default observer token scopes to exclude {unexpected:?}"
-        );
-    }
+    assert_eq!(
+        scopes.len(),
+        7,
+        "expected exactly 7 default observer token scopes, got {scopes:?}"
+    );
+    assert_eq!(
+        actual, expected,
+        "default observer token scopes must be exactly the minimal read-only set"
+    );
 }

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use crate::ids::{
-    ChannelName, DeliveryId, EventId, MessageTarget, WorkerName, WorkspaceAlias, WorkspaceId,
+    AgentId, ChannelName, DeliveryId, EventId, MessageTarget, WorkerName, WorkspaceAlias,
+    WorkspaceId,
 };
 use crate::protocol::{
     AgentSpec, BrokerEvent, DeliveryReadAckStatus, HarnessReleasePolicy, HeadlessHarnessConfig,
@@ -30,7 +31,7 @@ use tokio::sync::mpsc;
 use super::{
     apply_exit_after_task_instruction, build_agent_state_transition_event,
     build_http_api_spawn_spec, build_thread_infos, channels_from_csv,
-    clear_pending_delivery_if_event_matches, continuity_dir,
+    clear_pending_delivery_if_event_matches, continuity_dir, default_observer_token_scopes,
     delivery_read_ack_is_relaycast_message, delivery_retry_interval, drop_pending_for_worker,
     emit_delivery_attempt_outcome, emit_dropped_delivery_failures, ensure_ephemeral_paths,
     extract_mcp_message_ids, http_api_event_emit_timeout, http_api_local_delivery_timeout,
@@ -39,18 +40,19 @@ use super::{
     mark_delivery_read_ack_with_timeout, normalize_channel, normalize_initial_task,
     normalize_sender, parse_sort_key_from_raw_timestamp, persist_pending_on_shutdown,
     queue_inbound_for_delivery_mode, relaycast_spawn_control_dedup_key,
-    relaycast_ws_should_apply_local_spawn_echo_dedup, relaycast_ws_spawn_token,
+    relaycast_ws_should_apply_local_spawn_echo_dedup, relaycast_ws_spawn_token, resolve_workspace,
     retry_pending_delivery, seed_supplied_agent_token, send_broker_event,
     sender_is_dashboard_label, should_clear_pending_delivery_for_event,
     synthetic_delivery_read_ack_reason, AgentRuntime, DeliveryAttemptOutcome, InboundContext,
     InboundQueueOutcome, PendingDelivery, PendingDeliveryStore, ProtocolHeadlessProvider,
-    MAX_DELIVERY_RETRIES,
+    RelayWorkspace, MAX_DELIVERY_RETRIES,
 };
 use crate::dedup::DedupCache;
 use crate::relaycast::{
-    format_worker_preregistration_error, RelaycastHttpClient, RelaycastRegistrationError,
+    format_worker_preregistration_error, RelaycastHttpClient, RelaycastRegistrationError, WsControl,
 };
 use crate::types::{InboundDeliveryMode, InboundDeliveryState};
+use relaycast::ObserverScope;
 
 fn env_test_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -2644,4 +2646,167 @@ fn model_flag_injected_with_other_args() {
         Some("gpt-4o".to_string()),
         "model should be injected when other unrelated args exist"
     );
+}
+
+// ---------------------------------------------------------------------------
+// resolve_workspace / observer-token scope selection
+//
+// Exercises the workspace-resolution precedence shared by `/api/send` and
+// `/api/observer-token` (see `resolve_workspace` in `runtime/api.rs`), and
+// the fixed read-only scope set minted for `/api/observer-token` — the
+// endpoint that lets Pear's "Join as observer" link stop embedding the raw
+// `rk_live_...` workspace key (see `default_observer_token_scopes`).
+// ---------------------------------------------------------------------------
+
+fn test_relay_workspace(workspace_id: &str, workspace_alias: Option<&str>) -> RelayWorkspace {
+    let (ws_control_tx, _ws_control_rx) = mpsc::channel::<WsControl>(1);
+    RelayWorkspace {
+        workspace_id: WorkspaceId::from(workspace_id.to_string()),
+        workspace_alias: workspace_alias.map(|alias| WorkspaceAlias::from(alias.to_string())),
+        relay_workspace_key: "rk_live_test".to_string(),
+        self_name: "broker".to_string(),
+        self_agent_id: AgentId::from("agent_broker".to_string()),
+        self_names: HashSet::from(["broker".to_string()]),
+        self_agent_ids: HashSet::from([AgentId::from("agent_broker".to_string())]),
+        http_client: RelaycastHttpClient::new(None, "rk_live_test", "broker", "codex"),
+        ws_control_tx,
+    }
+}
+
+fn test_workspace_lookup(workspaces: &[RelayWorkspace]) -> HashMap<WorkspaceId, RelayWorkspace> {
+    workspaces
+        .iter()
+        .map(|workspace| (workspace.workspace_id.clone(), workspace.clone()))
+        .collect()
+}
+
+#[test]
+fn resolve_workspace_picks_the_sole_attached_workspace_by_default() {
+    let workspaces = vec![test_relay_workspace("ws_1", Some("main"))];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    let resolved = resolve_workspace(None, None, &workspaces, &lookup, None)
+        .expect("single attached workspace should resolve without a selector");
+    assert_eq!(resolved.workspace_id, WorkspaceId::from("ws_1".to_string()));
+}
+
+#[test]
+fn resolve_workspace_matches_explicit_workspace_id() {
+    let workspaces = vec![
+        test_relay_workspace("ws_1", Some("main")),
+        test_relay_workspace("ws_2", Some("secondary")),
+    ];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    let resolved = resolve_workspace(Some("ws_2"), None, &workspaces, &lookup, None)
+        .expect("explicit workspace_id should resolve");
+    assert_eq!(resolved.workspace_id, WorkspaceId::from("ws_2".to_string()));
+}
+
+#[test]
+fn resolve_workspace_matches_alias_case_insensitively() {
+    let workspaces = vec![
+        test_relay_workspace("ws_1", Some("Main")),
+        test_relay_workspace("ws_2", Some("Secondary")),
+    ];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    let resolved = resolve_workspace(None, Some("secondary"), &workspaces, &lookup, None)
+        .expect("workspace_alias lookup should be case-insensitive");
+    assert_eq!(resolved.workspace_id, WorkspaceId::from("ws_2".to_string()));
+}
+
+#[test]
+fn resolve_workspace_falls_back_to_configured_default() {
+    let workspaces = vec![
+        test_relay_workspace("ws_1", Some("main")),
+        test_relay_workspace("ws_2", Some("secondary")),
+    ];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    let resolved = resolve_workspace(None, None, &workspaces, &lookup, Some("ws_2"))
+        .expect("default_workspace_id should resolve when no explicit selector is given");
+    assert_eq!(resolved.workspace_id, WorkspaceId::from("ws_2".to_string()));
+}
+
+#[test]
+fn resolve_workspace_is_ambiguous_with_multiple_workspaces_and_no_default() {
+    let workspaces = vec![
+        test_relay_workspace("ws_1", Some("main")),
+        test_relay_workspace("ws_2", Some("secondary")),
+    ];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    // `RelayWorkspace` doesn't implement `Debug` (it embeds SDK client
+    // handles), so assert via `match` instead of `expect_err`/`unwrap_err`.
+    match resolve_workspace(None, None, &workspaces, &lookup, None) {
+        Err(error) => assert!(
+            error.starts_with("ambiguous_workspace:"),
+            "unexpected error: {error}"
+        ),
+        Ok(_) => panic!("multiple attached workspaces with no selector should be ambiguous"),
+    }
+}
+
+#[test]
+fn resolve_workspace_reports_not_found_for_unknown_id() {
+    let workspaces = vec![test_relay_workspace("ws_1", Some("main"))];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    match resolve_workspace(Some("ws_missing"), None, &workspaces, &lookup, None) {
+        Err(error) => assert!(
+            error.starts_with("workspace_not_found:"),
+            "unexpected error: {error}"
+        ),
+        Ok(_) => panic!("unknown workspace_id should not resolve"),
+    }
+}
+
+#[test]
+fn resolve_workspace_reports_not_found_for_unknown_alias() {
+    let workspaces = vec![test_relay_workspace("ws_1", Some("main"))];
+    let lookup = test_workspace_lookup(&workspaces);
+
+    match resolve_workspace(None, Some("nope"), &workspaces, &lookup, None) {
+        Err(error) => assert!(
+            error.starts_with("workspace_not_found:"),
+            "unexpected error: {error}"
+        ),
+        Ok(_) => panic!("unknown workspace_alias should not resolve"),
+    }
+}
+
+#[test]
+fn default_observer_token_scopes_are_read_only_and_exclude_unneeded_scopes() {
+    let scopes = default_observer_token_scopes();
+
+    for expected in [
+        ObserverScope::StreamRead,
+        ObserverScope::MessagesRead,
+        ObserverScope::ThreadsRead,
+        ObserverScope::DmsRead,
+        ObserverScope::ChannelsRead,
+        ObserverScope::ActivityRead,
+        ObserverScope::AgentsRead,
+    ] {
+        assert!(
+            scopes.contains(&expected),
+            "expected default observer token scopes to include {expected:?}"
+        );
+    }
+
+    // Scopes the observer-dashboard use case this unblocks doesn't need;
+    // keeping the grant minimal.
+    for unexpected in [
+        ObserverScope::SearchRead,
+        ObserverScope::NodesRead,
+        ObserverScope::DeliveriesRead,
+        ObserverScope::FilesRead,
+        ObserverScope::ReactionsRead,
+    ] {
+        assert!(
+            !scopes.contains(&unexpected),
+            "expected default observer token scopes to exclude {unexpected:?}"
+        );
+    }
 }

--- a/crates/broker/src/runtime/util.rs
+++ b/crates/broker/src/runtime/util.rs
@@ -258,6 +258,18 @@ pub(crate) fn http_api_relaycast_send_timeout() -> Duration {
     Duration::from_millis(ms.max(500))
 }
 
+// Deliberately separate from `http_api_relaycast_send_timeout`: observer-token
+// minting is a distinct Relaycast SDK call from the `/api/send` publish path,
+// with its own latency characteristics, so it gets its own tunable timeout
+// rather than being coupled to send-path tuning.
+pub(crate) fn http_api_observer_token_timeout() -> Duration {
+    let ms = std::env::var("AGENT_RELAY_HTTP_API_OBSERVER_TOKEN_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_HTTP_API_OBSERVER_TOKEN_TIMEOUT_MS);
+    Duration::from_millis(ms.max(500))
+}
+
 pub(crate) fn http_api_event_emit_timeout() -> Duration {
     let ms = std::env::var("AGENT_RELAY_HTTP_API_EVENT_EMIT_TIMEOUT_MS")
         .ok()


### PR DESCRIPTION
## Summary

Pear's "Join as observer" feature (`BrokerDetailsPage.tsx`'s `observerUrlForWorkspaceKey()`) currently builds shareable observer links by embedding the **full `rk_live_...` Relaycast workspace API key** — the same credential used for `RELAY_API_KEY`, granting full read/write/spawn access to the entire workspace. Anyone handed an "observer" link actually gets full workspace control.

This PR adds the broker-side capability a separate, in-flight Pear PR needs to fix that: a local HTTP endpoint that mints a scoped, read-only `ot_live_...` observer token via the Relaycast SDK, instead of ever handing out the raw workspace key.

## Endpoint contract

**`POST /api/observer-token`** — protected by the same `listen_api_auth_middleware` (broker API key) as every other `/api/*` route.

**Request body** (all fields optional, JSON, `Content-Type: application/json`; empty/missing body is accepted):
```json
{
  "workspaceId": "string?",     // or "workspace_id" (snake_case also accepted)
  "workspaceAlias": "string?",  // or "workspace_alias"
  "name": "string?"             // defaults to "pear-dashboard-observer" if omitted/blank
}
```
Workspace resolution follows the exact same precedence as `/api/send`: explicit `workspaceId` → explicit `workspaceAlias` (case-insensitive) → the sole attached workspace → the configured default workspace → `400` `ambiguous_workspace:...` if multiple workspaces are attached and none of the above apply.

**Success response** — `200 OK`:
```json
{
  "success": true,
  "id": "string",             // observer token id (safe to store/list by)
  "token": "string",          // raw ot_live_... token material — only present on this response
  "name": "string",
  "scopes": ["stream:read", "messages:read", "threads:read", "dms:read", "channels:read", "activity:read", "agents:read"],
  "workspace_id": "string",
  "workspace_alias": "string | null"
}
```

**Error responses**:
- `400` — `{ "success": false, "error": "..." }` for `ambiguous_workspace:...` / `workspace_not_found:...`
- `502` — `{ "success": false, "error": "Failed to create observer token: ..." }` for SDK/network failures or an uninitialized Relaycast client
- `504` — `{ "success": false, "error": "broker request timed out" }` if the broker doesn't reply within 30s
- `500` — internal channel/reply-drop failures

## Implementation

- `ListenApiRequest::CreateObserverToken` (`crates/broker/src/listen_api.rs`) plus the `listen_api_create_observer_token` handler and route registration.
- `RelaycastHttpClient::create_observer_token` (`crates/broker/src/relaycast/ws.rs`) wraps the SDK's `RelayCast::create_observer_token`, following the existing `register_action` pattern (same "SDK relay client not initialized" error path).
- Extracted the workspace-resolution logic shared by `/api/send` and this new endpoint into `resolve_workspace()` (`crates/broker/src/runtime/api.rs`) — `/api/send`'s behavior is unchanged, just de-duplicated.
- Minted scopes are a fixed, curated read-only set: `stream:read, messages:read, threads:read, dms:read, channels:read, activity:read, agents:read` — deliberately excluding `search:read`, `nodes:read`, `deliveries:read`, `files:read`, `reactions:read`, none of which the observer-dashboard use case needs.

## Test plan

- `cargo check -p agent-relay-broker` — clean
- `cargo clippy -p agent-relay-broker -- -D warnings` (the exact command this repo's CI runs) — clean
- `cargo fmt -p agent-relay-broker -- --check` — clean
- `cargo test -p agent-relay-broker --lib` — 805 passed (up from 797 baseline), 0 failed, 4 ignored, including 8 new tests in `crates/broker/src/runtime/tests.rs` covering:
  - `resolve_workspace`: explicit id, explicit alias (case-insensitive), sole-workspace fallback, default-workspace fallback, ambiguous-workspace error, not-found-by-id error, not-found-by-alias error
  - `default_observer_token_scopes`: asserts the exact minted scope set and that unneeded scopes are excluded

Not merging — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

