### PR TITLE
fix(cli): make JS/TS node configs load from the compiled binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay node up --config` now loads JavaScript and TypeScript node definitions with package imports from standalone binaries, while npm-installed Bun runs keep their existing in-process behavior.
 
 ## [10.6.0] - 2026-07-16
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -1,13 +1,38 @@
+import { EventEmitter } from 'node:events';
+import { setTimeout as delay } from 'node:timers/promises';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   classifyBrokerStartError,
   classifyBrokerStartStage,
   describeError,
+  isBundledBunExecutableEntrypoint,
   readNodeDeliveryStatus,
   resolveNodeIdentityFromSession,
   waitForNodeDelivery,
 } from './broker-lifecycle.js';
+import type { CoreDependencies } from '../commands/core.js';
+
+describe('isBundledBunExecutableEntrypoint', () => {
+  it.each(['/$bunfs/root/agent-relay', 'B:/~BUN/root/agent-relay.exe', 'B:\\~BUN\\root\\agent-relay.exe'])(
+    'recognizes the compiled Bun virtual entrypoint %s',
+    (cliScript) => {
+      expect(
+        isBundledBunExecutableEntrypoint({ argv: ['bun', cliScript], cliScript } as CoreDependencies)
+      ).toBe(true);
+    }
+  );
+
+  it('does not classify the npm CLI running under plain Bun as compiled', () => {
+    expect(
+      isBundledBunExecutableEntrypoint({
+        argv: ['bun', '/project/cli.js'],
+        cliScript: '/project/cli.js',
+      } as CoreDependencies)
+    ).toBe(false);
+  });
+});
 
 describe('describeError', () => {
   it('returns plain message for a bare Error', () => {
@@ -194,8 +219,6 @@ import os from 'node:os';
 import pathReal from 'node:path';
 import { startServeNode } from '@agent-relay/fleet';
 import { runUpCommand } from './broker-lifecycle.js';
-import type { CoreDependencies } from '../commands/core.js';
-
 class ExitSignal extends Error {
   constructor(public readonly code: number) {
     super(`exit:${code}`);
@@ -365,6 +388,42 @@ describe('runUpCommand node-config gating', () => {
       .map((arg) => String(arg))
       .join('\n');
     expect(output).not.toMatch(/rk_live_|nt_live_/);
+  });
+
+  it('shuts the broker down when its compiled-binary node provider exits', async () => {
+    const { deps, projectRoot, error, exit } = createUpHarness();
+    const config = pathReal.join(projectRoot, 'agent-relay.mjs');
+    fsReal.writeFileSync(
+      config,
+      "export default { __agentRelayFleetNode: true, name: 'child', capabilities: {}, triggers: [] };\n"
+    );
+    deps.argv = ['bun', '/$bunfs/root/agent-relay', 'node', 'up'];
+    deps.cliScript = '/$bunfs/root/agent-relay';
+    deps.holdOpen = async () => delay(100);
+    deps.execCommand = vi.fn(async (command: string) => ({
+      stdout: command.includes('--describe')
+        ? '__AGENT_RELAY_NODE_DESCRIPTOR__{"name":"child","capabilities":[]}\n'
+        : '',
+      stderr: '',
+    }));
+
+    const child = Object.assign(new EventEmitter(), {
+      pid: 42,
+      killed: false,
+      kill: vi.fn(),
+    });
+    deps.spawnProcess = vi.fn(() => {
+      queueMicrotask(() => {
+        child.emit('spawn');
+        queueMicrotask(() => child.emit('exit', 1, null));
+      });
+      return child;
+    });
+
+    await expect(runUpCommand({ discoverConfig: true }, deps)).rejects.toBeInstanceOf(ExitSignal);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(error.mock.calls.flat().join('\n')).toContain('exited unexpectedly');
   });
 });
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -12,7 +12,6 @@ import { createTriggerSyncClient, resolveNodeCapacityHarnesses } from './fleet-s
 import {
   discoverNodeConfigPath,
   discoverPythonNodeConfigPath,
-  isBunRuntime,
   loadNodeDefinition,
 } from './node-definition-loader.js';
 import {
@@ -20,6 +19,7 @@ import {
   descriptorCapacitySource,
   startNodeJsNodeProvider,
   type NodeDefinitionDescriptor,
+  type RunningNodeProviderChild,
 } from './node-provider-child.js';
 import { startReflexCapture, type RunningReflexCapture } from './reflex-capture.js';
 import { writeProjectWorkspaceKey } from './project-workspace-key.js';
@@ -345,6 +345,8 @@ export async function startBrokerWithPortFallback(
 
 /** A handle to stop the capability providers started alongside the broker. */
 export interface RunningNodeProviders {
+  /** Rejects when a supervised provider exits before broker shutdown. */
+  done?: Promise<void>;
   stop(): Promise<void>;
 }
 
@@ -488,7 +490,7 @@ async function startNodeCapabilityProviders(
 
   const served: RunningNode[] = [];
   let pythonChild: SpawnedProcess | undefined;
-  let nodeJsChild: SpawnedProcess | undefined;
+  let nodeJsChild: RunningNodeProviderChild | undefined;
 
   if (nodePlan?.mode === 'in-process') {
     const nodeDefinition = nodePlan.definition;
@@ -524,7 +526,7 @@ async function startNodeCapabilityProviders(
   }
 
   if (nodePlan?.mode === 'child-node') {
-    nodeJsChild = startNodeJsNodeProvider(
+    nodeJsChild = await startNodeJsNodeProvider(
       nodePlan.configPath,
       {
         nodeToken,
@@ -557,15 +559,14 @@ async function startNodeCapabilityProviders(
   }
 
   return {
+    ...(nodeJsChild ? { done: nodeJsChild.done } : {}),
     stop: async () => {
-      await Promise.all(served.map((node) => node.stop().catch(() => undefined)));
-      for (const child of [pythonChild, nodeJsChild]) {
-        if (child?.pid) {
-          try {
-            deps.killProcess(child.pid, 'SIGTERM');
-          } catch {
-            // Already exited.
-          }
+      await Promise.all([...served.map((node) => node.stop().catch(() => undefined)), nodeJsChild?.stop()]);
+      if (pythonChild?.pid) {
+        try {
+          deps.killProcess(pythonChild.pid, 'SIGTERM');
+        } catch {
+          // Already exited.
         }
       }
     },
@@ -963,9 +964,13 @@ function isCliScriptEntrypoint(deps: CoreDependencies): boolean {
   );
 }
 
-function isBundledBunExecutableEntrypoint(deps: CoreDependencies): boolean {
+export function isBundledBunExecutableEntrypoint(deps: CoreDependencies): boolean {
   // Bun --compile exposes argv[1] as a virtual path for the embedded executable.
-  return deps.argv[0] === 'bun' && deps.cliScript.startsWith('/$bunfs/root/');
+  const entrypoint = deps.cliScript.replace(/\\/g, '/');
+  return (
+    deps.argv[0] === 'bun' &&
+    (entrypoint.startsWith('/$bunfs/root/') || /^[A-Z]:\/~BUN\/root\//i.test(entrypoint))
+  );
 }
 
 function sameCliPath(left: string, right: string): boolean {
@@ -1121,11 +1126,11 @@ type NodeDefinitionPlan =
  * @param configPath - Absolute path to the node definition file.
  * @param deps - Core dependencies.
  */
-async function loadNodeDefinitionPlan(
+export async function loadNodeDefinitionPlan(
   configPath: string,
   deps: CoreDependencies
 ): Promise<NodeDefinitionPlan> {
-  if (!isBunRuntime()) {
+  if (!isBundledBunExecutableEntrypoint(deps)) {
     return { mode: 'in-process', definition: await loadNodeDefinition(configPath) };
   }
   const descriptor = await describeNodeDefinitionViaNode(configPath, deps);
@@ -1404,7 +1409,12 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       deps.exit(0);
     });
 
-    await deps.holdOpen();
+    const holdOpen = deps.holdOpen();
+    if (nodeProviders?.done) {
+      await Promise.race([holdOpen, nodeProviders.done]);
+    } else {
+      await holdOpen;
+    }
   } catch (err: unknown) {
     await shutdownOnce();
     const message = toErrorMessage(err);

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -12,8 +12,15 @@ import { createTriggerSyncClient, resolveNodeCapacityHarnesses } from './fleet-s
 import {
   discoverNodeConfigPath,
   discoverPythonNodeConfigPath,
+  isBunRuntime,
   loadNodeDefinition,
 } from './node-definition-loader.js';
+import {
+  describeNodeDefinitionViaNode,
+  descriptorCapacitySource,
+  startNodeJsNodeProvider,
+  type NodeDefinitionDescriptor,
+} from './node-provider-child.js';
 import { startReflexCapture, type RunningReflexCapture } from './reflex-capture.js';
 import { writeProjectWorkspaceKey } from './project-workspace-key.js';
 
@@ -445,12 +452,12 @@ async function startNodeCapabilityProviders(
   relay: CoreRelay,
   options: UpOptions,
   deps: CoreDependencies,
-  nodeDefinition: FleetNodeDefinition | undefined
+  nodePlan: NodeDefinitionPlan | undefined
 ): Promise<RunningNodeProviders | undefined> {
   // Definition discovery is opt-in (`node up` only), matching the TS config scan.
   const pythonConfig =
     options.discoverConfig === true ? discoverPythonNodeConfigPath(paths.projectRoot) : undefined;
-  if (!nodeDefinition && !pythonConfig) {
+  if (!nodePlan && !pythonConfig) {
     return undefined;
   }
 
@@ -481,8 +488,10 @@ async function startNodeCapabilityProviders(
 
   const served: RunningNode[] = [];
   let pythonChild: SpawnedProcess | undefined;
+  let nodeJsChild: SpawnedProcess | undefined;
 
-  if (nodeDefinition) {
+  if (nodePlan?.mode === 'in-process') {
+    const nodeDefinition = nodePlan.definition;
     try {
       const workspaceKey = relay.workspaceKey;
       served.push(
@@ -514,6 +523,20 @@ async function startNodeCapabilityProviders(
     }
   }
 
+  if (nodePlan?.mode === 'child-node') {
+    nodeJsChild = startNodeJsNodeProvider(
+      nodePlan.configPath,
+      {
+        nodeToken,
+        baseUrl,
+        nodeId: identity.nodeId,
+        nodeName: options.nodeName ?? identity.nodeName,
+        ...(relay.workspaceKey ? { workspaceKey: relay.workspaceKey } : {}),
+      },
+      deps
+    );
+  }
+
   if (pythonConfig) {
     pythonChild = startPythonNodeProvider(
       pythonConfig,
@@ -529,18 +552,20 @@ async function startNodeCapabilityProviders(
     );
   }
 
-  if (served.length === 0 && !pythonChild) {
+  if (served.length === 0 && !pythonChild && !nodeJsChild) {
     return undefined;
   }
 
   return {
     stop: async () => {
       await Promise.all(served.map((node) => node.stop().catch(() => undefined)));
-      if (pythonChild?.pid) {
-        try {
-          deps.killProcess(pythonChild.pid, 'SIGTERM');
-        } catch {
-          // Already exited.
+      for (const child of [pythonChild, nodeJsChild]) {
+        if (child?.pid) {
+          try {
+            deps.killProcess(child.pid, 'SIGTERM');
+          } catch {
+            // Already exited.
+          }
         }
       }
     },
@@ -1049,7 +1074,7 @@ async function resolveNodeDefinitionForUp(
   paths: CoreProjectPaths,
   options: UpOptions,
   deps: CoreDependencies
-): Promise<FleetNodeDefinition | undefined> {
+): Promise<NodeDefinitionPlan | undefined> {
   const fleetNodeDisabled = deps.env.AGENT_RELAY_DISABLE_IMPLICIT_FLEET_NODE === '1';
   if (fleetNodeDisabled || (!options.config && options.discoverConfig !== true)) {
     return undefined;
@@ -1061,10 +1086,10 @@ async function resolveNodeDefinitionForUp(
   }
   vlog(deps, options.verbose, `Loading fleet node definition from ${configPath}...`);
   if (explicitConfig) {
-    return loadNodeDefinition(configPath);
+    return loadNodeDefinitionPlan(configPath, deps);
   }
   try {
-    return await loadNodeDefinition(configPath);
+    return await loadNodeDefinitionPlan(configPath, deps);
   } catch (err) {
     deps.warn(
       `Ignoring discovered node config ${configPath}: ${toErrorMessage(err)}. ` +
@@ -1072,6 +1097,49 @@ async function resolveNodeDefinitionForUp(
     );
     return undefined;
   }
+}
+
+/**
+ * How a discovered JS/TS node definition will be served.
+ *
+ * Under Node the definition is imported and served in-process, unchanged. Under
+ * a `bun build --compile` binary it cannot be imported at all — the compiled
+ * runtime fails to resolve a bare specifier out of the user's `node_modules`
+ * whenever the package's entry lives in a subdirectory (`dist/`), i.e. every
+ * TypeScript-built package, and the failure is transitive through the user's
+ * whole dependency graph — so the CLI only learns its descriptor (via a
+ * `--describe` child) and hands the file to a child `node` process to serve,
+ * exactly as `agent-relay.py` is handed to `python3`.
+ */
+type NodeDefinitionPlan =
+  | { mode: 'in-process'; definition: FleetNodeDefinition }
+  | { mode: 'child-node'; configPath: string; descriptor: NodeDefinitionDescriptor };
+
+/**
+ * Decide how to serve `configPath` and gather what the broker needs before it
+ * starts (capacity, and a hard failure on a bad explicit --config).
+ * @param configPath - Absolute path to the node definition file.
+ * @param deps - Core dependencies.
+ */
+async function loadNodeDefinitionPlan(
+  configPath: string,
+  deps: CoreDependencies
+): Promise<NodeDefinitionPlan> {
+  if (!isBunRuntime()) {
+    return { mode: 'in-process', definition: await loadNodeDefinition(configPath) };
+  }
+  const descriptor = await describeNodeDefinitionViaNode(configPath, deps);
+  return { mode: 'child-node', configPath, descriptor };
+}
+
+/** The capability names a plan contributes to the broker's advertised capacity. */
+function planCapacitySource(
+  plan: NodeDefinitionPlan | undefined
+): { capabilities: Readonly<Record<string, unknown>> } | undefined {
+  if (!plan) {
+    return undefined;
+  }
+  return plan.mode === 'in-process' ? plan.definition : descriptorCapacitySource(plan.descriptor);
 }
 
 export async function runUpCommand(options: UpOptions, deps: CoreDependencies): Promise<void> {
@@ -1226,7 +1294,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
 
     // Resolved BEFORE the broker starts so an explicit bad --config fails
     // fast instead of tearing down a broker that just came up.
-    const nodeDefinition = await resolveNodeDefinitionForUp(paths, options, deps);
+    const nodePlan = await resolveNodeDefinitionForUp(paths, options, deps);
     const teamsConfig = deps.loadTeamsConfig(paths.projectRoot);
 
     // The broker advertises spawn:<harness> capacity for this set. A pre-set
@@ -1237,7 +1305,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     deps.env.AGENT_RELAY_NODE_HARNESSES = resolveNodeCapacityHarnesses(
       deps.env.AGENT_RELAY_NODE_HARNESSES,
       teamsConfig,
-      nodeDefinition
+      planCapacitySource(nodePlan)
     );
 
     // Kill any orphaned broker processes for this project that lost their PID
@@ -1273,7 +1341,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     }
 
     vlog(deps, options.verbose, 'Starting node capability providers (if any)...');
-    nodeProviders = await startNodeCapabilityProviders(paths, relay, options, deps, nodeDefinition);
+    nodeProviders = await startNodeCapabilityProviders(paths, relay, options, deps, nodePlan);
     // When Reflex is enabled, periodically sync + push local session history to
     // relayhistory-cloud in-process via the ai-hist-native addon (no subprocess).
     // No-op when disabled or the addon isn't available.

--- a/packages/cli/src/cli/lib/fleet-sidecar.ts
+++ b/packages/cli/src/cli/lib/fleet-sidecar.ts
@@ -1,5 +1,5 @@
 import { AgentRelay } from '@agent-relay/sdk';
-import type { FleetNodeDefinition, FleetTriggerSyncClient } from '@agent-relay/fleet';
+import type { FleetTriggerSyncClient } from '@agent-relay/fleet';
 
 import type { CoreTeamsConfig } from '../commands/core.js';
 
@@ -15,9 +15,18 @@ import type { CoreTeamsConfig } from '../commands/core.js';
 // broker's default capacity for it.
 const DEFAULT_HARNESSES = ['claude', 'codex', 'gemini', 'opencode'] as const;
 
+/**
+ * The minimum a node config has to expose to contribute `spawn:<harness>`
+ * capacity: its capability names. A full {@link FleetNodeDefinition} satisfies
+ * this, and so does the descriptor reported by a node definition served
+ * out-of-process (which the CLI never loads in-process, so it has capability
+ * names but no handlers).
+ */
+export type NodeCapacitySource = { capabilities: Readonly<Record<string, unknown>> };
+
 export function nodeCapacityHarnesses(
   teamsConfig: CoreTeamsConfig | null,
-  definition?: FleetNodeDefinition
+  definition?: NodeCapacitySource
 ): string[] {
   const harnesses = new Set<string>(DEFAULT_HARNESSES);
   for (const agent of teamsConfig?.agents ?? []) {
@@ -46,7 +55,7 @@ export function nodeCapacityHarnesses(
 export function resolveNodeCapacityHarnesses(
   preset: string | undefined,
   teamsConfig: CoreTeamsConfig | null,
-  definition?: FleetNodeDefinition
+  definition?: NodeCapacitySource
 ): string {
   const trimmed = preset?.trim();
   if (trimmed) {

--- a/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
+++ b/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
@@ -198,18 +198,26 @@ describe.skipIf(!bunAvailable)('node definition loading from a bun-compiled bina
     expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
   }, 60_000);
 
-  it.each(['mts', 'cts'])(
-    'serves a .%s config through the transpiling Node loader',
-    (extension) => {
-      const config = path.join(dir, `agent-relay-bare.${extension}`);
-      writeFileSync(config, "export { default } from '@fixture/node-lib';\n");
+  it('serves a .mts config through the transpiling Node loader', () => {
+    const config = path.join(dir, 'agent-relay-bare.mts');
+    writeFileSync(config, "export { default } from '@fixture/node-lib';\n");
 
-      const descriptor = describeViaHarness(dir, config);
+    const descriptor = describeViaHarness(dir, config);
 
-      expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
-    },
-    60_000
-  );
+    expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+  }, 60_000);
+
+  it('serves a CommonJS .cts config through the transpiling Node loader', () => {
+    const config = path.join(dir, 'agent-relay-bare.cts');
+    writeFileSync(
+      config,
+      ["const definition = require('@fixture/node-lib').default;", 'export = definition;'].join('\n')
+    );
+
+    const descriptor = describeViaHarness(dir, config);
+
+    expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+  }, 60_000);
 
   /**
    * Pins the bun limitation the child-process design exists for: a compiled

--- a/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
+++ b/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
@@ -209,9 +209,27 @@ describe.skipIf(!bunAvailable)('node definition loading from a bun-compiled bina
 
   it('serves a CommonJS .cts config through the transpiling Node loader', () => {
     const config = path.join(dir, 'agent-relay-bare.cts');
+    const helper = path.join(dir, 'node-definition.cts');
     writeFileSync(
       config,
-      ["const definition = require('@fixture/node-lib').default;", 'export = definition;'].join('\n')
+      [
+        "const definition = require('./node-definition.cts');",
+        "const direct = module.require('@fixture/node-lib').default;",
+        "if (definition !== direct) throw new Error('local CommonJS graph returned the wrong export');",
+        "if (module.filename !== __filename) throw new Error('module.filename mismatch: ' + module.filename + ' !== ' + __filename);",
+        "if (module.path !== __dirname) throw new Error('module.path mismatch: ' + module.path + ' !== ' + __dirname);",
+        'export = definition;',
+      ].join('\n')
+    );
+    writeFileSync(
+      helper,
+      [
+        "enum FixtureKind { Node = 'node' }",
+        'const kind: FixtureKind = FixtureKind.Node;',
+        "if (kind !== 'node') throw new Error('TypeScript was not transformed');",
+        "const definition = require('@fixture/node-lib').default;",
+        'export = definition;',
+      ].join('\n')
     );
 
     const descriptor = describeViaHarness(dir, config);

--- a/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
+++ b/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
@@ -1,0 +1,250 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for node-definition loading inside a `bun build --compile`
+ * binary — the artifact users actually install via the curl script.
+ *
+ * These MUST compile a real binary. Both bugs they cover are invisible to a
+ * plain `node`/vitest run (Node resolves bare specifiers correctly and jiti's
+ * Babel transpiler is present in node_modules), which is precisely why they
+ * shipped: every existing loader test passes against the broken code.
+ *
+ *   Bug 1: `.ts` configs were routed through jiti, whose Babel transpiler is
+ *          loaded via a dynamic `require('../dist/babel.cjs')` that bun cannot
+ *          embed -> `Cannot find module '../dist/babel.cjs' from '/$bunfs/root/...'`.
+ *   Bug 2: a bun-compiled binary cannot resolve a bare package specifier out of
+ *          the config's own node_modules when the package's entry point lives in
+ *          a subdirectory (dist/, lib/ — i.e. every package built from
+ *          TypeScript) -> `Cannot find module '@agent-relay/factory/node' from
+ *          '<config>'`, transitively through the user's whole dependency graph.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const LOADER = path.join(here, 'node-definition-loader.ts');
+const CHILD_PROVIDER = path.join(here, 'node-provider-child.ts');
+
+function hasBun(): boolean {
+  try {
+    execFileSync('bun', ['--version'], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Compile `source` into a standalone binary the same way scripts/build-bun.sh does. */
+function compile(dir: string, name: string, source: string): string {
+  const entry = path.join(dir, `${name}.ts`);
+  writeFileSync(entry, source, 'utf8');
+  const outfile = path.join(dir, name);
+  execFileSync('bun', ['build', '--compile', entry, '--outfile', outfile], { stdio: 'pipe' });
+  return outfile;
+}
+
+type RunResult = { status: number; stdout: string; stderr: string };
+
+function run(binary: string, args: string[], cwd: string): RunResult {
+  try {
+    const stdout = execFileSync(binary, args, { cwd, stdio: 'pipe', encoding: 'utf8' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+const bunAvailable = hasBun();
+
+describe.skipIf(!bunAvailable)('node definition loading from a bun-compiled binary', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), 'relay-bun-loader-'));
+
+    // A project with a package in its own node_modules, mirroring
+    // `@agent-relay/factory` in the factory#73 README instructions.
+    //
+    // The entry point MUST live in a subdirectory (dist/), like every package
+    // built from TypeScript — including @agent-relay/factory and
+    // @agent-relay/fleet. That is the exact trigger for the bun bug: a compiled
+    // binary resolves a bare specifier only when the package's entry is a file
+    // at the package ROOT. A fixture with `index.js` at the root resolves fine
+    // inside the binary and silently tests nothing.
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ type: 'module' }));
+    const pkgDir = path.join(dir, 'node_modules', '@fixture', 'node-lib');
+    mkdirSync(path.join(pkgDir, 'dist'), { recursive: true });
+    writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@fixture/node-lib',
+        version: '1.0.0',
+        type: 'module',
+        main: 'dist/index.js',
+        types: 'dist/index.d.ts',
+        exports: {
+          '.': { types: './dist/index.d.ts', import: './dist/index.js', default: './dist/index.js' },
+        },
+      })
+    );
+    writeFileSync(
+      path.join(pkgDir, 'dist', 'index.js'),
+      [
+        'export default {',
+        '  __agentRelayFleetNode: true,',
+        '  name: "fixture-node",',
+        '  capabilities: { "spawn:claude": { name: "spawn:claude", kind: "spawn", handler: () => undefined } },',
+        '  triggers: [],',
+        '};',
+      ].join('\n')
+    );
+  }, 60_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loads a self-contained .ts config in-process under Bun (native transpile, no jiti)', () => {
+    const config = path.join(dir, 'self-contained.ts');
+    writeFileSync(
+      config,
+      [
+        'type Capability = { name: string; kind: string; handler: () => void };',
+        'const capabilities: Record<string, Capability> = {};',
+        'export default {',
+        '  __agentRelayFleetNode: true as const,',
+        '  name: "ts-node",',
+        '  capabilities,',
+        '  triggers: [],',
+        '};',
+      ].join('\n')
+    );
+
+    const result = run(loadHarness(dir), [config], dir);
+
+    expect(result.stderr).not.toMatch(/babel\.cjs/);
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ name: 'ts-node' });
+  }, 60_000);
+
+  /**
+   * The `Cannot find module '../dist/babel.cjs'` failure users actually hit.
+   *
+   * It is a RED HERRING masking the real bug: jiti's native path cannot resolve
+   * the config's bare import (bun cannot reach a dist/-entry package from a
+   * compiled binary), so jiti falls back to Babel — whose transpiler bun never
+   * embedded, because jiti loads it via a dynamic require. The user is told the
+   * transpiler is missing, not that their import failed to resolve.
+   *
+   * Routing `.ts` through jiti under Bun is therefore never useful: it can only
+   * turn a resolution error into a confusing one. This asserts the real cause
+   * surfaces instead.
+   */
+  it('surfaces the real resolution error for a .ts config, not the babel.cjs red herring', () => {
+    const config = path.join(dir, 'bare-import.ts');
+    writeFileSync(config, `export { default } from '@fixture/node-lib';\n`);
+
+    const result = run(loadHarness(dir), [config], dir);
+
+    expect(result.status).not.toBe(0);
+    // Before the fix: "Cannot find module '../dist/babel.cjs' from '/$bunfs/root/...'"
+    expect(result.stderr).not.toMatch(/babel\.cjs/);
+    expect(result.stderr).toMatch(/@fixture\/node-lib/);
+  }, 60_000);
+
+  it('serves a .mjs config that imports a bare specifier from its own node_modules', () => {
+    const config = path.join(dir, 'agent-relay.mjs');
+    writeFileSync(config, `export { default } from '@fixture/node-lib';\n`);
+
+    const descriptor = describeViaHarness(dir, config);
+
+    expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+  }, 60_000);
+
+  it('serves a .ts config that imports a bare specifier from its own node_modules', () => {
+    // The exact shape factory#73's README documents:
+    //   agent-relay.ts: export { default } from '@agent-relay/factory/node'
+    const config = path.join(dir, 'agent-relay-bare.ts');
+    writeFileSync(config, `export { default } from '@fixture/node-lib';\n`);
+
+    const descriptor = describeViaHarness(dir, config);
+
+    expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+  }, 60_000);
+
+  /**
+   * Pins the bun limitation the child-process design exists for: a compiled
+   * binary cannot resolve a package whose entry lives in a subdirectory. If
+   * this ever starts passing, bun has fixed it and the child hop could be
+   * reconsidered — until then, "just import it in-process" is not an available
+   * simplification.
+   */
+  it('cannot import a bare specifier in-process from a compiled binary (why the child exists)', () => {
+    const config = path.join(dir, 'agent-relay.mjs');
+    const binary = compile(
+      dir,
+      'in-process-harness',
+      [
+        'import { pathToFileURL } from "node:url";',
+        'const m = await import(pathToFileURL(process.argv[2]).href);',
+        'console.log(JSON.stringify({ name: m.default?.name }));',
+      ].join('\n')
+    );
+
+    const result = run(binary, [config], dir);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/Cannot find (module|package) '@fixture\/node-lib'/);
+  }, 60_000);
+});
+
+/** A compiled binary that loads a node definition in-process via the real loader. */
+function loadHarness(dir: string): string {
+  return compile(
+    dir,
+    'load-harness',
+    [
+      `import { loadNodeDefinition } from ${JSON.stringify(LOADER)};`,
+      'const def = await loadNodeDefinition(process.argv[2]);',
+      'console.log(JSON.stringify({ name: def.name }));',
+    ].join('\n')
+  );
+}
+
+/**
+ * Drive `describeNodeDefinitionViaNode` from inside a compiled binary, which is
+ * how the shipped CLI learns about a JS/TS node definition it cannot import.
+ */
+function describeViaHarness(dir: string, config: string): unknown {
+  const binary = compile(
+    dir,
+    `describe-harness-${path.basename(config).replace(/\W/g, '-')}`,
+    [
+      `import { describeNodeDefinitionViaNode } from ${JSON.stringify(CHILD_PROVIDER)};`,
+      'import { promisify } from "node:util";',
+      'import { exec } from "node:child_process";',
+      'const execAsync = promisify(exec);',
+      'const deps = { env: process.env, execCommand: (command) => execAsync(command) };',
+      'const descriptor = await describeNodeDefinitionViaNode(process.argv[2], deps);',
+      'console.log("__RESULT__" + JSON.stringify(descriptor));',
+    ].join('\n')
+  );
+
+  const result = run(binary, [config], dir);
+  if (result.status !== 0) {
+    throw new Error(`describe harness failed (${result.status}): ${result.stderr || result.stdout}`);
+  }
+  const line = result.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.startsWith('__RESULT__'));
+  if (!line) {
+    throw new Error(`no descriptor in harness output: ${result.stdout}`);
+  }
+  return JSON.parse(line.slice('__RESULT__'.length));
+}

--- a/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
+++ b/packages/cli/src/cli/lib/node-definition-loader.bun.test.ts
@@ -28,6 +28,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const LOADER = path.join(here, 'node-definition-loader.ts');
 const CHILD_PROVIDER = path.join(here, 'node-provider-child.ts');
+const BROKER_LIFECYCLE = path.join(here, 'broker-lifecycle.ts');
 
 function hasBun(): boolean {
   try {
@@ -43,7 +44,9 @@ function compile(dir: string, name: string, source: string): string {
   const entry = path.join(dir, `${name}.ts`);
   writeFileSync(entry, source, 'utf8');
   const outfile = path.join(dir, name);
-  execFileSync('bun', ['build', '--compile', entry, '--outfile', outfile], { stdio: 'pipe' });
+  execFileSync('bun', ['build', '--compile', '--minify', entry, '--outfile', outfile], {
+    stdio: 'pipe',
+  });
   return outfile;
 }
 
@@ -177,6 +180,37 @@ describe.skipIf(!bunAvailable)('node definition loading from a bun-compiled bina
     expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
   }, 60_000);
 
+  it('serves a .tsx config through a transpiling Node loader', () => {
+    const config = path.join(dir, 'agent-relay-bare.tsx');
+    const helper = path.join(dir, 'node-definition.tsx');
+    writeFileSync(config, "export { default } from './node-definition.tsx';\n");
+    writeFileSync(
+      helper,
+      [
+        "import definition from '@fixture/node-lib';",
+        'const identity = <T,>(value: T): T => value;',
+        'export default identity(definition);',
+      ].join('\n')
+    );
+
+    const descriptor = describeViaHarness(dir, config);
+
+    expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+  }, 60_000);
+
+  it.each(['mts', 'cts'])(
+    'serves a .%s config through the transpiling Node loader',
+    (extension) => {
+      const config = path.join(dir, `agent-relay-bare.${extension}`);
+      writeFileSync(config, "export { default } from '@fixture/node-lib';\n");
+
+      const descriptor = describeViaHarness(dir, config);
+
+      expect(descriptor).toEqual({ name: 'fixture-node', capabilities: ['spawn:claude'] });
+    },
+    60_000
+  );
+
   /**
    * Pins the bun limitation the child-process design exists for: a compiled
    * binary cannot resolve a package whose entry lives in a subdirectory. If
@@ -200,6 +234,80 @@ describe.skipIf(!bunAvailable)('node definition loading from a bun-compiled bina
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toMatch(/Cannot find (module|package) '@fixture\/node-lib'/);
+  }, 60_000);
+});
+
+describe.skipIf(!bunAvailable)('node definition serving plan under plain Bun', () => {
+  it('keeps plain Bun in-process and reserves the node child for a compiled Bun binary', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'relay-plain-bun-plan-'));
+    const config = path.join(dir, 'agent-relay.mjs');
+    const harness = path.join(dir, 'plain-bun-plan.ts');
+    const packageRoot = path.join(dir, 'node_modules', '@fixture', 'plan-node');
+    mkdirSync(path.join(packageRoot, 'dist'), { recursive: true });
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ type: 'module' }));
+    writeFileSync(config, "export { default } from '@fixture/plan-node';\n");
+    writeFileSync(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: '@fixture/plan-node',
+        version: '1.0.0',
+        type: 'module',
+        main: 'dist/index.js',
+        exports: { '.': './dist/index.js' },
+      })
+    );
+    writeFileSync(
+      path.join(packageRoot, 'dist', 'index.js'),
+      "export default { __agentRelayFleetNode: true, name: 'plan', capabilities: {}, triggers: [] };\n"
+    );
+    writeFileSync(
+      harness,
+      [
+        `import { loadNodeDefinitionPlan } from ${JSON.stringify(BROKER_LIFECYCLE)};`,
+        'const configPath = process.argv[2];',
+        'const deps = {',
+        "  argv: ['bun', import.meta.path, 'node', 'up'],",
+        '  cliScript: import.meta.path,',
+        '  env: process.env,',
+        "  execCommand: async () => { throw new Error('plain Bun must not require node'); },",
+        '};',
+        'const plan = await loadNodeDefinitionPlan(configPath, deps);',
+        'console.log(plan.mode);',
+      ].join('\n')
+    );
+
+    try {
+      const stdout = execFileSync('bun', [harness, config], {
+        cwd: path.resolve(here, '../../../../..'),
+        stdio: 'pipe',
+        encoding: 'utf8',
+      });
+      expect(stdout.trim()).toBe('in-process');
+
+      const compiled = compile(
+        dir,
+        'compiled-serving-plan',
+        [
+          `import { loadNodeDefinitionPlan } from ${JSON.stringify(BROKER_LIFECYCLE)};`,
+          'import { exec } from "node:child_process";',
+          'import { promisify } from "node:util";',
+          'const execAsync = promisify(exec);',
+          'const deps = {',
+          '  argv: process.argv,',
+          '  cliScript: process.argv[1],',
+          '  env: process.env,',
+          '  execCommand: async (command) => execAsync(command),',
+          '};',
+          'const plan = await loadNodeDefinitionPlan(process.argv[2], deps);',
+          'console.log(plan.mode);',
+        ].join('\n')
+      );
+      const compiledResult = run(compiled, [config], dir);
+      expect(compiledResult.status).toBe(0);
+      expect(compiledResult.stdout.trim()).toBe('child-node');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   }, 60_000);
 });
 

--- a/packages/cli/src/cli/lib/node-definition-loader.ts
+++ b/packages/cli/src/cli/lib/node-definition-loader.ts
@@ -105,7 +105,7 @@ function isFleetNodeDefinitionLike(value: unknown): value is FleetNodeDefinition
 }
 
 async function importNodeDefinition(absolutePath: string): Promise<unknown> {
-  if (!JITI_NODE_DEFINITION_EXTENSIONS.has(path.extname(absolutePath).toLowerCase())) {
+  if (!needsJitiTranspile(absolutePath)) {
     try {
       return (await import(pathToFileURL(absolutePath).href)) as unknown;
     } catch (error) {
@@ -124,6 +124,25 @@ async function importNodeDefinition(absolutePath: string): Promise<unknown> {
   return importNodeDefinitionWithJiti(absolutePath);
 }
 
+/**
+ * Whether `absolutePath` has to go through jiti to be transpiled.
+ *
+ * Only TypeScript sources need a transpiler, and only when the host runtime
+ * cannot parse them itself. Bun transpiles TypeScript natively, so under Bun a
+ * plain `import()` handles `.ts` — and it *must* be used: jiti resolves its
+ * Babel transpiler through a dynamic `require('../dist/babel.cjs')`, which
+ * `bun build --compile` cannot see statically and therefore never embeds in the
+ * single-file binary. Routing `.ts` through jiti there fails with
+ * `Cannot find module '../dist/babel.cjs' from '/$bunfs/root/agent-relay-<target>'`,
+ * which broke every TypeScript node config on the shipped binary.
+ */
+function needsJitiTranspile(absolutePath: string): boolean {
+  if (!JITI_NODE_DEFINITION_EXTENSIONS.has(path.extname(absolutePath).toLowerCase())) {
+    return false;
+  }
+  return !isBunRuntime();
+}
+
 function shouldFallbackToJiti(error: unknown): boolean {
   if (isBunRuntime()) {
     return false;
@@ -131,7 +150,8 @@ function shouldFallbackToJiti(error: unknown): boolean {
   return error instanceof SyntaxError && getErrorCode(error) !== 'ERR_MODULE_NOT_FOUND';
 }
 
-function isBunRuntime(): boolean {
+/** Whether we are executing inside Bun (notably the `bun build --compile` binary). */
+export function isBunRuntime(): boolean {
   return typeof (process.versions as NodeJS.ProcessVersions & { bun?: string }).bun === 'string';
 }
 

--- a/packages/cli/src/cli/lib/node-provider-child.test.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.test.ts
@@ -1,14 +1,31 @@
-import { describe, expect, it, vi } from 'vitest';
+import { exec as execCallback, spawn, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   descriptorCapacitySource,
   describeNodeDefinitionViaNode,
   isJsNodeDefinition,
+  materializeNodeProviderChildScript,
+  packageRootFromEntry,
   parseNodeDescriptor,
   startNodeJsNodeProvider,
 } from './node-provider-child.js';
 import { nodeCapacityHarnesses } from './fleet-sidecar.js';
-import type { CoreDependencies } from '../commands/core.js';
+import type { CoreDependencies, SpawnedProcess } from '../commands/core.js';
 
 const MARKER = '__AGENT_RELAY_NODE_DESCRIPTOR__';
 
@@ -22,6 +39,12 @@ function deps(overrides: Partial<CoreDependencies> = {}): CoreDependencies {
     ...overrides,
   } as unknown as CoreDependencies;
 }
+
+const execAsync = promisify(execCallback);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('parseNodeDescriptor', () => {
   it('reads the marker line', () => {
@@ -70,6 +93,17 @@ describe('isJsNodeDefinition', () => {
   });
 });
 
+describe('packageRootFromEntry', () => {
+  it('finds the fleet root in a Windows require.resolve path', () => {
+    expect(
+      packageRootFromEntry(
+        'C:\\project\\node_modules\\@agent-relay\\fleet\\dist\\index.js',
+        '@agent-relay/fleet'
+      )
+    ).toBe('C:\\project\\node_modules\\@agent-relay\\fleet');
+  });
+});
+
 describe('describeNodeDefinitionViaNode', () => {
   it('quotes paths so a config in a directory with spaces still loads', async () => {
     const execCommand = vi.fn().mockResolvedValue({
@@ -113,14 +147,73 @@ describe('describeNodeDefinitionViaNode', () => {
       /must default-export defineNode/
     );
   });
+
+  it('removes the materialized bootstrap after a real describe child exits', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'relay-node-provider-describe-'));
+    const tempRoot = path.join(root, 'tmp');
+    const config = path.join(root, 'agent-relay.mjs');
+    mkdirSync(tempRoot);
+    writeFileSync(
+      config,
+      "export default { __agentRelayFleetNode: true, name: 'fixture', capabilities: {}, triggers: [] };\n"
+    );
+
+    try {
+      await expect(
+        describeNodeDefinitionViaNode(
+          config,
+          deps({
+            env: { ...process.env, TMPDIR: tempRoot },
+            execCommand: async (command) => {
+              const result = await execAsync(command);
+              return { stdout: result.stdout, stderr: result.stderr };
+            },
+          })
+        )
+      ).resolves.toEqual({ name: 'fixture', capabilities: [] });
+      expect(readdirSync(tempRoot)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('drains a large real child load error before exiting', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'relay-node-provider-error-drain-'));
+    const tempRoot = path.join(root, 'tmp');
+    const config = path.join(root, 'agent-relay.mjs');
+    const tail = '__AGENT_RELAY_ERROR_TAIL__';
+    mkdirSync(tempRoot);
+    writeFileSync(config, `throw new Error(${JSON.stringify('x'.repeat(256_000) + tail)});\n`);
+
+    try {
+      let message = '';
+      await describeNodeDefinitionViaNode(
+        config,
+        deps({
+          env: { ...process.env, TMPDIR: tempRoot },
+          execCommand: async (command) => {
+            const result = await execAsync(command);
+            return { stdout: result.stdout, stderr: result.stderr };
+          },
+        })
+      ).catch((err: unknown) => {
+        message = err instanceof Error ? err.message : String(err);
+      });
+
+      expect(message).toContain(tail);
+      expect(readdirSync(tempRoot)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('startNodeJsNodeProvider', () => {
-  it('passes node credentials through the env contract the child reads', () => {
-    const spawnProcess = vi.fn(() => ({ pid: 42 }));
+  it('passes node credentials through the env contract the child reads', async () => {
+    const spawnProcess = vi.fn(() => ({ pid: 42, kill: vi.fn() }));
     const d = deps({ spawnProcess });
 
-    startNodeJsNodeProvider(
+    const child = await startNodeJsNodeProvider(
       '/proj/agent-relay.ts',
       {
         nodeToken: 'nt_live_x',
@@ -147,12 +240,13 @@ describe('startNodeJsNodeProvider', () => {
       RELAY_BASE_URL: 'https://cast.example.com',
       RELAY_WORKSPACE_KEY: 'rk_live_y',
     });
+    await child?.stop();
   });
 
-  it('omits optional env when not provided, so the SDK applies its own defaults', () => {
-    const spawnProcess = vi.fn(() => ({ pid: 1 }));
+  it('omits optional env when not provided, so the SDK applies its own defaults', async () => {
+    const spawnProcess = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
 
-    startNodeJsNodeProvider(
+    const child = await startNodeJsNodeProvider(
       '/proj/agent-relay.ts',
       { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
       deps({ spawnProcess })
@@ -161,21 +255,210 @@ describe('startNodeJsNodeProvider', () => {
     const options = spawnProcess.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv };
     expect(options.env.RELAY_BASE_URL).toBeUndefined();
     expect(options.env.RELAY_WORKSPACE_KEY).toBeUndefined();
+    await child?.stop();
   });
 
-  it('warns with actionable guidance when node is missing rather than throwing', () => {
-    const warn = vi.fn();
-    const spawnProcess = vi.fn(() => {
-      throw new Error('spawn node ENOENT');
-    });
-
-    const child = startNodeJsNodeProvider(
-      '/proj/agent-relay.ts',
-      { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
-      deps({ spawnProcess, warn })
+  it('handles the real asynchronous ENOENT emitted when node is missing', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'relay-node-provider-missing-node-'));
+    const tempRoot = path.join(root, 'tmp');
+    const config = path.join(root, 'agent-relay.mjs');
+    mkdirSync(tempRoot);
+    writeFileSync(
+      config,
+      "export default { __agentRelayFleetNode: true, name: 'fixture', capabilities: {}, triggers: [] };\n"
     );
+    const warn = vi.fn();
+    try {
+      const child = await startNodeJsNodeProvider(
+        config,
+        { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+        realProcessDeps({
+          env: {
+            ...process.env,
+            TMPDIR: tempRoot,
+            AGENT_RELAY_NODE: path.join(root, 'node-does-not-exist'),
+            RELAY_WORKSPACE_KEY: '',
+          },
+          warn,
+        })
+      );
 
-    expect(child).toBeUndefined();
-    expect(warn.mock.calls[0]?.[0]).toMatch(/AGENT_RELAY_NODE/);
+      expect(child).toBeUndefined();
+      expect(warn.mock.calls[0]?.[0]).toMatch(/AGENT_RELAY_NODE/);
+      expect(readdirSync(tempRoot)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('routes real child lifecycle logs through the shared file/JSON logger', async () => {
+    const fixture = createServingFixture();
+    const logFile = path.join(fixture.root, 'node.log');
+    vi.stubEnv('AGENT_RELAY_LOG_FILE', logFile);
+    vi.stubEnv('AGENT_RELAY_LOG_LEVEL', 'DEBUG');
+    vi.stubEnv('AGENT_RELAY_LOG_JSON', '1');
+
+    try {
+      const child = await startNodeJsNodeProvider(
+        fixture.config,
+        { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+        realProcessDeps({
+          env: {
+            ...process.env,
+            TMPDIR: fixture.tempRoot,
+            RELAY_WORKSPACE_KEY: '',
+          },
+        })
+      );
+      expect(child).toBeDefined();
+
+      await waitFor(() => existsSync(logFile) && readFileSync(logFile, 'utf8').includes('fixture info'));
+      await child!.stop();
+      await expect(child!.done).resolves.toBeUndefined();
+
+      const entries = readFileSync(logFile, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ level: 'DEBUG', component: 'fleet', msg: 'fixture debug' }),
+          expect.objectContaining({ level: 'INFO', component: 'fleet', msg: 'fixture info' }),
+          expect.objectContaining({ level: 'WARN', component: 'fleet', msg: 'fixture warning' }),
+        ])
+      );
+      expect(readdirSync(fixture.tempRoot)).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('surfaces an unexpected real child exit through the managed handle', async () => {
+    const fixture = createServingFixture();
+    try {
+      const child = await startNodeJsNodeProvider(
+        fixture.config,
+        { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+        realProcessDeps({
+          env: {
+            ...process.env,
+            TMPDIR: fixture.tempRoot,
+            FIXTURE_EXIT_AFTER_LOG: '1',
+            RELAY_WORKSPACE_KEY: '',
+          },
+        })
+      );
+
+      await expect(child?.done).rejects.toThrow(/exited unexpectedly/);
+      expect(readdirSync(fixture.tempRoot)).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
+
+describe('node provider child logging defaults', () => {
+  it('keeps debug/info off inherited stdout when no logging flag is set', () => {
+    const fixture = createServingFixture();
+    const materialized = materializeNodeProviderChildScript(fixture.config, fixture.tempRoot);
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      RELAY_NODE_TOKEN: 't',
+      RELAY_NODE_ID: 'n',
+      RELAY_WORKSPACE_KEY: '',
+      FIXTURE_EXIT_AFTER_LOG: '1',
+    };
+    delete env.AGENT_RELAY_LOG_FILE;
+    delete env.AGENT_RELAY_LOG_LEVEL;
+    delete env.AGENT_RELAY_LOG_JSON;
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [...materialized.nodeArgs, materialized.scriptPath, fixture.config],
+        { cwd: fixture.root, env, encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).not.toMatch(/fixture (debug|info)/);
+      expect(result.stderr).toContain('fixture warning');
+    } finally {
+      materialized.cleanup();
+      fixture.cleanup();
+    }
+  });
+});
+
+function realProcessDeps(overrides: Partial<CoreDependencies> = {}): CoreDependencies {
+  return deps({
+    spawnProcess: (command, args, options) =>
+      spawn(command, args, options as never) as unknown as SpawnedProcess,
+    killProcess: (pid, signal) => process.kill(pid, signal),
+    sleep: delay,
+    env: { ...process.env },
+    ...overrides,
+  });
+}
+
+function createServingFixture(): {
+  root: string;
+  tempRoot: string;
+  config: string;
+  cleanup(): void;
+} {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'relay-node-provider-serving-'));
+  const tempRoot = path.join(root, 'tmp');
+  const config = path.join(root, 'agent-relay.mjs');
+  const fleetRoot = path.join(root, 'node_modules', '@agent-relay', 'fleet');
+  mkdirSync(path.join(fleetRoot, 'dist'), { recursive: true });
+  mkdirSync(tempRoot);
+  writeFileSync(
+    config,
+    "export default { __agentRelayFleetNode: true, name: 'fixture', capabilities: {}, triggers: [] };\n"
+  );
+  writeFileSync(
+    path.join(fleetRoot, 'package.json'),
+    JSON.stringify({
+      name: '@agent-relay/fleet',
+      version: '10.0.0',
+      type: 'module',
+      main: 'dist/index.js',
+      exports: { '.': './dist/index.js' },
+    })
+  );
+  writeFileSync(
+    path.join(fleetRoot, 'dist', 'index.js'),
+    [
+      'export async function serveNode(options) {',
+      "  options.logger?.debug('fixture debug', { capability: 'spawn:test' });",
+      "  options.logger?.info('fixture info', { action: 'spawn:test' });",
+      "  options.logger?.warn('fixture warning', { action: 'spawn:test' });",
+      "  options.log?.('fixture debug');",
+      "  options.log?.('fixture info');",
+      "  options.warn?.('fixture warning');",
+      "  if (process.env.FIXTURE_EXIT_AFTER_LOG === '1') return;",
+      '  if (options.signal.aborted) return;',
+      '  await new Promise((resolve) => {',
+      '    const keepAlive = setInterval(() => undefined, 1_000);',
+      "    options.signal.addEventListener('abort', () => { clearInterval(keepAlive); resolve(); }, { once: true });",
+      '  });',
+      '}',
+    ].join('\n')
+  );
+  return {
+    root,
+    tempRoot,
+    config,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`condition not met within ${timeoutMs}ms`);
+    }
+    await delay(20);
+  }
+}

--- a/packages/cli/src/cli/lib/node-provider-child.test.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  descriptorCapacitySource,
+  describeNodeDefinitionViaNode,
+  isJsNodeDefinition,
+  parseNodeDescriptor,
+  startNodeJsNodeProvider,
+} from './node-provider-child.js';
+import { nodeCapacityHarnesses } from './fleet-sidecar.js';
+import type { CoreDependencies } from '../commands/core.js';
+
+const MARKER = '__AGENT_RELAY_NODE_DESCRIPTOR__';
+
+function deps(overrides: Partial<CoreDependencies> = {}): CoreDependencies {
+  return {
+    env: {},
+    log: vi.fn(),
+    warn: vi.fn(),
+    execCommand: vi.fn(),
+    spawnProcess: vi.fn(),
+    ...overrides,
+  } as unknown as CoreDependencies;
+}
+
+describe('parseNodeDescriptor', () => {
+  it('reads the marker line', () => {
+    const stdout = `${MARKER}${JSON.stringify({ name: 'n', capabilities: ['spawn:claude'] })}\n`;
+
+    expect(parseNodeDescriptor(stdout)).toEqual({ name: 'n', capabilities: ['spawn:claude'] });
+  });
+
+  it('ignores output the config printed on import', () => {
+    const stdout = [
+      'booting my node...',
+      `${MARKER}${JSON.stringify({ name: 'real', capabilities: [], maxAgents: 3 })}`,
+    ].join('\n');
+
+    expect(parseNodeDescriptor(stdout)).toEqual({ name: 'real', capabilities: [], maxAgents: 3 });
+  });
+
+  it('returns undefined when the child produced no descriptor', () => {
+    expect(parseNodeDescriptor('some unrelated output\n')).toBeUndefined();
+  });
+});
+
+describe('descriptorCapacitySource', () => {
+  it('feeds a descriptor’s spawn capabilities into the advertised capacity', () => {
+    const source = descriptorCapacitySource({
+      name: 'factory',
+      capabilities: ['spawn:claude', 'spawn:my-harness', 'workflow:run'],
+    });
+
+    // A node definition served out-of-process must still contribute its
+    // spawn:<harness> capacity, exactly as an in-process definition does.
+    expect(nodeCapacityHarnesses(null, source)).toContain('my-harness');
+  });
+});
+
+describe('isJsNodeDefinition', () => {
+  it.each(['agent-relay.ts', 'agent-relay.mts', 'agent-relay.mjs', 'agent-relay.js'])(
+    'treats %s as a JS/TS definition',
+    (file) => {
+      expect(isJsNodeDefinition(file)).toBe(true);
+    }
+  );
+
+  it('leaves agent-relay.py to the python provider', () => {
+    expect(isJsNodeDefinition('agent-relay.py')).toBe(false);
+  });
+});
+
+describe('describeNodeDefinitionViaNode', () => {
+  it('quotes paths so a config in a directory with spaces still loads', async () => {
+    const execCommand = vi.fn().mockResolvedValue({
+      stdout: `${MARKER}${JSON.stringify({ name: 'n', capabilities: [] })}`,
+      stderr: '',
+    });
+
+    await describeNodeDefinitionViaNode('/tmp/my project/agent-relay.ts', deps({ execCommand }));
+
+    const command = execCommand.mock.calls[0]?.[0] as string;
+    expect(command).toContain(`'/tmp/my project/agent-relay.ts'`);
+    expect(command).toContain('--describe');
+  });
+
+  it('honors AGENT_RELAY_NODE', async () => {
+    const execCommand = vi.fn().mockResolvedValue({
+      stdout: `${MARKER}${JSON.stringify({ name: 'n', capabilities: [] })}`,
+      stderr: '',
+    });
+
+    await describeNodeDefinitionViaNode(
+      '/tmp/agent-relay.ts',
+      deps({ execCommand, env: { AGENT_RELAY_NODE: '/opt/node20/bin/node' } })
+    );
+
+    expect(execCommand.mock.calls[0]?.[0]).toContain(`'/opt/node20/bin/node'`);
+  });
+
+  it('surfaces the child’s stderr, which carries the real load error', async () => {
+    const execCommand = vi
+      .fn()
+      .mockRejectedValue({ stderr: '[agent-relay] node provider: failed to load /x: boom', status: 2 });
+
+    await expect(describeNodeDefinitionViaNode('/x', deps({ execCommand }))).rejects.toThrow(/boom/);
+  });
+
+  it('rejects a file that does not default-export defineNode(...)', async () => {
+    const execCommand = vi.fn().mockResolvedValue({ stdout: 'nothing\n', stderr: '' });
+
+    await expect(describeNodeDefinitionViaNode('/x/agent-relay.ts', deps({ execCommand }))).rejects.toThrow(
+      /must default-export defineNode/
+    );
+  });
+});
+
+describe('startNodeJsNodeProvider', () => {
+  it('passes node credentials through the env contract the child reads', () => {
+    const spawnProcess = vi.fn(() => ({ pid: 42 }));
+    const d = deps({ spawnProcess });
+
+    startNodeJsNodeProvider(
+      '/proj/agent-relay.ts',
+      {
+        nodeToken: 'nt_live_x',
+        nodeId: 'node-1',
+        nodeName: 'my-node',
+        baseUrl: 'https://cast.example.com',
+        workspaceKey: 'rk_live_y',
+      },
+      d
+    );
+
+    const [command, args, options] = spawnProcess.mock.calls[0] as [
+      string,
+      string[],
+      { env: NodeJS.ProcessEnv; cwd: string },
+    ];
+    expect(command).toBe('node');
+    expect(args[1]).toBe('/proj/agent-relay.ts');
+    expect(options.cwd).toBe('/proj');
+    expect(options.env).toMatchObject({
+      RELAY_NODE_TOKEN: 'nt_live_x',
+      RELAY_NODE_ID: 'node-1',
+      RELAY_NODE_NAME: 'my-node',
+      RELAY_BASE_URL: 'https://cast.example.com',
+      RELAY_WORKSPACE_KEY: 'rk_live_y',
+    });
+  });
+
+  it('omits optional env when not provided, so the SDK applies its own defaults', () => {
+    const spawnProcess = vi.fn(() => ({ pid: 1 }));
+
+    startNodeJsNodeProvider(
+      '/proj/agent-relay.ts',
+      { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+      deps({ spawnProcess })
+    );
+
+    const options = spawnProcess.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv };
+    expect(options.env.RELAY_BASE_URL).toBeUndefined();
+    expect(options.env.RELAY_WORKSPACE_KEY).toBeUndefined();
+  });
+
+  it('warns with actionable guidance when node is missing rather than throwing', () => {
+    const warn = vi.fn();
+    const spawnProcess = vi.fn(() => {
+      throw new Error('spawn node ENOENT');
+    });
+
+    const child = startNodeJsNodeProvider(
+      '/proj/agent-relay.ts',
+      { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+      deps({ spawnProcess, warn })
+    );
+
+    expect(child).toBeUndefined();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/AGENT_RELAY_NODE/);
+  });
+});

--- a/packages/cli/src/cli/lib/node-provider-child.test.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.test.ts
@@ -355,6 +355,44 @@ describe('startNodeJsNodeProvider', () => {
       fixture.cleanup();
     }
   });
+
+  it('force-kills a real provider that ignores graceful shutdown', async () => {
+    const fixture = createServingFixture();
+    const readyFile = path.join(fixture.root, 'ignore-abort-ready');
+    let pid: number | undefined;
+    try {
+      const child = await startNodeJsNodeProvider(
+        fixture.config,
+        { nodeToken: 't', nodeId: 'n', nodeName: 'x' },
+        realProcessDeps({
+          env: {
+            ...process.env,
+            TMPDIR: fixture.tempRoot,
+            FIXTURE_IGNORE_ABORT: '1',
+            FIXTURE_READY_FILE: readyFile,
+            RELAY_WORKSPACE_KEY: '',
+          },
+          sleep: (ms) => delay(Math.min(ms, 50)),
+        })
+      );
+      expect(child).toBeDefined();
+      pid = child!.pid;
+      expect(pid).toBeDefined();
+      await waitFor(() => existsSync(readyFile));
+
+      await child!.stop();
+
+      await expect(child!.done).resolves.toBeUndefined();
+      expect(isProcessRunning(pid!)).toBe(false);
+      expect(readdirSync(fixture.tempRoot)).toEqual([]);
+    } finally {
+      if (pid && isProcessRunning(pid)) {
+        process.kill(pid, 'SIGKILL');
+        await delay(50);
+      }
+      fixture.cleanup();
+    }
+  });
 });
 
 describe('node provider child logging defaults', () => {
@@ -429,6 +467,7 @@ function createServingFixture(): {
   writeFileSync(
     path.join(fleetRoot, 'dist', 'index.js'),
     [
+      "import { writeFileSync } from 'node:fs';",
       'export async function serveNode(options) {',
       "  options.logger?.debug('fixture debug', { capability: 'spawn:test' });",
       "  options.logger?.info('fixture info', { action: 'spawn:test' });",
@@ -437,6 +476,11 @@ function createServingFixture(): {
       "  options.log?.('fixture info');",
       "  options.warn?.('fixture warning');",
       "  if (process.env.FIXTURE_EXIT_AFTER_LOG === '1') return;",
+      "  if (process.env.FIXTURE_IGNORE_ABORT === '1') {",
+      "    writeFileSync(process.env.FIXTURE_READY_FILE, 'ready');",
+      '    setInterval(() => undefined, 1_000);',
+      '    await new Promise(() => undefined);',
+      '  }',
       '  if (options.signal.aborted) return;',
       '  await new Promise((resolve) => {',
       '    const keepAlive = setInterval(() => undefined, 1_000);',
@@ -451,6 +495,15 @@ function createServingFixture(): {
     config,
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { createLogger } from '@agent-relay/utils';
 
 import type { CoreDependencies, SpawnedProcess } from '../commands/core.js';
 
@@ -15,6 +19,12 @@ export type NodeProviderCredentials = {
   nodeName: string;
   workspaceKey?: string;
 };
+
+/** Derive a package root from a resolved entry on both POSIX and Windows. */
+export function packageRootFromEntry(entry: string, packageName: string): string {
+  const index = entry.replace(/\\/g, '/').lastIndexOf(packageName);
+  return index >= 0 ? entry.slice(0, index + packageName.length) : entry;
+}
 
 /**
  * Bootstrap executed by a child `node` process to serve a JS/TS fleet node
@@ -52,15 +62,13 @@ import { pathToFileURL } from 'node:url';
 
 const configPath = process.argv[2];
 const describeOnly = process.argv.includes('--describe');
+const FAILURE = Symbol('node-provider-failure');
 
 const fail = (message) => {
   console.error('[agent-relay] node provider: ' + message);
-  process.exit(2);
+  process.exitCode = 2;
+  throw FAILURE;
 };
-
-if (!configPath) {
-  fail('missing config path argument.');
-}
 
 const isDefinition = (value) =>
   Boolean(value && typeof value === 'object' && value.__agentRelayFleetNode === true);
@@ -75,11 +83,16 @@ const unwrap = (loaded) => {
   return candidate;
 };
 
+const errorText = (err) => (err && (err.stack || err.message)) || String(err);
+const packageRootFromEntry = ${packageRootFromEntry.toString()};
+
+const main = async () => {
+if (!configPath) {
+  fail('missing config path argument.');
+}
 const requireFromConfig = createRequire(configPath);
 const importFromConfig = async (specifier) =>
   import(pathToFileURL(requireFromConfig.resolve(specifier)).href);
-
-const errorText = (err) => (err && (err.stack || err.message)) || String(err);
 
 let definition;
 try {
@@ -103,7 +116,7 @@ if (describeOnly) {
     ...(typeof definition.maxAgents === 'number' ? { maxAgents: definition.maxAgents } : {}),
   };
   console.log('__AGENT_RELAY_NODE_DESCRIPTOR__' + JSON.stringify(descriptor));
-  process.exit(0);
+  return;
 }
 
 // Only serving needs the fleet runtime; describing must not require it, so a
@@ -122,10 +135,8 @@ try {
 
 // serveNode's connection contract below is fleet >=10 ({nodeToken, nodeId}).
 // Fleet 9 took {url, apiKey} and would silently reconnect forever instead.
-const fleetRoot = fleetEntry.slice(
-  0,
-  fleetEntry.lastIndexOf('@agent-relay/fleet') + '@agent-relay/fleet'.length
-);
+const fleetPackage = '@agent-relay/fleet';
+const fleetRoot = packageRootFromEntry(fleetEntry, fleetPackage);
 let fleetVersion;
 try {
   fleetVersion = requireFromConfig(fleetRoot + '/package.json').version;
@@ -157,6 +168,29 @@ const nodeId = env.RELAY_NODE_ID;
 const nodeName = env.RELAY_NODE_NAME;
 const baseUrl = env.RELAY_BASE_URL && env.RELAY_BASE_URL.trim();
 const workspaceKey = env.RELAY_WORKSPACE_KEY && env.RELAY_WORKSPACE_KEY.trim();
+const loggingEnabled = Boolean(
+  env.AGENT_RELAY_LOG_FILE || env.AGENT_RELAY_LOG_LEVEL || env.AGENT_RELAY_LOG_JSON === '1'
+);
+
+const sendLog = (level, message, extra) => {
+  if (typeof process.send === 'function') {
+    process.send({
+      __agentRelayNodeProviderLog: true,
+      level,
+      message,
+      ...(extra && typeof extra === 'object' ? { extra } : {}),
+    });
+  }
+};
+const logger = {
+  debug: (message, extra) => sendLog('debug', message, extra),
+  info: (message, extra) => sendLog('info', message, extra),
+  warn: (message, extra) => sendLog('warn', message, extra),
+  error: (message, extra) => sendLog('error', message, extra),
+};
+const warn = loggingEnabled
+  ? (message, extra) => logger.warn(message, extra)
+  : (message) => console.warn('[agent-relay][node] ' + message);
 
 if (!nodeToken || !nodeId) {
   fail('RELAY_NODE_TOKEN and RELAY_NODE_ID are required.');
@@ -174,9 +208,7 @@ if (workspaceKey) {
       delete: (id) => relay.triggers.delete(id),
     };
   } catch (err) {
-    console.warn(
-      '[agent-relay] node provider: message triggers will not sync (' + errorText(err) + ').'
-    );
+    warn('Message triggers will not sync (' + errorText(err) + ').');
   }
 }
 
@@ -194,12 +226,20 @@ try {
     ...(triggers ? { triggers } : {}),
     reconnect: true,
     signal: stopSignal.signal,
-    log: (message) => console.log('[agent-relay][node] ' + message),
-    warn: (message) => console.warn('[agent-relay][node] ' + message),
+    ...(loggingEnabled ? { logger } : { warn }),
   });
 } catch (err) {
   if (!stopSignal.signal.aborted) {
     fail('serving ' + configPath + ' failed: ' + errorText(err));
+  }
+}
+};
+
+try {
+  await main();
+} catch (err) {
+  if (err !== FAILURE) {
+    throw err;
   }
 }
 `;
