### PR TITLE
Swift SDK: outbound action invocation and message history on AgentClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `agent-relay skills add` installs the `/orchestrate` skill (from `agentrelay.com/skill.md`) into your coding harnesses. An interactive TUI asks whether to install for the current project or globally and which harnesses to target (Claude Code, Codex, Cursor, Gemini, OpenCode); `--global`/`--local`, `--harness <ids>`, and `--all` flags drive it non-interactively.
 - `agent-relay up --verbose` now prints step-by-step startup progress (port resolution, broker process spawn, handshake retries, fleet sidecar, node-delivery wait, agent spawns) and streams the broker's own startup-phase logs and stderr live, instead of only surfacing a terse error if startup fails.
+- Swift SDK (`AgentRelaySDK`, `packages/sdk-swift`): `AgentClient` gains `invokeAction(_:input:timeout:pollInterval:)` — invoke a relay action and await its output — plus `channelHistory(_:limit:before:)` and `dmHistory(with:limit:before:)` for reading channel and 1:1 DM message history as oldest-first `RelayChannelEvent`s.
 
 ### Changed
 

--- a/packages/sdk-swift/README.md
+++ b/packages/sdk-swift/README.md
@@ -63,6 +63,31 @@ for await event in channel.events {
 }
 ```
 
+### Actions & history
+
+Invoke a relay action registered by another agent and read message history
+(both served over the hosted REST API with the agent's token):
+
+```swift
+let output = try await agent.invokeAction(
+    "deploy.staging",
+    input: .object(["ref": .string("main")]),
+    timeout: 60
+)
+
+// Oldest-first; leading '#' / '@' sigils are accepted.
+let channelEvents = try await agent.channelHistory("#general", limit: 50)
+let dmEvents = try await agent.dmHistory(with: "planner", limit: 50)
+for event in dmEvents {
+    print("\(event.from): \(event.body)")
+}
+```
+
+`invokeAction` polls the invocation until it completes (returning its output),
+fails, or is denied (`RelayError.protocolError` with code `action_failed` /
+`action_denied`), or the timeout elapses (`RelayError.timeout`). `dmHistory`
+returns `[]` when no 1:1 conversation with the agent exists yet.
+
 Broker orchestration tools should import the broker product instead:
 
 ```swift
