### PR TITLE
fix(broker): preserve busy PTY message delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `agent-relay cloud enroll --workspace <id>` now mints and redeems a fleet-node enrollment token from the stored Cloud login, so admins can enroll machines without copying tokens from the dashboard.
+- `agent-relay-broker` `/health` now reports `deadLetterCount`, making terminal delivery loss visible alongside the pending queue.
+
+### Fixed
+
+- `agent-relay-broker` now keeps wait-mode PTY deliveries pending through busy turns and enrolls spawned workers in their declared Relaycast channels, preventing premature dead-lettering and missing channel mentions.
 
 ## [10.6.4] - 2026-07-18
 

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -544,6 +544,7 @@ pub(crate) fn listen_api_health_payload(
         "memberships": memberships,
         "agentCount": 0,
         "pendingDeliveryCount": 0,
+        "deadLetterCount": 0,
         "wsConnections": 0,
         "memoryMb": 0,
         "relaycastConnected": startup_error_code.is_none(),
@@ -585,6 +586,9 @@ fn merge_status_into_health_payload(payload: &mut Value, status: &Value) {
     }
     if let Some(pending_count) = status.get("pending_delivery_count").and_then(Value::as_u64) {
         object.insert("pendingDeliveryCount".to_string(), json!(pending_count));
+    }
+    if let Some(dead_letter_count) = status.get("dead_letter_count").and_then(Value::as_u64) {
+        object.insert("deadLetterCount".to_string(), json!(dead_letter_count));
     }
     let token_present = status
         .get("node_delivery")
@@ -3537,6 +3541,21 @@ mod auth_tests {
             .expect("request should succeed");
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn health_payload_surfaces_dead_letter_count_from_runtime_status() {
+        let mut payload = super::listen_api_health_payload(None, vec![]);
+        super::merge_status_into_health_payload(
+            &mut payload,
+            &json!({
+                "pending_delivery_count": 0,
+                "dead_letter_count": 353,
+            }),
+        );
+
+        assert_eq!(payload["pendingDeliveryCount"], 0);
+        assert_eq!(payload["deadLetterCount"], 353);
     }
 
     #[tokio::test]

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use relaycast::{
@@ -6,7 +6,7 @@ use relaycast::{
     retry_agent_registration as sdk_retry_agent_registration, ActionDefinition, ActionInvocation,
     AgentClient, AgentRegistrationClient, AgentRegistrationError, AgentRegistrationRetryOutcome,
     CompleteInvocationRequest, CreateObserverTokenRequest, MessageListQuery, ObserverToken,
-    RegisterActionRequest, RelayCast, RelayCastOptions, ReleaseAgentRequest,
+    RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
 };
 use serde_json::Value;
 
@@ -440,6 +440,125 @@ impl RelaycastHttpClient {
         Ok(())
     }
 
+    /// Ensure a spawned worker is a Relaycast member of every channel in its
+    /// broker spec. The worker token must already be seeded in the registration
+    /// cache; otherwise creating a client for an existing name can rotate that
+    /// agent's token (see [`Self::registered_agent_client_as`]).
+    pub(crate) async fn ensure_agent_channels(
+        &self,
+        agent_name: &str,
+        cli_hint: Option<&str>,
+        channels: &[crate::ids::ChannelName],
+    ) -> Result<()> {
+        if channels.is_empty() {
+            return Ok(());
+        }
+        let agent_client = self
+            .registered_agent_client_as(agent_name, cli_hint)
+            .await
+            .with_context(|| {
+                format!("failed to authenticate worker '{agent_name}' for channel membership")
+            })?;
+        let mut seen = BTreeSet::new();
+        let mut failures = Vec::new();
+        for channel in channels {
+            let name = channel.as_str();
+            if !seen.insert(name.to_ascii_lowercase()) {
+                continue;
+            }
+            match agent_client
+                .ensure_joined_channel(relaycast::CreateChannelRequest {
+                    name: name.to_string(),
+                    topic: None,
+                    metadata: None,
+                })
+                .await
+            {
+                Ok(outcome) => {
+                    tracing::info!(
+                        worker = %agent_name,
+                        channel = %outcome.name,
+                        created = outcome.created,
+                        joined = outcome.joined,
+                        "ensured worker channel membership"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        worker = %agent_name,
+                        channel = %name,
+                        error = %error,
+                        "failed to ensure worker channel membership"
+                    );
+                    failures.push(format!("{name}: {error}"));
+                }
+            }
+        }
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "failed to join worker '{agent_name}' to channels: {}",
+                failures.join("; ")
+            );
+        }
+        Ok(())
+    }
+
+    /// Reconcile worker-side Relaycast membership when the broker removes
+    /// channels from a running worker's spec. Missing memberships are already
+    /// in the desired state and are treated as success.
+    pub(crate) async fn leave_agent_channels(
+        &self,
+        agent_name: &str,
+        cli_hint: Option<&str>,
+        channels: &[crate::ids::ChannelName],
+    ) -> Result<()> {
+        if channels.is_empty() {
+            return Ok(());
+        }
+        let agent_client = self
+            .registered_agent_client_as(agent_name, cli_hint)
+            .await
+            .with_context(|| {
+                format!("failed to authenticate worker '{agent_name}' for channel membership")
+            })?;
+        let mut seen = BTreeSet::new();
+        let mut failures = Vec::new();
+        for channel in channels {
+            let name = channel.as_str();
+            if !seen.insert(name.to_ascii_lowercase()) {
+                continue;
+            }
+            match agent_client.leave_channel(name).await {
+                Ok(())
+                | Err(RelayError::Api {
+                    status: 404 | 409, ..
+                }) => {
+                    tracing::info!(
+                        worker = %agent_name,
+                        channel = %name,
+                        "reconciled worker channel removal"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        worker = %agent_name,
+                        channel = %name,
+                        error = %error,
+                        "failed to remove worker channel membership"
+                    );
+                    failures.push(format!("{name}: {error}"));
+                }
+            }
+        }
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "failed to remove worker '{agent_name}' from channels: {}",
+                failures.join("; ")
+            );
+        }
+        Ok(())
+    }
+
     /// Fetch recent DM history for an agent via the Relaycast REST API.
     pub async fn get_dms(&self, agent: &str, limit: usize) -> Result<Vec<Value>> {
         let agent_client = self.registered_agent_client().await?;
@@ -672,6 +791,8 @@ mod tests {
     use relaycast::AgentRegistrationError;
     use serde_json::json;
 
+    use crate::ids::ChannelName;
+
     use super::{
         format_worker_preregistration_error, registration_is_retryable,
         registration_retry_after_secs, MessageInjectionMode, RelaycastHttpClient,
@@ -752,6 +873,59 @@ mod tests {
 
         assert_eq!(result["agent_id"], "agent_existing_recipient");
         read_mock.assert_hits(1);
+        spawn_mock.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn worker_channel_membership_is_reconciled_for_mention_fanout() {
+        let server = MockServer::start();
+        let create_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/channels")
+                .header("authorization", "Bearer at_live_lead")
+                .body_contains("\"name\":\"pa-fixes-hardening\"");
+            then.status(409).json_body(json!({
+                "ok": false,
+                "error": {
+                    "code": "channel_already_exists",
+                    "message": "Channel exists"
+                }
+            }));
+        });
+        let join_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/channels/pa-fixes-hardening/join")
+                .header("authorization", "Bearer at_live_lead");
+            then.status(409).json_body(json!({
+                "ok": false,
+                "error": {
+                    "code": "already_member",
+                    "message": "Already joined"
+                }
+            }));
+        });
+        let spawn_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/agents");
+            then.status(500).json_body(json!({
+                "ok": false,
+                "error": { "code": "wrong_identity", "message": "must not respawn" }
+            }));
+        });
+        let client =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "codex");
+        client.seed_agent_token("lead", "at_live_lead");
+
+        client
+            .ensure_agent_channels(
+                "lead",
+                Some("claude"),
+                &[ChannelName::from("pa-fixes-hardening")],
+            )
+            .await
+            .expect("worker channel membership should be idempotently reconciled");
+
+        create_mock.assert_hits(1);
+        join_mock.assert_hits(1);
         spawn_mock.assert_hits(0);
     }
 

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -402,6 +402,30 @@ impl BrokerRuntime {
                         }
                     }
                 };
