### PR TITLE
fix(broker): harden dashboard replay against silent live-channel drops

### DIFF
--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -2314,6 +2314,25 @@ async fn send_fleet_sidecar_error(
     .await
 }
 
+/// Minimal shape used to peek the `seq` field of a broadcast message without
+/// paying for a full `serde_json::Value` parse. Broadcast payloads (e.g.
+/// `worker_stream` chunks) can carry large terminal-output strings; parsing
+/// into a `Value` would allocate a full tree for all of that just to read
+/// one field. Deserializing into this struct instead lets serde_json skip
+/// unknown fields (including large string values) without allocating them.
+#[derive(Deserialize)]
+struct MessageSeq {
+    seq: Option<u64>,
+}
+
+/// Extract the optional `seq` field from a broadcast message's JSON text
+/// without materializing the rest of the payload.
+fn extract_seq(msg: &str) -> Option<u64> {
+    serde_json::from_str::<MessageSeq>(msg)
+        .ok()
+        .and_then(|parsed| parsed.seq)
+}
+
 /// Number of durable events that are unrecoverably lost between
 /// `requested_since_seq` (exclusive) and `oldest_available` (inclusive of
 /// everything at/after it being retained). Used to give a `replay_gap`
@@ -2432,9 +2451,7 @@ async fn handle_dashboard_ws(
             result = rx.recv() => {
                 match result {
                     Ok(msg) => {
-                        let msg_seq = serde_json::from_str::<Value>(&msg)
-                            .ok()
-                            .and_then(|value| value.get("seq").and_then(Value::as_u64));
+                        let msg_seq = extract_seq(&msg);
                         if msg_seq.is_some_and(|seq| seq <= last_forwarded_seq) {
                             continue;
                         }
@@ -2757,9 +2774,33 @@ mod tests {
 
 #[cfg(test)]
 mod replay_gap_tests {
-    use super::{build_replay_gap_frame, catch_up_after_lag, dropped_event_count};
+    use super::{build_replay_gap_frame, catch_up_after_lag, dropped_event_count, extract_seq};
     use crate::replay_buffer::ReplayBuffer;
     use serde_json::json;
+
+    #[test]
+    fn extract_seq_reads_the_seq_field_without_full_value_parse() {
+        assert_eq!(
+            extract_seq(r#"{"kind":"relay_inbound","seq":42}"#),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_seq_ignores_unrelated_and_large_fields() {
+        // A worker_stream-shaped payload with a large `data` string and no
+        // `seq` at all (ephemeral events never get one from the replay
+        // buffer) should just yield None, not fail to parse.
+        let big_chunk = "x".repeat(64 * 1024);
+        let msg = format!(r#"{{"kind":"worker_stream","name":"Worker","data":"{big_chunk}"}}"#);
+        assert_eq!(extract_seq(&msg), None);
+    }
+
+    #[test]
+    fn extract_seq_returns_none_for_missing_or_invalid_json() {
+        assert_eq!(extract_seq(r#"{"kind":"agent_spawned"}"#), None);
+        assert_eq!(extract_seq("not json"), None);
+    }
 
     #[test]
     fn dropped_event_count_is_zero_when_nothing_was_actually_lost() {

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -2381,12 +2381,26 @@ fn build_replay_gap_frame(requested_since_seq: u64, oldest_available: u64, seq: 
 ///
 /// Returns the frames to forward to the socket, in order, and the new
 /// high-water `seq` the caller is caught up through.
+///
+/// `cutoff_seq` is derived from the entries `replay_since` actually
+/// returned (the last entry's `seq`), rather than from a separate
+/// `replay_buffer.current_seq()` call taken before it. Reading
+/// `current_seq()` first and `replay_since()` second is a TOCTOU race: a
+/// durable event pushed (or an eviction) in between would make that
+/// earlier snapshot stale relative to what `replay_since` saw, which could
+/// pair a `replay_gap` frame's `seq` with a mismatched `oldestAvailable`, or
+/// cause a `seq <= cutoff_seq` filter to wrongly drop entries `replay_since`
+/// had already committed to returning. Deriving the cutoff from the
+/// snapshot itself keeps everything internally consistent by construction.
 async fn catch_up_after_lag(
     replay_buffer: &ReplayBuffer,
     last_forwarded_seq: u64,
 ) -> (Vec<Value>, u64) {
-    let cutoff_seq = replay_buffer.current_seq();
     let (entries, gap_oldest) = replay_buffer.replay_since(last_forwarded_seq).await;
+    let cutoff_seq = entries
+        .last()
+        .map(|entry| entry.seq)
+        .unwrap_or(last_forwarded_seq);
 
     let mut frames = Vec::with_capacity(entries.len() + 1);
     if let Some(oldest_available) = gap_oldest {
@@ -2396,12 +2410,7 @@ async fn catch_up_after_lag(
             cutoff_seq,
         ));
     }
-    frames.extend(
-        entries
-            .into_iter()
-            .filter(|entry| entry.seq <= cutoff_seq)
-            .map(|entry| entry.event),
-    );
+    frames.extend(entries.into_iter().map(|entry| entry.event));
 
     (frames, cutoff_seq)
 }
@@ -2776,7 +2785,7 @@ mod tests {
 mod replay_gap_tests {
     use super::{build_replay_gap_frame, catch_up_after_lag, dropped_event_count, extract_seq};
     use crate::replay_buffer::ReplayBuffer;
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     #[test]
     fn extract_seq_reads_the_seq_field_without_full_value_parse() {
@@ -2903,6 +2912,55 @@ mod replay_gap_tests {
             "client was already caught up, lag must have been ephemeral-only traffic"
         );
         assert_eq!(new_high_water, 1);
+    }
+
+    /// Regression test for a TOCTOU race flagged in review: `catch_up_after_lag`
+    /// used to snapshot `replay_buffer.current_seq()` *before* calling
+    /// `replay_since()`, so a durable event pushed in between those two calls
+    /// would leave the returned cutoff stale relative to the entries actually
+    /// returned. The fix derives `cutoff_seq` from the entries snapshot
+    /// itself (its last entry's `seq`), so it is always internally
+    /// consistent with what was actually forwarded — even when more durable
+    /// events land after the caller decided `last_forwarded_seq` but before
+    /// recovery runs (exactly the interleaving that made the old
+    /// `current_seq()`-first approach stale).
+    #[tokio::test]
+    async fn catch_up_after_lag_cutoff_is_consistent_with_returned_entries() {
+        let replay_buffer = ReplayBuffer::new(50);
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "a"}))
+            .await
+            .unwrap();
+        // These land after the client's last_forwarded_seq was decided (0)
+        // but are still present by the time catch_up_after_lag's single
+        // replay_since call runs — they must be reflected in the cutoff.
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "b"}))
+            .await
+            .unwrap();
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "c"}))
+            .await
+            .unwrap();
+
+        let (frames, new_high_water) = catch_up_after_lag(&replay_buffer, 0).await;
+
+        assert_eq!(
+            frames.len(),
+            3,
+            "all three durable events should be forwarded"
+        );
+        assert!(frames.iter().all(|f| f["kind"] != "replay_gap"));
+        let max_forwarded_seq = frames
+            .iter()
+            .filter_map(|frame| frame.get("seq").and_then(Value::as_u64))
+            .max()
+            .expect("forwarded entries carry a seq field");
+        assert_eq!(
+            new_high_water, max_forwarded_seq,
+            "cutoff must exactly match the highest seq actually forwarded, not a stale snapshot"
+        );
+        assert_eq!(new_high_water, 3);
     }
 }
 

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -617,6 +617,9 @@ async fn listen_api_replay(
         "events": events,
         "gap": gap_oldest.is_some(),
         "oldestAvailable": gap_oldest.unwrap_or(since_seq),
+        "droppedCount": gap_oldest
+            .map(|oldest| dropped_event_count(since_seq, oldest))
+            .unwrap_or(0),
     }))
 }
 
@@ -2311,6 +2314,79 @@ async fn send_fleet_sidecar_error(
     .await
 }
 
+/// Number of durable events that are unrecoverably lost between
+/// `requested_since_seq` (exclusive) and `oldest_available` (inclusive of
+/// everything at/after it being retained). Used to give a `replay_gap`
+/// consumer a concrete sense of how large a gap it needs to resync around,
+/// beyond the boolean fact that a gap exists at all.
+fn dropped_event_count(requested_since_seq: u64, oldest_available: u64) -> u64 {
+    oldest_available
+        .saturating_sub(requested_since_seq)
+        .saturating_sub(1)
+}
+
+/// Build the `replay_gap` notification frame sent to a dashboard WS client
+/// when events it needs are no longer retained anywhere the broker can serve
+/// them from (neither the live broadcast nor the replay buffer). `seq` is the
+/// broker's current sequence cutoff at the moment the gap was detected, so
+/// the client knows every event up to and including that seq is either being
+/// forwarded now or was already delivered.
+fn build_replay_gap_frame(requested_since_seq: u64, oldest_available: u64, seq: u64) -> Value {
+    json!({
+        "kind": "replay_gap",
+        "requestedSinceSeq": requested_since_seq,
+        "oldestAvailable": oldest_available,
+        "seq": seq,
+        "droppedCount": dropped_event_count(requested_since_seq, oldest_available),
+    })
+}
+
+/// Recover from a `broadcast::error::RecvError::Lagged` on a dashboard WS
+/// client's live event subscription.
+///
+/// Tokio's `broadcast` channel is bounded independently of the replay
+/// buffer. A burst of high-frequency ephemeral events (chiefly
+/// `worker_stream`, which is intentionally excluded from the replay buffer
+/// but still flows over the same broadcast channel) can overflow that
+/// channel's ring for a client that's briefly slow to read, causing
+/// `recv()` to silently skip whatever it couldn't buffer. Previously this
+/// was only logged server-side — the client had no idea anything was
+/// dropped, and (unlike a reconnect) nothing prompted it to resync.
+///
+/// Because the replay buffer independently retains durable events (and,
+/// post-hardening, does not have to share capacity with `worker_stream`
+/// churn), it can usually backfill exactly what the broadcast channel
+/// dropped. When it can't (the durable event has also aged out of the
+/// replay buffer), this returns an explicit `replay_gap` frame instead of
+/// staying silent.
+///
+/// Returns the frames to forward to the socket, in order, and the new
+/// high-water `seq` the caller is caught up through.
+async fn catch_up_after_lag(
+    replay_buffer: &ReplayBuffer,
+    last_forwarded_seq: u64,
+) -> (Vec<Value>, u64) {
+    let cutoff_seq = replay_buffer.current_seq();
+    let (entries, gap_oldest) = replay_buffer.replay_since(last_forwarded_seq).await;
+
+    let mut frames = Vec::with_capacity(entries.len() + 1);
+    if let Some(oldest_available) = gap_oldest {
+        frames.push(build_replay_gap_frame(
+            last_forwarded_seq,
+            oldest_available,
+            cutoff_seq,
+        ));
+    }
+    frames.extend(
+        entries
+            .into_iter()
+            .filter(|entry| entry.seq <= cutoff_seq)
+            .map(|entry| entry.event),
+    );
+
+    (frames, cutoff_seq)
+}
+
 async fn handle_dashboard_ws(
     mut socket: axum::extract::ws::WebSocket,
     mut rx: broadcast::Receiver<String>,
@@ -2321,12 +2397,7 @@ async fn handle_dashboard_ws(
     let replay_cutoff_seq = replay_buffer.current_seq();
     let (replay_events, gap_oldest) = replay_buffer.replay_since(since_seq).await;
     if let Some(oldest_available) = gap_oldest {
-        let replay_gap = json!({
-            "kind": "replay_gap",
-            "requestedSinceSeq": since_seq,
-            "oldestAvailable": oldest_available,
-            "seq": replay_cutoff_seq,
-        });
+        let replay_gap = build_replay_gap_frame(since_seq, oldest_available, replay_cutoff_seq);
         if let Ok(msg) = serde_json::to_string(&replay_gap) {
             let _ = socket
                 .send(axum::extract::ws::Message::Text(msg.into()))
@@ -2347,17 +2418,24 @@ async fn handle_dashboard_ws(
             }
         }
     }
+
+    // High-water mark for the last durable (seq-bearing) event this client
+    // is known to be caught up through. Starts at the connect-time cutoff
+    // and advances as durable events are forwarded live; used both to
+    // de-duplicate against the initial replay and, on a broadcast lag, to
+    // ask the replay buffer for exactly what was missed.
+    let mut last_forwarded_seq = replay_cutoff_seq;
+
     let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
     loop {
         tokio::select! {
             result = rx.recv() => {
                 match result {
                     Ok(msg) => {
-                        let is_duplicate = serde_json::from_str::<Value>(&msg)
+                        let msg_seq = serde_json::from_str::<Value>(&msg)
                             .ok()
-                            .and_then(|value| value.get("seq").and_then(Value::as_u64))
-                            .is_some_and(|seq| seq <= replay_cutoff_seq);
-                        if is_duplicate {
+                            .and_then(|value| value.get("seq").and_then(Value::as_u64));
+                        if msg_seq.is_some_and(|seq| seq <= last_forwarded_seq) {
                             continue;
                         }
                         if socket
@@ -2367,9 +2445,35 @@ async fn handle_dashboard_ws(
                         {
                             break;
                         }
+                        if let Some(seq) = msg_seq {
+                            last_forwarded_seq = seq;
+                        }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(skipped = n, "dashboard WS client lagged, skipped messages");
+                        tracing::warn!(
+                            skipped = n,
+                            "dashboard WS client lagged, recovering from replay buffer"
+                        );
+                        let (frames, new_high_water) =
+                            catch_up_after_lag(&replay_buffer, last_forwarded_seq).await;
+                        last_forwarded_seq = new_high_water;
+                        let mut send_failed = false;
+                        for frame in frames {
+                            let Ok(msg) = serde_json::to_string(&frame) else {
+                                continue;
+                            };
+                            if socket
+                                .send(axum::extract::ws::Message::Text(msg.into()))
+                                .await
+                                .is_err()
+                            {
+                                send_failed = true;
+                                break;
+                            }
+                        }
+                        if send_failed {
+                            break;
+                        }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
@@ -2569,6 +2673,195 @@ mod tests {
             rx.try_recv(),
             Err(broadcast::error::TryRecvError::Empty)
         ));
+    }
+
+    /// Regression test for the durability gap this change hardens against:
+    /// a burst of high-frequency `worker_stream` PTY-output chunks must not
+    /// evict an earlier, low-frequency `relay_inbound` event from the replay
+    /// buffer. Before `worker_stream`/`delivery_active` were excluded from
+    /// replay-buffer storage, a large enough flood (bigger than
+    /// `DEFAULT_REPLAY_CAPACITY`) would silently push `relay_inbound` out of
+    /// the ring, so a reconnecting dashboard client would never see it
+    /// replayed — exactly the bug reported against Pear.
+    #[tokio::test]
+    async fn worker_stream_flood_does_not_evict_earlier_relay_inbound() {
+        let (tx, _rx) = broadcast::channel::<String>(DEFAULT_REPLAY_CAPACITY * 4);
+        // Deliberately small capacity: if worker_stream shared this capacity
+        // with durable events, a flood many times larger than it would
+        // evict the relay_inbound pushed before the flood.
+        let replay_buffer = ReplayBuffer::new(16);
+
+        let relay_inbound = json!({
+            "kind": "relay_inbound",
+            "from": "Worker",
+            "target": "#general",
+            "body": "the important message",
+        });
+        broadcast_if_relevant(&tx, &replay_buffer, &relay_inbound).await;
+
+        // Flood far more worker_stream chunks than the replay buffer's
+        // capacity, simulating an actively-printing agent.
+        for i in 0..10_000 {
+            let chunk = json!({
+                "kind": "worker_stream",
+                "name": "Worker",
+                "data": format!("chunk-{i}"),
+            });
+            broadcast_if_relevant(&tx, &replay_buffer, &chunk).await;
+        }
+
+        let (events, gap) = replay_buffer.replay_since(0).await;
+        assert!(
+            gap.is_none(),
+            "relay_inbound should still be the oldest (and only) durable entry, no gap expected"
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "worker_stream events must never be stored in the replay buffer"
+        );
+        assert_eq!(events[0].event["kind"], "relay_inbound");
+        assert_eq!(events[0].event["body"], "the important message");
+    }
+
+    /// `delivery_active` is the other high-frequency ephemeral kind excluded
+    /// from replay-buffer storage (see `broadcast_if_relevant`); make sure a
+    /// flood of it is equally harmless to durable events.
+    #[tokio::test]
+    async fn delivery_active_flood_does_not_evict_earlier_relay_inbound() {
+        let (tx, _rx) = broadcast::channel::<String>(DEFAULT_REPLAY_CAPACITY * 4);
+        let replay_buffer = ReplayBuffer::new(16);
+
+        broadcast_if_relevant(
+            &tx,
+            &replay_buffer,
+            &json!({"kind": "relay_inbound", "from": "Worker", "target": "#general", "body": "hi"}),
+        )
+        .await;
+
+        for _ in 0..5_000 {
+            broadcast_if_relevant(
+                &tx,
+                &replay_buffer,
+                &json!({"kind": "delivery_active", "name": "Worker"}),
+            )
+            .await;
+        }
+
+        let (events, gap) = replay_buffer.replay_since(0).await;
+        assert!(gap.is_none());
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event["kind"], "relay_inbound");
+    }
+}
+
+#[cfg(test)]
+mod replay_gap_tests {
+    use super::{build_replay_gap_frame, catch_up_after_lag, dropped_event_count};
+    use crate::replay_buffer::ReplayBuffer;
+    use serde_json::json;
+
+    #[test]
+    fn dropped_event_count_is_zero_when_nothing_was_actually_lost() {
+        // Requested seq 5, oldest available is 6: nothing between them was
+        // dropped (the client just needs 6..).
+        assert_eq!(dropped_event_count(5, 6), 0);
+    }
+
+    #[test]
+    fn dropped_event_count_reports_the_lost_range() {
+        // Requested seq 1, oldest available is 3: seq 2 was evicted.
+        assert_eq!(dropped_event_count(1, 3), 1);
+        // Requested seq 0, oldest available is 3: seq 1 and 2 were evicted.
+        assert_eq!(dropped_event_count(0, 3), 2);
+    }
+
+    #[test]
+    fn build_replay_gap_frame_has_expected_shape() {
+        let frame = build_replay_gap_frame(1, 3, 10);
+        assert_eq!(frame["kind"], "replay_gap");
+        assert_eq!(frame["requestedSinceSeq"], 1);
+        assert_eq!(frame["oldestAvailable"], 3);
+        assert_eq!(frame["seq"], 10);
+        assert_eq!(frame["droppedCount"], 1);
+    }
+
+    #[tokio::test]
+    async fn catch_up_after_lag_backfills_from_replay_buffer_without_a_gap_frame() {
+        // The replay buffer's capacity comfortably covers what a broadcast-
+        // channel lag would have dropped, so recovery should be silent: no
+        // replay_gap frame, just the missed durable events forwarded.
+        let replay_buffer = ReplayBuffer::new(100);
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "first"}))
+            .await
+            .unwrap();
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "second"}))
+            .await
+            .unwrap();
+
+        // Client was caught up through seq 0 (nothing yet) when it lagged.
+        let (frames, new_high_water) = catch_up_after_lag(&replay_buffer, 0).await;
+
+        assert_eq!(
+            frames.len(),
+            2,
+            "both missed durable events should be backfilled"
+        );
+        assert!(
+            frames.iter().all(|frame| frame["kind"] != "replay_gap"),
+            "no gap frame expected when the replay buffer still has everything"
+        );
+        assert_eq!(frames[0]["body"], "first");
+        assert_eq!(frames[1]["body"], "second");
+        assert_eq!(new_high_water, 2);
+    }
+
+    #[tokio::test]
+    async fn catch_up_after_lag_emits_gap_frame_when_replay_buffer_also_aged_out() {
+        // Tiny capacity: by the time we try to recover, even the replay
+        // buffer no longer has the range the client needs.
+        let replay_buffer = ReplayBuffer::new(2);
+        for i in 0..5 {
+            replay_buffer
+                .push(json!({"kind": "relay_inbound", "body": format!("msg-{i}")}))
+                .await
+                .unwrap();
+        }
+
+        // Client was caught up through seq 0, far behind the buffer's
+        // current oldest (seq 4, since only the last 2 of 5 are retained).
+        let (frames, new_high_water) = catch_up_after_lag(&replay_buffer, 0).await;
+
+        assert!(!frames.is_empty());
+        assert_eq!(
+            frames[0]["kind"], "replay_gap",
+            "first frame should be the gap notification"
+        );
+        assert_eq!(frames[0]["requestedSinceSeq"], 0);
+        assert_eq!(frames[0]["oldestAvailable"], 4);
+        assert_eq!(frames[0]["droppedCount"], 3);
+        // Remaining frames are the events still available in the buffer.
+        assert_eq!(frames.len(), 1 + 2);
+        assert_eq!(new_high_water, 5);
+    }
+
+    #[tokio::test]
+    async fn catch_up_after_lag_is_noop_when_nothing_new_happened() {
+        let replay_buffer = ReplayBuffer::new(10);
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "only"}))
+            .await
+            .unwrap();
+
+        let (frames, new_high_water) = catch_up_after_lag(&replay_buffer, 1).await;
+
+        assert!(
+            frames.is_empty(),
+            "client was already caught up, lag must have been ephemeral-only traffic"
+        );
+        assert_eq!(new_high_water, 1);
     }
 }
 

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -2962,6 +2962,103 @@ mod replay_gap_tests {
         );
         assert_eq!(new_high_water, 3);
     }
