### PR TITLE
fix(relay-feature-guardian): checkpoint cycle receipts

### DIFF
--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -187,6 +187,8 @@ describe('relay-feature-guardian runtime paths', () => {
   });
 
   it('requires a delivered Slack ts instead of a draft receipt id', () => {
+    expect(deliveredSlackTs(undefined)).toBe('');
+    expect(deliveredSlackTs(null)).toBe('');
     expect(
       deliveredSlackTs({
         path: '/draft.json',

--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -203,5 +203,12 @@ describe('relay-feature-guardian runtime paths', () => {
         receipt: { externalId: '1710000001.000100' },
       })
     ).toBe('1710000001.000100');
+    expect(
+      deliveredSlackTs({
+        path: '/delivered-via-ts.json',
+        absolutePath: '/delivered-via-ts.json',
+        receipt: { externalId: '   ', ts: '1710000002.000200' },
+      })
+    ).toBe('1710000002.000200');
   });
 });

--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -1,10 +1,109 @@
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
-import { resolveManifestPath } from './agent.ts';
+import type { MemoryItem, WorkforceCtx } from '@agentworkforce/runtime';
+import {
+  bindPreviewTransport,
+  type RelayTransport,
+  type RelayTransportRequest,
+  type RelayTransportWriteRequest,
+  type WritebackResult,
+} from '@relayfile/relay-helpers';
+import { describe, expect, it, vi } from 'vitest';
+import guardian, { deliveredSlackTs, featurePostIdempotencyKey, resolveManifestPath } from './agent.ts';
 
 const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.url), 'utf8')) as {
   inputs: { SLACK_CHANNEL: { default: string } };
 };