+                if let Some(token) = worker_relay_key.as_deref() {
+                    // Node registration returns a token without populating the
+                    // HTTP client's worker cache. Seed it before authenticating
+                    // as the worker so channel reconciliation cannot rotate an
+                    // already-live identity's token.
+                    seed_supplied_agent_token(relaycast_http, &name, token);
+                    if let Err(error) = relaycast_http
+                        .ensure_agent_channels(&name, Some(&cli), &effective_channels)
+                        .await
+                    {
+                        tracing::error!(
+                            worker = %name,
+                            channels = ?effective_channels,
+                            error = %error,
+                            "worker channel membership reconciliation failed"
+                        );
+                        let membership_warning =
+                            format!("worker channel membership was not fully reconciled: {error}");
+                        preregistration_warning = Some(match preregistration_warning.take() {
+                            Some(existing) => format!("{existing}; {membership_warning}"),
+                            None => membership_warning,
+                        });
+                    }
+                }
 
                 let mut effective_task = if exit_after_task {
                     Some(apply_exit_after_task_instruction(task))
@@ -1649,7 +1673,7 @@ impl BrokerRuntime {
                 channels,
                 reply,
             } => {
-                let (workspace_id, parent, spec, pid, added, all_channels) = {
+                let (workspace_id, cli_hint, parent, spec, pid, added, all_channels) = {
                     let Some(handle) = workers.workers.get_mut(&name) else {
                         let _ = reply.send(Err(format!("unknown worker '{}'", name)));
                         return;
@@ -1668,6 +1692,7 @@ impl BrokerRuntime {
                     }
                     (
                         handle.workspace_id.clone(),
+                        handle.spec.cli.clone(),
                         handle.parent.clone(),
                         handle.spec.clone(),
                         handle.child.id(),
@@ -1675,6 +1700,30 @@ impl BrokerRuntime {
                         handle.spec.channels.clone(),
                     )
                 };
+
+                let mut membership_error = None;
+                if !channels.is_empty() {
+                    let workspace = workspace_for_channel_update(
+                        workspace_id.as_deref(),
+                        workspace_lookup,
+                        default_workspace_id.as_deref(),
+                        default_workspace,
+                    );
+                    if let Err(error) = workspace
+                        .http_client
+                        .ensure_agent_channels(&name, cli_hint.as_deref(), &channels)
+                        .await
+                    {
+                        tracing::error!(
+                            worker = %name,
+                            workspace_id = %workspace.workspace_id,
+                            channels = ?channels,
+                            error = %error,
+                            "failed to reconcile worker channel subscriptions"
+                        );
+                        membership_error = Some(error.to_string());
+                    }
+                }
 
                 if !added.is_empty() {
                     let workspace = workspace_for_channel_update(
@@ -1718,17 +1767,22 @@ impl BrokerRuntime {
                         );
                     }
                 }
-                let _ = reply.send(Ok(json!({
-                    "name": name,
-                    "channels": all_channels,
-                })));
+                let _ = match membership_error {
+                    Some(error) => reply.send(Err(format!(
+                        "failed to reconcile worker channel subscriptions: {error}"
+                    ))),
+                    None => reply.send(Ok(json!({
+                        "name": name,
+                        "channels": all_channels,
+                    }))),
+                };
             }
             ListenApiRequest::UnsubscribeChannels {
                 name,
                 channels,
                 reply,
             } => {
-                let (workspace_id, parent, spec, pid, removed, remaining) = {
+                let (workspace_id, cli_hint, parent, spec, pid, removed, remaining) = {
                     let Some(handle) = workers.workers.get_mut(&name) else {
                         let _ = reply.send(Err(format!("unknown worker '{}'", name)));
                         return;
@@ -1749,6 +1803,7 @@ impl BrokerRuntime {
                         .collect::<Vec<_>>();
                     (
                         handle.workspace_id.clone(),
+                        handle.spec.cli.clone(),
                         handle.parent.clone(),
                         handle.spec.clone(),
                         handle.child.id(),
@@ -1756,6 +1811,30 @@ impl BrokerRuntime {
                         remaining,
                     )
                 };
+
+                let mut membership_error = None;
+                if !channels.is_empty() {
+                    let workspace = workspace_for_channel_update(
+                        workspace_id.as_deref(),
+                        workspace_lookup,
+                        default_workspace_id.as_deref(),
+                        default_workspace,
+                    );
+                    if let Err(error) = workspace
+                        .http_client
+                        .leave_agent_channels(&name, cli_hint.as_deref(), &channels)
+                        .await
+                    {
+                        tracing::error!(
+                            worker = %name,
+                            workspace_id = %workspace.workspace_id,
+                            channels = ?channels,
+                            error = %error,
+                            "failed to reconcile worker channel removals"
+                        );
+                        membership_error = Some(error.to_string());
+                    }
+                }
 
                 if !removed.is_empty() {
                     let workspace = workspace_for_channel_update(
@@ -1809,10 +1888,15 @@ impl BrokerRuntime {
                         );
                     }
                 }
-                let _ = reply.send(Ok(json!({
-                    "name": name,
-                    "channels": remaining,
-                })));
+                let _ = match membership_error {
+                    Some(error) => reply.send(Err(format!(
+                        "failed to reconcile worker channel removals: {error}"
+                    ))),
+                    None => reply.send(Ok(json!({
+                        "name": name,
+                        "channels": remaining,
+                    }))),
+                };
             }
             ListenApiRequest::GetInboundDeliveryMode { name, reply } => {
                 if !workers.has_worker(&name) {

--- a/crates/broker/src/runtime/dead_letter.rs
+++ b/crates/broker/src/runtime/dead_letter.rs
@@ -203,6 +203,7 @@ pub(crate) fn requeue_dead_letter(
         worker_name: entry.worker_name,
         delivery,
         attempts: 0,
+        failed_attempts: 0,
         next_retry_at: Instant::now(),
         queued_at_ms: entry.queued_at_ms,
         last_error: None,

--- a/crates/broker/src/runtime/delivery.rs
+++ b/crates/broker/src/runtime/delivery.rs
@@ -5,6 +5,10 @@ pub(crate) struct PendingDelivery {
     pub(super) worker_name: WorkerName,
     pub(super) delivery: RelayDelivery,
     pub(super) attempts: u32,
+    /// Consecutive broker-to-worker handoff failures. Successful writes reset
+    /// this count because waiting for the PTY to acknowledge an already queued
+    /// delivery is not a failed delivery attempt.
+    pub(super) failed_attempts: u32,
     pub(super) next_retry_at: Instant,
     pub(super) queued_at_ms: u64,
     pub(super) last_error: Option<String>,
@@ -16,6 +20,8 @@ pub(crate) struct PersistedPendingDelivery {
     pub(super) worker_name: WorkerName,
     pub(super) delivery: RelayDelivery,
     pub(super) attempts: u32,
+    #[serde(default)]
+    pub(super) failed_attempts: u32,
     #[serde(default)]
     pub(super) queued_at_ms: u64,
     #[serde(default)]
@@ -130,6 +136,7 @@ pub(crate) fn save_pending_deliveries(
             worker_name: pd.worker_name.clone(),
             delivery: pd.delivery.clone(),
             attempts: pd.attempts,
+            failed_attempts: pd.failed_attempts,
             queued_at_ms: pd.queued_at_ms,
             last_error: pd.last_error.clone(),
         })
@@ -156,6 +163,7 @@ pub(crate) fn load_pending_deliveries(path: &Path) -> HashMap<DeliveryId, Pendin
                     worker_name: p.worker_name,
                     delivery: p.delivery,
                     attempts: p.attempts,
+                    failed_attempts: p.failed_attempts,
                     next_retry_at: Instant::now(), // retry immediately on restart
                     queued_at_ms: if p.queued_at_ms == 0 {
                         unix_timestamp_millis()
@@ -671,15 +679,22 @@ pub(crate) async fn queue_and_try_delivery_raw(
             worker_name: WorkerName::new(worker_name),
             delivery,
             attempts: 0,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: unix_timestamp_millis(),
             last_error: None,
         },
     );
 
-    if let DeliveryAttemptOutcome::Failed { last_error, .. } =
-        retry_pending_delivery(&delivery_id, workers, pending_deliveries, retry_interval).await?
+    if let DeliveryAttemptOutcome::Failed {
+        pending,
+        last_error,
+    } = retry_pending_delivery(&delivery_id, workers, pending_deliveries, retry_interval).await?
     {
+        // The raw queue path has no dead-letter store/event sender. Preserve
+        // ownership locally so the maintenance retry path can record the
+        // terminal failure instead of silently discarding it here.
+        pending_deliveries.insert(pending.delivery.delivery_id.clone(), *pending);
         anyhow::bail!(last_error);
     }
     Ok(())
@@ -696,7 +711,7 @@ pub(crate) async fn retry_pending_delivery(
         None => return Ok(DeliveryAttemptOutcome::Noop),
     };
 
-    if pending.attempts >= MAX_DELIVERY_RETRIES {
+    if pending.failed_attempts >= MAX_DELIVERY_RETRIES {
         let removed = pending_deliveries.remove(delivery_id).unwrap_or(pending);
         let last_error = removed
             .last_error
@@ -723,7 +738,9 @@ pub(crate) async fn retry_pending_delivery(
         Ok(()) => {
             if let Some(current) = pending_deliveries.get_mut(delivery_id) {
                 current.attempts = current.attempts.saturating_add(1);
-                current.next_retry_at = Instant::now() + retry_interval;
+                current.failed_attempts = 0;
+                current.next_retry_at = Instant::now()
+                    + delivery_ack_timeout(&current.delivery.injection_mode, retry_interval);
                 current.last_error = None;
                 return Ok(DeliveryAttemptOutcome::Attempted {
                     worker_name: current.worker_name.clone(),
@@ -736,9 +753,10 @@ pub(crate) async fn retry_pending_delivery(
         Err(error) => {
             let should_fail = if let Some(current) = pending_deliveries.get_mut(delivery_id) {
                 current.attempts = current.attempts.saturating_add(1);
+                current.failed_attempts = current.failed_attempts.saturating_add(1);
                 current.next_retry_at = Instant::now() + retry_interval;
                 current.last_error = Some(error.to_string());
-                current.attempts >= MAX_DELIVERY_RETRIES
+                current.failed_attempts >= MAX_DELIVERY_RETRIES
             } else {
                 false
             };
@@ -759,6 +777,17 @@ pub(crate) async fn retry_pending_delivery(
             Ok(DeliveryAttemptOutcome::Noop)
         }
     }
+}
+
+pub(crate) fn delivery_ack_timeout(
+    injection_mode: &MessageInjectionMode,
+    retry_interval: Duration,
+) -> Duration {
+    let minimum = match injection_mode {
+        MessageInjectionMode::Wait => WAIT_DELIVERY_ACK_TIMEOUT,
+        MessageInjectionMode::Steer => crate::broker::delivery_verification::VERIFICATION_WINDOW,
+    };
+    std::cmp::max(retry_interval, minimum)
 }
 
 pub(crate) async fn emit_delivery_attempt_outcome(

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -342,6 +342,24 @@ impl BrokerRuntime {
                         }
                     }
                 };
+                if let Some(token) = worker_relay_key.as_deref() {
+                    seed_supplied_agent_token(relaycast_http, &name, token);
+                    if let Err(error) = relaycast_http
+                        .ensure_agent_channels(
+                            &name,
+                            rst.payload.spec.cli.as_deref(),
+                            &rst.payload.spec.channels,
+                        )
+                        .await
+                    {
+                        tracing::error!(
+                            worker = %name,
+                            channels = ?rst.payload.spec.channels,
+                            error = %error,
+                            "worker channel membership reconciliation failed before restart"
+                        );
+                    }
+                }
 
                 match workers
                     .spawn(

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -56,6 +56,7 @@ use crate::{broker, listen_api, worker_request};
 
 const DEFAULT_DELIVERY_RETRY_MS: u64 = 1_000;
 const MAX_DELIVERY_RETRIES: u32 = 10;
+const WAIT_DELIVERY_ACK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const THREAD_HISTORY_LIMIT: usize = 1_000;
 #[allow(dead_code)] // only http_api_local_delivery_timeout's default; see its own allow
 const DEFAULT_HTTP_API_LOCAL_DELIVERY_TIMEOUT_MS: u64 = 3_000;

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -477,6 +477,27 @@ pub(super) async fn spawn_worker_from_request(
             }
         }
     };
+    let channel_membership_warning = if let Some(token) = worker_relay_key.as_deref() {
+        seed_supplied_agent_token(workspace_http, &name, token);
+        if let Err(error) = workspace_http
+            .ensure_agent_channels(&name, Some(&cli), &channels)
+            .await
+        {
+            tracing::error!(
+                worker = %name,
+                channels = ?channels,
+                error = %error,
+                "worker channel membership reconciliation failed for Relaycast spawn"
+            );
+            Some(format!(
+                "worker channel membership was not fully reconciled: {error}"
+            ))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     match workers
         .spawn(
@@ -553,6 +574,7 @@ pub(super) async fn spawn_worker_from_request(
                     "pid": pid,
                     "source": "relaycast_ws",
                     "pre_registered": worker_relay_key.is_some(),
+                    "registration_warning": channel_membership_warning,
                 }),
             )
             .await;

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -187,6 +187,7 @@ fn pending_delivery(worker_name: &str, delivery_id: &str, event_id: &str) -> Pen
             injection_mode: MessageInjectionMode::Wait,
         },
         attempts: 1,
+        failed_attempts: 0,
         next_retry_at: Instant::now(),
         queued_at_ms: super::unix_timestamp_millis(),
         last_error: None,
@@ -436,6 +437,7 @@ fn make_pending_delivery(delivery_id: &str, worker: &str) -> PendingDelivery {
             injection_mode: MessageInjectionMode::Wait,
         },
         attempts: 1,
+        failed_attempts: 0,
         next_retry_at: Instant::now(),
         queued_at_ms: super::unix_timestamp_millis(),
         last_error: None,
@@ -446,10 +448,9 @@ fn make_pending_delivery(delivery_id: &str, worker: &str) -> PendingDelivery {
 fn shutdown_persists_nonempty_pending_deliveries() {
     let dir = tempfile::tempdir().expect("tempdir should create");
     let path = dir.path().join("pending-deliveries.json");
-    let deliveries = HashMap::from([(
-        DeliveryId::new("del_keep"),
-        make_pending_delivery("del_keep", "worker-a"),
-    )]);
+    let mut delivery = make_pending_delivery("del_keep", "worker-a");
+    delivery.failed_attempts = 2;
+    let deliveries = HashMap::from([(DeliveryId::new("del_keep"), delivery)]);
 
     persist_pending_on_shutdown(&path, true, &deliveries);
 
@@ -461,6 +462,32 @@ fn shutdown_persists_nonempty_pending_deliveries() {
     assert_eq!(pending.worker_name, WorkerName::from("worker-a"));
     assert_eq!(pending.delivery.event_id, EventId::new("evt_del_keep"));
     assert_eq!(pending.attempts, 1);
+    assert_eq!(pending.failed_attempts, 2);
+}
+
+#[test]
+fn pending_delivery_load_defaults_legacy_failure_count() {
+    let dir = tempfile::tempdir().expect("tempdir should create");
+    let path = dir.path().join("pending-deliveries.json");
+    let delivery = make_pending_delivery("del_legacy", "worker-a");
+    let deliveries = HashMap::from([(DeliveryId::new("del_legacy"), delivery)]);
+    super::save_pending_deliveries(&path, &deliveries).expect("pending delivery should save");
+    let mut json: Value = serde_json::from_slice(
+        &std::fs::read(&path).expect("pending delivery snapshot should read"),
+    )
+    .expect("pending delivery snapshot should parse");
+    json[0]
+        .as_object_mut()
+        .expect("pending delivery entry should be an object")
+        .remove("failed_attempts");
+    std::fs::write(
+        &path,
+        serde_json::to_vec(&json).expect("legacy snapshot encodes"),
+    )
+    .expect("legacy pending snapshot should write");
+
+    let loaded = load_pending_deliveries(&path);
+    assert_eq!(loaded["del_legacy"].failed_attempts, 0);
 }
 
 #[test]
@@ -781,6 +808,7 @@ async fn retry_exhaustion_dead_letters_instead_of_discarding() {
     );
     let mut exhausted = make_pending_delivery("del_exhausted", "ghost");
     exhausted.attempts = MAX_DELIVERY_RETRIES;
+    exhausted.failed_attempts = MAX_DELIVERY_RETRIES;
     exhausted.last_error = Some("failed writing frame".to_string());
     let mut pending_deliveries =
         HashMap::from([(DeliveryId::new("del_exhausted"), exhausted.clone())]);
@@ -857,6 +885,7 @@ async fn delivery_retry_fails_promptly_when_recipient_is_gone() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 3,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: Some("failed writing frame".to_string()),
@@ -894,6 +923,52 @@ async fn delivery_retry_fails_promptly_when_recipient_is_gone() {
 }
 
 #[tokio::test]
+async fn initial_delivery_failure_stays_owned_until_dead_lettered() {
+    let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+    let mut workers = WorkerRegistry::new(
+        tx,
+        Vec::new(),
+        PathBuf::from("/tmp/agent-relay-broker-tests"),
+        Instant::now(),
+    );
+    let mut pending_deliveries = HashMap::new();
+
+    let error = super::queue_and_try_delivery_raw(
+        &mut workers,
+        &mut pending_deliveries,
+        "ghost",
+        "evt_initial_failure",
+        "orchestrator",
+        "ghost",
+        "must remain auditable",
+        None,
+        Some(WorkspaceId::new("ws_demo")),
+        None,
+        2,
+        MessageInjectionMode::Wait,
+        Duration::from_millis(1),
+    )
+    .await
+    .expect_err("missing recipient should fail the initial handoff");
+
+    assert!(error.to_string().contains("recipient gone"));
+    assert_eq!(
+        pending_deliveries.len(),
+        1,
+        "the no-DLQ raw path must retain ownership for the maintenance dead-letter path"
+    );
+    let pending = pending_deliveries
+        .values()
+        .next()
+        .expect("failed initial delivery remains pending");
+    assert_eq!(
+        pending.delivery.event_id,
+        EventId::new("evt_initial_failure")
+    );
+    assert_eq!(pending.delivery.body, "must remain auditable");
+}
+
+#[tokio::test]
 async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
     let worker_name = "worker-blip";
     let mut workers = make_worker_registry_with_worker(worker_name).await;
@@ -927,6 +1002,7 @@ async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 0,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: None,
@@ -1066,6 +1142,7 @@ async fn delivery_retry_success_clears_stale_last_error() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 1,
+            failed_attempts: 1,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: Some("old transient failure".to_string()),
@@ -1088,6 +1165,62 @@ async fn delivery_retry_success_clears_stale_last_error() {
             .and_then(|pending| pending.last_error.as_ref()),
         None
     );
+    assert_eq!(
+        pending_deliveries["del_clear"].failed_attempts, 0,
+        "a successful broker-to-worker handoff resets consecutive failures"
+    );
+    cleanup_worker_registry(workers).await;
+}
+
+#[tokio::test]
+async fn wait_delivery_successful_handoffs_do_not_exhaust_failure_budget() {
+    let worker_name = "worker-busy-wait";
+    let mut workers = make_worker_registry_with_worker(worker_name).await;
+    let mut pending = make_pending_delivery("del_busy_wait", worker_name);
+    pending.attempts = MAX_DELIVERY_RETRIES - 1;
+    pending.delivery.injection_mode = MessageInjectionMode::Wait;
+    let mut pending_deliveries = HashMap::from([(pending.delivery.delivery_id.clone(), pending)]);
+
+    let first = retry_pending_delivery(
+        &DeliveryId::new("del_busy_wait"),
+        &mut workers,
+        &mut pending_deliveries,
+        Duration::from_secs(1),
+    )
+    .await
+    .expect("live worker should accept the tenth handoff");
+    assert!(matches!(
+        first,
+        DeliveryAttemptOutcome::Attempted {
+            attempts: MAX_DELIVERY_RETRIES,
+            ..
+        }
+    ));
+
+    let second = retry_pending_delivery(
+        &DeliveryId::new("del_busy_wait"),
+        &mut workers,
+        &mut pending_deliveries,
+        Duration::from_secs(1),
+    )
+    .await
+    .expect("a successful handoff must remain redeliverable while its wait ack is pending");
+
+    assert!(matches!(
+        second,
+        DeliveryAttemptOutcome::Attempted {
+            attempts,
+            ..
+        } if attempts == MAX_DELIVERY_RETRIES + 1
+    ));
+    let pending = pending_deliveries
+        .get("del_busy_wait")
+        .expect("successful wait handoffs must not be dead-lettered");
+    assert!(
+        pending.next_retry_at.duration_since(Instant::now()) > Duration::from_secs(60),
+        "wait-mode acknowledgements need a minutes-scale verification window"
+    );
+
     cleanup_worker_registry(workers).await;
 }
 
@@ -1398,6 +1531,19 @@ fn contract_timeout_fixture_requires_terminal_failed_guard_before_late_ack() {
         "delivery_ack branch lacks terminal guard for timeout status \"{}\" and late event \"{}\"",
         expected_terminal_status,
         late_event_kind
+    );
+}
+
+#[test]
+fn worker_reported_delivery_failures_use_the_dead_letter_path() {
+    let source = include_str!("worker_events.rs");
+    let failure_branch = source
+        .split("msg_type == \"delivery_failed\"")
+        .nth(1)
+        .expect("worker_events.rs must include delivery_failed handling");
+    assert!(
+        failure_branch.contains("emit_dropped_delivery_failures"),
+        "worker-reported terminal failures must be retained in the dead-letter store"
     );
 }
 
@@ -1906,6 +2052,7 @@ fn drop_pending_for_worker_removes_only_matching_entries() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 1,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: None,
@@ -1928,6 +2075,7 @@ fn drop_pending_for_worker_removes_only_matching_entries() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 1,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: None,
@@ -1957,6 +2105,7 @@ async fn dropped_pending_deliveries_emit_terminal_message_failures() {
             injection_mode: MessageInjectionMode::Wait,
         },
         attempts: 2,
+        failed_attempts: 1,
         next_retry_at: Instant::now(),
         queued_at_ms: super::unix_timestamp_millis(),
         last_error: Some("previous blip".to_string()),
@@ -2026,6 +2175,7 @@ fn should_clear_pending_delivery_when_event_id_matches() {
             injection_mode: MessageInjectionMode::Wait,
         },
         attempts: 1,
+        failed_attempts: 0,
         next_retry_at: Instant::now(),
         queued_at_ms: super::unix_timestamp_millis(),
         last_error: None,
@@ -2060,6 +2210,7 @@ fn clear_pending_delivery_returns_none_for_stale_event_id() {
                 injection_mode: MessageInjectionMode::Wait,
             },
             attempts: 1,
+            failed_attempts: 0,
             next_retry_at: Instant::now(),
             queued_at_ms: super::unix_timestamp_millis(),
             last_error: None,
@@ -2476,6 +2627,7 @@ fn should_clear_pending_delivery_without_event_id_for_compatibility() {
             injection_mode: MessageInjectionMode::Wait,
         },
         attempts: 1,
+        failed_attempts: 0,
         next_retry_at: Instant::now(),
         queued_at_ms: super::unix_timestamp_millis(),
         last_error: None,

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -12,6 +12,7 @@ impl BrokerRuntime {
         let workers = &mut self.workers;
         let dedup = &mut self.dedup;
         let pending_deliveries = &mut self.pending_deliveries;
+        let dead_letters = &mut self.dead_letters;
         let terminal_failed_deliveries = &mut self.terminal_failed_deliveries;
         let pending_requests = &mut self.pending_requests;
         let delivery_retry_interval = self.delivery_retry_interval;
@@ -112,9 +113,9 @@ impl BrokerRuntime {
                                 .unwrap_or("");
                             if let Some(pending) = pending_deliveries.get_mut(delivery_id) {
                                 pending.next_retry_at = Instant::now()
-                                    + std::cmp::max(
+                                    + delivery_ack_timeout(
+                                        &pending.delivery.injection_mode,
                                         delivery_retry_interval,
-                                        crate::broker::delivery_verification::VERIFICATION_WINDOW,
                                     );
                             }
                             if let Some(handle) = workers.workers.get_mut(&name) {
@@ -273,17 +274,11 @@ impl BrokerRuntime {
                                     handle.last_activity_at = Instant::now();
                                     handle.state = AgentWorkState::Working;
                                 }
-                                let _ = send_broker_event(
+                                let _ = emit_dropped_delivery_failures(
                                     sdk_out_tx,
-                                    BrokerEvent::MessageDeliveryFailed {
-                                        name: name.clone(),
-                                        delivery_id: Some(pending.delivery.delivery_id),
-                                        event_id: Some(pending.delivery.event_id),
-                                        from: pending.delivery.from,
-                                        to: pending.delivery.target,
-                                        attempts: pending.attempts,
-                                        last_error: reason.to_string(),
-                                    },
+                                    dead_letters,
+                                    std::slice::from_ref(&pending),
+                                    reason,
                                 )
                                 .await;
                             }

--- a/packages/contracts/fixtures/health-fixtures.json
+++ b/packages/contracts/fixtures/health-fixtures.json
@@ -7,6 +7,7 @@
     "workspaceId": "ws_cross_repo",
     "agentCount": 1,
     "pendingDeliveryCount": 0,
+    "deadLetterCount": 0,
     "wsConnections": 1,
     "memoryMb": 256,
     "relaycastConnected": true


### PR DESCRIPTION
## Summary

- keep wait-mode PTY deliveries pending while a busy worker has accepted the handoff but has not acknowledged injection
- reconcile each spawned or restarted worker into its declared Relaycast channels using its seeded worker token, including subscription changes
- retain raw and worker-reported terminal failures for dead-letter audit, and expose `deadLetterCount` from `/health`

## Root cause

The broker counted successful broker-to-PTY-worker pipe writes as retry failures. The initial queued event delayed verification by 5 seconds, duplicate delivery IDs were then ignored by the PTY, and the remaining one-second retries exhausted the shared ten-attempt cap in about 17 seconds even though the delivery was still legitimately waiting for an idle PTY.

Channel mention fanout was a separate pre-delivery gap. Worker channel declarations only updated local broker state; the worker identity was never joined to those channels in Relaycast. The incident worker was locally configured for the channel but absent from Relaycast membership, so no node delivery existed for the broker to persist or dead-letter.

## Validation

- `cargo test -p agent-relay-broker` — 789 passed, 4 ignored; all 16 integration tests passed
- `cargo fmt --all -- --check`
- `cargo clippy -p agent-relay-broker --lib -- -D warnings`
- focused real-worker regression proves successful wait handoffs remain pending beyond the former retry cap
- HTTP regression proves worker channel reconciliation uses the seeded worker token and performs no agent re-registration

Closes #1339


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

