### PR TITLE
Fix stale workspace resolution

### DIFF
--- a/packages/cli/src/cli/commands/workspace.test.ts
+++ b/packages/cli/src/cli/commands/workspace.test.ts
@@ -69,6 +69,7 @@ describe('registerWorkspaceCommands', () => {
       apiUrl: 'https://cloud.test',
       interactive: false,
       refreshTimeoutMs: 25,
+      bootstrapFromCloud: true,
     });
     expect(JSON.parse(String(vi.mocked(deps.log).mock.calls[0][0]))).toEqual({
       name: 'Ops',

--- a/packages/cli/src/cli/commands/workspace.ts
+++ b/packages/cli/src/cli/commands/workspace.ts
@@ -38,6 +38,7 @@ export function registerWorkspaceCommands(
           apiUrl: options.apiUrl,
           interactive: false,
           refreshTimeoutMs: options.refreshTimeout,
+          bootstrapFromCloud: true,
         });
 
         if (options.json) {

--- a/packages/cloud/src/workspaces.test.ts
+++ b/packages/cloud/src/workspaces.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { setWorkspaceKey } from './workspace-store.js';
-import { resolveActiveWorkspace } from './workspaces.js';
+import { readWorkspaceStore, setWorkspaceKey } from './workspace-store.js';
+import { issueWorkspaceToken, resolveActiveWorkspace } from './workspaces.js';
 
 let dir: string;
 const originalEnv = { ...process.env };
@@ -79,5 +79,167 @@ describe('resolveActiveWorkspace', () => {
     );
     const init = fetchSpy.mock.calls[0][1] as RequestInit;
     expect(new Headers(init.headers).get('authorization')).toBe('Bearer access-token');
+  });
+
+  it('repairs a stale workspace key from the authenticated cloud workspace', async () => {
+    setWorkspaceKey('stale', 'rk_live_stale');
+    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('rk_live_stale')) {
+        return Response.json({ error: 'Workspace not found' }, { status: 404 });
+      }
+      if (url.endsWith('/api/v1/auth/whoami')) {
+        return Response.json({
+          authenticated: true,
+          source: 'token',
+          subjectType: 'cli',
+          scopes: ['cli:auth'],
+          user: { id: 'user_1', email: null, name: null, avatarUrl: null },
+          currentOrganization: {
+            id: 'org_1',
+            slug: 'operations',
+            name: 'Operations',
+            role: 'owner',
+            status: 'active',
+          },
+          currentWorkspace: {
+            id: 'cloud_workspace_1',
+            organization_id: 'org_1',
+            slug: 'default',
+            name: 'Default',
+          },
+        });
+      }
+      if (url.endsWith('/api/v1/workspaces/cloud_workspace_1/join')) {
+        return Response.json({
+          workspaceId: 'rw_default',
+          token: 'short-lived-relayfile-token',
+          relaycastApiKey: 'rk_live_repaired',
+        });
+      }
+      if (url.endsWith('/api/v1/workspaces/rk_live_repaired/resolve')) {
+        return Response.json({
+          workspace: {
+            name: 'Default',
+            key: 'rk_live_repaired',
+            cloudWorkspaceId: 'cloud_workspace_1',
+            relaycastWorkspaceId: 'rw_default',
+            relaycastApiKey: 'rk_live_repaired',
+            relayfileWorkspaceId: 'rw_default',
+            relayauthWorkspaceId: 'rw_default',
+            organizationId: 'org_1',
+            slug: 'default',
+            urls: {},
+            provisioned: true,
+          },
+        });
+      }
+      return Response.json({ error: `Unexpected request: ${url}` }, { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(resolveActiveWorkspace()).resolves.toMatchObject({
+      name: 'Default',
+      key: 'rk_live_repaired',
+      cloudWorkspaceId: 'cloud_workspace_1',
+      relayfileWorkspaceId: 'rw_default',
+    });
+
+    expect(readWorkspaceStore()).toEqual({
+      active: 'Default',
+      workspaces: {
+        stale: { key: 'rk_live_stale' },
+        Default: { key: 'rk_live_repaired' },
+      },
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(6);
+  });
+
+  it('bootstraps the active workspace from cloud login when the local store is empty', async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/api/v1/auth/whoami')) {
+        return Response.json({
+          authenticated: true,
+          source: 'token',
+          subjectType: 'cli',
+          scopes: ['cli:auth'],
+          user: { id: 'user_1', email: null, name: null, avatarUrl: null },
+          currentOrganization: {
+            id: 'org_1',
+            slug: 'operations',
+            name: 'Operations',
+            role: 'owner',
+            status: 'active',
+          },
+          currentWorkspace: {
+            id: 'cloud_workspace_1',
+            organization_id: 'org_1',
+            slug: 'default',
+            name: 'Default',
+          },
+        });
+      }
+      if (url.endsWith('/api/v1/workspaces/cloud_workspace_1/join')) {
+        return Response.json({
+          workspaceId: 'rw_default',
+          token: 'short-lived-relayfile-token',
+          relaycastApiKey: 'rk_live_bootstrapped',
+        });
+      }
+      if (url.endsWith('/api/v1/workspaces/rk_live_bootstrapped/resolve')) {
+        return Response.json({
+          workspace: {
+            name: 'Default',
+            key: 'rk_live_bootstrapped',
+            cloudWorkspaceId: 'cloud_workspace_1',
+            relaycastWorkspaceId: 'rw_default',
+            relayfileWorkspaceId: 'rw_default',
+            relayauthWorkspaceId: 'rw_default',
+            urls: {},
+          },
+        });
+      }
+      return Response.json({ error: `Unexpected request: ${url}` }, { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(resolveActiveWorkspace({ bootstrapFromCloud: true })).resolves.toMatchObject({
+      key: 'rk_live_bootstrapped',
+      cloudWorkspaceId: 'cloud_workspace_1',
+    });
+    expect(readWorkspaceStore()).toEqual({
+      active: 'Default',
+      workspaces: { Default: { key: 'rk_live_bootstrapped' } },
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('issueWorkspaceToken', () => {
+  it('falls back to the canonical join contract when token routes are unavailable', async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/join')) {
+        return Response.json({
+          workspaceId: 'rw_default',
+          token: 'short-lived-relayfile-token',
+          relaycastApiKey: 'rk_live_joined',
+        });
+      }
+      return Response.json({ error: 'Not Found' }, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(issueWorkspaceToken('cloud_workspace_1', { name: 'Factory Local' })).resolves.toEqual({
+      key: 'rk_live_joined',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(String(fetchSpy.mock.calls[3][0])).toBe(
+      'https://cloud.example.test/api/v1/workspaces/cloud_workspace_1/join'
+    );
+    const init = fetchSpy.mock.calls[3][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ agentName: 'Factory-Local' });
   });
 });

--- a/packages/cloud/src/workspaces.ts
+++ b/packages/cloud/src/workspaces.ts
@@ -3,11 +3,12 @@ import {
   type ActiveWorkspaceDescriptor,
   type ActiveWorkspaceUrls,
   defaultApiUrl,
+  type WhoAmIResponse,
   type WorkspaceCreateResponse,
   type WorkspaceTokenIssueResponse,
   type WorkspaceTokenRecord,
 } from './types.js';
-import { resolveActiveWorkspaceKey } from './workspace-store.js';
+import { resolveActiveWorkspaceKey, setActiveWorkspace, setWorkspaceKey } from './workspace-store.js';
 
 type WorkspaceClientOptions = {
   apiUrl?: string;
@@ -21,6 +22,8 @@ type ResolveActiveWorkspaceOptions = WorkspaceClientOptions & {
   interactive?: boolean;
   refreshTimeoutMs?: number;
   env?: NodeJS.ProcessEnv;
+  /** Bootstrap an empty local workspace store from the authenticated Cloud session. */
+  bootstrapFromCloud?: boolean;
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -135,6 +138,39 @@ function normalizeWorkspaceTokenIssueResponse(
     key,
     ...(workspaceToken ? { workspaceToken } : {}),
   };
+}
+
+function workspaceJoinAgentName(name: string | undefined): string {
+  const normalized = name
+    ?.trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[^A-Za-z0-9]+/, '')
+    .slice(0, 128);
+  return normalized || 'agent-relay-cli';
+}
+
+async function joinWorkspaceKey(
+  workspaceId: string,
+  name: string | undefined,
+  options: WorkspaceClientOptions
+): Promise<string> {
+  const endpoint = `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/join`;
+  const { response, payload } = await tryPostJson(
+    endpoint,
+    { agentName: workspaceJoinAgentName(name) },
+    options
+  );
+  if (!response.ok) {
+    throw buildEndpointError('Workspace join', endpoint, response, payload);
+  }
+  if (!isObject(payload)) {
+    throw new Error(`Workspace join failed at ${endpoint}: response was not valid JSON.`);
+  }
+  const key = readString(payload, 'relaycastApiKey');
+  if (!key) {
+    throw new Error(`Workspace join failed at ${endpoint}: response is missing relaycastApiKey.`);
+  }
+  return key;
 }
 
 function readUrls(payload: JsonRecord): ActiveWorkspaceUrls {
@@ -317,13 +353,11 @@ export async function issueWorkspaceToken(
     `/api/v1/workspaces/${encodedWorkspaceId}/workspace-token`,
     `/api/v1/workspaces/${encodedWorkspaceId}/token`,
   ];
-  let lastUnsupported: Error | null = null;
 
   for (const endpoint of endpoints) {
     const { response, payload } = await tryPostJson(endpoint, body, options);
 
     if (response.status === 404 || response.status === 405) {
-      lastUnsupported = buildEndpointError('Workspace token issue', endpoint, response, payload);
       continue;
     }
 
@@ -334,21 +368,23 @@ export async function issueWorkspaceToken(
     return normalizeWorkspaceTokenIssueResponse(payload, workspaceId);
   }
 
-  throw (
-    lastUnsupported ?? new Error('Workspace token issuance is not supported by the configured cloud API.')
-  );
+  // Current Cloud deployments expose canonical workspace key recovery via the
+  // membership-aware /join contract. Keep the dedicated token endpoints first
+  // for forward compatibility, then use /join when those routes are absent.
+  return { key: await joinWorkspaceKey(workspaceId, options.name, options) };
 }
 
-export async function resolveActiveWorkspace(
-  options: ResolveActiveWorkspaceOptions = {}
-): Promise<ActiveWorkspaceDescriptor> {
-  const key = resolveActiveWorkspaceKey(options.env);
-  if (!key) {
-    throw new Error(
-      'No active Agent Relay workspace found. Run `agent-relay workspace set_key <name> <key>` or `agent-relay workspace join <name> <key>`.'
-    );
+class WorkspaceResolveMissError extends Error {
+  constructor(cause: Error) {
+    super(cause.message, { cause });
+    this.name = 'WorkspaceResolveMissError';
   }
+}
 
+async function resolveWorkspaceKey(
+  key: string,
+  options: ResolveActiveWorkspaceOptions
+): Promise<ActiveWorkspaceDescriptor> {
   const encodedKey = encodeURIComponent(key);
   const endpoints = [
     `/api/v1/workspaces/${encodedKey}/resolve`,
@@ -376,5 +412,63 @@ export async function resolveActiveWorkspace(
     return normalizeActiveWorkspaceDescriptor(payload, key, apiUrl);
   }
 
-  throw lastUnsupported ?? new Error('Workspace resolution is not supported by the configured cloud API.');
+  throw new WorkspaceResolveMissError(
+    lastUnsupported ?? new Error('Workspace resolution is not supported by the configured cloud API.')
+  );
+}
+
+async function repairActiveWorkspace(
+  options: ResolveActiveWorkspaceOptions
+): Promise<ActiveWorkspaceDescriptor> {
+  const apiUrl = options.apiUrl || defaultApiUrl();
+  const auth = await ensureAuthenticated(apiUrl, {
+    interactive: options.interactive ?? false,
+    refreshTimeoutMs: options.refreshTimeoutMs,
+  });
+  const { response } = await authorizedApiFetch(
+    auth,
+    '/api/v1/auth/whoami',
+    { method: 'GET' },
+    {
+      interactive: options.interactive ?? false,
+      refreshTimeoutMs: options.refreshTimeoutMs,
+    }
+  );
+  const payload = (await readJson(response)) as (WhoAmIResponse & { error?: string }) | null;
+  if (!response.ok || !payload?.authenticated || !payload.currentWorkspace?.id) {
+    const detail = payload?.error ?? (response.statusText || 'Failed to resolve auth status');
+    throw new Error(`Active workspace repair failed: ${response.status} ${detail}`.trim());
+  }
+
+  const workspaceName = payload.currentWorkspace.name?.trim() || payload.currentWorkspace.id;
+  const workspaceKey = await joinWorkspaceKey(payload.currentWorkspace.id, 'agent-relay-cli', {
+    apiUrl: auth.apiUrl,
+  });
+  setWorkspaceKey(workspaceName, workspaceKey, options.env);
+  setActiveWorkspace(workspaceName, options.env);
+
+  return resolveWorkspaceKey(workspaceKey, options);
+}
+
+export async function resolveActiveWorkspace(
+  options: ResolveActiveWorkspaceOptions = {}
+): Promise<ActiveWorkspaceDescriptor> {
+  const key = resolveActiveWorkspaceKey(options.env);
+  if (!key) {
+    if (options.bootstrapFromCloud) {
+      return repairActiveWorkspace(options);
+    }
+    throw new Error(
+      'No active Agent Relay workspace found. Run `agent-relay workspace set_key <name> <key>` or `agent-relay workspace join <name> <key>`.'
+    );
+  }
+
+  try {
+    return await resolveWorkspaceKey(key, options);
+  } catch (error) {
+    if (!(error instanceof WorkspaceResolveMissError)) {
+      throw error;
+    }
+    return repairActiveWorkspace(options);
+  }
 }


### PR DESCRIPTION
## What changed

- recover stale active workspace keys from the authenticated Cloud workspace
- bootstrap an empty workspace store for `agent-relay workspace active`
- fall back to the membership-aware workspace join contract when dedicated token routes are unavailable
- preserve strict fail-closed behavior for SDK callers that do not opt into empty-store bootstrapping
- persist and activate the recovered canonical workspace key before retrying resolution

## Root cause

Cloud authentication and local workspace selection are separate state. A valid `agent-relay cloud login` could coexist with a global active alias that referenced a deleted workspace. `workspace active` trusted only that stale alias, so every resolve endpoint returned 404 even though `cloud whoami` reported a valid current workspace. Current Cloud deployments expose canonical workspace recovery through the authenticated `/join` contract, while the dedicated token issue compatibility routes can be absent.

## User impact

`agent-relay workspace active` now repairs stale or missing local workspace state from the user's authenticated Cloud workspace. SDK consumers also recover stale keys, while callers that require an explicitly configured key still fail closed when the store is empty.

## Validation

- `npm run typecheck`
- full isolated unit suite: 113 test files passed, 1,428 tests passed, 25 skipped
- focused workspace and strict integration tests: 61 passed
- live Cloud E2E with an intentionally stale isolated workspace store
- live Cloud E2E with a completely empty isolated workspace store
- verified repaired stores use the canonical Default workspace and owner-only `0600` permissions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

