### PR TITLE
fix: run relay-pty in default cargo commands; trim broker deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ version = 4
 name = "agent-relay-broker"
 version = "3.0.0"
 dependencies = [
- "alacritty_terminal",
  "anyhow",
  "axum",
  "base64 0.22.1",
@@ -20,8 +19,6 @@ dependencies = [
  "httpmock",
  "libc",
  "nix 0.30.1",
- "parking_lot",
- "portable-pty",
  "rand 0.8.5",
  "regex",
  "relay-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = ["crates/broker", "crates/relay-pty"]
-default-members = ["crates/broker"]
+default-members = ["crates/broker", "crates/relay-pty"]
 resolver = "2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -19,8 +19,6 @@ chrono = { version = "0.4", features = ["serde", "clock"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6.0"
 hostname = "0.4"
-parking_lot = "0.12"
-portable-pty = "0.8"
 rand = "0.8"
 relay-pty = { path = "../relay-pty" }
 regex = "1.11"
@@ -41,7 +39,6 @@ futures-lite = "2.6"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 uuid = { version = "1.15", features = ["v4", "serde"] }
 urlencoding = "2.1"
-alacritty_terminal = "0.26"
 base64 = "0.22"
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 

--- a/crates/relay-pty/src/utf8_stream.rs
+++ b/crates/relay-pty/src/utf8_stream.rs
@@ -24,6 +24,7 @@ impl Utf8StreamDecoder {
     /// Decode an incoming byte chunk, returning all complete UTF-8 text
     /// available. Any trailing bytes that form an incomplete codepoint are
     /// retained for the next call.
+    #[must_use]
     pub fn decode(&mut self, bytes: &[u8]) -> String {
         if bytes.is_empty() && self.pending.is_empty() {
             return String::new();
@@ -71,6 +72,7 @@ impl Utf8StreamDecoder {
 
     /// Drain any remaining buffered bytes, emitting `U+FFFD` for each
     /// incomplete sequence. Call once no more bytes will arrive.
+    #[must_use]
     pub fn flush(&mut self) -> String {
         if self.pending.is_empty() {
             return String::new();


### PR DESCRIPTION
## Summary

Follow-up addressing the review comments on #1231, which merged before the fixes landed:

- **`crates/relay-pty` added to workspace `default-members`** — CI runs plain `cargo test`/`cargo test --release` (`.github/workflows/rust-ci.yml`), which only covers default members, so the crate's 119 tests were invisible to CI. Now root-level `cargo test`/`cargo clippy` cover both crates.
- **Removed the broker's direct `portable-pty`, `alacritty_terminal`, and `parking_lot` dependencies** — zero remaining direct usages after the PTY kernel moved to relay-pty (verified by grep; `regex` stays, still used by `redact.rs`, `node_control.rs`, `pty_worker.rs`). Lockfile updated accordingly.
- **`#[must_use]` on `Utf8StreamDecoder::decode`/`flush`** — both drain the internal pending buffer, so a caller that drops the returned `String` silently loses decoded output; now the compiler warns.

## Test Plan

- [x] Tests added/updated — no new behavior; `cargo test -p relay-pty` 119 passed, `cargo test -p agent-relay-broker --lib` 713 passed after the dep removal
- [x] Manual testing completed — full `cargo build` clean; with the `default-members` change, plain root `cargo test` (what CI runs) now includes relay-pty

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THtQJPnNH2rFizqRaN2Yok

---
_Generated by [Claude Code](https://claude.ai/code/session_01THtQJPnNH2rFizqRaN2Yok)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

