### PR TITLE
docs(workflows): fix cloud schedule syntax in verify-features header

### DIFF
--- a/workflows/verify-features.ts
+++ b/workflows/verify-features.ts
@@ -7,7 +7,7 @@
  * PASS/FAIL report into #relay-health.
  *
  * Designed to run on a schedule (nightly or post-merge):
- *   relay cloud schedule --file workflows/verify-features.ts --cron "0 3 * * *"
+ *   relay cloud schedule workflows/verify-features.ts --cron "0 3 * * *"
  *
  * Or manually:
  *   relay node workflow run workflows/verify-features.ts


### PR DESCRIPTION
## What

The scheduling example in the `workflows/verify-features.ts` header (added in #1283) passes the workflow via a `--file` flag:

```bash
relay cloud schedule --file workflows/verify-features.ts --cron "0 3 * * *"
```

`cloud schedule` takes the workflow as a **positional argument**, so this fails:

```
$ relay cloud schedule --file workflows/verify-features.ts --cron "0 3 * * *"
error: unknown option '--file'
```

The only `--file`-ish option is `--file-type` (`yaml|ts|py`), which is inferred from the extension and isn't needed here.

## Fix

```diff
- *   relay cloud schedule --file workflows/verify-features.ts --cron "0 3 * * *"
+ *   relay cloud schedule workflows/verify-features.ts --cron "0 3 * * *"
```

The intended cadence is unchanged: nightly at 03:00 UTC (`--timezone` already defaults to `UTC`).

## Verification

Checked against the built CLI (`packages/cli/src/cli/commands/cloud.ts:585-588`):

```
Usage: agent-relay cloud schedule [options] <workflow>
Arguments:
  workflow    Workflow file path or inline workflow content
```

The corrected form matches the positional signature, and `.agentworkforce/features/verify/procedures.md:344` already documents this same command correctly — the workflow header was the lone outlier.

## Notes

- Comment-only; no runtime surface and no behavior change.
- No changelog entry: `workflows/` lives in the private root monorepo and isn't in any published package's `files`, so this isn't user-visible under the impact-first changelog rule.
- The `relay node workflow run workflows/verify-features.ts` manual-run line in the same header was checked and is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