+
+    /// Directly exercises the TOCTOU hazard the previous test didn't: here a
+    /// durable event is pushed *for real, concurrently, from a separate
+    /// task* strictly between when a `current_seq()`-first cutoff would be
+    /// snapshotted and when `replay_since()` actually runs — using a
+    /// two-phase oneshot handshake so the interleaving is deterministic
+    /// rather than timing-dependent (per review feedback that the earlier
+    /// test never actually raced anything, since all its pushes landed
+    /// before `catch_up_after_lag` was even called).
+    ///
+    /// `catch_up_after_lag`'s fix *removes* the separate `current_seq()`
+    /// step entirely (cutoff is derived from `replay_since`'s own returned
+    /// entries), so there is no longer a window inside it to deterministically
+    /// race against without adding test-only instrumentation to production
+    /// code. Instead, this test reconstructs the pre-fix computation inline
+    /// (snapshot `current_seq()`, race a push in via a real concurrent task,
+    /// then call `replay_since()` and re-apply the old `seq <= cutoff`
+    /// filter) to prove, under genuine concurrency rather than just
+    /// sequential ordering, that the old shape really does produce a
+    /// stale/inconsistent result. It then confirms `catch_up_after_lag`,
+    /// run against the resulting buffer state, does not lose the event that
+    /// raced in.
+    #[tokio::test]
+    async fn a_push_racing_between_cutoff_read_and_replay_since_produces_a_stale_cutoff() {
+        let replay_buffer = ReplayBuffer::new(50);
+        replay_buffer
+            .push(json!({"kind": "relay_inbound", "body": "a"}))
+            .await
+            .unwrap();
+
+        let (snapshot_taken_tx, snapshot_taken_rx) = tokio::sync::oneshot::channel::<()>();
+        let (push_landed_tx, push_landed_rx) = tokio::sync::oneshot::channel::<()>();
+
+        // "Reader" task: reproduces the pre-fix `catch_up_after_lag` shape
+        // (current_seq() snapshot, *then* replay_since()), but pauses in
+        // between on a handshake so a concurrent push is guaranteed to land
+        // in the window the old code was vulnerable in.
+        let reader_buffer = replay_buffer.clone();
+        let reader = tokio::spawn(async move {
+            let stale_cutoff = reader_buffer.current_seq(); // pre-fix snapshot, == 1
+            snapshot_taken_tx
+                .send(())
+                .expect("test setup: writer must still be waiting");
+            push_landed_rx
+                .await
+                .expect("writer must signal after its push completes");
+            let (entries, _gap) = reader_buffer.replay_since(0).await;
+            (stale_cutoff, entries)
+        });
+
+        // "Writer" task: waits for the reader's snapshot, then pushes a new
+        // durable event — landing exactly between the reader's stale
+        // snapshot and its later `replay_since()` call.
+        let writer_buffer = replay_buffer.clone();
+        let writer = tokio::spawn(async move {
+            snapshot_taken_rx
+                .await
+                .expect("reader must signal after taking its snapshot");
+            writer_buffer
+                .push(json!({"kind": "relay_inbound", "body": "b"}))
+                .await
+                .unwrap();
+            push_landed_tx
+                .send(())
+                .expect("test setup: reader must still be waiting");
+        });
+
+        let (stale_cutoff, entries) = reader.await.expect("reader task panicked");
+        writer.await.expect("writer task panicked");
+
+        assert_eq!(stale_cutoff, 1, "snapshot was taken before the racing push");
+        assert_eq!(
+            entries.len(),
+            2,
+            "replay_since itself correctly sees both events, including the racing one"
+        );
+
+        // This is the actual pre-fix bug: filtering by the now-stale
+        // snapshot wrongly excludes the event that raced in.
+        let old_buggy_filtered_count = entries.iter().filter(|e| e.seq <= stale_cutoff).count();
+        assert_eq!(
+            old_buggy_filtered_count, 1,
+            "a current_seq()-first cutoff wrongly excludes the event that raced in concurrently"
+        );
+
+        // catch_up_after_lag itself, run against the same (now-settled)
+        // buffer state, must not reproduce that inconsistency: its cutoff
+        // comes from replay_since's own returned entries, so it has no
+        // separate stale snapshot to race against in the first place.
+        let (frames, new_high_water) = catch_up_after_lag(&replay_buffer, 0).await;
+        assert_eq!(
+            frames.len(),
+            2,
+            "catch_up_after_lag must forward both durable events"
+        );
+        assert_eq!(new_high_water, 2);
+    }
 }
 
 #[cfg(test)]

