### PR TITLE
fix(relay-feature-guardian): narrow Relayfile mount intent

### DIFF
--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -23,6 +23,10 @@ import guardian, {
 } from './agent.ts';
 
 const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.url), 'utf8')) as {
+  integrations: Record<
+    string,
+    { relayfileMount?: { requiredReadPaths?: unknown; writeOnlyPaths?: unknown } }
+  >;
   inputs: { SLACK_CHANNEL: { default: string } };
 };
 
@@ -316,6 +320,17 @@ describe('relay-feature-guardian runtime paths', () => {
 
   it('defaults delivery to the relay feature-check channel', () => {
     expect(persona.inputs.SLACK_CHANNEL.default).toBe('C0AEKNLDNKW');
+  });
+
+  it('mounts only the manifest directory and configured Slack output channel', () => {
+    expect(persona.integrations.github?.relayfileMount).toEqual({
+      requiredReadPaths: ['/github/repos/AgentWorkforce/relay/.agentworkforce/features/**'],
+      writeOnlyPaths: [],
+    });
+    expect(persona.integrations.slack?.relayfileMount).toEqual({
+      requiredReadPaths: [],
+      writeOnlyPaths: ['/slack/channels/${SLACK_CHANNEL}/**'],
+    });
   });
 
   it('deduplicates an ambiguous post retry and advances after a saved receipt', async () => {

--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -28,6 +28,7 @@ const persona = JSON.parse(readFileSync(new URL('./persona.json', import.meta.ur
     { relayfileMount?: { requiredReadPaths?: unknown; writeOnlyPaths?: unknown } }
   >;
   inputs: { SLACK_CHANNEL: { default: string } };
+  memory: { enabled: boolean; scopes: string[]; ttlDays: number };
 };
 
 const manifestFeatures = [
@@ -322,10 +323,15 @@ describe('relay-feature-guardian runtime paths', () => {
     expect(persona.inputs.SLACK_CHANNEL.default).toBe('C0AEKNLDNKW');
   });
 
-  it('mounts only the manifest directory and configured Slack output channel', () => {
+  it('declares bounded manifest and memory reads plus configured Slack output', () => {
     expect(persona.integrations.github?.relayfileMount).toEqual({
       requiredReadPaths: ['/github/repos/AgentWorkforce/relay/.agentworkforce/features/**'],
       writeOnlyPaths: [],
+    });
+    expect(persona.memory).toEqual({
+      enabled: true,
+      scopes: ['workspace'],
+      ttlDays: 14,
     });
     expect(persona.integrations.slack?.relayfileMount).toEqual({
       requiredReadPaths: [],

--- a/.agentworkforce/agents/relay-feature-guardian/persona.json
+++ b/.agentworkforce/agents/relay-feature-guardian/persona.json
@@ -13,11 +13,19 @@
     "github": {
       "scope": {
         "repo": "AgentWorkforce/relay"
+      },
+      "relayfileMount": {
+        "requiredReadPaths": ["/github/repos/AgentWorkforce/relay/.agentworkforce/features/**"],
+        "writeOnlyPaths": []
       }
     },
     "slack": {
       "scope": {
         "paths": "/slack/channels/**"
+      },
+      "relayfileMount": {
+        "requiredReadPaths": [],
+        "writeOnlyPaths": ["/slack/channels/${SLACK_CHANNEL}/**"]
       }
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `agent-relay integration` now discovers relayfile control-plane capabilities before sending API v3 headers, fails fast with upgrade and restart guidance for incompatible daemons, and safely replaces stale daemons when a compatible binary is installed.
 - `AgentRelaySDK` now maps Relaycast lifecycle states onto its existing Swift presence states, so root-package consumers compile with Relaycast 6.1 and later while package-local builds remain compatible with 6.0.5.
-- `relay-feature-guardian` now reads the scoped Relay clone, posts to its configured channel, and advances its exact, revision-safe cycle checkpoint only after a bounded wait returns a real Slack receipt, while safely reconciling retired manifest features.
+- `relay-feature-guardian` now limits read mirrors to the feature manifest and workspace memory while keeping Slack write-only to its configured output channel, and advances its exact, revision-safe cycle checkpoint only after a bounded wait returns a real Slack receipt while safely reconciling retired manifest features.
 - `agent-relay-broker` and `@agent-relay/utils` now preserve mise/asdf/rtx-style CLI shims when spawning provider workers, so Codex, Claude, Gemini, and other agent CLIs installed via a version manager receive their own permission flags (e.g. `--dangerously-bypass-approvals-and-sandbox`) instead of the manager binary rejecting them.
 
 ## [10.6.3] - 2026-07-17


### PR DESCRIPTION
## Summary

- declare the cloned feature-manifest directory as the bounded GitHub read authority
- retain workspace memory as an explicit derived read authority for the direct Relayfile cycle-state contract
- declare the configured Slack channel as write-only, removing the broad Slack history mirror from scheduled cold starts
- preserve the existing exact cycle-state and receipt behavior

## Safety contract

- handler audit: the production path reads the cloned manifest with `ctx.sandbox.readFile`; cycle state uses direct Relayfile HTTP under the declared workspace-memory scope; Slack is write-only
- Cloud-derived plan: exact deployed cloud#2734 planner output is mirror `/github/repos/AgentWorkforce/relay/.agentworkforce/features`, mirror `/memory/workspace`, and write-only `/slack/channels/C0AEKNLDNKW`
- bounded cold-start claim: the plan retains the small workspace-memory authority required for state access but removes the broad `/slack/channels` mirror that previously traversed 3,019 directories before the handler could start
- relayfile Path Contract v1: both declared integration authorities are contained by their scopes and use terminal directory `/**`; `${SLACK_CHANNEL}` is a declared whole-segment picker input
- Cloud support baseline: cloud#2734 deploy `29650253979` is green at `0e000208f1f1715ec7d3c7833b5de027f6929a6a`
- deploy-tool guard: CLI 4.1.23 strips this nested contract, while exact `agentworkforce@4.1.33` preserves the declarations and workspace-memory scope; rollout deploy must use exact 4.1.33

## RED to GREEN

- RED: the mount-intent regression failed because both declarations were absent
- GREEN: focused Guardian suite 31/31, including the explicit workspace-memory scope contract
- GREEN: strict targeted NodeNext TypeScript
- GREEN: Prettier and `git diff --check`
- GREEN: exact `npx --yes agentworkforce@4.1.33 ... --bundle-out` preserved both declarations and memory scope in the compiled persona artifact
- GREEN: exact cloud#2734 `deriveRelayfileMountIntentPlan` dry-run produced the three-authority plan above

## Acceptance

After exact-head review, CI, merge, and deploy, run at most three natural fires and prove `runner.started` within the cap plus durable `1/122 -> 2/122 -> 3/122` checkpoint advancement with real Slack receipts.
