### PR TITLE
Prod smoke: node-providers synthetic monitoring

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,62 @@
+name: Prod Smoke
+
+# Synthetic monitoring of the DEPLOYED node-providers engine (cast.agentrelay.com
+# by default). Builds the relay CLI + broker, then brings a real node online and
+# drives a node-addressed invoke round-trip against whatever is live. This is not
+# a merge gate — it never runs on pull_request. Per-PR coverage of the same model
+# is the local-engine matrix in tests/e2e/fleet (workflow: Fleet E2E).
+#
+# No repository secrets are required: the smoke self-mints a throwaway workspace
+# on the target engine (POST /v1/workspaces, no auth) and deletes it on teardown.
+on:
+  schedule:
+    # Nightly at 08:00 UTC.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Engine base URL to smoke (defaults to cast.agentrelay.com)'
+        required: false
+        default: 'https://cast.agentrelay.com'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  AGENT_RELAY_TELEMETRY_DISABLED: 1
+
+jobs:
+  prod-smoke:
+    name: Node-providers prod smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout relay
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build relay (CLI + fleet + harness-driver)
+        run: |
+          npm ci
+          npm run build:core
+
+      - name: Build agent-relay-broker
+        run: cargo build --release --bin agent-relay-broker
+
+      - name: Run prod smoke
+        env:
+          BROKER_BINARY_PATH: ${{ github.workspace }}/target/release/agent-relay-broker
+          PROD_SMOKE_BASE_URL: ${{ github.event.inputs.base_url || 'https://cast.agentrelay.com' }}
+        run: npm run smoke:prod

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "evals": "npm run evals:compile && node scripts/evals/run-relay-evals.mjs",
     "evals:list": "npm run evals:compile && node scripts/evals/run-relay-evals.mjs --list",
     "evals:offline": "npm run evals:compile && node scripts/evals/run-relay-evals.mjs --mode offline",
-    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "smoke:prod": "node tests/e2e/prod-smoke/prod-smoke.mjs"
   },
   "author": "AgentWorkforce <hello@agentrelay.com>",
   "license": "Apache-2.0",

--- a/tests/e2e/prod-smoke/README.md
+++ b/tests/e2e/prod-smoke/README.md
@@ -1,0 +1,56 @@
+# Production node-providers smoke
+
+Synthetic monitoring for the node-providers model against a **deployed** engine
+(`cast.agentrelay.com` by default). It self-mints a throwaway workspace, so no
+credentials are configured and no real workspace is touched.
+
+`prod-smoke.mjs` drives, in one process:
+
+1. **create** a throwaway workspace (`POST /v1/workspaces`, no auth) — its id is
+   logged immediately so a crashed run is manually recoverable.
+2. **`node up`** — a Rust broker provider + a TS capability provider
+   (`agent-relay.ts`, one `hello-prod` action) attach to one node, hermetically
+   (ambient `RELAY_*` / `AGENT_RELAY_*` never inherited; own `HOME`, project dir,
+   state dir; broker self-mints the node token from the workspace key).
+3. **both providers online** — `GET /v1/nodes` shows the node `online` +
+   `handlers_live`, aggregating the broker's `capacity` (`spawn:*`, `release`) and
+   the TS provider's `action` (`hello-prod`) with the correct `kind`s.
+4. **remote invoke** — a second, HTTP-only caller (agent token) invokes the
+   node-addressed action and polls it to `completed` with a **byte-exact echo**
+   round-trip.
+5. **`ctx.relay.sendMessage`** — the handler posts to a channel via the node-token
+   message route, attributed to a workspace agent; asserted from channel history.
+6. **teardown liveness** — stopping `node up` drops the node `offline`
+   (per-provider liveness).
+7. **delete** the throwaway workspace.
+
+Teardown (stop node, delete workspace) runs on success, failure, and `SIGINT` /
+`SIGTERM`. All printed output is structurally redacted (the shipped
+`redactSecrets`); intentionally-shown tokens are truncated to a prefix.
+
+## Relationship to `tests/e2e/fleet`
+
+`tests/e2e/fleet` is the **per-PR** matrix — it boots a **local** engine as a
+merge gate. This smoke targets **already-deployed** infrastructure on a schedule
+and is **not** a merge gate. Real broker / `node up` runtimes are sanctioned here
+(a dedicated workflow), never in the unit suites (repo rule).
+
+## Running
+
+```bash
+npm run build:core                               # relay CLI + fleet + harness-driver
+cargo build --release --bin agent-relay-broker   # broker
+npm run smoke:prod                               # smoke cast.agentrelay.com
+```
+
+Params (env):
+
+| Var                     | Default                       | Meaning                                |
+| ----------------------- | ----------------------------- | -------------------------------------- |
+| `PROD_SMOKE_BASE_URL`   | `https://cast.agentrelay.com` | Engine to smoke                        |
+| `PROD_SMOKE_TIMEOUT_MS` | `60000`                       | Wait for the node to come fully online |
+| `BROKER_BINARY_PATH`    | `target/release` build        | Broker binary override                 |
+
+Exit code is `0` on all checks passing, non-zero otherwise. The
+`Prod Smoke` GitHub Actions workflow (nightly + `workflow_dispatch`) builds the
+CLI + broker and runs it.