--- a/crates/broker/src/replay_buffer.rs
+++ b/crates/broker/src/replay_buffer.rs
@@ -21,6 +21,21 @@ pub struct ReplayEntry {
 }
 
 /// Thread-safe ring buffer that stores recent broadcast events.
+///
+/// The buffer is purely capacity-bound FIFO and **kind-agnostic**: it has no
+/// notion of "important" vs. "ephemeral" events, so every call to [`push`]
+/// counts equally against the shared `capacity`. That means callers are
+/// responsible for keeping high-frequency, replay-insensitive event kinds
+/// (e.g. `worker_stream`, which is raw per-chunk PTY output re-rendered from
+/// the terminal's own separate buffer, not something a reconnecting
+/// dashboard client needs replayed) out of this buffer entirely — otherwise a
+/// burst of them can evict low-frequency, durability-sensitive events (e.g.
+/// `relay_inbound`) before a reconnecting client ever gets a chance to
+/// request them. See `listen_api::broadcast_if_relevant` for the filtering
+/// policy the broker's dashboard WS pipeline applies before calling
+/// [`push`].
+///
+/// [`push`]: ReplayBuffer::push
 #[derive(Clone)]
 pub struct ReplayBuffer {
     inner: Arc<RwLock<ReplayBufferInner>>,
@@ -68,14 +83,24 @@ impl ReplayBuffer {
     }
 
     /// Retrieve all events with seq > since_seq.
-    /// Returns `(events, had_gap)` where `had_gap` is true if the requested
-    /// seq is older than the oldest event in the buffer.
+    /// Returns `(events, had_gap)` where `had_gap` is true if events the
+    /// caller needed (i.e. with seq in `(since_seq, oldest)`) have already
+    /// been evicted from the buffer.
+    ///
+    /// Note the strict `since_seq + 1 < oldest` comparison rather than
+    /// `since_seq < oldest`: sequence numbers are 1-based (the first event
+    /// ever pushed gets seq 1), so a brand-new client requesting
+    /// `since_seq = 0` against a buffer that has never evicted anything
+    /// (`oldest == 1`) is not missing anything — there is no seq 0 to have
+    /// lost. Using the looser comparison would falsely report a gap on
+    /// every first-time connection as soon as a single durable event had
+    /// ever been recorded.
     pub async fn replay_since(&self, since_seq: u64) -> (Vec<ReplayEntry>, Option<u64>) {
         let inner = self.inner.read().await;
         let oldest_seq = inner.entries.front().map(|e| e.seq);
 
         let gap = match oldest_seq {
-            Some(oldest) if since_seq < oldest => Some(oldest),
+            Some(oldest) if since_seq + 1 < oldest => Some(oldest),
             _ => None,
         };
 
@@ -212,5 +237,85 @@ mod tests {
         let (events, gap) = buf.replay_since(2).await;
         assert!(gap.is_none());
         assert!(events.is_empty());
+    }
+
+    /// Regression test for an off-by-one in gap detection: sequence numbers
+    /// are 1-based, so a brand-new dashboard client's default cursor
+    /// (`since_seq = 0`, i.e. "I have no cursor yet, replay everything")
+    /// must not be treated as a gap just because nothing has ever been
+    /// evicted. Before this fix, `since_seq < oldest` was `0 < 1` (true) as
+    /// soon as a single durable event existed, so *every* first-time
+    /// connection would receive a spurious `replay_gap` frame even though
+    /// nothing was actually lost.
+    #[tokio::test]
+    async fn since_zero_is_not_a_gap_when_nothing_has_been_evicted() {
+        let buf = ReplayBuffer::new(16);
+
+        buf.push(json!({"kind": "relay_inbound", "body": "first ever event"}))
+            .await
+            .unwrap();
+
+        let (events, gap) = buf.replay_since(0).await;
+        assert!(
+            gap.is_none(),
+            "no eviction ever happened, so since_seq=0 must not be reported as a gap"
+        );
+        assert_eq!(events.len(), 1);
+    }
+
+    /// Complement to the above: if a client's cursor already points at the
+    /// event immediately before the oldest retained one (i.e. they already
+    /// have everything up to and including that point), there is still no
+    /// gap even though `since_seq < oldest` in the old, looser sense.
+    #[tokio::test]
+    async fn since_seq_immediately_before_oldest_is_not_a_gap() {
+        let buf = ReplayBuffer::new(3);
+
+        for i in 0..5 {
+            buf.push(json!({"kind": format!("event_{}", i)}))
+                .await
+                .unwrap();
+        }
+        // Capacity 3, so entries with seq 3, 4, 5 remain (oldest = 3).
+        let (events, gap) = buf.replay_since(2).await;
+        assert!(
+            gap.is_none(),
+            "client already has everything through seq 2; nothing after that was evicted"
+        );
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].seq, 3);
+    }
+
+    /// `ReplayBuffer` itself has no concept of event "kind" — it is a plain
+    /// capacity-bound FIFO, and every `push` (whatever its `kind`) counts
+    /// against the same shared `capacity`. This test locks in that raw
+    /// eviction contract using realistic kind names: if a caller pushes
+    /// `worker_stream` chunks directly into this buffer alongside a durable
+    /// `relay_inbound` event, the flood *will* evict it once capacity is
+    /// exceeded. That's precisely why callers (see
+    /// `listen_api::broadcast_if_relevant`) must filter high-frequency
+    /// ephemeral kinds out *before* calling `push`, rather than relying on
+    /// this buffer to do it. Regression coverage for that filtering itself
+    /// lives in `listen_api.rs`'s `worker_stream_flood_does_not_evict_earlier_relay_inbound`.
+    #[tokio::test]
+    async fn raw_buffer_is_kind_agnostic_and_will_evict_anything_once_full() {
+        let buf = ReplayBuffer::new(4);
+
+        buf.push(json!({"kind": "relay_inbound", "body": "important"}))
+            .await
+            .unwrap();
+        for i in 0..10 {
+            buf.push(json!({"kind": "worker_stream", "data": format!("chunk-{i}")}))
+                .await
+                .unwrap();
+        }
+
+        let (events, gap) = buf.replay_since(0).await;
+        assert!(gap.is_some(), "oldest entry (relay_inbound) was evicted");
+        assert!(
+            events.iter().all(|e| e.event["kind"] != "relay_inbound"),
+            "the buffer does not distinguish event kinds, so relay_inbound was evicted \
+             along with everything else once capacity was exceeded"
+        );
     }
 }

