### PR TITLE
fix(relay-feature-guardian): clone relay repo for feature manifest

### DIFF
--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { resolveManifestPath } from './agent.ts';
+
+const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.url), 'utf8')) as {
+  inputs: { SLACK_CHANNEL: { default: string } };
+};
+
+describe('relay-feature-guardian runtime paths', () => {
+  it('reads the manifest from the cloned relay repository', () => {
+    assert.equal(
+      resolveManifestPath('/home/daytona/workspace'),
+      '/home/daytona/workspace/github/repos/AgentWorkforce/relay/.agentworkforce/features/manifest.yaml'
+    );
+  });
+
+  it('defaults delivery to the relay feature-check channel', () => {
+    assert.equal(persona.inputs.SLACK_CHANNEL.default, 'C0AEKNLDNKW');
+  });
+});

--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -1,6 +1,5 @@
-import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { describe, it } from 'node:test';
+import { describe, expect, it } from 'vitest';
 import { resolveManifestPath } from './agent.ts';
 
 const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.url), 'utf8')) as {
@@ -9,13 +8,12 @@ const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.ur
 
 describe('relay-feature-guardian runtime paths', () => {
   it('reads the manifest from the cloned relay repository', () => {
-    assert.equal(
-      resolveManifestPath('/home/daytona/workspace'),
+    expect(resolveManifestPath('/home/daytona/workspace')).toBe(
       '/home/daytona/workspace/github/repos/AgentWorkforce/relay/.agentworkforce/features/manifest.yaml'
     );
   });
 
   it('defaults delivery to the relay feature-check channel', () => {
-    assert.equal(persona.inputs.SLACK_CHANNEL.default, 'C0AEKNLDNKW');
+    expect(persona.inputs.SLACK_CHANNEL.default).toBe('C0AEKNLDNKW');
   });
 });

--- a/.agentworkforce/agents/relay-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.ts
@@ -2,7 +2,7 @@
  * relay-feature-guardian handler.
  *
  * Hourly cron tick:
- *   1. Read the feature list from .agentworkforce/features/manifest.yaml
+ *   1. Read the feature list from the cloned relay repository
  *   2. Load feature progress from memory
  *   3. Pick the next unchecked feature (ordered by criticality then tier)
  *   4. Generate a concise quiz question via ctx.llm
@@ -55,9 +55,20 @@ interface Feature {
 }
 
 const MANIFEST_RELPATH = '.agentworkforce/features/manifest.yaml';
+const RELAY_REPO_RELPATH = 'github/repos/AgentWorkforce/relay';
+
+/**
+ * GitHub-scoped repositories are cloned beneath the proactive workspace root.
+ * WorkforceCtx currently exposes that workspace root (`sandbox.cwd`), but not
+ * an integration-specific repository directory, so derive the clone path from
+ * the documented `/github/repos/{owner}/{repo}` layout.
+ */
+export function resolveManifestPath(workspaceDir: string): string {
+  return `${workspaceDir}/${RELAY_REPO_RELPATH}/${MANIFEST_RELPATH}`;
+}
 
 async function loadFeatures(ctx: WorkforceCtx): Promise<Feature[]> {
-  const absPath = `${ctx.sandbox.cwd}/${MANIFEST_RELPATH}`;
+  const absPath = resolveManifestPath(ctx.sandbox.cwd);
   const raw = await ctx.sandbox.readFile(absPath);
   const manifest = parse(raw) as Manifest;
   const features: Feature[] = [];
@@ -191,17 +202,21 @@ export default defineAgent({
     try {
       features = await loadFeatures(ctx);
     } catch (err) {
-      const absPath = `${ctx.sandbox.cwd}/${MANIFEST_RELPATH}`;
+      const absPath = resolveManifestPath(ctx.sandbox.cwd);
       ctx.log('error', 'relay-feature-guardian.manifest-load-failed', { path: absPath, err: String(err) });
       const isNotFound = String(err).includes('ENOENT');
       const errMsg = isNotFound
-        ? `⚠️ *relay-feature-guardian* can't find the feature manifest at \`${MANIFEST_RELPATH}\`.\n\nThe \`feature/verify-features-workflow\` branch hasn't been merged to main yet — the sandbox runs on main, so the manifest doesn't exist. Merge PR #1283 to fix this.`
+        ? `⚠️ *relay-feature-guardian* can't find the feature manifest in the cloned relay repository at \`${RELAY_REPO_RELPATH}/${MANIFEST_RELPATH}\`.`
         : `⚠️ *relay-feature-guardian* failed to load the feature manifest: \`${String(err)}\``;
       await slackClient()
         .post(channel, errMsg)
         .catch(() => undefined);
       return;
     }
+    ctx.log('info', 'relay-feature-guardian.manifest-loaded', {
+      path: resolveManifestPath(ctx.sandbox.cwd),
+      features: features.length,
+    });
     if (features.length === 0) {
       ctx.log('error', 'relay-feature-guardian.no-features', { reason: 'manifest parsed but empty' });
       await slackClient()

--- a/.agentworkforce/agents/relay-feature-guardian/persona.json
+++ b/.agentworkforce/agents/relay-feature-guardian/persona.json
@@ -10,6 +10,11 @@
     "timeoutSeconds": 300
   },
   "integrations": {
+    "github": {
+      "scope": {
+        "repo": "AgentWorkforce/relay"
+      }
+    },
     "slack": {
       "scope": {
         "paths": "/slack/channels/**"

--- a/.agentworkforce/agents/relay-feature-guardian/persona.json
+++ b/.agentworkforce/agents/relay-feature-guardian/persona.json
@@ -25,7 +25,7 @@
     "SLACK_CHANNEL": {
       "description": "Slack channel to post feature checks to (e.g. relay-health or general).",
       "env": "SLACK_CHANNEL",
-      "default": "C0BHWJSF309",
+      "default": "C0AEKNLDNKW",
       "picker": {
         "provider": "slack",
         "resource": "channels"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
     environment: 'node',
     setupFiles: [path.resolve(__dirname, './vitest.setup.ts')],
     include: [
+      '.agentworkforce/agents/**/*.test.ts',
       'tests/fixtures/**/*.test.ts',
       'tests/integration/broker/evals/**/*.unit.test.ts',
       'packages/**/src/**/*.test.ts',


### PR DESCRIPTION
## Problem

`relay-feature-guardian` reached `runner.started` but read `.agentworkforce/features/manifest.yaml` from the sandbox workspace root. GitHub integration clones repositories under `github/repos/<owner>/<repo>`, so the tracked manifest was never at that root path. The default Slack channel was also stale.

## Fix

- keep the `AgentWorkforce/relay` GitHub repo in the persona integration scope
- resolve the manifest from `github/repos/AgentWorkforce/relay/.agentworkforce/features/manifest.yaml`
- default Slack output to `C0AEKNLDNKW`
- add a focused path/channel regression and include `.agentworkforce/agents/**/*.test.ts` in root Vitest so the normal `npm test` CI command runs it

## Local verification

- clean install completed
- `npx vitest run .agentworkforce/agents/relay-feature-guardian/agent.test.ts`: 1 file, 2 tests passed
- deployment dry-run with `SLACK_CHANNEL=C0AEKNLDNKW` passed

## Deployed-agent evidence

Agent `45fc92b9-0104-48fc-a16a-ac15e27985c4`, fire `30930a8a-bc0d-4d70-bfed-ef823200302e`, sandbox `6aed7013-6c4f-4f12-9b87-edc224e0f2ac`:

- the cold tick exhausted its mount window, then the same sandbox warm-retried
- `runner.started` at `2026-07-17T23:27:13.136Z`
- `relay-feature-guardian.manifest-loaded` at `23:27:13.209Z` from `/home/daytona/workspace/github/repos/AgentWorkforce/relay/.agentworkforce/features/manifest.yaml` with 122 features
- the post attempted corrected channel `C0AEKNLDNKW`, but logged `relay-feature-guardian.post-failed`; the run also received an upstream Anthropic 429

The manifest path and channel target are proven in the deployed runtime. Merge remains gated on a real landed Slack post/`ts` and on GitHub actually running the regression.

## CI gate

At exact head `221754fa479fe5246682d878c107727a1c989551`, workflow run `29620653613` is `startup_failure` with zero jobs. The code wires the test into root Vitest, but GitHub has not executed it yet; this is an explicit merge HOLD until a non-startup-failure Test run passes at this SHA.