@@ -84,6 +109,9 @@ try await broker.spawnAgent(AgentSpec(name: "worker", runtime: .headless, provid
   - `AgentClient.events`
   - `AgentClient.inboundMessages`
   - `AgentClient.registerAction(name:description:inputSchemaJSON:handler:)`
+  - `AgentClient.invokeAction(_:input:timeout:pollInterval:)`
+  - `AgentClient.channelHistory(_:limit:before:)`
+  - `AgentClient.dmHistory(with:limit:before:)`
 - `AgentRelayBrokerSDK`
   - `AgentRelayBrokerClient(apiKey:baseURL:)`
   - `channel(_:)`

--- a/packages/sdk-swift/Sources/AgentRelaySDK/AgentRelayClient.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/AgentRelayClient.swift
@@ -277,13 +277,17 @@ public final class AgentClient: @unchecked Sendable {
     ///   - name: Registered action name. May contain dots (e.g.
     ///     `deploy.staging`); dots are preserved in the request path.
     ///   - input: JSON object passed to the action handler.
-    ///   - timeout: Maximum time to wait for completion.
+    ///   - timeout: Maximum time to wait for completion, measured on a
+    ///     monotonic clock. The budget also bounds each underlying HTTP
+    ///     request and clamps the final poll sleep, so a large `pollInterval`
+    ///     cannot extend the wait past the deadline.
     ///   - pollInterval: Delay between invocation-status polls.
     /// - Returns: The action output, or `.null` when the action completed
     ///   without output.
     /// - Throws: `RelayError.protocolError` with code `action_failed` /
-    ///   `action_denied` when the invocation fails or is denied;
-    ///   `RelayError.timeout` when `timeout` elapses first.
+    ///   `action_denied` when the invocation fails, is denied, or reports an
+    ///   unknown terminal status; `RelayError.timeout` when `timeout` elapses
+    ///   first.
     public func invokeAction(_ name: String, input: JSONValue = .object([:]), timeout: TimeInterval = 30, pollInterval: TimeInterval = 0.4) async throws -> JSONValue {
         try await rest.invokeAction(name, input: input, timeout: timeout, pollInterval: pollInterval)
     }

--- a/packages/sdk-swift/Sources/AgentRelaySDK/AgentRelayClient.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/AgentRelayClient.swift
@@ -5,6 +5,8 @@ import Relaycast
 /// engine SDK (`Relaycast`): registration, reconnect, workspace lookup, channel
 /// posting, DMs, action handling, and the realtime event stream are all served
 /// by `Relaycast.RelayCast` / `Relaycast.AgentClient` / `Relaycast.WsClient`.
+/// Outbound action invocation and message history are served directly over the
+/// hosted REST API by the internal `RelayRestClient`.
 ///
 /// The public surface (types, method signatures, AsyncStream APIs) is preserved
 /// so existing callers keep working; only the transport implementation changed.
@@ -209,6 +211,7 @@ final class HostedWorkspaceCore: @unchecked Sendable {
 
 public final class AgentClient: @unchecked Sendable {
     private let core: HostedParticipantCore
+    private let rest: RelayRestClient
     public let id: String
     public let name: String
     public let token: String
@@ -217,6 +220,10 @@ public final class AgentClient: @unchecked Sendable {
 
     init(core: HostedParticipantCore, id: String, name: String, token: String) {
         self.core = core
+        // Outbound action invocation and message history are served directly
+        // over the hosted REST API (agent-token auth), independent of the
+        // realtime engine held by `core`.
+        self.rest = RelayRestClient(baseURL: core.baseURL, token: token)
         self.id = id
         self.name = name
         self.token = token
@@ -254,6 +261,63 @@ public final class AgentClient: @unchecked Sendable {
             inputSchemaJSON: inputSchemaJSON,
             handler: handler
         )
+    }
+
+    /// Invoke a relay action registered by another agent and wait for its
+    /// output.
+    ///
+    /// Two-phase async RPC: `POST /v1/actions/{name}/invoke` returns an ack
+    /// (without the output), then the invocation record is polled until it
+    /// reaches a terminal status. Polling keeps the call deterministic and
+    /// does not require the realtime socket to be connected; listening for
+    /// the WS `action.completed` event instead is a future latency
+    /// optimization.
+    ///
+    /// - Parameters:
+    ///   - name: Registered action name. May contain dots (e.g.
+    ///     `deploy.staging`); dots are preserved in the request path.
+    ///   - input: JSON object passed to the action handler.
+    ///   - timeout: Maximum time to wait for completion.
+    ///   - pollInterval: Delay between invocation-status polls.
+    /// - Returns: The action output, or `.null` when the action completed
+    ///   without output.
+    /// - Throws: `RelayError.protocolError` with code `action_failed` /
+    ///   `action_denied` when the invocation fails or is denied;
+    ///   `RelayError.timeout` when `timeout` elapses first.
+    public func invokeAction(_ name: String, input: JSONValue = .object([:]), timeout: TimeInterval = 30, pollInterval: TimeInterval = 0.4) async throws -> JSONValue {
+        try await rest.invokeAction(name, input: input, timeout: timeout, pollInterval: pollInterval)
+    }
+
+    /// Fetch recent messages for a channel, oldest-first.
+    ///
+    /// A leading `#` is accepted and stripped (`"#general"` and `"general"`
+    /// are equivalent). The wire does not guarantee ordering, so results are
+    /// stably sorted ascending by timestamp.
+    ///
+    /// - Parameters:
+    ///   - channel: Channel name, with or without a leading `#`.
+    ///   - limit: Maximum number of messages to fetch.
+    ///   - before: Only fetch messages older than this message id.
+    /// - Returns: Channel messages as `RelayChannelEvent`s (`channel` is the
+    ///   normalized channel name; `rawEvent` is `nil` for history rows).
+    public func channelHistory(_ channel: String, limit: Int = 50, before: String? = nil) async throws -> [RelayChannelEvent] {
+        try await rest.channelHistory(channel: channel, limit: limit, before: before)
+    }
+
+    /// Fetch the 1:1 DM history with a named agent, oldest-first.
+    ///
+    /// The conversation is resolved via `GET /v1/dm/conversations` first
+    /// (there is no single-shot endpoint); when no 1:1 conversation with the
+    /// agent exists yet, an empty array is returned rather than an error.
+    ///
+    /// - Parameters:
+    ///   - agent: Agent name, with or without a leading `@`.
+    ///   - limit: Maximum number of messages to fetch.
+    ///   - before: Only fetch messages older than this message id.
+    /// - Returns: DM messages as `RelayChannelEvent`s (`channel` and
+    ///   `threadId` are `nil`; `rawEvent` is `nil` for history rows).
+    public func dmHistory(with agent: String, limit: Int = 50, before: String? = nil) async throws -> [RelayChannelEvent] {
+        try await rest.dmHistory(with: agent, limit: limit, before: before)
     }
 
     public var events: AsyncStream<RelayEvent> {
@@ -771,14 +835,16 @@ actor HostedParticipantCore {
         }
     }
 
-    private static func stripSigil(_ value: String) -> String {
+    // Internal (not private): `RelayRestClient` reuses the same channel/agent
+    // name normalization for the history endpoints.
+    static func stripSigil(_ value: String) -> String {
         if value.hasPrefix("@") || value.hasPrefix("#") {
             return String(value.dropFirst())
         }
         return value
     }
 
-    private static func normalizeChannel(_ value: String) -> String {
+    static func normalizeChannel(_ value: String) -> String {
         stripSigil(value).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
@@ -1,0 +1,435 @@
+import Foundation
+
+// MARK: - Wire types (snake_case hosted REST API)
+
+/// Ack returned by `POST /v1/actions/{name}/invoke`. The ack does NOT carry
+/// the action output; callers poll the invocation record for completion.
+struct ActionInvokeAck: Decodable, Sendable {
+    let invocationId: String
+    let actionName: String?
+    let handlerAgentId: String?
+    let input: JSONValue?
+    let status: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case input, status
+        case invocationId = "invocation_id"
+        case actionName = "action_name"
+        case handlerAgentId = "handler_agent_id"
+        case createdAt = "created_at"
+    }
+}
+
+/// Invocation record returned by
+/// `GET /v1/actions/{name}/invocations/{invocationId}`. `status` transitions
+/// `invoked` → `completed` | `failed` | `denied`.
+struct ActionInvocationRecord: Decodable, Sendable {
+    let invocationId: String
+    let actionName: String?
+    let callerId: String?
+    let callerName: String?
+    let input: JSONValue?
+    let output: JSONValue?
+    let status: String
+    let error: String?
+    let durationMs: Double?
+    let completedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case input, output, status, error
+        case invocationId = "invocation_id"
+        case actionName = "action_name"
+        case callerId = "caller_id"
+        case callerName = "caller_name"
+        case durationMs = "duration_ms"
+        case completedAt = "completed_at"
+    }
+}
+
+/// Row returned by `GET /v1/channels/{name}/messages`. Unlisted wire fields
+/// (blocks, attachments, ...) are ignored; everything but `id` is optional so
+/// decoding stays lenient, matching `RelayMessage`'s house style.
+struct ChannelMessageRow: Decodable, Sendable {
+    let id: String
+    let channelId: String?
+    let agentId: String?
+    let agentName: String?
+    let agentType: String?
+    let text: String?
+    let threadId: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, text
+        case channelId = "channel_id"
+        case agentId = "agent_id"
+        case agentName = "agent_name"
+        case agentType = "agent_type"
+        case threadId = "thread_id"
+        case createdAt = "created_at"
+    }
+}
+
+/// Row returned by `GET /v1/dm/conversations`.
+struct DmConversationSummaryRow: Decodable, Sendable {
+    struct Participant: Decodable, Sendable {
+        let agentId: String?
+        let agentName: String?
+
+        enum CodingKeys: String, CodingKey {
+            case agentId = "agent_id"
+            case agentName = "agent_name"
+        }
+    }
+
+    let id: String
+    let type: String?
+    let participants: [Participant]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, type, participants
+    }
+}
+
+/// Row returned by `GET /v1/dm/{conversationId}/messages`. DM rows carry no
+/// `thread_id` or `conversation_id`.
+struct DmMessageRow: Decodable, Sendable {
+    let id: String
+    let agentId: String?
+    let agentName: String?
+    let agentType: String?
+    let text: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, text
+        case agentId = "agent_id"
+        case agentName = "agent_name"
+        case agentType = "agent_type"
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - RelayRestClient
+
+/// Internal REST client for the hosted API endpoints the facade serves
+/// directly over HTTP: outbound action invocation and message history. Owned
+/// per-`AgentClient` and authenticated with the AGENT token (`at_...`), not
+/// the workspace key.
+///
+/// Every non-204 response uses the envelope
+/// `{"ok": true, "data": ...}` / `{"ok": false, "error": {"code", "message"}}`.
+/// HTTP 429/500/502/503/504 are retried up to `maxRetries` times with
+/// exponential backoff plus jitter; a `Retry-After` header on 429 overrides
+/// the computed backoff.
+struct RelayRestClient: Sendable {
+    let baseURL: URL
+    let token: String
+    let session: URLSession
+
+    private static let retryStatuses: Set<Int> = [429, 500, 502, 503, 504]
+    private static let maxRetries = 2
+    private static let baseBackoff: TimeInterval = 0.25
+
+    init(baseURL: URL, token: String, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.token = token
+        self.session = session
+    }
+
+    // MARK: - Actions
+
+    /// Invoke a relay action and wait for its output via the two-phase async
+    /// RPC: `POST .../invoke` returns an ack (no output), then the invocation
+    /// record is polled until it reaches a terminal status or `timeout`
+    /// elapses. Polling keeps the call deterministic and independent of the
+    /// realtime socket; listening for the WS `action.completed` event instead
+    /// is a future latency optimization.
+    func invokeAction(_ name: String, input: JSONValue, timeout: TimeInterval, pollInterval: TimeInterval) async throws -> JSONValue {
+        let actionName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !actionName.isEmpty else {
+            throw RelayError.protocolError(code: "invalid_action_name", message: "Action name cannot be empty", retryable: false)
+        }
+
+        let encodedName = Self.encodePathSegment(actionName)
+        let ack: ActionInvokeAck = try await post(
+            "/v1/actions/\(encodedName)/invoke",
+            body: ActionInvokeRequestBody(input: input)
+        )
+        let encodedInvocation = Self.encodePathSegment(ack.invocationId)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while true {
+            let record: ActionInvocationRecord = try await get(
+                "/v1/actions/\(encodedName)/invocations/\(encodedInvocation)"
+            )
+            switch record.status {
+            case "completed":
+                return record.output ?? .null
+            case "failed":
+                throw RelayError.protocolError(code: "action_failed", message: record.error ?? record.status, retryable: false)
+            case "denied":
+                throw RelayError.protocolError(code: "action_denied", message: record.error ?? record.status, retryable: false)
+            default:
+                break
+            }
+            if Date() >= deadline {
+                throw RelayError.timeout("Action '\(actionName)' did not complete within \(timeout)s (invocation \(ack.invocationId))")
+            }
+            // Task.sleep throws CancellationError when the caller is cancelled,
+            // which aborts the poll loop promptly.
+            try await Self.sleep(seconds: pollInterval)
+        }
+    }
+
+    // MARK: - History
+
+    /// Fetch channel history mapped to `RelayChannelEvent`, oldest-first.
+    /// Nothing on the wire guarantees ordering, so rows are stably sorted
+    /// ascending by timestamp to give UIs a consistent contract.
+    func channelHistory(channel: String, limit: Int, before: String?, after: String? = nil) async throws -> [RelayChannelEvent] {
+        let name = HostedParticipantCore.normalizeChannel(channel)
+        let rows: [ChannelMessageRow] = try await get(
+            "/v1/channels/\(Self.encodePathSegment(name))/messages",
+            query: Self.historyQuery(limit: limit, before: before, after: after)
+        )
+        let events = rows.map { row in
+            RelayChannelEvent(
+                from: row.agentName ?? row.agentId ?? "unknown",
+                body: row.text ?? "",
+                channel: name,
+                threadId: row.threadId,
+                messageId: row.id,
+                timestamp: Self.date(from: row.createdAt),
+                rawEvent: nil
+            )
+        }
+        return Self.sortedOldestFirst(events)
+    }
+
+    /// Fetch the 1:1 DM history with a named agent, oldest-first. There is no
+    /// single-shot endpoint: the 1:1 conversation is resolved from
+    /// `GET /v1/dm/conversations` first, then its messages are fetched. No
+    /// existing conversation is not an error — it returns `[]`.
+    func dmHistory(with agent: String, limit: Int, before: String?, after: String? = nil) async throws -> [RelayChannelEvent] {
+        let target = HostedParticipantCore.stripSigil(agent)
+        let conversations: [DmConversationSummaryRow] = try await get("/v1/dm/conversations")
+        let match = conversations.first { conversation in
+            conversation.type == "1:1"
+                && (conversation.participants ?? []).contains { $0.agentName == target }
+        }
+        guard let conversation = match else { return [] }
+
+        let rows: [DmMessageRow] = try await get(
+            "/v1/dm/\(Self.encodePathSegment(conversation.id))/messages",
+            query: Self.historyQuery(limit: limit, before: before, after: after)
+        )
+        let events = rows.map { row in
+            RelayChannelEvent(
+                from: row.agentName ?? row.agentId ?? "unknown",
+                body: row.text ?? "",
+                channel: nil,
+                threadId: nil,
+                messageId: row.id,
+                timestamp: Self.date(from: row.createdAt),
+                rawEvent: nil
+            )
+        }
+        return Self.sortedOldestFirst(events)
+    }
+
+    // MARK: - Generic transport
+
+    func get<T: Decodable>(_ path: String, query: [URLQueryItem] = []) async throws -> T {
+        try await send(method: "GET", path: path, query: query, body: nil)
+    }
+
+    func post<T: Decodable>(_ path: String, body: some Encodable) async throws -> T {
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(body)
+        } catch {
+            throw RelayError.encodingFailed("Failed to encode request body for \(path): \(error)")
+        }
+        return try await send(method: "POST", path: path, query: [], body: data)
+    }
+
+    private func send<T: Decodable>(method: String, path: String, query: [URLQueryItem], body: Data?) async throws -> T {
+        var attempt = 0
+        while true {
+            let request = try makeRequest(method: method, path: path, query: query, body: body)
+            let result: (Data, URLResponse)
+            do {
+                result = try await session.data(for: request)
+            } catch {
+                if attempt < Self.maxRetries {
+                    attempt += 1
+                    try await Self.sleep(seconds: Self.backoffDelay(attempt: attempt))
+                    continue
+                }
+                throw RelayError.connectionFailed("Request to \(path) failed: \(error.localizedDescription)")
+            }
+            let (data, response) = result
+            guard let http = response as? HTTPURLResponse else {
+                throw RelayError.connectionFailed("Non-HTTP response from \(path)")
+            }
+            if Self.retryStatuses.contains(http.statusCode), attempt < Self.maxRetries {
+                attempt += 1
+                let delay = http.statusCode == 429
+                    ? (Self.retryAfterSeconds(http) ?? Self.backoffDelay(attempt: attempt))
+                    : Self.backoffDelay(attempt: attempt)
+                try await Self.sleep(seconds: delay)
+                continue
+            }
+            if http.statusCode == 204 {
+                throw RelayError.decodingFailed("Unexpected empty (204) response from \(path)")
+            }
+            return try Self.decodeEnvelope(data: data, statusCode: http.statusCode, path: path)
+        }
+    }
+
+    private func makeRequest(method: String, path: String, query: [URLQueryItem], body: Data?) throws -> URLRequest {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw RelayError.invalidBaseURL(baseURL.absoluteString)
+        }
+        var basePath = components.percentEncodedPath
+        if basePath.hasSuffix("/") { basePath.removeLast() }
+        // `path` arrives with its segments already percent-encoded.
+        components.percentEncodedPath = basePath + path
+        if !query.isEmpty {
+            components.queryItems = query
+        }
+        guard let url = components.url else {
+            throw RelayError.invalidBaseURL("\(baseURL.absoluteString)\(path)")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+        return request
+    }
+
+    // MARK: - Envelope
+
+    private struct RestEnvelope<T: Decodable>: Decodable {
+        let ok: Bool
+        let data: T?
+        let error: RestErrorPayload?
+    }
+
+    private struct RestErrorPayload: Decodable {
+        let code: String?
+        let message: String?
+    }
+
+    private struct ActionInvokeRequestBody: Encodable {
+        let input: JSONValue
+    }
+
+    private static func decodeEnvelope<T: Decodable>(data: Data, statusCode: Int, path: String) throws -> T {
+        let envelope: RestEnvelope<T>
+        do {
+            envelope = try JSONDecoder().decode(RestEnvelope<T>.self, from: data)
+        } catch {
+            if !(200...299).contains(statusCode) {
+                throw RelayError.protocolError(
+                    code: "http_\(statusCode)",
+                    message: "HTTP \(statusCode) from \(path)",
+                    retryable: statusCode == 429 || statusCode >= 500
+                )
+            }
+            throw RelayError.decodingFailed("Invalid API envelope from \(path): \(error)")
+        }
+        if envelope.ok {
+            guard let payload = envelope.data else {
+                throw RelayError.decodingFailed("API envelope from \(path) is missing data")
+            }
+            return payload
+        }
+        let code = envelope.error?.code ?? "unknown_error"
+        let message = envelope.error?.message ?? "Unknown error"
+        throw RelayError.protocolError(code: code, message: message, retryable: Self.isRetryable(code: code, statusCode: statusCode))
+    }
+
+    private static func isRetryable(code: String, statusCode: Int) -> Bool {
+        switch code {
+        case "rate_limited", "rate_limit_exceeded", "backpressure", "queue_overloaded":
+            return true
+        default:
+            return statusCode == 429 || statusCode >= 500
+        }
+    }
+
+    // MARK: - Retry / backoff
+
+    private static func backoffDelay(attempt: Int) -> TimeInterval {
+        // attempt is 1-based: 0.25s, 0.5s, plus up to 100ms of jitter.
+        baseBackoff * pow(2.0, Double(attempt - 1)) + Double.random(in: 0...0.1)
+    }
+
+    private static func retryAfterSeconds(_ response: HTTPURLResponse) -> TimeInterval? {
+        // Only the delta-seconds form is honored; an HTTP-date value falls
+        // back to the computed backoff.
+        guard let header = response.value(forHTTPHeaderField: "Retry-After"),
+              let seconds = TimeInterval(header), seconds >= 0 else {
+            return nil
+        }
+        return seconds
+    }
+
+    private static func sleep(seconds: TimeInterval) async throws {
+        try await Task.sleep(nanoseconds: UInt64(max(seconds, 0) * 1_000_000_000))
+    }
+
+    // MARK: - Helpers
+
+    /// RFC 3986 unreserved characters. Dots stay unescaped so dotted action
+    /// names (e.g. `deploy.staging`) keep their wire form in the path.
+    private static let pathSegmentAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    static func encodePathSegment(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? value
+    }
+
+    private static func historyQuery(limit: Int, before: String?, after: String?) -> [URLQueryItem] {
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let before {
+            items.append(URLQueryItem(name: "before", value: before))
+        }
+        if let after {
+            items.append(URLQueryItem(name: "after", value: after))
+        }
+        return items
+    }
+
+    /// Parse an ISO-8601 timestamp, tolerating fractional seconds. Mirrors
+    /// `HostedParticipantCore.date(from:)`, falling back to `Date()`.
+    private static func date(from timestamp: String?) -> Date {
+        guard let timestamp else { return Date() }
+        if let date = ISO8601DateFormatter().date(from: timestamp) {
+            return date
+        }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: timestamp) ?? Date()
+    }
+
+    /// Stable ascending sort by timestamp. `Swift.sort` does not document
+    /// stability, so ties are broken by the original wire position.
+    private static func sortedOldestFirst(_ events: [RelayChannelEvent]) -> [RelayChannelEvent] {
+        events.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.timestamp == rhs.element.timestamp {
+                    return lhs.offset < rhs.offset
+                }
+                return lhs.element.timestamp < rhs.element.timestamp
+            }
+            .map { $0.element }
+    }
+}

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
@@ -131,6 +131,20 @@ struct RelayRestClient: Sendable {
     private static let retryStatuses: Set<Int> = [429, 500, 502, 503, 504]
     private static let maxRetries = 2
     private static let baseBackoff: TimeInterval = 0.25
+    /// Upper bound on a honored `Retry-After` delay so a hostile or misconfigured
+    /// header cannot stall the client for minutes/hours.
+    private static let maxRetryAfter: TimeInterval = 10
+    /// Upper bound on a single `sleep(seconds:)` call. Keeps the UInt64
+    /// nanosecond conversion far from overflow and bounds any one wait; loops
+    /// that need a longer total wait simply iterate.
+    private static let maxSleepSeconds: TimeInterval = 60
+    /// Floor for a per-request `timeoutInterval` derived from a nearly
+    /// exhausted poll budget, so the final poll still gets a usable window.
+    private static let minRequestTimeout: TimeInterval = 1
+    /// Invocation statuses that mean "still in flight — keep polling". Any
+    /// status outside this set and the explicit terminal cases fails fast
+    /// instead of burning the remaining timeout budget.
+    private static let inFlightStatuses: Set<String> = ["invoked", "pending", "dispatched", "running"]
 
     init(baseURL: URL, token: String, session: URLSession = .shared) {
         self.baseURL = baseURL
@@ -146,6 +160,12 @@ struct RelayRestClient: Sendable {
     /// elapses. Polling keeps the call deterministic and independent of the
     /// realtime socket; listening for the WS `action.completed` event instead
     /// is a future latency optimization.
+    ///
+    /// The `timeout` budget bounds the whole call: the initial POST and each
+    /// poll GET carry a `timeoutInterval` derived from the remaining budget
+    /// (floored at `minRequestTimeout`), and each poll sleep is clamped to the
+    /// time left. Statuses outside `inFlightStatuses` that are not one of the
+    /// known terminal states fail fast with `action_failed`.
     func invokeAction(_ name: String, input: JSONValue, timeout: TimeInterval, pollInterval: TimeInterval) async throws -> JSONValue {
         let actionName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !actionName.isEmpty else {
@@ -155,14 +175,21 @@ struct RelayRestClient: Sendable {
         let encodedName = Self.encodePathSegment(actionName)
         let ack: ActionInvokeAck = try await post(
             "/v1/actions/\(encodedName)/invoke",
-            body: ActionInvokeRequestBody(input: input)
+            body: ActionInvokeRequestBody(input: input),
+            requestTimeout: max(timeout, Self.minRequestTimeout)
         )
         let encodedInvocation = Self.encodePathSegment(ack.invocationId)
-        let deadline = Date().addingTimeInterval(timeout)
+        // Monotonic deadline: `systemUptime` is immune to wall-clock jumps
+        // (NTP, manual changes) that could otherwise skew the timeout.
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
 
         while true {
+            // Bound the in-flight poll by the remaining budget so a hung
+            // request cannot run past the caller's timeout.
+            let remainingForRequest = deadline - ProcessInfo.processInfo.systemUptime
             let record: ActionInvocationRecord = try await get(
-                "/v1/actions/\(encodedName)/invocations/\(encodedInvocation)"
+                "/v1/actions/\(encodedName)/invocations/\(encodedInvocation)",
+                requestTimeout: max(remainingForRequest, Self.minRequestTimeout)
             )
             switch record.status {
             case "completed":
@@ -171,15 +198,26 @@ struct RelayRestClient: Sendable {
                 throw RelayError.protocolError(code: "action_failed", message: record.error ?? record.status, retryable: false)
             case "denied":
                 throw RelayError.protocolError(code: "action_denied", message: record.error ?? record.status, retryable: false)
-            default:
+            case let status where Self.inFlightStatuses.contains(status):
                 break
+            default:
+                // Unknown status (e.g. a server-side "cancelled"/"expired"
+                // added later): fail fast rather than polling out the budget.
+                throw RelayError.protocolError(
+                    code: "action_failed",
+                    message: record.error ?? "Action ended with unexpected status '\(record.status)'",
+                    retryable: false
+                )
             }
-            if Date() >= deadline {
+            let remaining = deadline - ProcessInfo.processInfo.systemUptime
+            if remaining <= 0 {
                 throw RelayError.timeout("Action '\(actionName)' did not complete within \(timeout)s (invocation \(ack.invocationId))")
             }
+            // Sleep is clamped to the remaining budget so a pollInterval larger
+            // than the timeout cannot extend the wait past the deadline.
             // Task.sleep throws CancellationError when the caller is cancelled,
             // which aborts the poll loop promptly.
-            try await Self.sleep(seconds: pollInterval)
+            try await Self.sleep(seconds: min(pollInterval, remaining))
         }
     }
 
@@ -217,7 +255,9 @@ struct RelayRestClient: Sendable {
         let conversations: [DmConversationSummaryRow] = try await get("/v1/dm/conversations")
         let match = conversations.first { conversation in
             conversation.type == "1:1"
-                && (conversation.participants ?? []).contains { $0.agentName == target }
+                && (conversation.participants ?? []).contains {
+                    $0.agentName?.caseInsensitiveCompare(target) == .orderedSame
+                }
         }
         guard let conversation = match else { return [] }
 
@@ -241,28 +281,36 @@ struct RelayRestClient: Sendable {
 
     // MARK: - Generic transport
 
-    func get<T: Decodable>(_ path: String, query: [URLQueryItem] = []) async throws -> T {
-        try await send(method: "GET", path: path, query: query, body: nil)
+    /// `requestTimeout`, when set, becomes the `URLRequest.timeoutInterval` of
+    /// each attempt (it bounds a single in-flight request, not the retries).
+    /// When `nil` the session's default applies.
+    func get<T: Decodable>(_ path: String, query: [URLQueryItem] = [], requestTimeout: TimeInterval? = nil) async throws -> T {
+        try await send(method: "GET", path: path, query: query, body: nil, requestTimeout: requestTimeout)
     }
 
-    func post<T: Decodable>(_ path: String, body: some Encodable) async throws -> T {
+    func post<T: Decodable>(_ path: String, body: some Encodable, requestTimeout: TimeInterval? = nil) async throws -> T {
         let data: Data
         do {
             data = try JSONEncoder().encode(body)
         } catch {
             throw RelayError.encodingFailed("Failed to encode request body for \(path): \(error)")
         }
-        return try await send(method: "POST", path: path, query: [], body: data)
+        return try await send(method: "POST", path: path, query: [], body: data, requestTimeout: requestTimeout)
     }
 
-    private func send<T: Decodable>(method: String, path: String, query: [URLQueryItem], body: Data?) async throws -> T {
+    private func send<T: Decodable>(method: String, path: String, query: [URLQueryItem], body: Data?, requestTimeout: TimeInterval? = nil) async throws -> T {
         var attempt = 0
         while true {
-            let request = try makeRequest(method: method, path: path, query: query, body: body)
+            let request = try makeRequest(method: method, path: path, query: query, body: body, requestTimeout: requestTimeout)
             let result: (Data, URLResponse)
             do {
                 result = try await session.data(for: request)
             } catch {
+                // Cancellation must propagate immediately: retrying wastes work
+                // and delays teardown when the caller has abandoned the request.
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    throw error
+                }
                 if attempt < Self.maxRetries {
                     attempt += 1
                     try await Self.sleep(seconds: Self.backoffDelay(attempt: attempt))
@@ -289,7 +337,7 @@ struct RelayRestClient: Sendable {
         }
     }
 
-    private func makeRequest(method: String, path: String, query: [URLQueryItem], body: Data?) throws -> URLRequest {
+    private func makeRequest(method: String, path: String, query: [URLQueryItem], body: Data?, requestTimeout: TimeInterval? = nil) throws -> URLRequest {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw RelayError.invalidBaseURL(baseURL.absoluteString)
         }
@@ -298,13 +346,20 @@ struct RelayRestClient: Sendable {
         // `path` arrives with its segments already percent-encoded.
         components.percentEncodedPath = basePath + path
         if !query.isEmpty {
-            components.queryItems = query
+            // Append rather than replace so query parameters already present in
+            // `baseURL` (versioning, routing, gateway keys) are preserved.
+            var mergedItems = components.queryItems ?? []
+            mergedItems.append(contentsOf: query)
+            components.queryItems = mergedItems
         }
         guard let url = components.url else {
             throw RelayError.invalidBaseURL("\(baseURL.absoluteString)\(path)")
         }
         var request = URLRequest(url: url)
         request.httpMethod = method
+        if let requestTimeout {
+            request.timeoutInterval = requestTimeout
+        }
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         if let body {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -373,16 +428,23 @@ struct RelayRestClient: Sendable {
 
     private static func retryAfterSeconds(_ response: HTTPURLResponse) -> TimeInterval? {
         // Only the delta-seconds form is honored; an HTTP-date value falls
-        // back to the computed backoff.
+        // back to the computed backoff. The delay is capped at `maxRetryAfter`.
         guard let header = response.value(forHTTPHeaderField: "Retry-After"),
               let seconds = TimeInterval(header), seconds >= 0 else {
             return nil
         }
-        return seconds
+        return min(seconds, maxRetryAfter)
     }
 
     private static func sleep(seconds: TimeInterval) async throws {
-        try await Task.sleep(nanoseconds: UInt64(max(seconds, 0) * 1_000_000_000))
+        // Non-positive (or NaN) delays only check for cancellation. A single
+        // sleep is capped at `maxSleepSeconds`, which keeps the UInt64
+        // nanosecond conversion from ever trapping on oversized values.
+        guard seconds > 0 else {
+            try Task.checkCancellation()
+            return
+        }
+        try await Task.sleep(nanoseconds: UInt64(min(seconds, maxSleepSeconds) * 1_000_000_000))
     }
 
     // MARK: - Helpers
@@ -408,16 +470,22 @@ struct RelayRestClient: Sendable {
         return items
     }
 
+    // Shared formatters: `ISO8601DateFormatter` is documented thread-safe, so
+    // read-only reuse across rows avoids one or two allocations per message.
+    private static let iso8601 = ISO8601DateFormatter()
+    private static let iso8601Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
     /// Parse an ISO-8601 timestamp, tolerating fractional seconds. Mirrors
     /// `HostedParticipantCore.date(from:)`, falling back to `Date()`.
     private static func date(from timestamp: String?) -> Date {
         guard let timestamp else { return Date() }
-        if let date = ISO8601DateFormatter().date(from: timestamp) {
-            return date
-        }
-        let fractional = ISO8601DateFormatter()
-        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return fractional.date(from: timestamp) ?? Date()
+        return iso8601.date(from: timestamp)
+            ?? iso8601Fractional.date(from: timestamp)
+            ?? Date()
     }
 
     /// Stable ascending sort by timestamp. `Swift.sort` does not document

--- a/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
+++ b/packages/sdk-swift/Sources/AgentRelaySDK/RelayRestClient.swift
@@ -134,10 +134,15 @@ struct RelayRestClient: Sendable {
     /// Upper bound on a honored `Retry-After` delay so a hostile or misconfigured
     /// header cannot stall the client for minutes/hours.
     private static let maxRetryAfter: TimeInterval = 10
-    /// Upper bound on a single `sleep(seconds:)` call. Keeps the UInt64
-    /// nanosecond conversion far from overflow and bounds any one wait; loops
-    /// that need a longer total wait simply iterate.
+    /// Upper bound on a single `Task.sleep` chunk inside `sleep(seconds:)`.
+    /// Longer waits iterate in chunks of this size, so the requested total is
+    /// preserved while each UInt64 nanosecond conversion stays far from
+    /// overflow.
     private static let maxSleepSeconds: TimeInterval = 60
+    /// Ceiling on the total wait a single `sleep(seconds:)` call honors
+    /// (24 hours). Guards against pathological inputs so the chunked loop
+    /// always terminates.
+    private static let maxTotalSleepSeconds: TimeInterval = 86_400
     /// Floor for a per-request `timeoutInterval` derived from a nearly
     /// exhausted poll budget, so the final poll still gets a usable window.
     private static let minRequestTimeout: TimeInterval = 1
@@ -437,14 +442,24 @@ struct RelayRestClient: Sendable {
     }
 
     private static func sleep(seconds: TimeInterval) async throws {
-        // Non-positive (or NaN) delays only check for cancellation. A single
-        // sleep is capped at `maxSleepSeconds`, which keeps the UInt64
-        // nanosecond conversion from ever trapping on oversized values.
+        // Non-positive (or NaN) delays only check for cancellation. Longer
+        // waits sleep in `maxSleepSeconds` chunks so the requested total is
+        // honored while each UInt64 nanosecond conversion stays far from
+        // overflow. The total is clamped to `maxTotalSleepSeconds` (also
+        // covering non-finite input, and values so large that floating-point
+        // subtraction of a chunk would stop making progress). Task.sleep
+        // throws CancellationError between chunks when the caller is
+        // cancelled.
         guard seconds > 0 else {
             try Task.checkCancellation()
             return
         }
-        try await Task.sleep(nanoseconds: UInt64(min(seconds, maxSleepSeconds) * 1_000_000_000))
+        var remaining = seconds.isFinite ? min(seconds, maxTotalSleepSeconds) : maxSleepSeconds
+        while remaining > 0 {
+            let chunk = min(remaining, maxSleepSeconds)
+            try await Task.sleep(nanoseconds: UInt64(chunk * 1_000_000_000))
+            remaining -= chunk
+        }
     }
 
     // MARK: - Helpers

--- a/packages/sdk-swift/Tests/AgentRelaySDKTests/RelayRestTests.swift
+++ b/packages/sdk-swift/Tests/AgentRelaySDKTests/RelayRestTests.swift
@@ -84,6 +84,31 @@ final class RelayRestTests: XCTestCase {
         }
     }
 
+    func testRetries429ThenSucceedsWithSecondRequest() async throws {
+        // First attempt is rate limited (Retry-After: 0 keeps the test fast);
+        // the retry succeeds and the caller only observes the success.
+        StubURLProtocol.store.enqueue(StubResponse(
+            statusCode: 429,
+            headers: ["Retry-After": "0"],
+            json: """
+            {"ok":false,"error":{"code":"rate_limited","message":"slow down"}}
+            """
+        ))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"conv_1","type":"1:1","name":null,
+             "participants":[{"agent_id":"agent_1","agent_name":"alice"}],
+             "last_message":null,"unread_count":0,"created_at":"2026-07-01T09:00:00Z"}
+        ]}
+        """))
+
+        let rows: [DmConversationSummaryRow] = try await client.get("/v1/dm/conversations")
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].id, "conv_1")
+        // Retry-and-recover really executed: two requests hit the wire.
+        XCTAssertEqual(StubURLProtocol.store.recordedRequests().count, 2)
+    }
+
     // MARK: - invokeAction
 
     func testInvokeActionHappyPathPollsUntilCompleted() async throws {
@@ -203,6 +228,64 @@ final class RelayRestTests: XCTestCase {
         } catch {
             XCTFail("Expected RelayError, got \(error)")
         }
+    }
+
+    func testInvokeActionUnknownTerminalStatusFailsFast() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_5","action_name":"demo.echo",
+         "input":{},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_5","action_name":"demo.echo",
+         "input":{},"output":null,"status":"cancelled","error":null,
+         "duration_ms":null,"completed_at":null}}
+        """))
+
+        do {
+            _ = try await client.invokeAction("demo.echo", input: .object([:]), timeout: 5, pollInterval: 0.01)
+            XCTFail("Expected RelayError")
+        } catch let error as RelayError {
+            guard case .protocolError(let code, let message, let retryable) = error else {
+                return XCTFail("Expected protocolError, got \(error)")
+            }
+            XCTAssertEqual(code, "action_failed")
+            XCTAssertTrue(message.contains("cancelled"), "message should name the unexpected status: \(message)")
+            XCTAssertFalse(retryable)
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+        // Fails fast: one invoke plus a single poll, no further polling.
+        XCTAssertEqual(StubURLProtocol.store.recordedRequests().count, 2)
+    }
+
+    func testInvokeActionTimeoutNotExtendedByLargePollInterval() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_6","action_name":"demo.echo",
+         "input":{},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        // Every poll keeps reporting "invoked".
+        StubURLProtocol.store.setFallback(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_6","action_name":"demo.echo",
+         "input":{},"output":null,"status":"invoked","error":null,
+         "duration_ms":null,"completed_at":null}}
+        """))
+
+        let start = ProcessInfo.processInfo.systemUptime
+        do {
+            _ = try await client.invokeAction("demo.echo", input: .object([:]), timeout: 0.2, pollInterval: 60)
+            XCTFail("Expected RelayError.timeout")
+        } catch let error as RelayError {
+            guard case .timeout = error else {
+                return XCTFail("Expected timeout, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+        // The poll sleep is clamped to the remaining budget, so the call must
+        // finish near the 0.2s timeout rather than after the 60s pollInterval.
+        // The bound is generous to absorb CI scheduling noise.
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+        XCTAssertLessThan(elapsed, 5)
     }
 
     // MARK: - channelHistory
@@ -485,9 +568,9 @@ final class StubResponseStore: @unchecked Sendable {
 final class StubURLProtocol: URLProtocol {
     static let store = StubResponseStore()
 
-    override class func canInit(with request: URLRequest) -> Bool { true }
+    static override func canInit(with request: URLRequest) -> Bool { true }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    static override func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         Self.store.record(

--- a/packages/sdk-swift/Tests/AgentRelaySDKTests/RelayRestTests.swift
+++ b/packages/sdk-swift/Tests/AgentRelaySDKTests/RelayRestTests.swift
@@ -1,0 +1,541 @@
+import Foundation
+import XCTest
+@testable import AgentRelaySDK
+
+/// Tests for the internal `RelayRestClient` that serves outbound action
+/// invocation and message history. All responses are scripted through a
+/// `URLProtocol` stub registered on an ephemeral `URLSession` — no network.
+final class RelayRestTests: XCTestCase {
+
+    private var client: RelayRestClient!
+
+    override func setUp() {
+        super.setUp()
+        StubURLProtocol.store.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        client = RelayRestClient(
+            baseURL: URL(string: "https://stub.test")!,
+            token: "at_test_token",
+            session: session
+        )
+    }
+
+    // MARK: - Envelope
+
+    func testEnvelopeOkDataDecodesAndSendsAgentBearerToken() async throws {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"conv_1","type":"1:1","name":null,
+             "participants":[{"agent_id":"agent_1","agent_name":"alice"}],
+             "last_message":null,"unread_count":0,"created_at":"2026-07-01T09:00:00Z"}
+        ]}
+        """))
+
+        let rows: [DmConversationSummaryRow] = try await client.get("/v1/dm/conversations")
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].id, "conv_1")
+        XCTAssertEqual(rows[0].type, "1:1")
+        XCTAssertEqual(rows[0].participants?.first?.agentName, "alice")
+
+        let request = try XCTUnwrap(StubURLProtocol.store.recordedRequests().first)
+        XCTAssertEqual(request.url?.path, "/v1/dm/conversations")
+        XCTAssertEqual(request.method, "GET")
+        XCTAssertEqual(request.headers["Authorization"], "Bearer at_test_token")
+    }
+
+    func testErrorEnvelopeMapsToProtocolError() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":false,"error":{"code":"not_found","message":"channel missing"}}
+        """))
+
+        do {
+            let _: [ChannelMessageRow] = try await client.get("/v1/channels/nope/messages")
+            XCTFail("Expected RelayError")
+        } catch let error as RelayError {
+            guard case .protocolError(let code, let message, let retryable) = error else {
+                return XCTFail("Expected protocolError, got \(error)")
+            }
+            XCTAssertEqual(code, "not_found")
+            XCTAssertEqual(message, "channel missing")
+            XCTAssertFalse(retryable)
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+    }
+
+    func testErrorEnvelopeRateLimitedIsRetryable() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":false,"error":{"code":"rate_limited","message":"slow down"}}
+        """))
+
+        do {
+            let _: [DmConversationSummaryRow] = try await client.get("/v1/dm/conversations")
+            XCTFail("Expected RelayError")
+        } catch let error as RelayError {
+            guard case .protocolError(let code, _, let retryable) = error else {
+                return XCTFail("Expected protocolError, got \(error)")
+            }
+            XCTAssertEqual(code, "rate_limited")
+            XCTAssertTrue(retryable)
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+    }
+
+    // MARK: - invokeAction
+
+    func testInvokeActionHappyPathPollsUntilCompleted() async throws {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_1","action_name":"demo.echo",
+         "handler_agent_id":"agent_9","input":{"message":"hi"},
+         "status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_1","action_name":"demo.echo",
+         "caller_id":"agent_1","caller_name":"alice","input":{"message":"hi"},
+         "output":null,"status":"invoked","error":null,
+         "duration_ms":null,"completed_at":null}}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_1","action_name":"demo.echo",
+         "caller_id":"agent_1","caller_name":"alice","input":{"message":"hi"},
+         "output":{"echo":"hi"},"status":"completed","error":null,
+         "duration_ms":42,"completed_at":"2026-07-01T10:00:01Z"}}
+        """))
+
+        let output = try await client.invokeAction(
+            "demo.echo",
+            input: .object(["message": .string("hi")]),
+            timeout: 5,
+            pollInterval: 0.01
+        )
+        XCTAssertEqual(output, .object(["echo": .string("hi")]))
+
+        let requests = StubURLProtocol.store.recordedRequests()
+        XCTAssertEqual(requests.count, 3)
+        // Dots in the action name are preserved in the request path.
+        XCTAssertEqual(requests[0].url?.path, "/v1/actions/demo.echo/invoke")
+        XCTAssertEqual(requests[0].method, "POST")
+        XCTAssertEqual(requests[0].headers["Content-Type"], "application/json")
+        XCTAssertEqual(requests[1].url?.path, "/v1/actions/demo.echo/invocations/inv_1")
+        XCTAssertEqual(requests[1].method, "GET")
+        XCTAssertEqual(requests[2].url?.path, "/v1/actions/demo.echo/invocations/inv_1")
+
+        // The invoke body wraps the payload under "input".
+        let body = try XCTUnwrap(requests[0].body)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: body)
+        XCTAssertEqual(decoded, .object(["input": .object(["message": .string("hi")])]))
+    }
+
+    func testInvokeActionFailedStatusThrowsActionFailed() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_2","action_name":"demo.echo",
+         "input":{},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_2","action_name":"demo.echo",
+         "caller_id":null,"input":{},"output":null,"status":"failed",
+         "error":"boom","duration_ms":7,"completed_at":"2026-07-01T10:00:01Z"}}
+        """))
+
+        do {
+            _ = try await client.invokeAction("demo.echo", input: .object([:]), timeout: 5, pollInterval: 0.01)
+            XCTFail("Expected RelayError")
+        } catch let error as RelayError {
+            guard case .protocolError(let code, let message, let retryable) = error else {
+                return XCTFail("Expected protocolError, got \(error)")
+            }
+            XCTAssertEqual(code, "action_failed")
+            XCTAssertEqual(message, "boom")
+            XCTAssertFalse(retryable)
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+    }
+
+    func testInvokeActionDeniedStatusThrowsActionDenied() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_3","action_name":"demo.echo",
+         "input":{},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_3","action_name":"demo.echo",
+         "input":{},"output":null,"status":"denied","error":null,
+         "duration_ms":null,"completed_at":null}}
+        """))
+
+        do {
+            _ = try await client.invokeAction("demo.echo", input: .object([:]), timeout: 5, pollInterval: 0.01)
+            XCTFail("Expected RelayError")
+        } catch let error as RelayError {
+            guard case .protocolError(let code, let message, _) = error else {
+                return XCTFail("Expected protocolError, got \(error)")
+            }
+            XCTAssertEqual(code, "action_denied")
+            // With a null wire error the status is used as the message.
+            XCTAssertEqual(message, "denied")
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+    }
+
+    func testInvokeActionTimesOutWhileInvoked() async {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_4","action_name":"demo.echo",
+         "input":{},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}}
+        """))
+        // Every poll keeps reporting "invoked".
+        StubURLProtocol.store.setFallback(StubResponse(json: """
+        {"ok":true,"data":{"invocation_id":"inv_4","action_name":"demo.echo",
+         "input":{},"output":null,"status":"invoked","error":null,
+         "duration_ms":null,"completed_at":null}}
+        """))
+
+        do {
+            _ = try await client.invokeAction("demo.echo", input: .object([:]), timeout: 0.05, pollInterval: 0.01)
+            XCTFail("Expected RelayError.timeout")
+        } catch let error as RelayError {
+            guard case .timeout = error else {
+                return XCTFail("Expected timeout, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected RelayError, got \(error)")
+        }
+    }
+
+    // MARK: - channelHistory
+
+    func testChannelHistoryStripsHashMapsRowsAndSortsAscending() async throws {
+        // Newest-first on the wire; the client must return oldest-first.
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"msg_3","channel_id":"ch_1","agent_id":"agent_2","agent_name":"bob",
+             "agent_type":"agent","text":"newest","thread_id":null,
+             "created_at":"2026-07-01T10:00:02Z"},
+            {"id":"msg_2","channel_id":"ch_1","agent_id":"agent_1",
+             "text":"middle","thread_id":"msg_1",
+             "created_at":"2026-07-01T10:00:01Z"},
+            {"id":"msg_1","channel_id":"ch_1","agent_id":"agent_1","agent_name":"alice",
+             "agent_type":"human","text":"oldest","thread_id":null,
+             "created_at":"2026-07-01T10:00:00.500Z"}
+        ]}
+        """))
+
+        let events = try await client.channelHistory(channel: "#general", limit: 3, before: "msg_9")
+
+        // '#' is stripped from the request path; pagination goes via query.
+        let request = try XCTUnwrap(StubURLProtocol.store.recordedRequests().first)
+        XCTAssertEqual(request.url?.path, "/v1/channels/general/messages")
+        let components = try XCTUnwrap(request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) })
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(query["limit"], "3")
+        XCTAssertEqual(query["before"], "msg_9")
+
+        XCTAssertEqual(events.map(\.messageId), ["msg_1", "msg_2", "msg_3"])
+        XCTAssertEqual(events.map(\.body), ["oldest", "middle", "newest"])
+        XCTAssertEqual(events[2].from, "bob")
+        // Missing agent_name falls back to agent_id.
+        XCTAssertEqual(events[1].from, "agent_1")
+        XCTAssertEqual(events[1].threadId, "msg_1")
+        XCTAssertEqual(events[0].channel, "general")
+        XCTAssertNil(events[0].rawEvent)
+
+        let formatter = ISO8601DateFormatter()
+        XCTAssertEqual(events[2].timestamp, formatter.date(from: "2026-07-01T10:00:02Z"))
+        // Fractional-second timestamps are tolerated.
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(events[0].timestamp, fractional.date(from: "2026-07-01T10:00:00.500Z"))
+    }
+
+    func testChannelHistoryStableSortKeepsWireOrderOnTies() async throws {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"msg_a","channel_id":"ch_1","agent_id":"agent_1","agent_name":"alice",
+             "text":"first on wire","created_at":"2026-07-01T10:00:00Z"},
+            {"id":"msg_b","channel_id":"ch_1","agent_id":"agent_1","agent_name":"alice",
+             "text":"second on wire","created_at":"2026-07-01T10:00:00Z"}
+        ]}
+        """))
+
+        let events = try await client.channelHistory(channel: "general", limit: 2, before: nil)
+        XCTAssertEqual(events.map(\.messageId), ["msg_a", "msg_b"])
+    }
+
+    // MARK: - dmHistory
+
+    func testDmHistoryResolvesOneToOneConversationAndMapsRows() async throws {
+        // The group conversation containing bob must be ignored; only the
+        // 1:1 whose participants include bob resolves.
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"conv_group","type":"group","name":"team",
+             "participants":[{"agent_id":"agent_1","agent_name":"alice"},
+                             {"agent_id":"agent_2","agent_name":"bob"},
+                             {"agent_id":"agent_3","agent_name":"carol"}],
+             "last_message":null,"unread_count":0,"created_at":"2026-07-01T08:00:00Z"},
+            {"id":"conv_11","type":"1:1","name":null,
+             "participants":[{"agent_id":"agent_1","agent_name":"alice"},
+                             {"agent_id":"agent_2","agent_name":"bob"}],
+             "last_message":null,"unread_count":0,"created_at":"2026-07-01T09:00:00Z"}
+        ]}
+        """))
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"dm_2","agent_id":"agent_2","agent_name":"bob","agent_type":"agent",
+             "text":"newer","created_at":"2026-07-01T09:31:00Z"},
+            {"id":"dm_1","agent_id":"agent_1","agent_name":"alice","agent_type":"agent",
+             "text":"older","created_at":"2026-07-01T09:30:00Z"}
+        ]}
+        """))
+
+        let events = try await client.dmHistory(with: "@bob", limit: 10, before: nil)
+
+        let requests = StubURLProtocol.store.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[0].url?.path, "/v1/dm/conversations")
+        XCTAssertEqual(requests[1].url?.path, "/v1/dm/conv_11/messages")
+
+        XCTAssertEqual(events.map(\.messageId), ["dm_1", "dm_2"])
+        XCTAssertEqual(events.map(\.from), ["alice", "bob"])
+        XCTAssertEqual(events.map(\.body), ["older", "newer"])
+        // DM history rows have no channel and no thread.
+        XCTAssertNil(events[0].channel)
+        XCTAssertNil(events[0].threadId)
+    }
+
+    func testDmHistoryWithoutConversationReturnsEmptyWithoutSecondRequest() async throws {
+        StubURLProtocol.store.enqueue(StubResponse(json: """
+        {"ok":true,"data":[
+            {"id":"conv_group","type":"group","name":"team",
+             "participants":[{"agent_id":"agent_1","agent_name":"alice"},
+                             {"agent_id":"agent_2","agent_name":"bob"}],
+             "last_message":null,"unread_count":0,"created_at":"2026-07-01T08:00:00Z"}
+        ]}
+        """))
+
+        let events = try await client.dmHistory(with: "bob", limit: 10, before: nil)
+        XCTAssertEqual(events.count, 0)
+        XCTAssertEqual(StubURLProtocol.store.recordedRequests().count, 1)
+    }
+
+    // MARK: - Pure row decoding
+
+    func testActionInvokeAckDecodes() throws {
+        let json = """
+        {"invocation_id":"inv_1","action_name":"demo.echo","handler_agent_id":"agent_9",
+         "input":{"message":"hi"},"status":"invoked","created_at":"2026-07-01T10:00:00Z"}
+        """
+        let ack = try JSONDecoder().decode(ActionInvokeAck.self, from: Data(json.utf8))
+        XCTAssertEqual(ack.invocationId, "inv_1")
+        XCTAssertEqual(ack.actionName, "demo.echo")
+        XCTAssertEqual(ack.handlerAgentId, "agent_9")
+        XCTAssertEqual(ack.input, .object(["message": .string("hi")]))
+        XCTAssertEqual(ack.status, "invoked")
+        XCTAssertEqual(ack.createdAt, "2026-07-01T10:00:00Z")
+    }
+
+    func testActionInvocationRecordDecodes() throws {
+        let json = """
+        {"invocation_id":"inv_1","action_name":"demo.echo","caller_id":"agent_1",
+         "caller_name":"alice","input":{"message":"hi"},"output":{"echo":"hi"},
+         "status":"completed","error":null,"duration_ms":42,
+         "completed_at":"2026-07-01T10:00:01Z"}
+        """
+        let record = try JSONDecoder().decode(ActionInvocationRecord.self, from: Data(json.utf8))
+        XCTAssertEqual(record.invocationId, "inv_1")
+        XCTAssertEqual(record.callerName, "alice")
+        XCTAssertEqual(record.output, .object(["echo": .string("hi")]))
+        XCTAssertEqual(record.status, "completed")
+        XCTAssertNil(record.error)
+        XCTAssertEqual(record.durationMs, 42)
+        XCTAssertEqual(record.completedAt, "2026-07-01T10:00:01Z")
+    }
+
+    func testChannelMessageRowDecodesAndIgnoresUnknownFields() throws {
+        let json = """
+        {"id":"msg_1","channel_id":"ch_1","agent_id":"agent_1","agent_name":"alice",
+         "agent_type":"human","text":"hello","thread_id":"msg_0",
+         "created_at":"2026-07-01T10:00:00Z","blocks":null,"workspace_id":"ws_1"}
+        """
+        let row = try JSONDecoder().decode(ChannelMessageRow.self, from: Data(json.utf8))
+        XCTAssertEqual(row.id, "msg_1")
+        XCTAssertEqual(row.channelId, "ch_1")
+        XCTAssertEqual(row.agentId, "agent_1")
+        XCTAssertEqual(row.agentName, "alice")
+        XCTAssertEqual(row.agentType, "human")
+        XCTAssertEqual(row.text, "hello")
+        XCTAssertEqual(row.threadId, "msg_0")
+        XCTAssertEqual(row.createdAt, "2026-07-01T10:00:00Z")
+    }
+
+    func testDmConversationSummaryRowDecodes() throws {
+        let json = """
+        {"id":"conv_1","type":"1:1","name":null,
+         "participants":[{"agent_id":"agent_1","agent_name":"alice"},
+                         {"agent_id":"agent_2","agent_name":"bob"}],
+         "last_message":{"id":"dm_9","text":"latest","agent_id":"agent_2",
+                         "created_at":"2026-07-01T09:59:00Z"},
+         "unread_count":2,"created_at":"2026-07-01T09:00:00Z"}
+        """
+        let row = try JSONDecoder().decode(DmConversationSummaryRow.self, from: Data(json.utf8))
+        XCTAssertEqual(row.id, "conv_1")
+        XCTAssertEqual(row.type, "1:1")
+        XCTAssertEqual(row.participants?.count, 2)
+        XCTAssertEqual(row.participants?[1].agentId, "agent_2")
+        XCTAssertEqual(row.participants?[1].agentName, "bob")
+    }
+
+    func testDmMessageRowDecodes() throws {
+        let json = """
+        {"id":"dm_1","agent_id":"agent_2","agent_name":"bob","agent_type":"agent",
+         "text":"hi","injection_mode":"wait","created_at":"2026-07-01T09:30:00Z"}
+        """
+        let row = try JSONDecoder().decode(DmMessageRow.self, from: Data(json.utf8))
+        XCTAssertEqual(row.id, "dm_1")
+        XCTAssertEqual(row.agentId, "agent_2")
+        XCTAssertEqual(row.agentName, "bob")
+        XCTAssertEqual(row.agentType, "agent")
+        XCTAssertEqual(row.text, "hi")
+        XCTAssertEqual(row.createdAt, "2026-07-01T09:30:00Z")
+    }
+}
+
+// MARK: - URLProtocol stub
+
+/// A scripted HTTP response for `StubURLProtocol`.
+struct StubResponse {
+    let statusCode: Int
+    let headers: [String: String]
+    let body: Data
+
+    init(statusCode: Int = 200, headers: [String: String] = [:], json: String) {
+        self.statusCode = statusCode
+        var merged = ["Content-Type": "application/json"]
+        for (key, value) in headers {
+            merged[key] = value
+        }
+        self.headers = merged
+        self.body = Data(json.utf8)
+    }
+}
+
+/// A request as observed by the stub, with the body materialized (URLSession
+/// exposes outbound bodies to `URLProtocol` as a stream).
+struct RecordedRequest {
+    let url: URL?
+    let method: String?
+    let headers: [String: String]
+    let body: Data?
+}
+
+/// Thread-safe FIFO script of responses plus recorded requests. Responses are
+/// consumed in order; when the queue is empty the optional fallback response
+/// is served repeatedly (used for poll-forever scenarios).
+final class StubResponseStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queue: [StubResponse] = []
+    private var fallback: StubResponse?
+    private var requests: [RecordedRequest] = []
+
+    func enqueue(_ response: StubResponse) {
+        lock.lock()
+        defer { lock.unlock() }
+        queue.append(response)
+    }
+
+    func setFallback(_ response: StubResponse) {
+        lock.lock()
+        defer { lock.unlock() }
+        fallback = response
+    }
+
+    func next() -> StubResponse? {
+        lock.lock()
+        defer { lock.unlock() }
+        if queue.isEmpty {
+            return fallback
+        }
+        return queue.removeFirst()
+    }
+
+    func record(_ request: RecordedRequest) {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+    }
+
+    func recordedRequests() -> [RecordedRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        queue.removeAll()
+        fallback = nil
+        requests.removeAll()
+    }
+}
+
+final class StubURLProtocol: URLProtocol {
+    static let store = StubResponseStore()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.store.record(
+            RecordedRequest(
+                url: request.url,
+                method: request.httpMethod,
+                headers: request.allHTTPHeaderFields ?? [:],
+                body: Self.bodyData(of: request)
+            )
+        )
+
+        guard let stub = Self.store.next(), let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(of request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
## Summary

Closes the two gaps that block thin Swift clients (first consumer: the Chief macOS app) from fulfilling the relay protocol — the `AgentRelaySDK` facade could serve actions and stream live events, but could not *invoke* another agent's action or fetch message history for scrollback.

`AgentClient` gains three methods, served directly over the hosted REST API with the agent token:

- `invokeAction(_:input:timeout:pollInterval:)` — `POST /v1/actions/{name}/invoke`, then polls the invocation record until `completed` (returns `output`), `failed`/`denied` (throws `RelayError.protocolError` with code `action_failed`/`action_denied`), or timeout (`RelayError.timeout`). Polling is deterministic and works without the realtime socket; the WS `action.completed` event path is noted as a future latency optimization.
- `channelHistory(_:limit:before:)` — `GET /v1/channels/{name}/messages`, sigil-normalized channel names, rows mapped to oldest-first `RelayChannelEvent`s (stable timestamp sort).
- `dmHistory(with:limit:before:)` — resolves the 1:1 conversation via `GET /v1/dm/conversations` (there is no single-shot endpoint), then reads `/v1/dm/{id}/messages`; returns `[]` when no conversation exists yet.

Implementation is a new internal `RelayRestClient` (URLSession-injectable): `{ok, data, error}` envelope decode, snake_case wire structs, retries on 429/500/502/503/504 with exponential backoff + jitter and `Retry-After` support, and `RelayError` mapping (no new error types). Wire shapes were verified against two authoritative references: the Rust broker's relaycast client (`crates/broker/src/relaycast/`) and the published `@relaycast/sdk` 5.1.0 JS client. No public init signatures changed; two `private static` name-normalization helpers were widened to internal for reuse.

Also updates the sdk-swift README (API index + usage section) and adds a CHANGELOG `[Unreleased]` entry.

## Test Plan

- [x] Tests added/updated — 14 new `RelayRestTests` using a `URLProtocol` stub (no network): envelope ok/error decode, invoke happy path (exact poll count), failure and timeout paths, `#`-stripping in request paths, snake_case row decode, ascending sort, DM conversation resolve (1:1 match, group ignored, no-match → `[]`)
- [ ] Manual testing completed — **needs a Mac**: this was authored in a Linux container with no Swift toolchain. Please run `cd packages/sdk-swift && swift test` (verifies compile + all tests, including the pre-existing suites against the `private static` → `static` visibility change)

## Screenshots

N/A (SDK-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvFT5BtnEoYzXvYLS3RiYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvFT5BtnEoYzXvYLS3RiYe)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

