### PR TITLE
fix(cli): resolve cloud enrollment workspace identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay cloud enroll --workspace` now resolves Cloud UUIDs, unified `rw_` IDs, and workspace keys before minting, and reports incompatible Relaycast-only IDs instead of mislabeling them as permission failures.
 
 ## [10.6.5] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `agent-relay cloud enroll --workspace` now resolves Cloud UUIDs, unified `rw_` IDs, and workspace keys before minting, and reports incompatible Relaycast-only IDs instead of mislabeling them as permission failures.
+- `agent-relay cloud enroll --workspace` now validates and resolves Cloud UUIDs and unified `rw_` IDs before minting, and reports unresolvable identifiers instead of mislabeling them as permission failures.
 
 ## [10.6.5] - 2026-07-19
 

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -892,6 +892,101 @@ describe('registerCloudCommands', () => {
     expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      status: 403,
+      body: { error: 'Forbidden: rw_7ccfea89' },
+      message: 'You do not have access to that Cloud workspace.',
+    },
+    {
+      status: 404,
+      body: { error: 'Workspace rw_7ccfea89 was not found' },
+      message:
+        'The workspace identifier was not found by Agent Relay Cloud. Use a Cloud workspace UUID or unified rw_ workspace ID.',
+    },
+  ])(
+    'cloud enroll --workspace maps a $status resolver response without minting',
+    async ({ status, body, message }) => {
+      const workspaceId = 'rw_7ccfea89';
+      const auth = {
+        apiUrl: 'https://cloud.test',
+        accessToken: 'access-secret',
+        refreshToken: 'refresh-secret',
+        accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+      };
+      vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
+      vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
+        response: new Response(JSON.stringify(body), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        }),
+        auth,
+      });
+      const { program, deps } = createHarness();
+
+      await expect(
+        program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', workspaceId])
+      ).rejects.toThrow('exit:1');
+
+      expect(deps.error).toHaveBeenCalledWith(message);
+      expect(deps.error.mock.calls.flat().join('\n')).not.toContain(workspaceId);
+      expect(authorizedApiFetch).toHaveBeenCalledTimes(1);
+      expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
+    }
+  );
+
+  it('cloud enroll --workspace preserves Retry-After from the resolver without minting', async () => {
+    const auth = {
+      apiUrl: 'https://cloud.test',
+      accessToken: 'access-secret',
+      refreshToken: 'refresh-secret',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    };
+    vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
+    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json', 'retry-after': '90' },
+      }),
+      auth,
+    });
+    const { program, deps } = createHarness();
+
+    await expect(
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_7ccfea89'])
+    ).rejects.toThrow('exit:1');
+
+    expect(deps.error).toHaveBeenCalledWith(expect.stringContaining('Retry-After: 90 seconds'));
+    expect(authorizedApiFetch).toHaveBeenCalledTimes(1);
+    expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new Response('not-json', { status: 200, headers: { 'content-type': 'application/json' } }),
+    new Response(JSON.stringify({ workspaceId: 'rw_7ccfea89' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  ])('cloud enroll --workspace rejects an invalid resolver descriptor without minting', async (response) => {
+    const auth = {
+      apiUrl: 'https://cloud.test',
+      accessToken: 'access-secret',
+      refreshToken: 'refresh-secret',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    };
+    vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
+    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({ response, auth });
+    const { program, deps } = createHarness();
+
+    await expect(
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_7ccfea89'])
+    ).rejects.toThrow('exit:1');
+
+    expect(deps.error).toHaveBeenCalledWith('Cloud workspace resolver returned an invalid response.');
+    expect(authorizedApiFetch).toHaveBeenCalledTimes(1);
+    expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
+  });
+
   it.each(['204337648549896192', 'rk_live_SECRET'])(
     'cloud enroll --workspace rejects unsupported identifier %s without disclosing it',
     async (workspaceId) => {

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -697,27 +697,46 @@ describe('registerCloudCommands', () => {
     expect(deps.log).toHaveBeenCalledWith('  cloud: patch pending - run still active');
   });
 
-  it('cloud enroll --workspace mints with the stored session then uses the existing enrollment flow', async () => {
+  it('cloud enroll --workspace resolves a supported workspace selector before minting', async () => {
     const auth = {
       apiUrl: 'https://cloud.test',
       accessToken: 'access-secret',
       refreshToken: 'refresh-secret',
       accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
     };
+    const resolvedAuth = {
+      ...auth,
+      accessToken: 'refreshed-access-secret',
+    };
     vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
-    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
-      response: new Response(
-        JSON.stringify({
-          token: 'ocl_node_enr_minted_secret',
-          enrollmentUrl: 'https://cloud.test/api/v1/fleet/register',
-          enrollCommand: 'agent-relay cloud enroll --token redacted',
-          relayWorkspaceId: 'rw_relay_123',
-          expiresAt: '2999-01-01T00:05:00.000Z',
-        }),
-        { status: 200, headers: { 'content-type': 'application/json' } }
-      ),
-      auth,
-    });
+    vi.mocked(authorizedApiFetch)
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            workspaceId: 'rw_7ccfea89',
+            cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
+            relaycastWorkspaceId: 'rw_7ccfea89',
+            relayfileWorkspaceId: 'rw_7ccfea89',
+            relayauthWorkspaceId: 'rw_7ccfea89',
+            urls: {},
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        ),
+        auth: resolvedAuth,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            token: 'ocl_node_enr_minted_secret',
+            enrollmentUrl: 'https://cloud.test/api/v1/fleet/register',
+            enrollCommand: 'agent-relay cloud enroll --token redacted',
+            relayWorkspaceId: 'rw_7ccfea89',
+            expiresAt: '2999-01-01T00:05:00.000Z',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        ),
+        auth: resolvedAuth,
+      });
     cloudMocks.enrollFleetNode.mockResolvedValueOnce({
       nodeId: 'node_abc',
       nodeName: 'kjglaptop',
@@ -735,7 +754,7 @@ describe('registerCloudCommands', () => {
       'cloud',
       'enroll',
       '--workspace',
-      'rw_cloud_123',
+      'rw_7ccfea89',
       '--name',
       'kjglaptop',
       '--max-agents',
@@ -746,12 +765,24 @@ describe('registerCloudCommands', () => {
       apiUrl: 'https://cloud.test',
       interactive: false,
     });
-    expect(authorizedApiFetch).toHaveBeenCalledWith(
+    expect(authorizedApiFetch).toHaveBeenNthCalledWith(
+      1,
       auth,
+      '/api/v1/workspaces/rw_7ccfea89/resolve',
+      { method: 'GET' },
+      { interactive: false }
+    );
+    expect(authorizedApiFetch).toHaveBeenNthCalledWith(
+      2,
+      resolvedAuth,
       '/api/v1/fleet/enrollment-tokens',
       {
         method: 'POST',
-        body: JSON.stringify({ workspaceId: 'rw_cloud_123', name: 'kjglaptop', maxAgents: 4 }),
+        body: JSON.stringify({
+          workspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
+          name: 'kjglaptop',
+          maxAgents: 4,
+        }),
       },
       { interactive: false }
     );
@@ -803,13 +834,21 @@ describe('registerCloudCommands', () => {
       accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
     };
     vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
-    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
-      response: new Response(JSON.stringify(body), {
-        status,
-        headers: { 'content-type': 'application/json' },
-      }),
-      auth,
-    });
+    vi.mocked(authorizedApiFetch)
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify(body), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        }),
+        auth,
+      });
     const { program, deps } = createHarness();
 
     await expect(
@@ -828,13 +867,21 @@ describe('registerCloudCommands', () => {
       accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
     };
     vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
-    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
-      response: new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
-        status: 429,
-        headers: { 'content-type': 'application/json', 'retry-after': '180' },
-      }),
-      auth,
-    });
+    vi.mocked(authorizedApiFetch)
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '180' },
+        }),
+        auth,
+      });
     const { program, deps } = createHarness();
 
     await expect(
@@ -842,6 +889,35 @@ describe('registerCloudCommands', () => {
     ).rejects.toThrow('exit:1');
 
     expect(deps.error).toHaveBeenCalledWith(expect.stringContaining('Retry-After: 180 seconds'));
+    expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
+  });
+
+  it('cloud enroll --workspace rejects a Relaycast-only workspace ID before minting', async () => {
+    const auth = {
+      apiUrl: 'https://cloud.test',
+      accessToken: 'access-secret',
+      refreshToken: 'refresh-secret',
+      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
+    };
+    vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
+    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ error: 'Workspace not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }),
+      auth,
+    });
+    const { program, deps } = createHarness();
+
+    await expect(
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', '204337648549896192'])
+    ).rejects.toThrow('exit:1');
+
+    expect(deps.error).toHaveBeenCalledWith(
+      'Workspace 204337648549896192 was not found by Agent Relay Cloud. ' +
+        'Use a Cloud workspace UUID, unified rw_ workspace ID, or workspace key.'
+    );
+    expect(authorizedApiFetch).toHaveBeenCalledTimes(1);
     expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -808,7 +808,7 @@ describe('registerCloudCommands', () => {
     const { program, deps } = createHarness();
 
     await expect(
-      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_cloud_123'])
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_7ccfea89'])
     ).rejects.toThrow('exit:1');
 
     expect(deps.error).toHaveBeenCalledWith('Cloud login required. Run `agent-relay cloud login` and retry.');
@@ -819,12 +819,12 @@ describe('registerCloudCommands', () => {
     {
       status: 403,
       body: { error: 'Forbidden' },
-      message: 'You do not have permission to enroll nodes in workspace rw_cloud_123',
+      message: 'You do not have permission to enroll nodes in workspace rw_7ccfea89',
     },
     {
       status: 404,
       body: { error: 'Workspace not found' },
-      message: 'Workspace rw_cloud_123 was not found',
+      message: 'Workspace rw_7ccfea89 was not found',
     },
   ])('cloud enroll --workspace maps a $status mint response', async ({ status, body, message }) => {
     const auth = {
@@ -852,7 +852,7 @@ describe('registerCloudCommands', () => {
     const { program, deps } = createHarness();
 
     await expect(
-      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_cloud_123'])
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_7ccfea89'])
     ).rejects.toThrow('exit:1');
 
     expect(deps.error).toHaveBeenCalledWith(expect.stringContaining(message));
@@ -885,41 +885,31 @@ describe('registerCloudCommands', () => {
     const { program, deps } = createHarness();
 
     await expect(
-      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_cloud_123'])
+      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', 'rw_7ccfea89'])
     ).rejects.toThrow('exit:1');
 
     expect(deps.error).toHaveBeenCalledWith(expect.stringContaining('Retry-After: 180 seconds'));
     expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
   });
 
-  it('cloud enroll --workspace rejects a Relaycast-only workspace ID before minting', async () => {
-    const auth = {
-      apiUrl: 'https://cloud.test',
-      accessToken: 'access-secret',
-      refreshToken: 'refresh-secret',
-      accessTokenExpiresAt: '2999-01-01T00:00:00.000Z',
-    };
-    vi.mocked(ensureCloudSession).mockResolvedValueOnce({ auth, client: {} as never });
-    vi.mocked(authorizedApiFetch).mockResolvedValueOnce({
-      response: new Response(JSON.stringify({ error: 'Workspace not found' }), {
-        status: 404,
-        headers: { 'content-type': 'application/json' },
-      }),
-      auth,
-    });
-    const { program, deps } = createHarness();
+  it.each(['204337648549896192', 'rk_live_SECRET'])(
+    'cloud enroll --workspace rejects unsupported identifier %s without disclosing it',
+    async (workspaceId) => {
+      const { program, deps } = createHarness();
 
-    await expect(
-      program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', '204337648549896192'])
-    ).rejects.toThrow('exit:1');
+      await expect(
+        program.parseAsync(['node', 'agent-relay', 'cloud', 'enroll', '--workspace', workspaceId])
+      ).rejects.toThrow('exit:1');
 
-    expect(deps.error).toHaveBeenCalledWith(
-      'Workspace 204337648549896192 was not found by Agent Relay Cloud. ' +
-        'Use a Cloud workspace UUID, unified rw_ workspace ID, or workspace key.'
-    );
-    expect(authorizedApiFetch).toHaveBeenCalledTimes(1);
-    expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
-  });
+      expect(deps.error).toHaveBeenCalledWith(
+        'Unsupported Cloud workspace identifier. Use a Cloud workspace UUID or unified rw_ workspace ID.'
+      );
+      expect(deps.error.mock.calls.flat().join('\n')).not.toContain(workspaceId);
+      expect(ensureCloudSession).not.toHaveBeenCalled();
+      expect(authorizedApiFetch).not.toHaveBeenCalled();
+      expect(cloudMocks.enrollFleetNode).not.toHaveBeenCalled();
+    }
+  );
 
   it('cloud enroll rejects --token and --workspace together before using either credential', async () => {
     const { program } = createHarness();

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -142,6 +142,13 @@ type MintedFleetNodeEnrollment = {
   enrollmentUrl: string;
 };
 
+type CloudAuth = Awaited<ReturnType<typeof ensureCloudSession>>['auth'];
+
+type ResolvedCloudWorkspace = {
+  cloudWorkspaceId: string;
+  auth: CloudAuth;
+};
+
 function isCloudLoginError(error: unknown): boolean {
   if (!isObject(error) || typeof error.code !== 'string') {
     return false;
@@ -178,6 +185,59 @@ function enrollmentTokenMintError(response: Response, payload: unknown, workspac
   return new Error(`Failed to mint a Cloud enrollment token: ${detail}`);
 }
 
+function workspaceResolveError(response: Response, payload: unknown, workspaceId: string): Error {
+  if (response.status === 401) {
+    return new Error('Cloud login required. Run `agent-relay cloud login` and retry.');
+  }
+  if (response.status === 403) {
+    return new Error(`You do not have access to Cloud workspace ${workspaceId}.`);
+  }
+  if (response.status === 404) {
+    return new Error(
+      `Workspace ${workspaceId} was not found by Agent Relay Cloud. ` +
+        'Use a Cloud workspace UUID, unified rw_ workspace ID, or workspace key.'
+    );
+  }
+
+  const detail =
+    isObject(payload) && typeof payload.error === 'string' && payload.error.trim()
+      ? payload.error.trim()
+      : `${response.status} ${response.statusText}`.trim();
+  return new Error(`Failed to resolve Cloud workspace ${workspaceId}: ${detail}`);
+}
+
+async function resolveCloudWorkspace(
+  workspaceId: string,
+  auth: CloudAuth,
+  deps: Pick<CloudDependencies, 'authorizedApiFetch'>
+): Promise<ResolvedCloudWorkspace> {
+  const { response, auth: activeAuth } = await deps.authorizedApiFetch(
+    auth,
+    `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/resolve`,
+    { method: 'GET' },
+    { interactive: false }
+  );
+  const payload = (await response.json().catch(() => null)) as unknown;
+
+  if (!response.ok) {
+    throw workspaceResolveError(response, payload, workspaceId);
+  }
+  if (!isObject(payload) || typeof payload.cloudWorkspaceId !== 'string') {
+    throw new Error(
+      `Workspace ${workspaceId} is not linked to a Cloud workspace and cannot be enrolled with a Cloud login.`
+    );
+  }
+
+  const cloudWorkspaceId = payload.cloudWorkspaceId.trim();
+  if (!cloudWorkspaceId) {
+    throw new Error(
+      `Workspace ${workspaceId} is not linked to a Cloud workspace and cannot be enrolled with a Cloud login.`
+    );
+  }
+
+  return { cloudWorkspaceId, auth: activeAuth };
+}
+
 async function mintFleetNodeEnrollment(
   options: { workspaceId: string; name?: string; maxAgents?: number },
   deps: Pick<CloudDependencies, 'ensureCloudSession' | 'authorizedApiFetch'>
@@ -192,13 +252,14 @@ async function mintFleetNodeEnrollment(
       apiUrl: defaultApiUrl(),
       interactive: false,
     });
+    const resolved = await resolveCloudWorkspace(workspaceId, session.auth, deps);
     const { response } = await deps.authorizedApiFetch(
-      session.auth,
+      resolved.auth,
       '/api/v1/fleet/enrollment-tokens',
       {
         method: 'POST',
         body: JSON.stringify({
-          workspaceId,
+          workspaceId: resolved.cloudWorkspaceId,
           ...(options.name ? { name: options.name } : {}),
           ...(options.maxAgents !== undefined ? { maxAgents: options.maxAgents } : {}),
         }),
@@ -578,7 +639,7 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
     .addOption(
       new Option(
         '--workspace <workspaceId>',
-        'Mint an enrollment token using the stored Cloud login'
+        'Resolve a Cloud workspace UUID, unified rw_ ID, or workspace key and mint using the stored login'
       ).conflicts('token')
     )
     .option('--enrollment-url <url>', 'Cloud enrollment endpoint that redeems the token')

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -149,6 +149,9 @@ type ResolvedCloudWorkspace = {
   auth: CloudAuth;
 };
 
+const CLOUD_WORKSPACE_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UNIFIED_WORKSPACE_ID_PATTERN = /^rw_[a-z0-9]{8}$/;
+
 function isCloudLoginError(error: unknown): boolean {
   if (!isObject(error) || typeof error.code !== 'string') {
     return false;
@@ -185,17 +188,17 @@ function enrollmentTokenMintError(response: Response, payload: unknown, workspac
   return new Error(`Failed to mint a Cloud enrollment token: ${detail}`);
 }
 
-function workspaceResolveError(response: Response, payload: unknown, workspaceId: string): Error {
+function workspaceResolveError(response: Response, payload: unknown): Error {
   if (response.status === 401) {
     return new Error('Cloud login required. Run `agent-relay cloud login` and retry.');
   }
   if (response.status === 403) {
-    return new Error(`You do not have access to Cloud workspace ${workspaceId}.`);
+    return new Error('You do not have access to that Cloud workspace.');
   }
   if (response.status === 404) {
     return new Error(
-      `Workspace ${workspaceId} was not found by Agent Relay Cloud. ` +
-        'Use a Cloud workspace UUID, unified rw_ workspace ID, or workspace key.'
+      'The workspace identifier was not found by Agent Relay Cloud. ' +
+        'Use a Cloud workspace UUID or unified rw_ workspace ID.'
     );
   }
 
@@ -203,7 +206,7 @@ function workspaceResolveError(response: Response, payload: unknown, workspaceId
     isObject(payload) && typeof payload.error === 'string' && payload.error.trim()
       ? payload.error.trim()
       : `${response.status} ${response.statusText}`.trim();
-  return new Error(`Failed to resolve Cloud workspace ${workspaceId}: ${detail}`);
+  return new Error(`Failed to resolve the Cloud workspace: ${detail}`);
 }
 
 async function resolveCloudWorkspace(
@@ -220,19 +223,15 @@ async function resolveCloudWorkspace(
   const payload = (await response.json().catch(() => null)) as unknown;
 
   if (!response.ok) {
-    throw workspaceResolveError(response, payload, workspaceId);
+    throw workspaceResolveError(response, payload);
   }
   if (!isObject(payload) || typeof payload.cloudWorkspaceId !== 'string') {
-    throw new Error(
-      `Workspace ${workspaceId} is not linked to a Cloud workspace and cannot be enrolled with a Cloud login.`
-    );
+    throw new Error('That identifier is not linked to a Cloud workspace and cannot be enrolled.');
   }
 
   const cloudWorkspaceId = payload.cloudWorkspaceId.trim();
   if (!cloudWorkspaceId) {
-    throw new Error(
-      `Workspace ${workspaceId} is not linked to a Cloud workspace and cannot be enrolled with a Cloud login.`
-    );
+    throw new Error('That identifier is not linked to a Cloud workspace and cannot be enrolled.');
   }
 
   return { cloudWorkspaceId, auth: activeAuth };
@@ -245,6 +244,11 @@ async function mintFleetNodeEnrollment(
   const workspaceId = options.workspaceId.trim();
   if (!workspaceId) {
     throw new Error('A workspace ID is required for session-based enrollment.');
+  }
+  if (!CLOUD_WORKSPACE_UUID_PATTERN.test(workspaceId) && !UNIFIED_WORKSPACE_ID_PATTERN.test(workspaceId)) {
+    throw new Error(
+      'Unsupported Cloud workspace identifier. Use a Cloud workspace UUID or unified rw_ workspace ID.'
+    );
   }
 
   try {
@@ -639,7 +643,7 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
     .addOption(
       new Option(
         '--workspace <workspaceId>',
-        'Resolve a Cloud workspace UUID, unified rw_ ID, or workspace key and mint using the stored login'
+        'Resolve a Cloud workspace UUID or unified rw_ ID and mint using the stored login'
       ).conflicts('token')
     )
     .option('--enrollment-url <url>', 'Cloud enrollment endpoint that redeems the token')

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -188,7 +188,7 @@ function enrollmentTokenMintError(response: Response, payload: unknown, workspac
   return new Error(`Failed to mint a Cloud enrollment token: ${detail}`);
 }
 
-function workspaceResolveError(response: Response, payload: unknown): Error {
+function workspaceResolveError(response: Response): Error {
   if (response.status === 401) {
     return new Error('Cloud login required. Run `agent-relay cloud login` and retry.');
   }
@@ -201,11 +201,16 @@ function workspaceResolveError(response: Response, payload: unknown): Error {
         'Use a Cloud workspace UUID or unified rw_ workspace ID.'
     );
   }
+  if (response.status === 429) {
+    const retryAfter = response.headers.get('retry-after')?.trim();
+    return new Error(
+      `Cloud workspace resolution rate limit exceeded.${
+        retryAfter ? ` Retry-After: ${retryAfter} seconds.` : ' Wait and retry.'
+      }`
+    );
+  }
 
-  const detail =
-    isObject(payload) && typeof payload.error === 'string' && payload.error.trim()
-      ? payload.error.trim()
-      : `${response.status} ${response.statusText}`.trim();
+  const detail = `${response.status} ${response.statusText}`.trim();
   return new Error(`Failed to resolve the Cloud workspace: ${detail}`);
 }
 
@@ -223,15 +228,15 @@ async function resolveCloudWorkspace(
   const payload = (await response.json().catch(() => null)) as unknown;
 
   if (!response.ok) {
-    throw workspaceResolveError(response, payload);
+    throw workspaceResolveError(response);
   }
   if (!isObject(payload) || typeof payload.cloudWorkspaceId !== 'string') {
-    throw new Error('That identifier is not linked to a Cloud workspace and cannot be enrolled.');
+    throw new Error('Cloud workspace resolver returned an invalid response.');
   }
 
   const cloudWorkspaceId = payload.cloudWorkspaceId.trim();
-  if (!cloudWorkspaceId) {
-    throw new Error('That identifier is not linked to a Cloud workspace and cannot be enrolled.');
+  if (!CLOUD_WORKSPACE_UUID_PATTERN.test(cloudWorkspaceId)) {
+    throw new Error('Cloud workspace resolver returned an invalid response.');
   }
 
   return { cloudWorkspaceId, auth: activeAuth };


### PR DESCRIPTION
## Scope

This Relay PR fixes the client-side workspace-ID namespace and diagnostics for session-based fleet enrollment. It **does not claim to fix the production owner denial**: the authoritative authorization defect is in `AgentWorkforce/cloud` and requires a Cloud change plus deploy.

## What changed

- validate `--workspace` as a non-secret Cloud UUID or unified `rw_` ID, then resolve it through `GET /api/v1/workspaces/:workspaceId/resolve` before minting
- send the returned Cloud workspace UUID to `POST /api/v1/fleet/enrollment-tokens`
- carry any refreshed bearer returned by workspace resolution into the mint request
- reject unsupported identifiers before auth or network I/O, never echoing the supplied value (including an `rk_live_...` secret) in errors
- cover canonical resolution, refreshed-auth continuity, secret-safe identifier rejection, resolver 403/404/429 and malformed responses, and downstream mint errors

## Root cause and production blocker

There are two independent failures:

1. `204337648549896192` is not a supported Cloud workspace UUID or unified `rw_` workspace ID. A raw production request returns `404 {"error":"Workspace not found"}` from `GET /api/v1/workspaces/204337648549896192/resolve`. The current Cloud workspace UUID is `50587328-441d-4acb-b8f3-dbe1b3c5de99`.
2. Even with that correct UUID, production enrollment returns 403. The Cloud route [`packages/web/app/api/v1/fleet/enrollment-tokens/route.ts`](https://github.com/AgentWorkforce/cloud/blob/main/packages/web/app/api/v1/fleet/enrollment-tokens/route.ts) calls `resolveRequestAuth(request)` and then immediately rejects `!requireSessionAuth(auth)`. The stored Cloud login is `source=token`, `subjectType=cli`, with scopes `auth:workspace:follow-user, cli:auth`, so every CLI bearer is rejected before `findWorkspace` or `requireOrgOwner` can evaluate the owner's role. `/api/v1/auth/whoami` reports the current organization role as `owner`.

The Cloud fix must keep the secret-mint boundary strict: admit only an authenticated CLI subject with the required CLI scope(s), bind it to the exact target Cloud workspace, then query an active `owner|admin` role before minting. `packages/web/lib/auth/deployment-api-token-access.ts` is an existing exact-workspace/active-role DB-join reference; `packages/web/app/api/v1/fleet/local-surface/route.ts` is the existing deliberate session-or-`cli:auth` route pattern. The Cloud regression suite must prove owner/admin success and deny member/non-owner, unrelated workspace, non-CLI token, and missing-scope token cases. A production Cloud deploy is required after that fix.

## Verbatim evidence

Before, released `agent-relay` 10.6.5:

```text
$ agent-relay cloud enroll --workspace 204337648549896192
You do not have permission to enroll nodes in workspace 204337648549896192. An organization owner or admin must run this command.
```

After this Relay change, the unsupported identifier is rejected locally—without being echoed—before auth, resolution, or minting:

```text
$ node packages/cli/dist/cli/index.js cloud enroll --workspace 204337648549896192
Unsupported Cloud workspace identifier. Use a Cloud workspace UUID or unified rw_ workspace ID.
```

The canonical UUID reaches the authoritative mint route and proves the remaining Cloud blocker:

```text
$ node packages/cli/dist/cli/index.js cloud enroll --workspace 50587328-441d-4acb-b8f3-dbe1b3c5de99
You do not have permission to enroll nodes in workspace 50587328-441d-4acb-b8f3-dbe1b3c5de99. An organization owner or admin must run this command.
```

Direct production contract evidence:

```text
GET  /api/v1/workspaces/204337648549896192/resolve -> 404 {"error":"Workspace not found"}
GET  /api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/resolve -> 200 (cloudWorkspaceId 50587328-441d-4acb-b8f3-dbe1b3c5de99)
POST /api/v1/fleet/enrollment-tokens {"workspaceId":"50587328-441d-4acb-b8f3-dbe1b3c5de99"} -> 403 {"error":"Forbidden"}
```

## Validation

- failing regressions first: canonical resolution failed with `exit:1`; unsupported numeric/`rk_live_...` selectors reached resolution and were echoed before validation/redaction; resolver 429 responses lost `Retry-After`; malformed resolver descriptors were misreported as unlinked workspaces
- `npm run build`
- `npm run typecheck`
- `npm test` — 96 files passed, 2 skipped; 1,297 tests passed, 18 skipped
- `npm run lint` — 0 errors (38 pre-existing warnings)
- `npm run format:check`
- live before/after commands above

PR #1342 has no enrollment-source overlap; only the root changelog may need routine rebase conflict resolution.