@@ -256,6 +296,7 @@ export function descriptorCapacitySource(descriptor: NodeDefinitionDescriptor): 
  * a `bun build --compile` binary.
  */
 const JS_NODE_DEFINITION_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs']);
+const TS_NODE_DEFINITION_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 
 /** Whether `configPath` is a JS/TS node definition (as opposed to `agent-relay.py`). */
 export function isJsNodeDefinition(configPath: string): boolean {
@@ -266,16 +307,205 @@ export function isJsNodeDefinition(configPath: string): boolean {
  * Write the child bootstrap to a temp file so a child `node` process has
  * something on disk to execute. The compiled binary has no `dist/` on disk, so
  * the source is materialized per run.
- * @param mkdtemp - Temp-dir factory, injectable for tests.
- * @returns Absolute path to the materialized bootstrap module.
+ * TypeScript inputs are pre-transpiled by the compiled Bun parent and served
+ * through a Node loader hook at their original file URLs. Keeping the original
+ * URLs preserves both relative imports and bare-specifier resolution from the
+ * config's own `node_modules`.
+ * @param configPath - Node definition the bootstrap will load.
+ * @param tempRoot - Root in which to create the private bootstrap directory.
+ * @returns Materialized bootstrap arguments and an idempotent cleanup handle.
  */
 export function materializeNodeProviderChildScript(
-  mkdtemp: (prefix: string) => string = (prefix) => fs.mkdtempSync(prefix)
-): string {
-  const dir = mkdtemp(path.join(os.tmpdir(), 'agent-relay-node-provider-'));
-  const file = path.join(dir, 'node-provider-child.mjs');
-  fs.writeFileSync(file, NODE_PROVIDER_CHILD_SOURCE, 'utf8');
-  return file;
+  configPath: string,
+  tempRoot = os.tmpdir()
+): MaterializedNodeProviderChild {
+  const directory = fs.mkdtempSync(path.join(tempRoot, 'agent-relay-node-provider-'));
+  activeTempDirectories.add(directory);
+  registerTempCleanupFallback();
+
+  try {
+    const scriptPath = path.join(directory, 'node-provider-child.mjs');
+    fs.writeFileSync(scriptPath, NODE_PROVIDER_CHILD_SOURCE, 'utf8');
+
+    const nodeArgs: string[] = [];
+    const transpiled = transpileTypeScriptGraph(configPath);
+    if (transpiled) {
+      const loaderPath = path.join(directory, 'node-definition-loader.mjs');
+      const registerPath = path.join(directory, 'register-node-definition-loader.mjs');
+      fs.writeFileSync(loaderPath, renderNodeLoader(transpiled), 'utf8');
+      fs.writeFileSync(
+        registerPath,
+        [
+          "import { register } from 'node:module';",
+          `register(${JSON.stringify(pathToFileURL(loaderPath).href)}, import.meta.url);`,
+          '',
+        ].join('\n'),
+        'utf8'
+      );
+      nodeArgs.push('--import', registerPath);
+    }
+
+    let cleaned = false;
+    return {
+      scriptPath,
+      nodeArgs,
+      directory,
+      cleanup: () => {
+        if (cleaned) return;
+        cleaned = true;
+        cleanupTempDirectory(directory);
+      },
+    };
+  } catch (err) {
+    cleanupTempDirectory(directory);
+    throw err;
+  }
+}
+
+export type MaterializedNodeProviderChild = {
+  scriptPath: string;
+  nodeArgs: string[];
+  directory: string;
+  cleanup(): void;
+};
+
+type BunTranspiler = {
+  transformSync(source: string, loader?: 'ts' | 'tsx'): string;
+  scanImports(source: string): Array<{ path: string }>;
+};
+
+type BunRuntime = {
+  Transpiler: new (options: { loader: 'ts' | 'tsx'; target: 'node' }) => BunTranspiler;
+};
+
+type TranspiledGraph = {
+  sources: Record<string, string>;
+  resolutions: Record<string, string>;
+};
+
+const activeTempDirectories = new Set<string>();
+let tempCleanupFallbackRegistered = false;
+
+function registerTempCleanupFallback(): void {
+  if (tempCleanupFallbackRegistered) return;
+  tempCleanupFallbackRegistered = true;
+  process.once('exit', () => {
+    for (const directory of [...activeTempDirectories]) {
+      cleanupTempDirectory(directory);
+    }
+  });
+}
+
+function cleanupTempDirectory(directory: string): void {
+  activeTempDirectories.delete(directory);
+  try {
+    fs.rmSync(directory, { recursive: true, force: true });
+  } catch {
+    // Best effort: lifecycle cleanup must never mask the provider result.
+  }
+}
+
+/** Pre-transpile the entry and its statically imported local TypeScript graph. */
+function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefined {
+  if (!TS_NODE_DEFINITION_EXTENSIONS.has(path.extname(configPath).toLowerCase())) {
+    return undefined;
+  }
+  const bun = (globalThis as typeof globalThis & { Bun?: BunRuntime }).Bun;
+  if (!bun?.Transpiler) {
+    // This helper is only selected by the compiled-Bun serving plan. Retaining
+    // the native Node path here keeps isolated Node unit tests injectable.
+    return undefined;
+  }
+
+  const sources: Record<string, string> = {};
+  const resolutions: Record<string, string> = {};
+  const queued = [path.resolve(configPath)];
+  const seen = new Set<string>();
+
+  while (queued.length > 0) {
+    const file = queued.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = fs.readFileSync(file, 'utf8');
+    const loader = path.extname(file).toLowerCase() === '.tsx' ? 'tsx' : 'ts';
+    const transpiler = new bun.Transpiler({ loader, target: 'node' });
+    const parentUrls = new Set([pathToFileURL(file).href, pathToFileURL(fs.realpathSync(file)).href]);
+    const transformed = transpiler.transformSync(source, loader);
+    for (const parentUrl of parentUrls) {
+      sources[parentUrl] = transformed;
+    }
+
+    for (const imported of transpiler.scanImports(source)) {
+      const resolved = resolveImportedTypeScript(file, imported.path);
+      if (!resolved) continue;
+      const resolvedUrl = pathToFileURL(fs.realpathSync(resolved)).href;
+      for (const parentUrl of parentUrls) {
+        resolutions[loaderResolutionKey(parentUrl, imported.path)] = resolvedUrl;
+      }
+      queued.push(resolved);
+    }
+  }
+
+  return { sources, resolutions };
+}
+
+function resolveImportedTypeScript(parentFile: string, specifier: string): string | undefined {
+  let candidate: string;
+  try {
+    if (specifier.startsWith('file:')) {
+      candidate = fileURLToPath(specifier);
+    } else if (specifier.startsWith('.') || path.isAbsolute(specifier)) {
+      candidate = path.resolve(path.dirname(parentFile), specifier);
+    } else {
+      candidate = createRequire(parentFile).resolve(specifier);
+    }
+  } catch {
+    return undefined;
+  }
+
+  const attempts = [candidate];
+  if (!path.extname(candidate)) {
+    for (const extension of TS_NODE_DEFINITION_EXTENSIONS) {
+      attempts.push(candidate + extension, path.join(candidate, 'index' + extension));
+    }
+  } else if (/\.[cm]?js$/i.test(candidate)) {
+    const stem = candidate.replace(/\.[cm]?js$/i, '');
+    attempts.push(stem + '.ts', stem + '.tsx', stem + '.mts', stem + '.cts');
+  }
+  const resolved = attempts.find(
+    (attempt) => TS_NODE_DEFINITION_EXTENSIONS.has(path.extname(attempt).toLowerCase()) && isFile(attempt)
+  );
+  return resolved ? path.resolve(resolved) : undefined;
+}
+
+function isFile(file: string): boolean {
+  try {
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function loaderResolutionKey(parentUrl: string, specifier: string): string {
+  return `${parentUrl}\0${specifier}`;
+}
+
+function renderNodeLoader(graph: TranspiledGraph): string {
+  return [
+    `const sources = new Map(Object.entries(${JSON.stringify(graph.sources)}));`,
+    `const resolutions = new Map(Object.entries(${JSON.stringify(graph.resolutions)}));`,
+    `const key = (parentURL, specifier) => parentURL + '\\0' + specifier;`,
+    'export async function resolve(specifier, context, nextResolve) {',
+    '  const url = resolutions.get(key(context.parentURL || "", specifier));',
+    '  return url ? { url, shortCircuit: true } : nextResolve(specifier, context);',
+    '}',
+    'export async function load(url, context, nextLoad) {',
+    '  const source = sources.get(url);',
+    "  return source === undefined ? nextLoad(url, context) : { format: 'module', source, shortCircuit: true };",
+    '}',
+    '',
+  ].join('\n');
 }
 
 /** Single-quote a path for safe interpolation into a shell command. */
@@ -301,8 +531,10 @@ export async function describeNodeDefinitionViaNode(
   deps: CoreDependencies
 ): Promise<NodeDefinitionDescriptor> {
   const nodeBin = deps.env.AGENT_RELAY_NODE?.trim() || 'node';
-  const script = materializeNodeProviderChildScript();
-  const command = `${shellQuote(nodeBin)} ${shellQuote(script)} ${shellQuote(configPath)} --describe`;
+  const materialized = materializeNodeProviderChildScript(configPath, deps.env.TMPDIR?.trim() || os.tmpdir());
+  const command = [nodeBin, ...materialized.nodeArgs, materialized.scriptPath, configPath, '--describe']
+    .map(shellQuote)
+    .join(' ');
 
   let stdout: string;
   try {
@@ -314,6 +546,8 @@ export async function describeNodeDefinitionViaNode(
         `Serving a JS/TS node definition from the standalone agent-relay binary requires \`${nodeBin}\` on PATH ` +
         '(set AGENT_RELAY_NODE to override).'
     );
+  } finally {
+    materialized.cleanup();
   }
 
   const descriptor = parseNodeDescriptor(stdout);
@@ -345,13 +579,13 @@ function extractChildFailure(err: unknown): string {
  * @param configPath - Absolute path to the user's node definition file.
  * @param credentials - Node identity/token the child registers with.
  * @param deps - Core dependencies (spawn, env, logging).
- * @returns The spawned child, or `undefined` when it could not be started.
+ * @returns A supervised child handle, or `undefined` when it could not be started.
  */
-export function startNodeJsNodeProvider(
+export async function startNodeJsNodeProvider(
   configPath: string,
   credentials: NodeProviderCredentials,
   deps: CoreDependencies
-): SpawnedProcess | undefined {
+): Promise<RunningNodeProviderChild | undefined> {
   const nodeBin = deps.env.AGENT_RELAY_NODE?.trim() || 'node';
   const env: NodeJS.ProcessEnv = {
     ...deps.env,
@@ -361,19 +595,29 @@ export function startNodeJsNodeProvider(
     ...(credentials.baseUrl ? { RELAY_BASE_URL: credentials.baseUrl } : {}),
     ...(credentials.workspaceKey ? { RELAY_WORKSPACE_KEY: credentials.workspaceKey } : {}),
   };
+  const loggingEnabled = childLoggingEnabled(env);
+  let materialized: MaterializedNodeProviderChild | undefined;
 
   try {
-    const script = materializeNodeProviderChildScript();
-    const child = deps.spawnProcess(nodeBin, [script, configPath], {
-      stdio: 'inherit',
-      env,
-      cwd: path.dirname(configPath),
-    });
+    materialized = materializeNodeProviderChildScript(configPath, deps.env.TMPDIR?.trim() || os.tmpdir());
+    const child = deps.spawnProcess(
+      nodeBin,
+      [...materialized.nodeArgs, materialized.scriptPath, configPath],
+      {
+        stdio: loggingEnabled ? ['inherit', 'inherit', 'inherit', 'ipc'] : 'inherit',
+        env,
+        cwd: path.dirname(configPath),
+      }
+    );
+    attachChildLogger(child, loggingEnabled);
+    const managed = manageNodeProviderChild(child, materialized, deps, configPath);
+    await managed.started;
     deps.log(
       `Serving fleet node provider: ${nodeBin} ${path.basename(configPath)} (pid: ${child.pid ?? 'unknown'}).`
     );
-    return child;
+    return managed.handle;
   } catch (err) {
+    materialized?.cleanup();
     deps.warn(
       `Fleet node provider skipped: ${err instanceof Error ? err.message : String(err)}. ` +
         `Serving a JS/TS node definition from the standalone agent-relay binary requires \`${nodeBin}\` on PATH; ` +
@@ -381,4 +625,129 @@ export function startNodeJsNodeProvider(
     );
     return undefined;
   }
+}
+
+/** Managed child contract used by the broker lifecycle. */
+export type RunningNodeProviderChild = {
+  pid?: number;
+  done: Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EventedSpawnedProcess = SpawnedProcess & {
+  once?: (event: string, listener: (...args: unknown[]) => void) => unknown;
+  on?: (event: string, listener: (...args: unknown[]) => void) => unknown;
+};
+
+function childLoggingEnabled(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env.AGENT_RELAY_LOG_FILE || env.AGENT_RELAY_LOG_LEVEL || env.AGENT_RELAY_LOG_JSON === '1');
+}
+
+function attachChildLogger(child: SpawnedProcess, enabled: boolean): void {
+  const evented = child as EventedSpawnedProcess;
+  if (!enabled || typeof evented.on !== 'function') return;
+  const logger = createLogger('fleet');
+  evented.on('message', (message: unknown) => {
+    if (!isChildLogMessage(message)) return;
+    logger[message.level](message.message, message.extra);
+  });
+}
+
+type ChildLogMessage = {
+  __agentRelayNodeProviderLog: true;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  extra?: Record<string, unknown>;
+};
+
+function isChildLogMessage(value: unknown): value is ChildLogMessage {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ChildLogMessage>;
+  return (
+    candidate.__agentRelayNodeProviderLog === true &&
+    typeof candidate.message === 'string' &&
+    ['debug', 'info', 'warn', 'error'].includes(String(candidate.level)) &&
+    (candidate.extra === undefined ||
+      (typeof candidate.extra === 'object' && candidate.extra !== null && !Array.isArray(candidate.extra)))
+  );
+}
+
+function manageNodeProviderChild(
+  child: SpawnedProcess,
+  materialized: MaterializedNodeProviderChild,
+  deps: CoreDependencies,
+  configPath: string
+): { started: Promise<void>; handle: RunningNodeProviderChild } {
+  const evented = child as EventedSpawnedProcess;
+  const observesLifecycle = typeof evented.once === 'function';
+  let stopping = false;
+  let settled = false;
+  let resolveDone!: () => void;
+  let rejectDone!: (err: Error) => void;
+  let resolveStarted!: () => void;
+  let rejectStarted!: (err: Error) => void;
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+  // A child may fail between startNodeJsNodeProvider returning and the broker
+  // attaching its lifecycle race. Mark the promise handled without changing
+  // what callers observe when they await the original promise.
+  void done.catch(() => undefined);
+  const started = new Promise<void>((resolve, reject) => {
+    resolveStarted = resolve;
+    rejectStarted = reject;
+  });
+
+  const finish = (error?: Error): void => {
+    if (settled) return;
+    settled = true;
+    materialized.cleanup();
+    if (error && !stopping) {
+      rejectDone(error);
+    } else {
+      resolveDone();
+    }
+  };
+
+  if (observesLifecycle) {
+    evented.once!('spawn', () => resolveStarted());
+    evented.once!('error', (rawError: unknown) => {
+      const error = rawError instanceof Error ? rawError : new Error(String(rawError));
+      rejectStarted(error);
+      finish(new Error(`Fleet node provider for ${configPath} failed: ${error.message}`, { cause: error }));
+    });
+    evented.once!('exit', (code: unknown, signal: unknown) => {
+      const detail = signal ? `signal ${String(signal)}` : `code ${String(code)}`;
+      finish(new Error(`Fleet node provider for ${configPath} exited unexpectedly (${detail}).`));
+    });
+  } else {
+    resolveStarted();
+  }
+
+  return {
+    started,
+    handle: {
+      ...(child.pid !== undefined ? { pid: child.pid } : {}),
+      done,
+      stop: async () => {
+        stopping = true;
+        if (!settled) {
+          try {
+            if (child.pid) {
+              deps.killProcess(child.pid, 'SIGTERM');
+            } else {
+              child.kill?.('SIGTERM');
+            }
+          } catch {
+            // The child may already have exited between the state check and kill.
+          }
+        }
+        if (observesLifecycle && !settled) {
+          await Promise.race([done.catch(() => undefined), deps.sleep(5_000)]);
+        }
+        finish();
+      },
+    },
+  };
 }

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -375,7 +375,11 @@ type BunTranspiler = {
 };
 
 type BunRuntime = {
-  Transpiler: new (options: { loader: 'ts' | 'tsx'; target: 'node' }) => BunTranspiler;
+  Transpiler: new (options: {
+    loader: 'ts' | 'tsx';
+    target: 'node';
+    define?: Record<string, string>;
+  }) => BunTranspiler;
 };
 
 type TranspiledGraph = {
@@ -419,6 +423,7 @@ function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefin
 
   const sources: Record<string, string> = {};
   const resolutions: Record<string, string> = {};
+  const commonJsSources: Record<string, string> = {};
   const queued = [path.resolve(configPath)];
   const seen = new Set<string>();
 
@@ -430,12 +435,26 @@ function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefin
     const source = fs.readFileSync(file, 'utf8');
     const extension = path.extname(file).toLowerCase();
     const loader = extension === '.tsx' ? 'tsx' : 'ts';
-    const transpiler = new bun.Transpiler({ loader, target: 'node' });
+    const transpiler = new bun.Transpiler({
+      loader,
+      target: 'node',
+      ...(extension === '.cts'
+        ? {
+            define: {
+              __filename: '__relayCommonJsFilename',
+              __dirname: '__relayCommonJsDirname',
+            },
+          }
+        : {}),
+    });
     const parentUrls = new Set([pathToFileURL(file).href, pathToFileURL(fs.realpathSync(file)).href]);
-    const rawTransformed = transpiler.transformSync(source, loader);
-    const transformed = extension === '.cts' ? wrapCommonJsAsModule(rawTransformed) : rawTransformed;
+    const transformed = transpiler.transformSync(source, loader);
     for (const parentUrl of parentUrls) {
-      sources[parentUrl] = transformed;
+      if (extension === '.cts') {
+        commonJsSources[parentUrl] = transformed;
+      } else {
+        sources[parentUrl] = transformed;
+      }
     }
 
     for (const imported of transpiler.scanImports(source)) {
@@ -449,30 +468,63 @@ function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefin
     }
   }
 
+  for (const entryUrl of Object.keys(commonJsSources)) {
+    sources[entryUrl] = wrapCommonJsAsModule(entryUrl, commonJsSources, resolutions);
+  }
+
   return { sources, resolutions };
 }
 
-/** Execute transpiled .cts output with the CommonJS bindings users expect. */
-function wrapCommonJsAsModule(source: string): string {
+/** Execute a transpiled .cts graph synchronously with Node-like CommonJS modules. */
+function wrapCommonJsAsModule(
+  entryUrl: string,
+  commonJsSources: Record<string, string>,
+  resolutions: Record<string, string>
+): string {
   return [
-    "import { createRequire as __relayCreateRequire } from 'node:module';",
+    "import { Module as __RelayModule, createRequire as __relayCreateRequire } from 'node:module';",
     "import { dirname as __relayDirname } from 'node:path';",
     "import { fileURLToPath as __relayFileURLToPath } from 'node:url';",
-    'const __relayModule = { exports: {} };',
-    'const __relayFilename = __relayFileURLToPath(import.meta.url);',
-    'const __relayRequire = __relayCreateRequire(import.meta.url);',
-    'const __relayDir = __relayDirname(__relayFilename);',
-    '(function (exports, require, module, __filename, __dirname) {',
-    source,
-    '}).call(',
-    '  __relayModule.exports,',
-    '  __relayModule.exports,',
-    '  __relayRequire,',
-    '  __relayModule,',
-    '  __relayFilename,',
-    '  __relayDir',
-    ');',
-    'export default __relayModule.exports;',
+    `const __relaySources = new Map(Object.entries(${JSON.stringify(commonJsSources)}));`,
+    `const __relayResolutions = new Map(Object.entries(${JSON.stringify(resolutions)}));`,
+    `const __relayKey = (parentURL, specifier) => parentURL + '\\0' + specifier;`,
+    'const __relayCache = new Map();',
+    'const __relayLoad = (url, parent) => {',
+    '  const cached = __relayCache.get(url);',
+    '  if (cached) return cached.exports;',
+    '  const source = __relaySources.get(url);',
+    "  if (source === undefined) throw new Error('Missing transpiled CommonJS source for ' + url);",
+    '  const filename = __relayFileURLToPath(url);',
+    '  const dirname = __relayDirname(filename);',
+    '  const nativeRequire = __relayCreateRequire(url);',
+    '  const relayModule = new __RelayModule(filename, parent);',
+    '  relayModule.filename = filename;',
+    '  relayModule.path = dirname;',
+    "  relayModule.paths = nativeRequire.resolve.paths('__agent_relay_module_paths__') || [];",
+    '  const relayRequire = (specifier) => {',
+    '    const resolved = __relayResolutions.get(__relayKey(url, specifier));',
+    '    return resolved && __relaySources.has(resolved)',
+    '      ? __relayLoad(resolved, relayModule)',
+    '      : nativeRequire(specifier);',
+    '  };',
+    '  relayRequire.resolve = nativeRequire.resolve;',
+    '  relayRequire.cache = nativeRequire.cache;',
+    '  relayRequire.extensions = nativeRequire.extensions;',
+    '  relayRequire.main = nativeRequire.main;',
+    '  relayModule.require = relayRequire;',
+    '  __relayCache.set(url, relayModule);',
+    '  const factory = new Function(',
+    "    'exports', 'require', 'module', '__filename', '__dirname',",
+    "    '__relayCommonJsFilename', '__relayCommonJsDirname', source",
+    '  );',
+    '  factory.call(',
+    '    relayModule.exports, relayModule.exports, relayRequire, relayModule,',
+    '    filename, dirname, filename, dirname',
+    '  );',
+    '  relayModule.loaded = true;',
+    '  return relayModule.exports;',
+    '};',
+    `export default __relayLoad(${JSON.stringify(entryUrl)}, undefined);`,
     '',
   ].join('\n');
 }
@@ -771,7 +823,25 @@ function manageNodeProviderChild(
           }
         }
         if (observesLifecycle && !settled) {
-          await Promise.race([done.catch(() => undefined), deps.sleep(5_000)]);
+          const exited = await Promise.race([
+            done.then(
+              () => true,
+              () => true
+            ),
+            deps.sleep(5_000).then(() => false),
+          ]);
+          if (!exited && !settled) {
+            try {
+              if (child.pid) {
+                deps.killProcess(child.pid, 'SIGKILL');
+              } else {
+                child.kill?.('SIGKILL');
+              }
+            } catch {
+              // The child may have exited while graceful shutdown timed out.
+            }
+            await Promise.race([done.catch(() => undefined), deps.sleep(1_000)]);
+          }
         }
         finish();
       },

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -428,10 +428,12 @@ function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefin
     seen.add(file);
 
     const source = fs.readFileSync(file, 'utf8');
-    const loader = path.extname(file).toLowerCase() === '.tsx' ? 'tsx' : 'ts';
+    const extension = path.extname(file).toLowerCase();
+    const loader = extension === '.tsx' ? 'tsx' : 'ts';
     const transpiler = new bun.Transpiler({ loader, target: 'node' });
     const parentUrls = new Set([pathToFileURL(file).href, pathToFileURL(fs.realpathSync(file)).href]);
-    const transformed = transpiler.transformSync(source, loader);
+    const rawTransformed = transpiler.transformSync(source, loader);
+    const transformed = extension === '.cts' ? wrapCommonJsAsModule(rawTransformed) : rawTransformed;
     for (const parentUrl of parentUrls) {
       sources[parentUrl] = transformed;
     }
@@ -448,6 +450,31 @@ function transpileTypeScriptGraph(configPath: string): TranspiledGraph | undefin
   }
 
   return { sources, resolutions };
+}
+
+/** Execute transpiled .cts output with the CommonJS bindings users expect. */
+function wrapCommonJsAsModule(source: string): string {
+  return [
+    "import { createRequire as __relayCreateRequire } from 'node:module';",
+    "import { dirname as __relayDirname } from 'node:path';",
+    "import { fileURLToPath as __relayFileURLToPath } from 'node:url';",
+    'const __relayModule = { exports: {} };',
+    'const __relayFilename = __relayFileURLToPath(import.meta.url);',
+    'const __relayRequire = __relayCreateRequire(import.meta.url);',
+    'const __relayDir = __relayDirname(__relayFilename);',
+    '(function (exports, require, module, __filename, __dirname) {',
+    source,
+    '}).call(',
+    '  __relayModule.exports,',
+    '  __relayModule.exports,',
+    '  __relayRequire,',
+    '  __relayModule,',
+    '  __relayFilename,',
+    '  __relayDir',
+    ');',
+    'export default __relayModule.exports;',
+    '',
+  ].join('\n');
 }
 
 function resolveImportedTypeScript(parentFile: string, specifier: string): string | undefined {

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -1,0 +1,384 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { CoreDependencies, SpawnedProcess } from '../commands/core.js';
+
+/**
+ * Credentials handed to an out-of-process node provider, mirroring the env
+ * contract the Python provider already uses.
+ */
+export type NodeProviderCredentials = {
+  nodeToken: string;
+  baseUrl?: string;
+  nodeId: string;
+  nodeName: string;
+  workspaceKey?: string;
+};
+
+/**
+ * Bootstrap executed by a child `node` process to serve a JS/TS fleet node
+ * definition.
+ *
+ * Why this exists: a `bun build --compile` binary cannot resolve a bare package
+ * specifier out of a user's on-disk `node_modules` when the package's entry
+ * point lives in a subdirectory (`dist/`, `lib/`) rather than at the package
+ * root — which is every package built from TypeScript, `@agent-relay/factory`
+ * and `@agent-relay/fleet` included. So importing a node config inside the
+ * shipped binary fails on the config's own `@agent-relay/factory/node` import,
+ * and the failure is transitive through the user's whole dependency graph, so
+ * no entry-point-only resolution fix can work.
+ *
+ * Node resolves bare specifiers relative to the *importing file*, so importing
+ * the config by absolute path from this bootstrap (wherever the bootstrap
+ * itself lives) resolves the config's imports against the config's own
+ * `node_modules`, exactly as a plain `node` run would.
+ *
+ * Kept as source text rather than a shipped file because the compiled binary
+ * has no `dist/` on disk to point `node` at; it is materialized to a temp file
+ * at spawn time.
+ *
+ * `@agent-relay/fleet` and `@agent-relay/sdk` are resolved from the *config's*
+ * directory — the only copies on disk, since the compiled binary's own are
+ * sealed inside it — mirroring how the Python provider uses the user's own SDK.
+ * That makes the user's fleet version part of the contract: `serveNode`'s
+ * connection shape changed in fleet 10 (`{nodeToken, nodeId}`; fleet 9 took
+ * `{url, apiKey}`), so an older fleet is rejected up front rather than left to
+ * fail as an endless reconnect loop against a URL it never received.
+ */
+export const NODE_PROVIDER_CHILD_SOURCE = String.raw`
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const configPath = process.argv[2];
+const describeOnly = process.argv.includes('--describe');
+
+const fail = (message) => {
+  console.error('[agent-relay] node provider: ' + message);
+  process.exit(2);
+};
+
+if (!configPath) {
+  fail('missing config path argument.');
+}
+
+const isDefinition = (value) =>
+  Boolean(value && typeof value === 'object' && value.__agentRelayFleetNode === true);
+
+const unwrap = (loaded) => {
+  let candidate = loaded;
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (isDefinition(candidate)) return candidate;
+    if (!candidate || typeof candidate !== 'object' || !('default' in candidate)) return candidate;
+    candidate = candidate.default;
+  }
+  return candidate;
+};
+
+const requireFromConfig = createRequire(configPath);
+const importFromConfig = async (specifier) =>
+  import(pathToFileURL(requireFromConfig.resolve(specifier)).href);
+
+const errorText = (err) => (err && (err.stack || err.message)) || String(err);
+
+let definition;
+try {
+  definition = unwrap(await import(pathToFileURL(configPath).href));
+} catch (err) {
+  fail('failed to load ' + configPath + ': ' + errorText(err));
+}
+
+if (!isDefinition(definition)) {
+  fail(configPath + ' must default-export defineNode(...)');
+}
+
+// Describe mode: report the definition's identity/capability names so the CLI can
+// advertise spawn:<harness> capacity and fail fast on a bad explicit --config
+// without ever loading the definition in-process. Marker-prefixed and read from
+// the last matching line, so a config that prints on import cannot corrupt it.
+if (describeOnly) {
+  const descriptor = {
+    name: definition.name,
+    capabilities: Object.keys(definition.capabilities || {}),
+    ...(typeof definition.maxAgents === 'number' ? { maxAgents: definition.maxAgents } : {}),
+  };
+  console.log('__AGENT_RELAY_NODE_DESCRIPTOR__' + JSON.stringify(descriptor));
+  process.exit(0);
+}
+
+// Only serving needs the fleet runtime; describing must not require it, so a
+// config can be validated even where @agent-relay/fleet is not installed.
+let fleetEntry;
+try {
+  fleetEntry = requireFromConfig.resolve('@agent-relay/fleet');
+} catch (err) {
+  fail(
+    "cannot resolve '@agent-relay/fleet' from " +
+      configPath +
+      '. Install it alongside your node config (npm i @agent-relay/fleet). Cause: ' +
+      errorText(err)
+  );
+}
+
+// serveNode's connection contract below is fleet >=10 ({nodeToken, nodeId}).
+// Fleet 9 took {url, apiKey} and would silently reconnect forever instead.
+const fleetRoot = fleetEntry.slice(
+  0,
+  fleetEntry.lastIndexOf('@agent-relay/fleet') + '@agent-relay/fleet'.length
+);
+let fleetVersion;
+try {
+  fleetVersion = requireFromConfig(fleetRoot + '/package.json').version;
+} catch {
+  // Version unreadable (exports-gated package.json): proceed rather than block
+  // an install that may well work.
+}
+const fleetMajor = Number.parseInt(String(fleetVersion).split('.')[0], 10);
+if (Number.isFinite(fleetMajor) && fleetMajor < 10) {
+  fail(
+    'the @agent-relay/fleet installed next to ' +
+      configPath +
+      ' is v' +
+      fleetVersion +
+      ', which cannot be served by this CLI (needs >=10). Upgrade it: npm i @agent-relay/fleet@latest'
+  );
+}
+
+let fleet;
+try {
+  fleet = await import(pathToFileURL(fleetEntry).href);
+} catch (err) {
+  fail('failed to load @agent-relay/fleet from ' + configPath + ': ' + errorText(err));
+}
+
+const env = process.env;
+const nodeToken = env.RELAY_NODE_TOKEN;
+const nodeId = env.RELAY_NODE_ID;
+const nodeName = env.RELAY_NODE_NAME;
+const baseUrl = env.RELAY_BASE_URL && env.RELAY_BASE_URL.trim();
+const workspaceKey = env.RELAY_WORKSPACE_KEY && env.RELAY_WORKSPACE_KEY.trim();
+
+if (!nodeToken || !nodeId) {
+  fail('RELAY_NODE_TOKEN and RELAY_NODE_ID are required.');
+}
+
+let triggers;
+if (workspaceKey) {
+  try {
+    const { AgentRelay } = await importFromConfig('@agent-relay/sdk');
+    const relay = new AgentRelay({ workspaceKey, ...(baseUrl ? { baseUrl } : {}) });
+    triggers = {
+      list: () => relay.triggers.list(),
+      create: (input) => relay.triggers.create(input),
+      update: (id, input) => relay.triggers.update(id, input),
+      delete: (id) => relay.triggers.delete(id),
+    };
+  } catch (err) {
+    console.warn(
+      '[agent-relay] node provider: message triggers will not sync (' + errorText(err) + ').'
+    );
+  }
+}
+
+const stopSignal = new AbortController();
+for (const signal of ['SIGTERM', 'SIGINT']) {
+  process.on(signal, () => stopSignal.abort());
+}
+
+try {
+  await fleet.serveNode({
+    definition,
+    connection: { nodeToken, nodeId, ...(baseUrl ? { baseUrl } : {}) },
+    ...(nodeName ? { nameOverride: nodeName } : {}),
+    providerName: definition.name,
+    ...(triggers ? { triggers } : {}),
+    reconnect: true,
+    signal: stopSignal.signal,
+    log: (message) => console.log('[agent-relay][node] ' + message),
+    warn: (message) => console.warn('[agent-relay][node] ' + message),
+  });
+} catch (err) {
+  if (!stopSignal.signal.aborted) {
+    fail('serving ' + configPath + ' failed: ' + errorText(err));
+  }
+}
+`;
+
+/** Marker the child prints its descriptor JSON behind, so config output can't corrupt it. */
+export const NODE_DESCRIPTOR_MARKER = '__AGENT_RELAY_NODE_DESCRIPTOR__';
+
+/**
+ * What the CLI learns about a node definition it never loads in-process:
+ * enough to advertise capacity and to validate an explicit `--config`.
+ */
+export type NodeDefinitionDescriptor = {
+  name: string;
+  capabilities: string[];
+  maxAgents?: number;
+};
+
+/**
+ * Parse the descriptor a `--describe` child printed.
+ * @param stdout - Raw child stdout, which may contain the config's own output.
+ * @returns The descriptor, or `undefined` when no marker line was produced.
+ */
+export function parseNodeDescriptor(stdout: string): NodeDefinitionDescriptor | undefined {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(NODE_DESCRIPTOR_MARKER));
+  const last = lines.at(-1);
+  if (!last) {
+    return undefined;
+  }
+  const parsed = JSON.parse(last.slice(NODE_DESCRIPTOR_MARKER.length)) as NodeDefinitionDescriptor;
+  return {
+    name: parsed.name,
+    capabilities: Array.isArray(parsed.capabilities) ? parsed.capabilities : [],
+    ...(typeof parsed.maxAgents === 'number' ? { maxAgents: parsed.maxAgents } : {}),
+  };
+}
+
+/**
+ * Adapt a descriptor to the capacity shape, so a node definition served
+ * out-of-process still contributes its `spawn:<harness>` capabilities to the
+ * broker's advertised capacity.
+ * @param descriptor - Descriptor reported by the `--describe` child.
+ */
+export function descriptorCapacitySource(descriptor: NodeDefinitionDescriptor): {
+  capabilities: Record<string, unknown>;
+} {
+  return { capabilities: Object.fromEntries(descriptor.capabilities.map((name) => [name, true])) };
+}
+
+/**
+ * File extensions served through a child `node` process when the CLI itself is
+ * a `bun build --compile` binary.
+ */
+const JS_NODE_DEFINITION_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs']);
+
+/** Whether `configPath` is a JS/TS node definition (as opposed to `agent-relay.py`). */
+export function isJsNodeDefinition(configPath: string): boolean {
+  return JS_NODE_DEFINITION_EXTENSIONS.has(path.extname(configPath).toLowerCase());
+}
+
+/**
+ * Write the child bootstrap to a temp file so a child `node` process has
+ * something on disk to execute. The compiled binary has no `dist/` on disk, so
+ * the source is materialized per run.
+ * @param mkdtemp - Temp-dir factory, injectable for tests.
+ * @returns Absolute path to the materialized bootstrap module.
+ */
+export function materializeNodeProviderChildScript(
+  mkdtemp: (prefix: string) => string = (prefix) => fs.mkdtempSync(prefix)
+): string {
+  const dir = mkdtemp(path.join(os.tmpdir(), 'agent-relay-node-provider-'));
+  const file = path.join(dir, 'node-provider-child.mjs');
+  fs.writeFileSync(file, NODE_PROVIDER_CHILD_SOURCE, 'utf8');
+  return file;
+}
+
+/** Single-quote a path for safe interpolation into a shell command. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Load a node definition's descriptor by running the bootstrap in `--describe`
+ * mode under a child `node` process.
+ *
+ * This is how the compiled binary learns anything at all about a JS/TS node
+ * definition: it cannot import one itself (scoped specifiers in the user's
+ * `node_modules` do not resolve under `bun build --compile`), so it asks Node.
+ *
+ * @param configPath - Absolute path to the user's node definition file.
+ * @param deps - Core dependencies (exec, env).
+ * @returns The descriptor.
+ * @throws When the child cannot load or validate the definition.
+ */
+export async function describeNodeDefinitionViaNode(
+  configPath: string,
+  deps: CoreDependencies
+): Promise<NodeDefinitionDescriptor> {
+  const nodeBin = deps.env.AGENT_RELAY_NODE?.trim() || 'node';
+  const script = materializeNodeProviderChildScript();
+  const command = `${shellQuote(nodeBin)} ${shellQuote(script)} ${shellQuote(configPath)} --describe`;
+
+  let stdout: string;
+  try {
+    ({ stdout } = await deps.execCommand(command));
+  } catch (err) {
+    const detail = extractChildFailure(err);
+    throw new Error(
+      `Failed to load ${configPath} via ${nodeBin}: ${detail}. ` +
+        `Serving a JS/TS node definition from the standalone agent-relay binary requires \`${nodeBin}\` on PATH ` +
+        '(set AGENT_RELAY_NODE to override).'
+    );
+  }
+
+  const descriptor = parseNodeDescriptor(stdout);
+  if (!descriptor) {
+    throw new Error(`Fleet node file ${configPath} must default-export defineNode(...)`);
+  }
+  return descriptor;
+}
+
+/** Pull the useful text out of an execCommand rejection (stderr beats the generic message). */
+function extractChildFailure(err: unknown): string {
+  const stderr =
+    err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr?: unknown }).stderr) : '';
+  const trimmed = stderr.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Serve a JS/TS fleet node definition in a child `node` process.
+ *
+ * Used only when the CLI is running as a `bun build --compile` binary, where
+ * loading the definition in-process is impossible (see
+ * {@link NODE_PROVIDER_CHILD_SOURCE}). Under Node the definition is still
+ * served in-process, which keeps the existing behavior unchanged.
+ *
+ * @param configPath - Absolute path to the user's node definition file.
+ * @param credentials - Node identity/token the child registers with.
+ * @param deps - Core dependencies (spawn, env, logging).
+ * @returns The spawned child, or `undefined` when it could not be started.
+ */
+export function startNodeJsNodeProvider(
+  configPath: string,
+  credentials: NodeProviderCredentials,
+  deps: CoreDependencies
+): SpawnedProcess | undefined {
+  const nodeBin = deps.env.AGENT_RELAY_NODE?.trim() || 'node';
+  const env: NodeJS.ProcessEnv = {
+    ...deps.env,
+    RELAY_NODE_TOKEN: credentials.nodeToken,
+    RELAY_NODE_ID: credentials.nodeId,
+    RELAY_NODE_NAME: credentials.nodeName,
+    ...(credentials.baseUrl ? { RELAY_BASE_URL: credentials.baseUrl } : {}),
+    ...(credentials.workspaceKey ? { RELAY_WORKSPACE_KEY: credentials.workspaceKey } : {}),
+  };
+
+  try {
+    const script = materializeNodeProviderChildScript();
+    const child = deps.spawnProcess(nodeBin, [script, configPath], {
+      stdio: 'inherit',
+      env,
+      cwd: path.dirname(configPath),
+    });
+    deps.log(
+      `Serving fleet node provider: ${nodeBin} ${path.basename(configPath)} (pid: ${child.pid ?? 'unknown'}).`
+    );
+    return child;
+  } catch (err) {
+    deps.warn(
+      `Fleet node provider skipped: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Serving a JS/TS node definition from the standalone agent-relay binary requires \`${nodeBin}\` on PATH; ` +
+        'set AGENT_RELAY_NODE to point at a Node.js executable.'
+    );
+    return undefined;
+  }
+}


### PR DESCRIPTION
`agent-relay node up --config agent-relay.ts` — the exact invocation [factory#73](https://github.com/AgentWorkforce/factory/pull/73)'s README documents (merged) — **cannot work on the shipped binary today**. That README tells users to create an `agent-relay.ts` that default-exports `@agent-relay/factory/node` and run `agent-relay node up --config agent-relay.ts`. The documented happy path fails on every install.

Reproduced on macOS arm64 against both the installed binary (v10.6.0) and a binary freshly compiled from `main` via `scripts/build-bun.sh` flags:

```
$ agent-relay node up --config agent-relay.ts --no-spawn --verbose
Failed to start broker: ResolveMessage: Cannot find module '../dist/babel.cjs' from '/$bunfs/root/agent-relay-darwin-arm64'

$ agent-relay node up --config agent-relay.mjs --no-spawn --verbose   # .mjs to dodge the above
Failed to start broker: ResolveMessage: Cannot find module '@agent-relay/factory/node' from '/Users/.../factory-node/agent-relay.mjs'
```

## Root cause — both failures are the same bug

A `bun build --compile` binary **cannot resolve a bare package specifier out of the user's on-disk `node_modules` when the package's entry point lives in a subdirectory** (`dist/`, `lib/`) rather than at the package root. That is every package built from TypeScript — `@agent-relay/factory`, `@agent-relay/fleet`, `@relayflows/core`, `@clack/prompts`. Packages whose entry is a file at the package root (`zod`, `commander`) resolve fine.

That last detail is why this looked scope- or version-specific at first. Bisected on identical hand-built packages, changing only the entry location:

| package entry | compiled binary |
|---|---|
| `index.js` (root) | resolves |
| `dist/index.js` | **fails** |

Holds for scoped and unscoped alike, and regardless of export conditions (`main`, string `exports`, `import`/`default`). Plain `bun` and `node` resolve all of them — **only the compiled binary fails**. That is exactly why this shipped: every existing loader test runs under vitest/Node and passes against the broken code.

### The `babel.cjs` error is a red herring

Not a separate bug. jiti's native path can't resolve the config's bare import, so it falls back to Babel — whose transpiler bun never embedded, because jiti loads it via a *dynamic* `require('../dist/babel.cjs')` the bundler can't see. The user is told the transpiler is missing, not that their import failed to resolve. Proof — same binary, same jiti, only the imported package's entry location differs:

```
.ts importing a root-entry package  -> jiti OK, no Babel involved
.ts importing a dist-entry package  -> Cannot find module '../dist/babel.cjs'
```

### Why no entry-point-only fix works

The failure is **transitive**. The relative-path workaround (`./node_modules/@agent-relay/factory/dist/node/factory.node.js`) doesn't actually work — it moves the error one hop deeper, onto factory's own `@agent-relay/fleet` import:

```
Cannot find module '@agent-relay/fleet' from '.../factory/dist/node/factory-node.js'
```

Every in-process fix was tested against a real compiled binary and **all fail**:

| approach | result |
|---|---|
| `createRequire(configPath).resolve(...)` | fails — same broken resolver |
| `import.meta.resolve(spec, configURL)` | fails |
| `Bun.plugin({ onResolve })` | registers, but **never fires** for runtime dynamic import |
| `Bun.build()` at runtime | resolver works, but yields a 4.6MB bundle that then breaks on a package doing `require('../package.json')` — too fragile to ship |

`FleetNodeDefinition.capabilities[].handler` is a function invoked in-process, so a child cannot simply hand a definition back.

## Fix

Under the compiled binary only (Node keeps today's in-process path, unchanged — zero regression risk for npm installs; under Bun it is 100% broken today, so any change is strictly an improvement):

- **Serve JS/TS definitions in a child `node` process**, mirroring the supervised `agent-relay.py` provider this repo already has. Node resolves bare specifiers relative to the *importing file*, so the config's imports resolve against its own `node_modules` regardless of where the bootstrap lives.
- **Learn the descriptor via a `--describe` child**, preserving two documented behaviors for a definition the CLI never loads: fail-fast on a bad explicit `--config`, and `spawn:<harness>` capacity contribution.
- **Skip jiti under Bun** (which transpiles TypeScript natively), so a genuine resolution error surfaces instead of the `babel.cjs` red herring.
- Reject a user fleet `<10` up front — `serveNode`'s connection shape changed (`{nodeToken, nodeId}`; fleet 9 took `{url, apiKey}`), which would otherwise fail as an endless reconnect loop.

## Test evidence

Regression tests compile **real bun binaries** (`node-definition-loader.bun.test.ts`). A Node-only test cannot catch either bug — that's the whole point. The fixture's entry point deliberately lives in `dist/`; a root-entry fixture resolves inside the binary and silently tests nothing (my first draft did exactly that and passed against broken code).

Verified the tests fail without the fix:

```
$ # Bug 1 fix reverted:
× surfaces the real resolution error for a .ts config, not the babel.cjs red herring
  AssertionError: expected 'error: Cannot find module '../dist/babel.cjs' from '/$bunfs/root/load-harness'' not to match /babel\.cjs/
```

End-to-end against the **real** `@agent-relay/factory@0.1.18` with a bare `@agent-relay/factory/node` import, from inside a compiled binary:

```
baseline binary: Cannot find module '../dist/babel.cjs' ...        (.ts)
baseline binary: Cannot find module '@agent-relay/factory/node'    (.mjs)

fixed binary:    DESCRIBE OK -> {"name":"factory-...","capabilities":["spawn:claude"]}   (.ts)
fixed binary:    DESCRIBE OK -> {"name":"factory-...","capabilities":["spawn:claude"]}   (.mjs)
fixed binary:    Serving fleet node provider: node agent-relay.ts (pid: 63960)
```

`spawn:claude` is picked up, so capacity advertising survives the out-of-process hop.

- `packages/cli/src/cli/lib`: **327 tests passing**, 0 type errors, lint clean.
- No tests were weakened, skipped, or mocked to get green. The bun suite skips only when `bun` is absent (it cannot compile a binary without it); CI installs bun via `scripts/build-bun.sh`.

## Notes / follow-ups

- This is an upstream `bun --compile` bug (reproduced minimally on bun 1.3.14, the current latest — no upgrade escape). The child hop can be removed if bun fixes it; the test named *"cannot import a bare specifier in-process from a compiled binary (why the child exists)"* pins that limitation and will start failing when it's fixed.
- Serving a JS/TS config from the standalone binary now requires `node` on PATH (`AGENT_RELAY_NODE` overrides). Defensible: a JS/TS node config already requires an npm install to exist at all. Configs are unaffected under the npm-installed CLI.
- Trigger sync is preserved in the child (`@agent-relay/sdk` resolved from the config's directory), matching the in-process path.
- factory#73's README instruction is broken on today's binary and starts working with this fix — no README change needed there, and deliberately **not** "fixed" by documenting `.mjs` + relative paths, which don't actually work (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