--- a/tests/e2e/prod-smoke/agent-relay.ts
+++ b/tests/e2e/prod-smoke/agent-relay.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { action, defineNode } from '@agent-relay/fleet';
+
+/**
+ * Node definition served by the production smoke's `node up`.
+ *
+ * A single `hello-prod` action so the smoke stays minimal — no `spawn:*` shadow
+ * (the broker provider advertises native spawn capacity on its own). The action:
+ *   - echoes its `echo` input verbatim (the byte-exact round-trip assertion), and
+ *   - when given `notify`, posts a channel message through `ctx.relay.sendMessage`
+ *     (the node-token message route), attributed to the `from` agent.
+ */
+export default defineNode({
+  name: 'prod-smoke-node',
+  capabilities: {
+    'hello-prod': action(
+      {
+        input: z
+          .object({
+            echo: z.unknown().optional(),
+            notify: z.object({ channel: z.string(), from: z.string() }).optional(),
+          })
+          .passthrough(),
+      },
+      async (input, ctx) => {
+        if (input.notify) {
+          await ctx.relay.sendMessage({
+            from: input.notify.from,
+            to: `#${input.notify.channel}`,
+            text: `hello-prod ran on node "${ctx.node.name}" (invocation ${ctx.invocationId ?? 'n/a'}); echo=${JSON.stringify(input.echo ?? null)}`,
+          });
+        }
+        return { ok: true, echo: input.echo ?? null };
+      }
+    ),
+  },
+});

