### PR TITLE
fix(node): use enrolled fleet node identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay node up` now serves persisted Cloud-enrolled nodes with the enrolled `nodeId`, so the broker and local providers authenticate with the node token's bound identity instead of a fresh local node id.
 
 ## [10.6.0] - 2026-07-16
 

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -871,6 +871,7 @@ fn node_max_agents() -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::sync::{Mutex, MutexGuard};
 
@@ -878,28 +879,70 @@ mod tests {
 
     struct NodeIdEnvGuard {
         _guard: MutexGuard<'static, ()>,
+        original_node_id: Option<OsString>,
+        original_node_token: Option<OsString>,
     }
 
     impl Drop for NodeIdEnvGuard {
         fn drop(&mut self) {
             // SAFETY: These tests hold NODE_ID_ENV_MUTEX while mutating the
-            // process environment, serializing access within this test module.
+            // process environment, serializing access within this test module
+            // until the inherited RELAY_NODE_* values have been restored.
             unsafe {
-                std::env::remove_var("RELAY_NODE_ID");
-                std::env::remove_var("RELAY_NODE_TOKEN");
+                match &self.original_node_id {
+                    Some(value) => std::env::set_var("RELAY_NODE_ID", value),
+                    None => std::env::remove_var("RELAY_NODE_ID"),
+                }
+                match &self.original_node_token {
+                    Some(value) => std::env::set_var("RELAY_NODE_TOKEN", value),
+                    None => std::env::remove_var("RELAY_NODE_TOKEN"),
+                }
             }
         }
     }
 
     fn clear_node_id_env() -> NodeIdEnvGuard {
+        clear_node_id_env_with_originals().0
+    }
+
+    fn clear_node_id_env_with_originals() -> (NodeIdEnvGuard, Option<OsString>, Option<OsString>) {
         let guard = NODE_ID_ENV_MUTEX.lock().unwrap();
+        let original_node_id = std::env::var_os("RELAY_NODE_ID");
+        let original_node_token = std::env::var_os("RELAY_NODE_TOKEN");
         // SAFETY: NODE_ID_ENV_MUTEX serializes environment mutations for these
         // tests before any code under test observes RELAY_NODE_* values.
         unsafe {
             std::env::remove_var("RELAY_NODE_ID");
             std::env::remove_var("RELAY_NODE_TOKEN");
         }
-        NodeIdEnvGuard { _guard: guard }
+        (
+            NodeIdEnvGuard {
+                _guard: guard,
+                original_node_id: original_node_id.clone(),
+                original_node_token: original_node_token.clone(),
+            },
+            original_node_id,
+            original_node_token,
+        )
+    }
+
+    #[test]
+    fn node_id_env_guard_restores_original_node_env() {
+        let (env_guard, original_node_id, original_node_token) = clear_node_id_env_with_originals();
+        assert!(std::env::var_os("RELAY_NODE_ID").is_none());
+        assert!(std::env::var_os("RELAY_NODE_TOKEN").is_none());
+
+        // SAFETY: env_guard holds NODE_ID_ENV_MUTEX for the duration of this
+        // test, so RELAY_NODE_* mutations are serialized.
+        unsafe {
+            std::env::set_var("RELAY_NODE_ID", "node_test_mutation");
+            std::env::set_var("RELAY_NODE_TOKEN", "nt_live_test_mutation");
+        }
+
+        drop(env_guard);
+
+        assert_eq!(std::env::var_os("RELAY_NODE_ID"), original_node_id);
+        assert_eq!(std::env::var_os("RELAY_NODE_TOKEN"), original_node_token);
     }
 
     #[test]

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -882,6 +882,8 @@ mod tests {
 
     impl Drop for NodeIdEnvGuard {
         fn drop(&mut self) {
+            // SAFETY: These tests hold NODE_ID_ENV_MUTEX while mutating the
+            // process environment, serializing access within this test module.
             unsafe {
                 std::env::remove_var("RELAY_NODE_ID");
                 std::env::remove_var("RELAY_NODE_TOKEN");
@@ -891,6 +893,8 @@ mod tests {
 
     fn clear_node_id_env() -> NodeIdEnvGuard {
         let guard = NODE_ID_ENV_MUTEX.lock().unwrap();
+        // SAFETY: NODE_ID_ENV_MUTEX serializes environment mutations for these
+        // tests before any code under test observes RELAY_NODE_* values.
         unsafe {
             std::env::remove_var("RELAY_NODE_ID");
             std::env::remove_var("RELAY_NODE_TOKEN");
@@ -946,6 +950,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let seed_path = dir.path().join("machine-id");
         std::fs::write(&seed_path, "node_legacy_file\n").unwrap();
+        // SAFETY: clear_node_id_env holds NODE_ID_ENV_MUTEX for the duration
+        // of this test, so RELAY_NODE_* mutations are serialized.
         unsafe {
             std::env::set_var("RELAY_NODE_TOKEN", "nt_live_enrolled");
             std::env::set_var("RELAY_NODE_ID", "node_enrolled");
@@ -962,6 +968,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let seed_path = dir.path().join("machine-id");
         std::fs::write(&seed_path, "node_legacy_file\n").unwrap();
+        // SAFETY: clear_node_id_env holds NODE_ID_ENV_MUTEX for the duration
+        // of this test, so RELAY_NODE_* mutations are serialized.
         unsafe {
             std::env::set_var("RELAY_NODE_TOKEN", "nt_live_enrolled");
         }

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -219,32 +219,7 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
     let ws_control_tx = default_workspace.ws_control_tx.clone();
     let relaycast_http = default_workspace.http_client.clone();
     let node_workspace_id = default_workspace.workspace_id.as_str().to_string();
-    let node_id = match crate::node_control::default_node_id_path() {
-        Some(path) => {
-            // Node-id mode — explicit vs auto:
-            //   * Explicit / fleet: when an operator pre-enrolls this node and
-            //     supplies `RELAY_NODE_TOKEN`, the node id is pinned (via the
-            //     machine-id file) and MUST be sent verbatim in `node.register`,
-            //     or the engine rejects it with `node_id_mismatch`. Use the file
-            //     content as-is — do NOT derive.
-            //   * Auto / direct: with no supplied token the broker mints its own
-            //     node via `create_node`; derive the id from the machine seed +
-            //     cwd so one host serving multiple workspaces/dirs doesn't collide.
-            let pinned = std::env::var("RELAY_NODE_TOKEN")
-                .ok()
-                .is_some_and(|value| !value.trim().is_empty());
-            let loaded = if pinned {
-                crate::node_control::load_or_create_machine_seed(&path)
-            } else {
-                crate::node_control::load_or_create_node_id(&path, &node_workspace_id)
-            };
-            loaded.unwrap_or_else(|error| {
-                tracing::warn!(error = %error, "failed to load fleet node machine id; using ephemeral id");
-                format!("node_{}", Uuid::new_v4().simple())
-            })
-        }
-        None => format!("node_{}", Uuid::new_v4().simple()),
-    };
+    let node_id = resolve_broker_node_id(&node_workspace_id);
     // The node registers under its resolved instance name (--instance-name, the
     // legacy --name/--broker-name alias, or AGENT_RELAY_BROKER_NAME), falling back
     // to the machine hostname only when none is set. Deriving this from the raw
@@ -735,6 +710,58 @@ fn resolve_cached_node_token(
     None
 }
 
+fn explicit_env_node_id() -> Option<String> {
+    std::env::var("RELAY_NODE_ID")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn explicit_env_node_token_present() -> bool {
+    std::env::var("RELAY_NODE_TOKEN")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn resolve_broker_node_id(workspace_id: &str) -> String {
+    resolve_broker_node_id_from_path(
+        crate::node_control::default_node_id_path().as_deref(),
+        workspace_id,
+    )
+}
+
+fn resolve_broker_node_id_from_path(seed_path: Option<&Path>, workspace_id: &str) -> String {
+    if let Some(node_id) = explicit_env_node_id() {
+        return node_id;
+    }
+
+    match seed_path {
+        Some(path) => {
+            // Node-id mode — explicit vs auto:
+            //   * Cloud enrollment: `relay node up` supplies RELAY_NODE_ID and
+            //     RELAY_NODE_TOKEN from the enrollment store. The env node id
+            //     must be sent verbatim in `node.register`, or the engine rejects
+            //     the token-bound handshake with `node_id_mismatch`.
+            //   * Legacy explicit / fleet: before RELAY_NODE_ID existed,
+            //     operators pre-seeded the machine-id file and supplied
+            //     RELAY_NODE_TOKEN. Keep honoring that file as the pinned id.
+            //   * Auto / direct: with no supplied token the broker mints its own
+            //     node via `create_node`; derive the id from the machine seed +
+            //     cwd so one host serving multiple workspaces/dirs doesn't collide.
+            let loaded = if explicit_env_node_token_present() {
+                crate::node_control::load_or_create_machine_seed(path)
+            } else {
+                crate::node_control::load_or_create_node_id(path, workspace_id)
+            };
+            loaded.unwrap_or_else(|error| {
+                tracing::warn!(error = %error, "failed to load fleet node machine id; using ephemeral id");
+                format!("node_{}", Uuid::new_v4().simple())
+            })
+        }
+        None => format!("node_{}", Uuid::new_v4().simple()),
+    }
+}
+
 fn callback_host_for_url(api_bind: &str, local_addr: SocketAddr) -> String {
     let host = match unbracket_ipv6(api_bind.trim()) {
         "" => {
@@ -845,6 +872,31 @@ fn node_max_agents() -> Option<u32> {
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::sync::{Mutex, MutexGuard};
+
+    static NODE_ID_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct NodeIdEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for NodeIdEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var("RELAY_NODE_ID");
+                std::env::remove_var("RELAY_NODE_TOKEN");
+            }
+        }
+    }
+
+    fn clear_node_id_env() -> NodeIdEnvGuard {
+        let guard = NODE_ID_ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::remove_var("RELAY_NODE_ID");
+            std::env::remove_var("RELAY_NODE_TOKEN");
+        }
+        NodeIdEnvGuard { _guard: guard }
+    }
 
     #[test]
     fn bootstrap_node_manifest_advertises_capacity_not_bare_spawn() {
@@ -886,6 +938,37 @@ mod tests {
         assert_eq!(manifest.name, "node-a");
         assert_eq!(manifest.node_id.as_deref(), Some("node_a"));
         assert_eq!(manifest.version.as_deref(), Some("relay-broker/9.1.1"));
+    }
+
+    #[test]
+    fn broker_node_id_prefers_explicit_relay_node_id_env() {
+        let _env_guard = clear_node_id_env();
+        let dir = tempfile::tempdir().unwrap();
+        let seed_path = dir.path().join("machine-id");
+        std::fs::write(&seed_path, "node_legacy_file\n").unwrap();
+        unsafe {
+            std::env::set_var("RELAY_NODE_TOKEN", "nt_live_enrolled");
+            std::env::set_var("RELAY_NODE_ID", "node_enrolled");
+        }
+
+        let node_id = resolve_broker_node_id_from_path(Some(&seed_path), "rw_test");
+
+        assert_eq!(node_id, "node_enrolled");
+    }
+
+    #[test]
+    fn broker_node_id_keeps_legacy_token_pinned_machine_file_without_env_id() {
+        let _env_guard = clear_node_id_env();
+        let dir = tempfile::tempdir().unwrap();
+        let seed_path = dir.path().join("machine-id");
+        std::fs::write(&seed_path, "node_legacy_file\n").unwrap();
+        unsafe {
+            std::env::set_var("RELAY_NODE_TOKEN", "nt_live_enrolled");
+        }
+
+        let node_id = resolve_broker_node_id_from_path(Some(&seed_path), "rw_test");
+
+        assert_eq!(node_id, "node_legacy_file");
     }
 
     #[test]

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -480,14 +480,16 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
                 `The one-time enrollment token has been consumed. Credentials were saved to ${recoveryPath} (owner-only permissions).`
               );
               deps.error(
-                "Fix the store problem and re-add them from that file, or export RELAY_NODE_TOKEN/RELAY_BASE_URL from it before 'relay node up'. Delete the file afterwards."
+                "Fix the store problem and re-add them from that file, or export RELAY_NODE_TOKEN/RELAY_NODE_ID/RELAY_BASE_URL from it before 'relay node up'. Delete the file afterwards."
               );
             } catch {
               deps.error(
                 'The one-time enrollment token has been consumed and a recovery file could not be written. SAVE THESE CREDENTIALS NOW:'
               );
               deps.error(JSON.stringify(record, null, 2));
-              deps.error("Export RELAY_NODE_TOKEN/RELAY_BASE_URL from them before 'relay node up'.");
+              deps.error(
+                "Export RELAY_NODE_TOKEN/RELAY_NODE_ID/RELAY_BASE_URL from them before 'relay node up'."
+              );
             }
             deps.exit(1);
             return;

--- a/packages/cli/src/cli/commands/node.test.ts
+++ b/packages/cli/src/cli/commands/node.test.ts
@@ -97,6 +97,7 @@ describe('registerNodeCommands', () => {
 
     expect(resolveEnrollment).toHaveBeenCalledTimes(1);
     expect(env.RELAY_NODE_TOKEN).toBe('nt_secret');
+    expect(env.RELAY_NODE_ID).toBe('node_abc');
     expect(env.RELAY_BASE_URL).toBe('https://relaycast.example.com');
     expect(brokerMocks.runUpCommand).toHaveBeenCalledWith(
       expect.objectContaining({ discoverConfig: true, nodeName: 'kjglaptop' }),

--- a/packages/cli/src/cli/commands/node.ts
+++ b/packages/cli/src/cli/commands/node.ts
@@ -97,6 +97,7 @@ async function runNodeUp(options: UpCommandOptions, deps: NodeCommandDependencie
     }
     if (record) {
       env.RELAY_NODE_TOKEN = record.nodeToken;
+      env.RELAY_NODE_ID = record.nodeId;
       if (!env.RELAY_BASE_URL) {
         env.RELAY_BASE_URL = record.relaycastUrl;
       }

--- a/tests/e2e/fleet/README.md
+++ b/tests/e2e/fleet/README.md
@@ -72,6 +72,8 @@ vars are stripped (so the broker never rejoins the operator's real workspace), w
 its own `HOME`, project dir, state dir, and broker port. The broker reads its
 node id from `<data_local_dir>/agent-relay/machine-id`, which the harness pre-seeds
 to match the enrolled node id (otherwise `node.register` is rejected
-`node_id_mismatch`). `FleetNode.stop()` kills the broker child too (by its
+`node_id_mismatch`) for direct-token fixtures. The Cloud-enrollment regression
+intentionally does not pre-seed that file; it verifies `cloud enroll` persistence
+drives `node up` through `RELAY_NODE_ID`/`RELAY_NODE_TOKEN` instead. `FleetNode.stop()` kills the broker child too (by its
 `connection.json` pid) so a SIGKILLed sidecar doesn't orphan a broker that would
 hold the node online + the state-dir flock and break a later restart.

--- a/tests/e2e/fleet/fleet-e2e.test.ts
+++ b/tests/e2e/fleet/fleet-e2e.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   AgentStream,
+  CLOUD_ENROLLED_NODE_FILE,
   cleanupTmp,
   createTrigger,
   createWorkspace,
@@ -25,6 +26,7 @@ import {
   registerAgent,
   releaseAgent,
   sendDm,
+  startCloudEnrollmentEndpoint,
   startEngine,
   waitFor,
   type EngineHandle,
@@ -43,6 +45,73 @@ if (!pre.ok) {
   // eslint-disable-next-line no-console
   console.warn(`[fleet-e2e] skipped: ${pre.reason}`);
 }
+
+describe.skipIf(!pre.ok)('Cloud-enrolled node startup', () => {
+  let tmpRoot: string;
+  let engine: EngineHandle;
+  let workspaceKey: string;
+  let enrolledNode: FleetNode;
+
+  beforeAll(async () => {
+    tmpRoot = makeTmpRoot();
+    engine = await startEngine(pre.engineServe!, tmpRoot);
+    workspaceKey = await createWorkspace(engine, 'cloud-enrollment-e2e');
+
+    const nodeId = 'node_cloud_enrolled';
+    const nodeName = 'cloud-enrolled';
+    const nodeToken = await enrollNode(engine, workspaceKey, nodeId, nodeName, ['cloud:ping']);
+    const enrollmentToken = 'ocl_node_enr_e2e_once';
+    const endpoint = await startCloudEnrollmentEndpoint({
+      enrollmentToken,
+      nodeId,
+      nodeName,
+      nodeToken,
+      relayWorkspaceId: 'fleet-e2e',
+      relaycastUrl: engine.baseUrl,
+    });
+
+    enrolledNode = new FleetNode({
+      name: nodeName,
+      nodeId,
+      nodeFile: CLOUD_ENROLLED_NODE_FILE,
+      nodeToken,
+      workspaceKey,
+      engineBaseUrl: engine.baseUrl,
+      brokerBinary: pre.brokerBinary!,
+      tmpRoot,
+      brokerPort: await getFreePort(),
+      capacityHarnesses: 'claude',
+      usePersistedEnrollment: true,
+    });
+    try {
+      await enrolledNode.cloudEnroll(endpoint.url, enrollmentToken);
+    } finally {
+      await endpoint.stop();
+    }
+    enrolledNode.start();
+  }, 45_000);
+
+  afterAll(async () => {
+    await enrolledNode?.stop();
+    await engine?.stop();
+    if (tmpRoot && !process.env.CI) cleanupTmp(tmpRoot);
+  });
+
+  it('enroll -> node up presents the enrolled id and registers its capabilities and tags', async () => {
+    const enrolled = await waitFor(
+      async () => {
+        const nodes = await getNodes(engine, workspaceKey, { name: 'cloud-enrolled' });
+        const match = nodes.find((node) => node.id === 'node_cloud_enrolled');
+        return match?.live && match.handlers_live ? match : null;
+      },
+      { timeoutMs: 30_000, label: 'Cloud-enrolled node online with live handlers' }
+    );
+
+    expect(enrolled.name).toBe('cloud-enrolled');
+    expect(enrolled.capabilities.map((capability) => capability.name)).toContain('cloud:ping');
+    expect(enrolled.tags).toEqual(expect.arrayContaining(['cloud-enrolled', 'e2e']));
+  });
+});
 
 async function pollUntilStable<T>(
   read: () => Promise<T>,

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -447,56 +447,55 @@ export class FleetNode {
   start(): void {
     const o = this.opts;
     const stateDir = path.join(this.projectDir, '.agentworkforce', 'relay');
-    this.child = spawn(
-      process.execPath,
-      [
-        CLI_ENTRY,
-        'node',
-        'up',
-        '--config',
-        o.nodeFile,
-        // `fleet serve --name` → `node up --broker-name` (the served node's name).
-        '--broker-name',
-        o.name,
-        // `fleet serve --workspace` → `node up --workspace-key`.
-        '--workspace-key',
-        o.workspaceKey,
-        // `node up` has no `--base-url`; the engine URL is carried by the
-        // RELAY_BASE_URL / RELAYCAST_BASE_URL env vars set below (as it was for
-        // `fleet serve --base-url`). Serve only — never auto-spawn teams.json
-        // agents (there are none in this hermetic project dir).
-        '--no-spawn',
-      ],
-      {
-        cwd: REPO_ROOT,
-        env: cleanEnv({
-          HOME: this.home,
-          BROKER_BINARY_PATH: o.brokerBinary,
-          RELAYCAST_BASE_URL: o.engineBaseUrl,
-          RELAY_BASE_URL: o.engineBaseUrl,
-          ...(o.usePersistedEnrollment
-            ? {
-                AGENT_RELAY_HOME: this.enrollmentHome,
-                // Supply the broker-self workspace membership without using
-                // RELAY_WORKSPACE_KEY, which is intentionally an explicit
-                // direct-workspace choice that disables enrollment pickup.
-                RELAY_WORKSPACES_JSON: JSON.stringify([
-                  { workspace_id: 'fleet-e2e', api_key: o.workspaceKey },
-                ]),
-              }
-            : {
-                RELAY_NODE_TOKEN: o.nodeToken,
-                RELAY_WORKSPACE_KEY: o.workspaceKey,
-                RELAY_API_KEY: o.workspaceKey,
-              }),
-          AGENT_RELAY_PROJECT: this.projectDir,
-          AGENT_RELAY_STATE_DIR: stateDir,
-          AGENT_RELAY_BROKER_PORT: String(o.brokerPort),
-          ...(o.capacityHarnesses ? { AGENT_RELAY_NODE_HARNESSES: o.capacityHarnesses } : {}),
-        }),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }
-    );
+    const args = [
+      CLI_ENTRY,
+      'node',
+      'up',
+      '--config',
+      o.nodeFile,
+      // `fleet serve --name` → `node up --broker-name` (the served node's name).
+      '--broker-name',
+      o.name,
+      // `node up` has no `--base-url`; the engine URL is carried by the
+      // RELAY_BASE_URL / RELAYCAST_BASE_URL env vars set below (as it was for
+      // `fleet serve --base-url`). Serve only — never auto-spawn teams.json
+      // agents (there are none in this hermetic project dir).
+      '--no-spawn',
+    ];
+    if (!o.usePersistedEnrollment) {
+      // Direct-token fixtures predate Cloud enrollment pickup and still model
+      // an explicit direct workspace selection. The persisted-enrollment
+      // regression must NOT pass this flag: `node up` intentionally treats it
+      // as an operator override and skips the enrollment store.
+      args.splice(args.length - 1, 0, '--workspace-key', o.workspaceKey);
+    }
+    this.child = spawn(process.execPath, args, {
+      cwd: REPO_ROOT,
+      env: cleanEnv({
+        HOME: this.home,
+        BROKER_BINARY_PATH: o.brokerBinary,
+        RELAYCAST_BASE_URL: o.engineBaseUrl,
+        RELAY_BASE_URL: o.engineBaseUrl,
+        ...(o.usePersistedEnrollment
+          ? {
+              AGENT_RELAY_HOME: this.enrollmentHome,
+              // Supply the broker-self workspace membership without using
+              // RELAY_WORKSPACE_KEY, which is intentionally an explicit
+              // direct-workspace choice that disables enrollment pickup.
+              RELAY_WORKSPACES_JSON: JSON.stringify([{ workspace_id: 'fleet-e2e', api_key: o.workspaceKey }]),
+            }
+          : {
+              RELAY_NODE_TOKEN: o.nodeToken,
+              RELAY_WORKSPACE_KEY: o.workspaceKey,
+              RELAY_API_KEY: o.workspaceKey,
+            }),
+        AGENT_RELAY_PROJECT: this.projectDir,
+        AGENT_RELAY_STATE_DIR: stateDir,
+        AGENT_RELAY_BROKER_PORT: String(o.brokerPort),
+        ...(o.capacityHarnesses ? { AGENT_RELAY_NODE_HARNESSES: o.capacityHarnesses } : {}),
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     // Persist the sidecar's output to serve.log (append across restarts) so the
     // CI "upload node logs on failure" step has something to attach.
     const record = (d: Buffer) => {

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { createServer } from 'node:net';
+import { createServer as createHttpServer } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import {
   appendFileSync,
   existsSync,
@@ -26,6 +27,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 export const NODE_A_FILE = path.join(HERE, 'nodes', 'node-a.ts');
 export const NODE_B_FILE = path.join(HERE, 'nodes', 'node-b.ts');
+export const CLOUD_ENROLLED_NODE_FILE = path.join(HERE, 'nodes', 'cloud-enrolled.ts');
 
 const CLI_ENTRY = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'index.js');
 
@@ -105,7 +107,7 @@ export function preflight(): Preflight {
 
 export function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
-    const srv = createServer();
+    const srv = createNetServer();
     srv.unref();
     srv.on('error', reject);
     srv.listen(0, '127.0.0.1', () => {
@@ -249,6 +251,71 @@ export async function enrollNode(
   return body.data.token as string;
 }
 
+export interface CloudEnrollmentEndpoint {
+  url: string;
+  stop(): Promise<void>;
+}
+
+/**
+ * Serve one Cloud enrollment exchange locally. The exchange itself is a small
+ * stand-in for Cloud's control-plane endpoint; the returned node token was
+ * minted by the real relaycast engine, so the subsequent broker registration
+ * still exercises the real token-to-node binding and fails on node_id_mismatch.
+ */
+export async function startCloudEnrollmentEndpoint(input: {
+  enrollmentToken: string;
+  nodeId: string;
+  nodeName: string;
+  nodeToken: string;
+  relayWorkspaceId: string;
+  relaycastUrl: string;
+}): Promise<CloudEnrollmentEndpoint> {
+  const server = createHttpServer((request, response) => {
+    let raw = '';
+    request.setEncoding('utf-8');
+    request.on('data', (chunk) => {
+      raw += chunk;
+    });
+    request.on('end', () => {
+      let token = '';
+      try {
+        token = String((JSON.parse(raw) as { enrollmentToken?: unknown }).enrollmentToken ?? '');
+      } catch {
+        // The 400 response below covers malformed JSON as an invalid exchange.
+      }
+      if (request.method !== 'POST' || token !== input.enrollmentToken) {
+        response.writeHead(400, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: 'Invalid enrollment token' }));
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          nodeId: input.nodeId,
+          nodeName: input.nodeName,
+          nodeToken: input.nodeToken,
+          relayWorkspaceId: input.relayWorkspaceId,
+          relaycastUrl: input.relaycastUrl,
+          websocketUrl: `${input.relaycastUrl}/v1/node/ws`,
+        })
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('cloud enrollment endpoint did not bind a TCP port');
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/api/v1/fleet/register`,
+    stop: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
 export interface NodeRosterEntry {
   id: string;
   name: string;
@@ -259,6 +326,7 @@ export interface NodeRosterEntry {
   load: number;
   active_agents: number;
   max_agents: number;
+  tags?: string[];
 }
 
 export async function getNodes(
@@ -300,6 +368,9 @@ export class FleetNode {
       /** Pins the broker's `spawn:<harness>` capacity set (AGENT_RELAY_NODE_HARNESSES)
        * so two nodes on one host advertise distinct capabilities. */
       capacityHarnesses?: string;
+      /** Exercise `cloud enroll` persistence + automatic `node up` pickup rather
+       * than injecting the node token and pre-seeding the broker machine id. */
+      usePersistedEnrollment?: boolean;
     }
   ) {
     this.projectDir = path.join(opts.tmpRoot, `node-${opts.name}`);
@@ -307,22 +378,71 @@ export class FleetNode {
     this.home = path.join(this.projectDir, 'home');
     mkdirSync(this.home, { recursive: true });
     this.logPath = path.join(this.projectDir, 'serve.log');
-    // The broker reads its node id from `<data_local_dir>/agent-relay/machine-id`
-    // (macOS: ~/Library/Application Support, Linux: ~/.local/share). Seed both so
-    // the broker's `node.register` node_id matches the enrolled token's node id —
-    // otherwise the engine rejects the register (node_id_mismatch) and the
-    // capability→action binding never happens.
-    for (const rel of [
-      ['Library', 'Application Support', 'agent-relay', 'machine-id'],
-      ['.local', 'share', 'agent-relay', 'machine-id'],
-    ]) {
-      const file = path.join(this.home, ...rel);
-      mkdirSync(path.dirname(file), { recursive: true });
-      writeFileSync(file, `${opts.nodeId}\n`);
+    if (!opts.usePersistedEnrollment) {
+      // Direct-token fixtures predate the Cloud enrollment store. Keep their
+      // explicit machine-id setup so those scenarios remain focused on their
+      // existing fleet behavior; the persisted-enrollment regression below
+      // intentionally takes the unseeded path that failed in production.
+      for (const rel of [
+        ['Library', 'Application Support', 'agent-relay', 'machine-id'],
+        ['.local', 'share', 'agent-relay', 'machine-id'],
+      ]) {
+        const file = path.join(this.home, ...rel);
+        mkdirSync(path.dirname(file), { recursive: true });
+        writeFileSync(file, `${opts.nodeId}\n`);
+      }
     }
   }
 
   private readonly home: string;
+
+  /** Redeem through the real CLI so the production enrollment store writer and
+   * subsequent `node up` resolver are both part of the regression boundary. */
+  async cloudEnroll(enrollmentUrl: string, enrollmentToken: string): Promise<void> {
+    if (!this.opts.usePersistedEnrollment) {
+      throw new Error('cloudEnroll requires usePersistedEnrollment');
+    }
+    const child = spawn(
+      process.execPath,
+      [
+        CLI_ENTRY,
+        'cloud',
+        'enroll',
+        '--token',
+        enrollmentToken,
+        '--enrollment-url',
+        enrollmentUrl,
+        '--name',
+        this.opts.name,
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: cleanEnv({ HOME: this.home, AGENT_RELAY_HOME: this.enrollmentHome }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    let output = '';
+    child.stdout?.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', resolve);
+    });
+    if (exitCode !== 0) {
+      throw new Error(`cloud enroll exited ${exitCode}: ${output}`);
+    }
+    if (!output.includes(`Enrolled node "${this.opts.name}"`)) {
+      throw new Error(`cloud enroll did not report success: ${output}`);
+    }
+  }
+
+  private get enrollmentHome(): string {
+    return path.join(this.home, '.agentworkforce', 'relay');
+  }
 
   start(): void {
     const o = this.opts;
@@ -354,9 +474,21 @@ export class FleetNode {
           BROKER_BINARY_PATH: o.brokerBinary,
           RELAYCAST_BASE_URL: o.engineBaseUrl,
           RELAY_BASE_URL: o.engineBaseUrl,
-          RELAY_NODE_TOKEN: o.nodeToken,
-          RELAY_WORKSPACE_KEY: o.workspaceKey,
-          RELAY_API_KEY: o.workspaceKey,
+          ...(o.usePersistedEnrollment
+            ? {
+                AGENT_RELAY_HOME: this.enrollmentHome,
+                // Supply the broker-self workspace membership without using
+                // RELAY_WORKSPACE_KEY, which is intentionally an explicit
+                // direct-workspace choice that disables enrollment pickup.
+                RELAY_WORKSPACES_JSON: JSON.stringify([
+                  { workspace_id: 'fleet-e2e', api_key: o.workspaceKey },
+                ]),
+              }
+            : {
+                RELAY_NODE_TOKEN: o.nodeToken,
+                RELAY_WORKSPACE_KEY: o.workspaceKey,
+                RELAY_API_KEY: o.workspaceKey,
+              }),
           AGENT_RELAY_PROJECT: this.projectDir,
           AGENT_RELAY_STATE_DIR: stateDir,
           AGENT_RELAY_BROKER_PORT: String(o.brokerPort),

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -456,19 +456,19 @@ export class FleetNode {
       // `fleet serve --name` → `node up --broker-name` (the served node's name).
       '--broker-name',
       o.name,
-      // `node up` has no `--base-url`; the engine URL is carried by the
-      // RELAY_BASE_URL / RELAYCAST_BASE_URL env vars set below (as it was for
-      // `fleet serve --base-url`). Serve only — never auto-spawn teams.json
-      // agents (there are none in this hermetic project dir).
-      '--no-spawn',
     ];
     if (!o.usePersistedEnrollment) {
       // Direct-token fixtures predate Cloud enrollment pickup and still model
       // an explicit direct workspace selection. The persisted-enrollment
       // regression must NOT pass this flag: `node up` intentionally treats it
       // as an operator override and skips the enrollment store.
-      args.splice(args.length - 1, 0, '--workspace-key', o.workspaceKey);
+      args.push('--workspace-key', o.workspaceKey);
     }
+    // `node up` has no `--base-url`; the engine URL is carried by the
+    // RELAY_BASE_URL / RELAYCAST_BASE_URL env vars set below (as it was for
+    // `fleet serve --base-url`). Serve only — never auto-spawn teams.json
+    // agents (there are none in this hermetic project dir).
+    args.push('--no-spawn');
     this.child = spawn(process.execPath, args, {
       cwd: REPO_ROOT,
       env: cleanEnv({

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -273,6 +273,13 @@ export async function startCloudEnrollmentEndpoint(input: {
   const server = createHttpServer((request, response) => {
     let raw = '';
     request.setEncoding('utf-8');
+    request.on('error', () => {
+      if (response.writableEnded) return;
+      if (!response.headersSent) {
+        response.writeHead(400, { 'content-type': 'application/json' });
+      }
+      response.end(JSON.stringify({ error: 'Enrollment request stream error' }));
+    });
     request.on('data', (chunk) => {
       raw += chunk;
     });
@@ -430,7 +437,7 @@ export class FleetNode {
     });
     const exitCode = await new Promise<number | null>((resolve, reject) => {
       child.once('error', reject);
-      child.once('exit', resolve);
+      child.once('close', resolve);
     });
     if (exitCode !== 0) {
       throw new Error(`cloud enroll exited ${exitCode}: ${output}`);

--- a/tests/e2e/fleet/nodes/cloud-enrolled.ts
+++ b/tests/e2e/fleet/nodes/cloud-enrolled.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { action, defineNode } from '@agent-relay/fleet';
+
+/** Minimal definition for the Cloud enrollment -> node-up regression. */
+export default defineNode({
+  name: 'cloud-enrolled',
+  tags: ['cloud-enrolled', 'e2e'],
+  capabilities: {
+    'cloud:ping': action({ input: z.object({ nonce: z.string() }) }, async (input) => ({
+      pong: input.nonce,
+    })),
+  },
+});


### PR DESCRIPTION
## Summary

Fixes #1285.

`relay cloud enroll` persisted the Cloud fleet node token and `relay node up` picked that token up, but the CLI did not thread the enrolled `nodeId` into broker startup. The broker then paired the enrollment's `nodeToken` with a fresh local broker node id, so the real node-control/provider handshake failed with `node_id_mismatch`.

This PR:

- exports `RELAY_NODE_ID` from the persisted Cloud enrollment during `node up` pickup;
- makes broker startup prefer explicit `RELAY_NODE_ID` before falling back to the legacy pre-seeded machine-id behavior;
- keeps the legacy direct-token path working when only `RELAY_NODE_TOKEN` and a pre-seeded machine-id file are present;
- fixes the fleet e2e harness so the Cloud-enrollment regression no longer passes `--workspace-key`, which intentionally disables enrollment pickup;
- updates recovery guidance to include `RELAY_NODE_ID` with `RELAY_NODE_TOKEN` and `RELAY_BASE_URL`.

This unblocks the documented Cloud-managed node path used by AgentWorkforce/cloud#2655 and AgentWorkforce/cloud#2656.

## Validation

- `npx vitest run packages/cli/src/cli/commands/node.test.ts packages/cli/src/cli/commands/cloud.test.ts`
- `$HOME/.cargo/bin/cargo test -p agent-relay-broker broker_node_id -- --nocapture`
- `npm run build:core`
- `$HOME/.cargo/bin/cargo build --release --bin agent-relay-broker`
- Real prod repro using `~/factory-node` and the existing persisted enrollment, without re-enrolling:
  - `node up` used the persisted Cloud enrollment for `sf-mini`.
  - `/tmp/node1285-fixed.log` showed provider registration succeeded with `Fleet node "sf-mini" registered provider ... with 3 capabilities`.
  - Local broker `/api/session` reported `node_id=node_203549044126121984`, `node_name=sf-mini`, and node token present.
  - No `node_id_mismatch` occurred.
- Focused local e2e command was attempted: `BROKER_BINARY_PATH="$PWD/target/release/agent-relay-broker" npx vitest run --config vitest.e2e.config.ts tests/e2e/fleet/fleet-e2e.test.ts -t "Cloud-enrolled node startup"`; it skipped because the expected relaycast engine worktree/build (`packages/engine/dist/bin/serve.js`) is not present locally. The available relaycast checkout is older and does not contain `packages/engine`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

