### PR TITLE
Remove Node 20 publish verification

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Test error messages are helpful
         run: |
           # Verify helpful error messages exist
-          MESSAGES="Node.js 18+ is required|nvm|brew install node|apt-get install"
+          MESSAGES="Node\\.js 22\\+ is required|nvm|brew install node|apt-get install"
 
           for msg in $MESSAGES; do
             if grep -qE "$msg" install.sh; then

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -362,7 +362,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['22', '24']
 
     steps:
       - name: Checkout

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['22.14.0', '24']
 
     steps:
       - name: Checkout (for scripts)
@@ -410,7 +410,7 @@ jobs:
           echo "### Native Tests" >> $GITHUB_STEP_SUMMARY
           echo "| Node Version | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|--------------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Node 22 | ${{ needs.verify.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Node 22 and 24 | ${{ needs.verify.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### macOS Tests (broker binary)" >> $GITHUB_STEP_SUMMARY
           echo "| Architecture | Status |" >> $GITHUB_STEP_SUMMARY
@@ -420,7 +420,7 @@ jobs:
           echo "### Docker Tests (Linux)" >> $GITHUB_STEP_SUMMARY
           echo "| Node Version | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|--------------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Node 22 | ${{ needs.verify-docker.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Node 22 and 24 | ${{ needs.verify-docker.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Overall" >> $GITHUB_STEP_SUMMARY
           if [ "${{ needs.verify.result }}" = "success" ] && [ "${{ needs.verify-macos-arm64.result }}" = "success" ] && [ "${{ needs.verify-docker.result }}" = "success" ]; then

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ get_latest_version() {
 check_node() {
     if command -v node &> /dev/null; then
         NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-        if [ "$NODE_VERSION" -ge 18 ]; then
+        if [ "$NODE_VERSION" -ge 22 ]; then
             HAS_NODE=true
             info "Node.js $(node -v) detected"
             return 0
@@ -582,7 +582,7 @@ install_from_source() {
     step "Installing from source..."
 
     if ! check_node; then
-        error "Node.js 18+ is required for source installation"
+        error "Node.js 22+ is required for source installation"
     fi
 
     mkdir -p "$INSTALL_DIR"
@@ -743,7 +743,7 @@ main() {
         if [ -n "$STANDALONE_FAILURE_REASON" ]; then
             warn "Standalone install was cleaned up after verification failed."
             echo "  $STANDALONE_FAILURE_REASON"
-            echo "  Install Node.js 18+ to use the npm fallback, then rerun this installer."
+            echo "  Install Node.js 22+ to use the npm fallback, then rerun this installer."
             echo ""
         fi
         warn "No standalone binary available and Node.js not found."

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ get_latest_version() {
 check_node() {
     if command -v node &> /dev/null; then
         NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-        if [ "$NODE_VERSION" -ge 22 ]; then
+        if [ "$NODE_VERSION" -ge 18 ]; then
             HAS_NODE=true
             info "Node.js $(node -v) detected"
             return 0

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ get_latest_version() {
 check_node() {
     if command -v node &> /dev/null; then
         NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-        if [ "$NODE_VERSION" -ge 18 ]; then
+        if [ "$NODE_VERSION" -ge 22 ]; then
             HAS_NODE=true
             info "Node.js $(node -v) detected"
             return 0
@@ -477,10 +477,10 @@ install_via_npm() {
     step "Installing via npm..."
 
     if ! check_node; then
-        error "Node.js 18+ is required for npm installation. Please install Node.js first:
+        error "Node.js 22+ is required for npm installation. Please install Node.js first:
 
   macOS:   brew install node
-  Linux:   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs
+  Linux:   curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs
 
 Or use nvm: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash"
     fi
@@ -752,12 +752,12 @@ main() {
         echo ""
         echo "  1. Wait for standalone binaries (coming soon for your platform)"
         echo ""
-        echo "  2. Install Node.js 18+ using one of these methods:"
+        echo "  2. Install Node.js 22+ using one of these methods:"
         echo ""
         echo "     # Using nvm (recommended - works on macOS and Linux)"
         echo "     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash"
         echo "     source ~/.bashrc  # or ~/.zshrc"
-        echo "     nvm install 20"
+        echo "     nvm install 22"
         echo ""
 
         if [ "$OS" = "darwin" ]; then
@@ -770,7 +770,7 @@ main() {
             # Detect package manager
             if command -v apt-get &> /dev/null; then
                 echo "     # Ubuntu/Debian"
-                echo "     curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -"
+                echo "     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -"
                 echo "     sudo apt-get install -y nodejs"
             elif command -v dnf &> /dev/null; then
                 echo "     # Fedora/RHEL"

--- a/packages/cli/src/cli/lib/ensure-websocket.ts
+++ b/packages/cli/src/cli/lib/ensure-websocket.ts
@@ -1,12 +1,9 @@
 import WebSocketImpl from 'ws';
 
 /**
- * Node exposes a global `WebSocket` only from v22 (unflagged). Relay supports
- * Node >=20.9 (root `engines`), where `@relaycast/sdk`'s WebSocket transport
- * (`AgentClient`, `NodeProviderClient`) would otherwise throw
- * `WebSocket is not defined` at connect time. Install the bundled `ws`
- * implementation as the global when the runtime lacks its own; a no-op on
- * Node 22+ and in browsers.
+ * Node exposes a global `WebSocket` from v22. Relay supports Node 22+, but
+ * install the bundled `ws` implementation when a non-Node runtime lacks one;
+ * this is a no-op on supported Node versions and in browsers.
  */
 export function ensureWebSocketGlobal(): void {
   const target = globalThis as { WebSocket?: unknown };

--- a/packages/sdk/src/messaging/observer-source.ts
+++ b/packages/sdk/src/messaging/observer-source.ts
@@ -125,9 +125,8 @@ function createRawObserverStream(
     if (!WebSocketImpl) {
       report(
         new Error(
-          'No WebSocket implementation available for the observer stream. Node exposes a ' +
-            'global `WebSocket` only from v22; on earlier supported runtimes (Node >= 20.9) ' +
-            'install one as `globalThis.WebSocket` (e.g. the `ws` package) or pass ' +
+          'No WebSocket implementation available for the observer stream. Node 22+ exposes a ' +
+            'global `WebSocket`; otherwise install one as `globalThis.WebSocket` (e.g. the `ws` package) or pass ' +
             '`webSocketImpl`/`createLiveStream` to observer mode.'
         )
       );

--- a/scripts/post-publish-verify/Dockerfile
+++ b/scripts/post-publish-verify/Dockerfile
@@ -2,10 +2,10 @@
 # Tests agent-relay npm package across Node.js versions
 #
 # Build args:
-#   NODE_VERSION: Node.js version to test (18, 20, 22)
+#   NODE_VERSION: Node.js version to test (22, 24)
 #   PACKAGE_VERSION: agent-relay version to test (default: latest)
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=22
 
 FROM node:${NODE_VERSION}-slim
 

--- a/scripts/post-publish-verify/README.md
+++ b/scripts/post-publish-verify/README.md
@@ -22,9 +22,8 @@ Automated tests to verify the `agent-relay` npm package works correctly after pu
 
 Tests run across all supported Node.js versions:
 
-- Node.js 18 (minimum supported)
-- Node.js 20 (LTS)
-- Node.js 22 (Current)
+- Node.js 22 (minimum supported)
+- Node.js 24 (current)
 
 ## Usage
 
@@ -41,7 +40,7 @@ Tests run across all supported Node.js versions:
 ./scripts/post-publish-verify/run-verify.sh latest --parallel
 
 # Test single Node.js version
-./scripts/post-publish-verify/run-verify.sh latest --node 20
+./scripts/post-publish-verify/run-verify.sh latest --node 22
 ```
 
 ### Docker Compose Directly
@@ -56,7 +55,7 @@ docker compose up --build
 PACKAGE_VERSION=2.0.25 docker compose up --build
 
 # Test single Node version
-docker compose up --build node20
+docker compose up --build node22
 
 # Cleanup
 docker compose down --rmi local

--- a/scripts/post-publish-verify/docker-compose.yml
+++ b/scripts/post-publish-verify/docker-compose.yml
@@ -1,6 +1,6 @@
 # Post-publish verification - Multi-Node.js version testing
 #
-# Tests agent-relay npm package installation across Node.js 18, 20, and 22
+# Tests agent-relay npm package installation across Node.js 22 and 24
 #
 # Usage:
 #   # Test latest published version across all Node versions
@@ -10,37 +10,13 @@
 #   PACKAGE_VERSION=2.0.25 docker compose -f scripts/post-publish-verify/docker-compose.yml up --build
 #
 #   # Test single Node version
-#   docker compose -f scripts/post-publish-verify/docker-compose.yml up --build node20
+#   docker compose -f scripts/post-publish-verify/docker-compose.yml up --build node22
 #
 #   # Cleanup
 #   docker compose -f scripts/post-publish-verify/docker-compose.yml down --rmi local
 
 services:
-  # Node.js 18 (minimum supported version)
-  node18:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        NODE_VERSION: '18'
-        PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
-    environment:
-      NODE_VERSION: '18'
-      PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
-
-  # Node.js 20 (LTS)
-  node20:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        NODE_VERSION: '20'
-        PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
-    environment:
-      NODE_VERSION: '20'
-      PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
-
-  # Node.js 22 (Current)
+  # Node.js 22 (minimum supported version)
   node22:
     build:
       context: .
@@ -50,6 +26,18 @@ services:
         PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
     environment:
       NODE_VERSION: '22'
+      PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
+
+  # Node.js 24 (current)
+  node24:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NODE_VERSION: '24'
+        PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
+    environment:
+      NODE_VERSION: '24'
       PACKAGE_VERSION: '${PACKAGE_VERSION:-latest}'
 
 networks:

--- a/scripts/post-publish-verify/run-verify.sh
+++ b/scripts/post-publish-verify/run-verify.sh
@@ -7,7 +7,7 @@
 #   ./run-verify.sh                    # Test latest version
 #   ./run-verify.sh 2.0.25             # Test specific version
 #   ./run-verify.sh latest --parallel  # Run all versions in parallel
-#   ./run-verify.sh 2.0.25 --node 20   # Test specific Node.js version only
+#   ./run-verify.sh 2.0.25 --node 22   # Test specific Node.js version only
 
 set -e
 
@@ -52,14 +52,14 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --parallel, -p   Run all Node versions in parallel"
-            echo "  --node, -n VER   Test only specific Node.js version (18, 20, or 22)"
+            echo "  --node, -n VER   Test only specific Node.js version (22 or 24)"
             echo "  --help, -h       Show this help"
             echo ""
             echo "Examples:"
             echo "  $0                     # Test latest across all Node versions"
             echo "  $0 2.0.25              # Test version 2.0.25"
             echo "  $0 latest --parallel   # Test in parallel"
-            echo "  $0 2.0.25 --node 20    # Test only Node 20"
+            echo "  $0 2.0.25 --node 22    # Test only Node 22"
             exit 0
             ;;
         *)
@@ -68,6 +68,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ -n "$SPECIFIC_NODE" ] && [ "$SPECIFIC_NODE" != "22" ] && [ "$SPECIFIC_NODE" != "24" ]; then
+    log_error "Unsupported Node.js version: $SPECIFIC_NODE (supported: 22, 24)"
+    exit 1
+fi
 
 log_header "Agent Relay Post-Publish Verification"
 log_info "Package version: $PACKAGE_VERSION"
@@ -83,7 +88,7 @@ export PACKAGE_VERSION
 if [ -n "$SPECIFIC_NODE" ]; then
     SERVICES="node${SPECIFIC_NODE}"
 else
-    SERVICES="node18 node20 node22"
+    SERVICES="node22 node24"
 fi
 
 # Build images


### PR DESCRIPTION
## Summary

- run post-publish verification on supported Node 22 and 24 instead of Node 20
- update local Docker verification and installer guidance to require Node 22+
- remove stale Node 20 runtime documentation from WebSocket fallbacks

## Why

Relay now declares Node 22 as its minimum supported version, but the publish verification tooling and installer still exercised or recommended unsupported Node 20.

## Validation

- `git diff --check`
- `bash -n install.sh scripts/post-publish-verify/run-verify.sh`
- post-publish verifier help and unsupported-version guard
- Prettier check for changed YAML, Markdown, and TypeScript
- support-reference scan (only an intentionally arbitrary test path remains)

Docker is not installed in the local validation environment, so the Compose containers were not run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