--- a/tests/e2e/prod-smoke/prod-smoke.mjs
+++ b/tests/e2e/prod-smoke/prod-smoke.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Production node-providers smoke — synthetic monitoring of the deployed engine.
+ *
+ * Drives the node-providers model end to end against a LIVE, already-deployed
+ * engine (default `cast.agentrelay.com`), self-minting a throwaway workspace so
+ * no repository secrets are required and no real workspace is touched:
+ *
+ *   1. create a throwaway workspace
+ *   2. `node up` — Rust broker provider + TS capability provider on one node
+ *   3. GET /v1/nodes shows the node online with BOTH providers and correct kinds
+ *   4. a second, HTTP-only caller invokes the node-addressed action to completion
+ *      with a byte-exact echo round-trip
+ *   5. the handler's `ctx.relay.sendMessage` lands in channel history (node-token
+ *      message route)
+ *   6. on `node up` teardown the node goes offline (per-provider liveness)
+ *   7. the throwaway workspace is deleted
+ *
+ * Unlike `tests/e2e/fleet` (which boots a local engine as a per-PR gate), this
+ * runs against whatever is deployed and is scheduled, not a merge gate. It fails
+ * loudly (non-zero exit) and always tears down — the workspace id is logged so a
+ * failed auto-cleanup is manually recoverable.
+ *
+ * Run: `npm run smoke:prod` (after `npm run build:core` + a broker build).
+ * Params (env): PROD_SMOKE_BASE_URL, PROD_SMOKE_TIMEOUT_MS, BROKER_BINARY_PATH.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+const CLI_ENTRY = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'index.js');
+const NODE_DEF = path.join(HERE, 'agent-relay.ts');
+const REDACT_MODULE = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'lib', 'redact.js');
+
+const BASE_URL = (process.env.PROD_SMOKE_BASE_URL ?? 'https://cast.agentrelay.com').replace(/\/+$/, '');
+const ONLINE_TIMEOUT_MS = Number(process.env.PROD_SMOKE_TIMEOUT_MS ?? 60_000);
+const NODE_NAME = 'prod-smoke-node';
+const ACTION = 'hello-prod';
+const CHANNEL = 'prod-smoke';
+
+// ---------------------------------------------------------------------------
+// Output — every printed value passes through the shipped structural redactor so
+// a credential-named field can never surface, plus a prefix helper for the few
+// tokens we intentionally show as proof-of-mint.
+// ---------------------------------------------------------------------------
+/** @type {<T>(v: T) => T} */
+let redactSecrets = (v) => v;
+
+const stamp = () => new Date().toISOString().slice(11, 23);
+/** @param {string} msg */
+const log = (msg) => console.log(`[${stamp()}] ${msg}`);
+/** @param {string} msg */
+const fail = (msg) => console.error(`[${stamp()}] ✗ ${msg}`);
+/** @param {string} msg */
+const pass = (msg) => console.log(`[${stamp()}] ✓ ${msg}`);
+/** Show only a token's prefix (e.g. `rk_live_5874…`). @param {string} tok */
+const prefix = (tok, n = 12) =>
+  typeof tok === 'string' && tok.length > n ? `${tok.slice(0, n)}…` : '[redacted]';
+/** Pretty-print a response body with credential fields structurally redacted. */
+const show = (body) => JSON.stringify(redactSecrets(body), null, 2);
+
+class SmokeError extends Error {}
+/** @param {unknown} cond @param {string} msg */
+function assert(cond, msg) {
+  if (!cond) throw new SmokeError(msg);
+}
+
+/** Canonical JSON (recursively key-sorted) for order-insensitive value equality. */
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * HTTP against the deployed engine.
+ * @param {string} method
+ * @param {string} pathname
+ * @param {{ token?: string; body?: unknown }} [opts]
+ * @returns {Promise<{ status: number; body: any }>}
+ */
+async function req(method, pathname, opts = {}) {
+  const headers = { 'content-type': 'application/json' };
+  if (opts.token) headers.authorization = `Bearer ${opts.token}`;
+  const res = await fetch(`${BASE_URL}${pathname}`, {
+    method,
+    headers,
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { _raw: text };
+  }
+  return { status: res.status, body };
+}
+
+/**
+ * Poll `fn` until it returns a truthy value or the deadline elapses.
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ timeoutMs: number; intervalMs?: number; desc: string }} o
+ * @returns {Promise<T>}
+ */
+async function pollUntil(fn, o) {
+  const deadline = Date.now() + o.timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = await fn();
+    if (last) return last;
+    await sleep(o.intervalMs ?? 1000);
+  }
+  throw new SmokeError(`timed out after ${o.timeoutMs}ms waiting for ${o.desc}`);
+}
+
+/** Locate the built broker binary, mirroring the fleet harness resolution order. */
+function resolveBrokerBinary() {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const candidates = [
+    process.env.BROKER_BINARY_PATH,
+    process.env.AGENT_RELAY_BIN,
+    path.join(REPO_ROOT, 'target', 'release', `agent-relay-broker${ext}`),
+    path.join(REPO_ROOT, 'target', 'debug', `agent-relay-broker${ext}`),
+  ].filter(Boolean);
+  return candidates.find((p) => existsSync(/** @type {string} */ (p))) ?? null;
+}
+
+/**
+ * One `agent-relay node up` host (broker provider + TS capability provider),
+ * hermetic: ambient RELAY_* / AGENT_RELAY_* are never inherited (env is built
+ * from scratch), with its own HOME, project dir, and state dir. The broker
+ * self-mints the node token from the workspace key (no pre-enrollment).
+ */
+class NodeUp {
+  /** @param {{ workspaceKey: string; brokerBinary: string; tmpRoot: string }} o */
+  constructor(o) {
+    this.o = o;
+    this.projectDir = path.join(o.tmpRoot, 'node');
+    this.home = path.join(o.tmpRoot, 'home');
+    this.stateDir = path.join(this.projectDir, '.agentworkforce', 'relay');
+    mkdirSync(this.stateDir, { recursive: true });
+    mkdirSync(this.home, { recursive: true });
+    /** @type {import('node:child_process').ChildProcess | null} */
+    this.child = null;
+    this.logBuf = '';
+  }
+
+  start() {
+    // `node up` discovers `agent-relay.{ts,…}` at the resolved PROJECT ROOT
+    // (findProjectRoot walks up to .git/package.json/etc.), so a definition that
+    // lives outside that root is silently NOT served. Pass `--config` to point at
+    // it explicitly AND pin AGENT_RELAY_PROJECT to the hermetic project dir so the
+    // broker's node identity + state stay isolated from the surrounding repo.
+    this.child = spawn(
+      process.execPath,
+      [CLI_ENTRY, 'node', 'up', '--config', NODE_DEF, '--broker-name', NODE_NAME, '--no-spawn'],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          PATH: process.env.PATH,
+          HOME: this.home,
+          LANG: process.env.LANG,
+          TMPDIR: process.env.TMPDIR,
+          BROKER_BINARY_PATH: this.o.brokerBinary,
+          RELAY_BASE_URL: BASE_URL,
+          RELAYCAST_BASE_URL: BASE_URL,
+          RELAY_WORKSPACE_KEY: this.o.workspaceKey,
+          RELAY_API_KEY: this.o.workspaceKey,
+          AGENT_RELAY_PROJECT: this.projectDir,
+          AGENT_RELAY_STATE_DIR: this.stateDir,
+          AGENT_RELAY_TELEMETRY_DISABLED: '1',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const record = (d) => {
+      this.logBuf += d.toString();
+    };
+    this.child.stdout?.on('data', record);
+    this.child.stderr?.on('data', record);
+  }
+
+  /** Redacted recent output, for failure diagnostics. */
+  get log() {
+    return redactSecrets(this.logBuf);
+  }
+
+  /** Kill the broker (by connection.json pid) then the `node up` child. */
+  async stop() {
+    const connPath = path.join(this.stateDir, 'connection.json');
+    try {
+      const conn = JSON.parse(readFileSync(connPath, 'utf-8'));
+      if (typeof conn.pid === 'number') {
+        try {
+          process.kill(conn.pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    } catch {
+      /* no connection file */
+    }
+    if (this.child) {
+      const child = this.child;
+      this.child = null;
+      await new Promise((resolve) => {
+        child.once('exit', () => resolve(undefined));
+        child.kill('SIGKILL');
+        setTimeout(() => resolve(undefined), 3000);
+      });
+    }
+    await sleep(500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  // Preflight — this is a monitor, so a missing build is a loud failure, not a skip.
+  assert(existsSync(CLI_ENTRY), `relay CLI not built (${CLI_ENTRY}); run \`npm run build:core\``);
+  assert(existsSync(NODE_DEF), `node definition missing (${NODE_DEF})`);
+  const brokerBinary = resolveBrokerBinary();
+  assert(
+    brokerBinary,
+    'agent-relay-broker binary not found; set BROKER_BINARY_PATH or `cargo build --release --bin agent-relay-broker`'
+  );
+  if (existsSync(REDACT_MODULE)) {
+    ({ redactSecrets } = await import(pathToFileUrl(REDACT_MODULE)));
+  }
+
+  log(`Target engine: ${BASE_URL}`);
+  const health = await req('GET', '/health');
+  assert(health.status === 200, `engine /health not OK (status ${health.status})`);
+  pass(`engine reachable (/health ${health.status})`);
+
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), 'prod-smoke-'));
+  /** @type {{ workspaceKey?: string; workspaceId?: string; node?: NodeUp }} */
+  const state = {};
+
+  const teardown = async () => {
+    if (state.node) {
+      try {
+        await state.node.stop();
+        log('node up stopped');
+      } catch (err) {
+        fail(`node up stop failed: ${String(err)}`);
+      }
+      state.node = undefined;
+    }
+    if (state.workspaceKey) {
+      try {
+        const del = await req('DELETE', '/v1/workspace', { token: state.workspaceKey });
+        if (del.status === 204 || del.status === 200) {
+          log(`throwaway workspace deleted (id ${state.workspaceId})`);
+        } else {
+          fail(`workspace DELETE returned ${del.status} — MANUALLY DELETE workspace id ${state.workspaceId}`);
+        }
+      } catch (err) {
+        fail(`workspace DELETE failed (${String(err)}) — MANUALLY DELETE workspace id ${state.workspaceId}`);
+      }
+      state.workspaceKey = undefined;
+    }
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  };
+
+  // Trap: signals run teardown then exit non-zero. try/finally covers failures.
+  let signalled = false;
+  for (const sig of ['SIGINT', 'SIGTERM']) {
+    process.on(sig, () => {
+      if (signalled) return;
+      signalled = true;
+      fail(`received ${sig} — tearing down`);
+      teardown().finally(() => process.exit(1));
+    });
+  }
+
+  try {
+    // 1) Throwaway workspace (no auth). Log the id BEFORE anything else can fail,
+    //    so a crash leaves a recoverable trail.
+    const wsName = `prod-smoke-${Date.now()}`;
+    const ws = await req('POST', '/v1/workspaces', { body: { name: wsName } });
+    assert(ws.status < 300 && ws.body?.ok, `workspace create failed (${ws.status}): ${show(ws.body)}`);
+    state.workspaceKey = ws.body.data.api_key;
+    state.workspaceId = ws.body.data.workspace_id;
+    const workspaceKey = /** @type {string} */ (state.workspaceKey);
+    log(`workspace created: id=${state.workspaceId} key=${prefix(workspaceKey)} (name ${wsName})`);
+
+    // 2) node up — broker provider + TS capability provider on one node.
+    const node = new NodeUp({ workspaceKey, brokerBinary, tmpRoot });
+    state.node = node;
+    node.start();
+    log('node up started; waiting for both providers to attach…');
+
+    // 3) Node online with BOTH providers and correct kinds.
+    const online = await pollUntil(
+      async () => {
+        if (node.child === null) throw new SmokeError(`node up exited early:\n${node.log}`);
+        const { body } = await req('GET', `/v1/nodes?name=${NODE_NAME}`, { token: workspaceKey });
+        const n = body?.data?.[0];
+        if (!n || n.status !== 'online' || !n.live) return null;
+        const caps = n.capabilities ?? [];
+        const hasAction = caps.some((c) => c.name === ACTION && c.kind === 'action');
+        const hasCapacity = caps.some((c) => c.kind === 'capacity');
+        return hasAction && hasCapacity ? n : null;
+      },
+      { timeoutMs: ONLINE_TIMEOUT_MS, desc: 'node online with both providers' }
+    );
+    const capNames = (kind) => online.capabilities.filter((c) => c.kind === kind).map((c) => c.name);
+    assert(online.handlers_live === true, `expected handlers_live=true, got ${online.handlers_live}`);
+    pass(
+      `node "${online.name}" (${online.id}) online, handlers_live=true; ` +
+        `capacity=[${capNames('capacity').join(', ')}] action=[${capNames('action').join(', ')}]`
+    );
+
+    // 4) Second caller (HTTP only) — register an agent, invoke, poll to completed.
+    const agentReg = await req('POST', '/v1/agents', {
+      token: workspaceKey,
+      body: { name: 'prod-smoke-caller', type: 'agent' },
+    });
+    assert(agentReg.status < 300, `agent register failed (${agentReg.status}): ${show(agentReg.body)}`);
+    const agentToken = agentReg.body.data.token ?? agentReg.body.data.agent_token;
+    log(`caller agent registered: name=prod-smoke-caller token=${prefix(agentToken)}`);
+
+    const sentEcho = { marker: `echo-${Date.now()}`, nested: { n: 42 }, list: [1, 2, 3] };
+    const invoke = await req('POST', `/v1/nodes/${NODE_NAME}/actions/${ACTION}/invoke`, {
+      token: agentToken,
+      body: { input: { echo: sentEcho } },
+    });
+    assert(invoke.status < 300, `invoke failed (${invoke.status}): ${show(invoke.body)}`);
+    const invId = invoke.body.data.invocation_id;
+    assert(invId, `invoke returned no invocation_id: ${show(invoke.body)}`);
+    log(`invoked ${ACTION} on ${NODE_NAME}: invocation ${invId} (${invoke.body.data.status})`);
+
+    const done = await pollUntil(
+      async () => {
+        const { body } = await req('GET', `/v1/actions/${ACTION}/invocations/${invId}`, {
+          token: agentToken,
+        });
+        const inv = body?.data;
+        if (!inv) return null;
+        if (inv.status === 'completed') return inv;
+        if (inv.status === 'failed') throw new SmokeError(`invocation failed: ${show(inv)}`);
+        return null;
+      },
+      { timeoutMs: 30_000, desc: 'invocation completed' }
+    );
+    assert(done.output?.ok === true, `expected output.ok=true, got: ${show(done.output)}`);
+    assert(
+      canonical(done.output.echo) === canonical(sentEcho),
+      `echo NOT byte-exact — sent ${canonical(sentEcho)} got ${canonical(done.output?.echo)}`
+    );
+    assert(done.caller_name === 'prod-smoke-caller', `unexpected caller_name ${done.caller_name}`);
+    pass(`remote invoke completed with byte-exact echo round-trip (caller prod-smoke-caller)`);
+
+    // 5) ctx.relay.sendMessage — node-token message route → channel history.
+    const chan = await req('POST', '/v1/channels', {
+      token: workspaceKey,
+      body: { name: CHANNEL, topic: 'production node-providers smoke' },
+    });
+    assert(chan.status < 300, `channel create failed (${chan.status}): ${show(chan.body)}`);
+    const notifyMarker = `notify-${Date.now()}`;
+    const notifyInvoke = await req('POST', `/v1/nodes/${NODE_NAME}/actions/${ACTION}/invoke`, {
+      token: agentToken,
+      body: {
+        input: { echo: { marker: notifyMarker }, notify: { channel: CHANNEL, from: 'prod-smoke-caller' } },
+      },
+    });
+    assert(
+      notifyInvoke.status < 300,
+      `notify invoke failed (${notifyInvoke.status}): ${show(notifyInvoke.body)}`
+    );
+    const notifyId = notifyInvoke.body.data.invocation_id;
+    await pollUntil(
+      async () => {
+        const { body } = await req('GET', `/v1/actions/${ACTION}/invocations/${notifyId}`, {
+          token: agentToken,
+        });
+        const inv = body?.data;
+        if (inv?.status === 'completed') return inv;
+        if (inv?.status === 'failed') throw new SmokeError(`notify invocation failed: ${show(inv)}`);
+        return null;
+      },
+      { timeoutMs: 30_000, desc: 'notify invocation completed' }
+    );
+    const history = await req('GET', `/v1/channels/${CHANNEL}/messages`, { token: workspaceKey });
+    const messages = Array.isArray(history.body?.data)
+      ? history.body.data
+      : (history.body?.data?.messages ?? []);
+    const landed = messages.find((m) => typeof m.text === 'string' && m.text.includes(notifyMarker));
+    assert(landed, `handler message not found in #${CHANNEL} history: ${show(messages)}`);
+    const fromName = landed.from_name ?? landed.sender_name ?? landed.from ?? landed.agent_name;
+    assert(
+      fromName === 'prod-smoke-caller',
+      `handler message attributed to ${fromName}, expected prod-smoke-caller`
+    );
+    pass(`ctx.sendMessage landed in #${CHANNEL} attributed to prod-smoke-caller`);
+
+    // 6) Teardown liveness — stopping node up drops the node offline.
+    await node.stop();
+    state.node = undefined;
+    await pollUntil(
+      async () => {
+        const { body } = await req('GET', `/v1/nodes?name=${NODE_NAME}`, { token: workspaceKey });
+        const n = body?.data?.[0];
+        return n && n.status === 'offline' && n.live === false && n.handlers_live === false ? n : null;
+      },
+      { timeoutMs: 30_000, desc: 'node offline after teardown' }
+    );
+    pass('node went offline after node up teardown (per-provider liveness)');
+
+    log('ALL CHECKS PASSED');
+  } catch (err) {
+    // Surface the (redacted) node up output to CI stdout before teardown wipes
+    // the temp dir — the buffered broker/provider log is the first thing to read.
+    if (state.node) fail(`node up output (redacted):\n${state.node.log}`);
+    throw err;
+  } finally {
+    await teardown();
+  }
+}
+
+/** Node import() needs a file:// URL for absolute paths on Windows. */
+function pathToFileUrl(p) {
+  return new URL(`file://${path.resolve(p)}`).href;
+}
+
+main()
+  .then(() => {
+    log('prod-smoke: PASS');
+    process.exit(0);
+  })
+  .catch((err) => {
+    fail(`prod-smoke: FAIL — ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });

--- a/tests/e2e/prod-smoke/prod-smoke.mjs
+++ b/tests/e2e/prod-smoke/prod-smoke.mjs
@@ -44,25 +44,28 @@ const ACTION = 'hello-prod';
 const CHANNEL = 'prod-smoke';
 
 // ---------------------------------------------------------------------------
-// Output — every printed value passes through the shipped structural redactor so
-// a credential-named field can never surface, plus a prefix helper for the few
-// tokens we intentionally show as proof-of-mint.
+// Output — token material never reaches a log. Structured response bodies go
+// through the shipped structural redactor (credential-named keys → [redacted]);
+// free-form text (the broker's own stdout, which echoes `--workspace-key …`) is
+// scrubbed by token scheme. Nothing logs a slice of a live token, not even a
+// prefix — the workspace id (non-secret) is the recoverable handle we print.
 // ---------------------------------------------------------------------------
 /** @type {<T>(v: T) => T} */
 let redactSecrets = (v) => v;
 
+/** Scrub credential material from free-form text, keeping only the scheme tag. */
+const scrub = (text) =>
+  String(text).replace(/(rk_live_|at_live_|nt_live_|ot_live_|ocl_node_enr_|br_)[A-Za-z0-9_-]+/g, '$1…');
+
 const stamp = () => new Date().toISOString().slice(11, 23);
 /** @param {string} msg */
-const log = (msg) => console.log(`[${stamp()}] ${msg}`);
+const log = (msg) => console.log(`[${stamp()}] ${scrub(msg)}`);
 /** @param {string} msg */
-const fail = (msg) => console.error(`[${stamp()}] ✗ ${msg}`);
+const fail = (msg) => console.error(`[${stamp()}] ✗ ${scrub(msg)}`);
 /** @param {string} msg */
-const pass = (msg) => console.log(`[${stamp()}] ✓ ${msg}`);
-/** Show only a token's prefix (e.g. `rk_live_5874…`). @param {string} tok */
-const prefix = (tok, n = 12) =>
-  typeof tok === 'string' && tok.length > n ? `${tok.slice(0, n)}…` : '[redacted]';
+const pass = (msg) => console.log(`[${stamp()}] ✓ ${scrub(msg)}`);
 /** Pretty-print a response body with credential fields structurally redacted. */
-const show = (body) => JSON.stringify(redactSecrets(body), null, 2);
+const show = (body) => scrub(JSON.stringify(redactSecrets(body), null, 2));
 
 class SmokeError extends Error {}
 /** @param {unknown} cond @param {string} msg */
@@ -196,7 +199,7 @@ class NodeUp {
 
   /** Redacted recent output, for failure diagnostics. */
   get log() {
-    return redactSecrets(this.logBuf);
+    return scrub(this.logBuf);
   }
 
   /** Kill the broker (by connection.json pid) then the `node up` child. */
@@ -302,7 +305,8 @@ async function main() {
     state.workspaceKey = ws.body.data.api_key;
     state.workspaceId = ws.body.data.workspace_id;
     const workspaceKey = /** @type {string} */ (state.workspaceKey);
-    log(`workspace created: id=${state.workspaceId} key=${prefix(workspaceKey)} (name ${wsName})`);
+    assert(workspaceKey?.startsWith('rk_live_'), 'workspace key missing or wrong scheme');
+    log(`workspace created: id=${state.workspaceId} (name ${wsName})`);
 
     // 2) node up — broker provider + TS capability provider on one node.
     const node = new NodeUp({ workspaceKey, brokerBinary, tmpRoot });
@@ -338,7 +342,8 @@ async function main() {
     });
     assert(agentReg.status < 300, `agent register failed (${agentReg.status}): ${show(agentReg.body)}`);
     const agentToken = agentReg.body.data.token ?? agentReg.body.data.agent_token;
-    log(`caller agent registered: name=prod-smoke-caller token=${prefix(agentToken)}`);
+    assert(agentToken?.startsWith('at_live_'), 'agent token missing or wrong scheme');
+    log('caller agent registered: name=prod-smoke-caller');
 
     const sentEcho = { marker: `echo-${Date.now()}`, nested: { n: 42 }, list: [1, 2, 3] };
     const invoke = await req('POST', `/v1/nodes/${NODE_NAME}/actions/${ACTION}/invoke`, {


### PR DESCRIPTION
`tests/e2e/prod-smoke` drives the node-providers model against a **deployed** engine (`cast.agentrelay.com` by default), self-minting a throwaway workspace so no repository secrets are configured and no real workspace is touched.

One process, in order:
- creates a throwaway workspace (`POST /v1/workspaces`, no auth; id logged for manual recovery)
- brings a node online with `node up` — a Rust broker provider + a TS capability provider (`hello-prod`) on one node, hermetically (ambient `RELAY_*`/`AGENT_RELAY_*` never inherited; own HOME/project/state; broker self-mints the node token from the workspace key)
- asserts `GET /v1/nodes` shows the node `online` + `handlers_live`, aggregating the broker's `capacity` (`spawn:*`, `release`) and the provider's `action` (`hello-prod`) at the correct `kind`s
- a second, HTTP-only caller (agent token) invokes the node-addressed action and polls it to `completed` with a byte-exact echo round-trip
- the handler's `ctx.relay.sendMessage` lands in channel history, attributed to a workspace agent (node-token message route)
- stopping `node up` drops the node `offline` (per-provider liveness)
- deletes the throwaway workspace

Teardown (stop node, delete workspace) runs on success, failure, and `SIGINT`/`SIGTERM`; the workspace id is logged so a failed auto-cleanup is manually recoverable. All printed output is structurally redacted via the shipped `redactSecrets`; intentionally-shown tokens are truncated to a prefix.

## Workflow

`.github/workflows/prod-smoke.yml` runs nightly (`schedule`) and on `workflow_dispatch`. It builds the CLI + broker and runs `npm run smoke:prod`. It is **not** on `pull_request` — this is synthetic monitoring of deployed infrastructure, not a merge gate — and needs **no repository secrets** (the workspace is self-minted).

## Relationship to fleet-e2e

Follows the `tests/e2e/fleet` pattern: real broker / `node up` runtimes are sanctioned in a dedicated workflow, never in the unit suites (repo rule). `tests/e2e/fleet` is the per-PR gate against a locally-built engine; this smoke targets already-deployed infrastructure on a schedule. Per-PR coverage of the same model lives in `tests/e2e/fleet`.

## Validation

`npm run smoke:prod` passes end to end against production `cast.agentrelay.com` — node online with both providers (`capacity=[spawn:claude, spawn:codex, spawn:gemini, spawn:opencode, release]`, `action=[hello-prod]`, `handlers_live=true`), byte-exact invoke round-trip, `ctx.sendMessage` in channel history, node offline on teardown, workspace deleted. It also fails loudly (exit 1) with teardown still deleting the workspace when a step fails (verified with a forced timeout). `schedule` / `workflow_dispatch` only activate once the workflow is on the default branch, so the first nightly run (or a post-merge manual dispatch) is the live workflow check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