+
+const manifest = `
+version: '1'
+categories:
+  core:
+    name: Core
+    criticality: critical
+    features:
+      - id: start-broker
+        name: Start Broker
+        cli: relay node up
+        description: Starts the local broker.
+        verify_tier: 1
+      - id: stop-broker
+        name: Stop Broker
+        cli: relay node down
+        description: Stops the local broker.
+        verify_tier: 1
+`;
+
+class IdempotentSlackTransport implements RelayTransport {
+  readonly attempts: RelayTransportWriteRequest[] = [];
+  providerCreates = 0;
+  private readonly results = new Map<string, WritebackResult>();
+
+  async read<T = unknown>(_request: RelayTransportRequest): Promise<T> {
+    return undefined as T;
+  }
+
+  async list<T = unknown>(_request: RelayTransportRequest): Promise<T[]> {
+    return [];
+  }
+
+  async write(request: RelayTransportWriteRequest): Promise<WritebackResult> {
+    this.attempts.push(request);
+    const body = request.body as { idempotencyKey?: string };
+    const key = body.idempotencyKey ?? `unkeyed:${this.attempts.length}`;
+    const replay = this.results.get(key);
+    if (replay) return replay;
+
+    this.providerCreates += 1;
+    const ts = `171000000${this.providerCreates}.000100`;
+    const path = `${request.path}/message-${this.providerCreates}.json`;
+    const result: WritebackResult = {
+      path,
+      absolutePath: path,
+      receipt: { externalId: ts, ts },
+    };
+    this.results.set(key, result);
+    return result;
+  }
+}
+
+function guardianContext(failSaveCall: number): {
+  ctx: WorkforceCtx;
+  memoryItems: MemoryItem[];
+} {
+  const memoryItems: MemoryItem[] = [];
+  let saveCalls = 0;
+  const ctx = {
+    persona: {
+      inputs: { SLACK_CHANNEL: 'C0AEKNLDNKW' },
+      inputSpecs: {},
+    },
+    sandbox: {
+      cwd: '/home/daytona/workspace',
+      readFile: vi.fn(async () => manifest),
+    },
+    llm: {
+      complete: vi.fn(async () => 'Is this feature working as expected?'),
+    },
+    memory: {
+      recall: vi.fn(async () => [...memoryItems]),
+      save: vi.fn(async (content: string, options?: { tags?: string[]; scope?: string }) => {
+        saveCalls += 1;
+        if (saveCalls === failSaveCall) return undefined;
+        const id = `memory-${saveCalls}`;
+        memoryItems.push({
+          id,
+          content,
+          tags: options?.tags ?? [],
+          scope: 'workspace',
+          createdAt: new Date(Date.UTC(2026, 6, 18, 0, 0, saveCalls)).toISOString(),
+        });
+        return { id };
+      }),
+    },
+    log: vi.fn(),
+  } as unknown as WorkforceCtx;
+  return { ctx, memoryItems };
+}
 
 describe('relay-feature-guardian runtime paths', () => {
   it('reads the manifest from the cloned relay repository', () => {
@@ -15,5 +114,92 @@ describe('relay-feature-guardian runtime paths', () => {
 
   it('defaults delivery to the relay feature-check channel', () => {
     expect(persona.inputs.SLACK_CHANNEL.default).toBe('C0AEKNLDNKW');
+  });
+
+  it('deduplicates an ambiguous post retry and advances after a saved receipt', async () => {
+    const transport = new IdempotentSlackTransport();
+    const restore = bindPreviewTransport(transport);
+    const { ctx, memoryItems } = guardianContext(2);
+
+    try {
+      // Run 1: the provider delivers Start Broker, then the progress save
+      // silently returns undefined. Only the pre-post cycle checkpoint remains.
+      await guardian.handler(ctx, { type: 'cron.tick' } as never);
+      expect(transport.providerCreates).toBe(1);
+      expect(memoryItems).toHaveLength(1);
+      expect(JSON.parse(memoryItems[0].content).checkedIds).toEqual([]);
+
+      // Run 2: the same feature uses the same deterministic key, so the
+      // provider receipt is replayed rather than creating a duplicate post.
+      await guardian.handler(ctx, { type: 'cron.tick' } as never);
+      expect(transport.providerCreates).toBe(1);
+      expect(transport.attempts).toHaveLength(2);
+      const firstBody = transport.attempts[0].body as { idempotencyKey: string };
+      const retryBody = transport.attempts[1].body as { idempotencyKey: string };
+      expect(retryBody.idempotencyKey).toBe(firstBody.idempotencyKey);
+
+      const completed = JSON.parse(memoryItems.at(-1)?.content ?? '{}') as {
+        checkedIds: string[];
+        lastPost?: { featureId: string; ts: string };
+      };
+      expect(completed.checkedIds).toEqual(['start-broker']);
+      expect(completed.lastPost).toEqual({
+        featureId: 'start-broker',
+        ts: '1710000001.000100',
+      });
+
+      // Run 3: persisted progress selects the next feature in the cycle.
+      await guardian.handler(ctx, { type: 'cron.tick' } as never);
+      expect(transport.providerCreates).toBe(2);
+      const advanced = JSON.parse(memoryItems.at(-1)?.content ?? '{}') as {
+        checkedIds: string[];
+      };
+      expect(advanced.checkedIds).toEqual(['start-broker', 'stop-broker']);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not post when the initial cycle checkpoint has no receipt', async () => {
+    const transport = new IdempotentSlackTransport();
+    const restore = bindPreviewTransport(transport);
+    const { ctx, memoryItems } = guardianContext(1);
+
+    try {
+      await guardian.handler(ctx, { type: 'cron.tick' } as never);
+      expect(transport.providerCreates).toBe(0);
+      expect(memoryItems).toEqual([]);
+      expect(ctx.log).toHaveBeenCalledWith('error', 'relay-feature-guardian.cycle-checkpoint-failed', {
+        feature: 'start-broker',
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('scopes provider idempotency to a feature within one cycle', () => {
+    expect(featurePostIdempotencyKey('cycle-a', 'start-broker')).toBe(
+      featurePostIdempotencyKey('cycle-a', 'start-broker')
+    );
+    expect(featurePostIdempotencyKey('cycle-a', 'start-broker')).not.toBe(
+      featurePostIdempotencyKey('cycle-b', 'start-broker')
+    );
+  });
+
+  it('requires a delivered Slack ts instead of a draft receipt id', () => {
+    expect(
+      deliveredSlackTs({
+        path: '/draft.json',
+        absolutePath: '/draft.json',
+        receipt: { id: 'mountcmd-draft', created: 'mountcmd-draft' },
+      })
+    ).toBe('');
+    expect(
+      deliveredSlackTs({
+        path: '/delivered.json',
+        absolutePath: '/delivered.json',
+        receipt: { externalId: '1710000001.000100' },
+      })
+    ).toBe('1710000001.000100');
   });
 });

--- a/.agentworkforce/agents/relay-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.ts
@@ -13,7 +13,7 @@
  */
 import { defineAgent, type WorkforceCtx } from '@agentworkforce/runtime';
 import { input } from '@agentworkforce/delivery';
-import { slackClient } from '@relayfile/relay-helpers';
+import { slackClient, type WritebackResult } from '@relayfile/relay-helpers';
 import { parse } from 'yaml';
 
 // ── manifest types ────────────────────────────────────────────────────────────
@@ -92,10 +92,14 @@ async function loadFeatures(ctx: WorkforceCtx): Promise<Feature[]> {
 
 interface ProgressState {
   kind: 'relay-feature-guardian:progress';
-  version: 1;
+  version: 1 | 2;
   checkedIds: string[];
   cycleStartedAt: string;
   totalFeatures: number;
+  lastPost?: {
+    featureId: string;
+    ts: string;
+  };
 }
 
 async function loadProgress(ctx: WorkforceCtx): Promise<ProgressState | null> {
@@ -121,12 +125,23 @@ async function loadProgress(ctx: WorkforceCtx): Promise<ProgressState | null> {
   return null;
 }
 
-async function saveProgress(ctx: WorkforceCtx, state: ProgressState): Promise<void> {
-  await ctx.memory.save(JSON.stringify(state), {
+async function saveProgress(ctx: WorkforceCtx, state: ProgressState): Promise<string | null> {
+  const receipt = await ctx.memory.save(JSON.stringify(state), {
     tags: ['relay-feature-guardian:progress'],
     scope: 'workspace',
     ttlSeconds: 60 * 60 * 24 * 14, // 14 days
   });
+  return receipt ? receipt.id : null;
+}
+
+export function featurePostIdempotencyKey(cycleStartedAt: string, featureId: string): string {
+  return `relay-feature-guardian:${cycleStartedAt}:${featureId}`;
+}
+
+export function deliveredSlackTs(result: WritebackResult): string {
+  const receipt = result.receipt as { externalId?: unknown; ts?: unknown } | undefined;
+  const value = receipt?.externalId ?? receipt?.ts;
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 // ── feature selection ─────────────────────────────────────────────────────────
@@ -232,15 +247,37 @@ export default defineAgent({
     const progress = await loadProgress(ctx);
     const checkedIds = new Set(progress?.checkedIds ?? []);
     const totalFeatures = features.length;
+    let cycleStartedAt = progress?.cycleStartedAt ?? new Date().toISOString();
+    let needsCycleCheckpoint = !progress;
 
     // Pick the next unchecked feature; reset if the cycle is complete
     let feature = pickNextFeature(features, checkedIds);
     if (!feature) {
       ctx.log('info', 'relay-feature-guardian.cycle-complete', { total: totalFeatures });
       checkedIds.clear();
+      cycleStartedAt = new Date().toISOString();
+      needsCycleCheckpoint = true;
       feature = pickNextFeature(features, checkedIds);
     }
     if (!feature) return;
+
+    // Persist a stable cycle identity before the side effect. If memory is
+    // unavailable, stop instead of posting a feature we cannot checkpoint.
+    if (needsCycleCheckpoint) {
+      const checkpointId = await saveProgress(ctx, {
+        kind: 'relay-feature-guardian:progress',
+        version: 2,
+        checkedIds: [...checkedIds],
+        cycleStartedAt,
+        totalFeatures,
+      });
+      if (!checkpointId) {
+        ctx.log('error', 'relay-feature-guardian.cycle-checkpoint-failed', {
+          feature: feature.id,
+        });
+        return;
+      }
+    }
 
     // Build @mention string
     const userWill = input(ctx, 'SLACK_USER_WILL');
@@ -258,21 +295,43 @@ export default defineAgent({
 
     // Post to Slack
     const slack = slackClient();
-    const result = await slack.post(channel, message);
-    if (!result.ts) {
+    const result = await slack.messages.write(
+      { channelId: channel },
+      {
+        text: message,
+        idempotencyKey: featurePostIdempotencyKey(cycleStartedAt, feature.id),
+      }
+    );
+    const ts = deliveredSlackTs(result);
+    if (!ts) {
       ctx.log('error', 'relay-feature-guardian.post-failed', { channel, feature: feature.id });
       return;
     }
-    ctx.log('info', 'relay-feature-guardian.posted', { channel, feature: feature.id, ts: result.ts });
 
-    // Persist updated progress
+    // Checkpoint immediately after the confirmed provider receipt. The stable
+    // idempotency key makes a retry safe if this save times out or the run caps.
     checkedIds.add(feature.id);
-    await saveProgress(ctx, {
+    const checkpointId = await saveProgress(ctx, {
       kind: 'relay-feature-guardian:progress',
-      version: 1,
+      version: 2,
       checkedIds: [...checkedIds],
-      cycleStartedAt: progress?.cycleStartedAt ?? new Date().toISOString(),
+      cycleStartedAt,
       totalFeatures,
+      lastPost: { featureId: feature.id, ts },
+    });
+    if (!checkpointId) {
+      ctx.log('error', 'relay-feature-guardian.progress-checkpoint-failed', {
+        channel,
+        feature: feature.id,
+        ts,
+      });
+      return;
+    }
+    ctx.log('info', 'relay-feature-guardian.posted', {
+      channel,
+      feature: feature.id,
+      ts,
+      checkpointId,
     });
   },
 });

--- a/.agentworkforce/agents/relay-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.ts
@@ -140,8 +140,9 @@ export function featurePostIdempotencyKey(cycleStartedAt: string, featureId: str
 
 export function deliveredSlackTs(result: WritebackResult | null | undefined): string {
   const receipt = result?.receipt as { externalId?: unknown; ts?: unknown } | undefined;
-  const value = receipt?.externalId ?? receipt?.ts;
-  return typeof value === 'string' ? value.trim() : '';
+  const externalId = typeof receipt?.externalId === 'string' ? receipt.externalId.trim() : '';
+  if (externalId) return externalId;
+  return typeof receipt?.ts === 'string' ? receipt.ts.trim() : '';
 }
 
 // ── feature selection ─────────────────────────────────────────────────────────

--- a/.agentworkforce/agents/relay-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.ts
@@ -138,8 +138,8 @@ export function featurePostIdempotencyKey(cycleStartedAt: string, featureId: str
   return `relay-feature-guardian:${cycleStartedAt}:${featureId}`;
 }
 
-export function deliveredSlackTs(result: WritebackResult): string {
-  const receipt = result.receipt as { externalId?: unknown; ts?: unknown } | undefined;
+export function deliveredSlackTs(result: WritebackResult | null | undefined): string {
+  const receipt = result?.receipt as { externalId?: unknown; ts?: unknown } | undefined;
   const value = receipt?.externalId ?? receipt?.ts;
   return typeof value === 'string' ? value.trim() : '';
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `agent-relay integration` now discovers relayfile control-plane capabilities before sending API v3 headers, fails fast with upgrade and restart guidance for incompatible daemons, and safely replaces stale daemons when a compatible binary is installed.
 - `AgentRelaySDK` now maps Relaycast lifecycle states onto its existing Swift presence states, so root-package consumers compile with Relaycast 6.1 and later while package-local builds remain compatible with 6.0.5.
+- `relay-feature-guardian` now reads the scoped Relay clone, posts to its configured channel, and checkpoints receipt-confirmed cycle progress so retries do not repeat a feature check.
 
 ## [10.6.3] - 2026-07-17
 


### PR DESCRIPTION
## Summary

- checkpoint stable cycle identity before posting and require a durable memory receipt
- reuse a deterministic cycle-and-feature Slack idempotency key across ambiguous retries
- advance checked features only after a real Slack externalId or ts and a receipt-confirmed progress save
- preserve version 1 cycle memory compatibility while recording the last delivered post receipt

Follow-up to merged #1329. This PR contains only the cycle-persistence fix plus its changelog entry.

## Local validation

- npx vitest run .agentworkforce/agents/relay-feature-guardian/agent.test.ts: 6/6 pass
- targeted TypeScript compile with allowImportingTsExtensions: pass
- Prettier check for changed files: pass
- git diff --check against main: pass

## Remaining gates

- exact-head CI must start, classify the agent-only diff as Node-affecting, schedule the Node matrix, and explicitly execute the guardian Vitest
- after SHA-bound review, spend exactly one deployed guardian fire and require cloned-path manifest-loaded, advance beyond Start Broker without a duplicate, channel C0AEKNLDNKW, and a real Slack ts receipt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