--- a/crates/broker/src/replay_buffer.rs
+++ b/crates/broker/src/replay_buffer.rs
@@ -95,12 +95,19 @@ impl ReplayBuffer {
     /// lost. Using the looser comparison would falsely report a gap on
     /// every first-time connection as soon as a single durable event had
     /// ever been recorded.
+    ///
+    /// `since_seq` is bumped via `saturating_add(1)` rather than a plain
+    /// `+ 1`: it's untrusted, client-supplied input (e.g. a `sinceSeq` query
+    /// param), and `since_seq == u64::MAX` would otherwise overflow —
+    /// panicking in debug/overflow-checked builds and wrapping to 0 in
+    /// release, which would falsely report a gap for a cursor that is
+    /// actually ahead of everything retained.
     pub async fn replay_since(&self, since_seq: u64) -> (Vec<ReplayEntry>, Option<u64>) {
         let inner = self.inner.read().await;
         let oldest_seq = inner.entries.front().map(|e| e.seq);
 
         let gap = match oldest_seq {
-            Some(oldest) if since_seq + 1 < oldest => Some(oldest),
+            Some(oldest) if since_seq.saturating_add(1) < oldest => Some(oldest),
             _ => None,
         };
 
@@ -284,6 +291,28 @@ mod tests {
         );
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].seq, 3);
+    }
+
+    /// Regression test for an integer-overflow bug flagged in review: a
+    /// client-supplied `since_seq` is untrusted input, and `u64::MAX` would
+    /// overflow a plain `since_seq + 1` — panicking in debug/overflow-checked
+    /// builds and wrapping to 0 in release, which would falsely report a gap
+    /// for a cursor that is actually ahead of everything retained. Must not
+    /// panic, and a cursor beyond every retained seq is not a gap.
+    #[tokio::test]
+    async fn since_seq_of_u64_max_does_not_overflow_or_panic() {
+        let buf = ReplayBuffer::new(4);
+
+        buf.push(json!({"kind": "relay_inbound", "body": "only"}))
+            .await
+            .unwrap();
+
+        let (events, gap) = buf.replay_since(u64::MAX).await;
+        assert!(
+            gap.is_none(),
+            "since_seq=u64::MAX is ahead of every retained seq, not a gap"
+        );
+        assert!(events.is_empty());
     }
 
     /// `ReplayBuffer` itself has no concept of event "kind" — it is a plain


### PR DESCRIPTION
## Background

Pear (Electron app) observed a bug: a message sent to a channel would show up in a hosted Relaycast observer but sometimes never appear in Pear's own local UI. Pear's Electron main process holds one persistent WS connection to the broker's `/ws` endpoint (`handle_dashboard_ws`), and every broker event — including `relay_inbound` — flows over it. On reconnect the broker replays missed events from a shared `ReplayBuffer` (capacity 1000, all event kinds).

## What was already true on `main`

`worker_stream`/`delivery_active` were already excluded from replay-buffer storage (`broadcast_if_relevant` in `listen_api.rs`), so a PTY-output burst can no longer evict a `relay_inbound` event *from the replay buffer*. That mitigation had **zero test coverage**, though — nothing proved a flood couldn't regress this.

## What this PR adds

1. **Regression tests locking in the existing worker_stream/delivery_active exclusion** (`listen_api.rs`): floods of 10k `worker_stream` / 5k `delivery_active` events no longer evict an earlier `relay_inbound` entry. Also documents, at the `ReplayBuffer` level, that the buffer itself is plain kind-agnostic FIFO — callers must filter ephemeral kinds out before calling `push` (with a test proving what happens if they don't).

2. **The actual remaining silent-drop path, found while writing the tests above and fixed**: the *live* `broadcast::channel` feeding the dashboard WS loop is bounded independently of the replay buffer (capacity 512). A `worker_stream` burst can still overflow it for a momentarily slow reader, producing `RecvError::Lagged`. Previously this was only `tracing::warn!`'d server-side — the client's connection stayed open and it was never told anything was dropped or prompted to resync, so it could silently drift out of sync indefinitely (not just until next reconnect — there may never be one).

   Fix: on `Lagged`, the WS loop now calls a new `catch_up_after_lag` helper that consults the replay buffer (independently sized, and no longer sharing capacity with `worker_stream` churn) to backfill exactly what the broadcast channel dropped. Only if the replay buffer has *also* aged the range out does it fall back to an explicit `replay_gap` frame — so gaps are either silently healed or explicitly signaled, never silently lost.

3. **Off-by-one bug fix in `ReplayBuffer::replay_since`**, found by the new tests: `since_seq < oldest` incorrectly reported a gap whenever a brand-new client (`since_seq = 0`, the default with no cursor) connected after at least one durable event had ever been recorded — even with **zero** evictions — because sequence numbers are 1-based (first entry is seq 1, so `0 < 1` is trivially true). This meant **every first-time dashboard connection** was getting a spurious `replay_gap` frame. Fixed to `since_seq + 1 < oldest`.

4. **`replay_gap` frame now includes `droppedCount`** (both the WS push and the `GET /api/events/replay` HTTP endpoint), so a consuming client can gauge the size of a gap instead of only getting a boolean.

## `replay_gap` frame shape after this change

```json
{
  "kind": "replay_gap",
  "requestedSinceSeq": 0,
  "oldestAvailable": 42,
  "seq": 100,
  "droppedCount": 41
}
```

Only `droppedCount` is new; the other four fields are unchanged from before. `droppedCount = oldestAvailable - requestedSinceSeq - 1` (durable events in that range that are unrecoverably gone). This same frame shape is now used both at connect-time (in `handle_dashboard_ws`) and from the new post-`Lagged` recovery path (`catch_up_after_lag`) — previously only the former existed. NOT touching Pear's client-side gap-handling (separate PR) or client-side channel/DM-scoped resync — that's out of scope here per the task; per-channel identifiers aren't reliably derivable from the buffer today (event schemas use inconsistent field names — `target` vs `name` — across kinds), so this is intentionally not attempted.

## Files changed
- `crates/broker/src/listen_api.rs` — `dropped_event_count`, `build_replay_gap_frame`, `catch_up_after_lag`, `handle_dashboard_ws` lag-recovery wiring, `listen_api_replay` `droppedCount` field, new tests.
- `crates/broker/src/replay_buffer.rs` — off-by-one fix in `replay_since`, doc comment on the kind-agnostic FIFO contract, new tests.

## Test plan
- `cargo check -p agent-relay-broker` — clean
- `cargo clippy -p agent-relay-broker -- -D warnings` — clean, zero warnings
- `cargo fmt -p agent-relay-broker -- --check` — clean
- `cargo test -p agent-relay-broker --lib` — 808 passed, 0 failed (baseline ~794 + 14 new/updated tests)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

