### PR TITLE
fix: suppress view scroll escape reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native AI SDK harnesses now permit official adapter bootstrap files under their fixed cache root and invoke pnpm independently of Relay's npm workspace, preventing successful-looking spawns from immediately disappearing.
 - Native `node agent attach --mode drive` sessions now show an interactive prompt, preserve structured adapter error messages, and close their broker connection when detached.
 
+- `agent-relay agent attach --mode view` now consumes local input while viewing, preventing mouse-wheel reports from appearing as scroll-up and scroll-down escape characters.
 ### Breaking Changes
 
 - Agent Relay now requires Node.js 22 or newer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native `node agent attach --mode drive` sessions now show an interactive prompt, preserve structured adapter error messages, and close their broker connection when detached.
 
 - `agent-relay agent attach --mode view` now consumes local input while viewing, preventing mouse-wheel reports from appearing as scroll-up and scroll-down escape characters.
+
 ### Breaking Changes
 
 - Agent Relay now requires Node.js 22 or newer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay agent attach --mode view` now consumes local input while viewing, preventing mouse-wheel reports from appearing as scroll-up and scroll-down escape characters.
 
 ## [11.0.0] - 2026-07-21
 
@@ -27,8 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay-broker` now orders fleet `agent.deregister` before acknowledging a local worker release, so a restarted node can immediately recover the same agent name without an active-location collision, and fails fast instead of stalling the runtime API when fleet-control delivery is backpressured.
 - Native AI SDK harnesses now permit official adapter bootstrap files under their fixed cache root and invoke pnpm independently of Relay's npm workspace, preventing successful-looking spawns from immediately disappearing.
 - Native `node agent attach --mode drive` sessions now show an interactive prompt, preserve structured adapter error messages, and close their broker connection when detached.
-
-- `agent-relay agent attach --mode view` now consumes local input while viewing, preventing mouse-wheel reports from appearing as scroll-up and scroll-down escape characters.
 
 ### Breaking Changes
 

--- a/packages/cli/src/cli/lib/attach-view.test.ts
+++ b/packages/cli/src/cli/lib/attach-view.test.ts
@@ -64,6 +64,36 @@ interface HarnessOverrides {
   stdoutIsTty?: boolean;
 }
 
+class FakeStdin {
+  isTTY = true;
+  isRaw = false;
+  readonly listeners = new Map<string, Array<(chunk: Buffer) => void>>();
+  readonly setRawMode = vi.fn((mode: boolean) => {
+    this.isRaw = mode;
+  });
+  readonly resume = vi.fn();
+  readonly pause = vi.fn();
+
+  on(event: 'data', listener: (chunk: Buffer) => void): this {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+
+  off(event: 'data', listener: (chunk: Buffer) => void): this {
+    this.listeners.set(
+      event,
+      (this.listeners.get(event) ?? []).filter((candidate) => candidate !== listener)
+    );
+    return this;
+  }
+
+  emitData(chunk: Buffer): void {
+    for (const listener of this.listeners.get('data') ?? []) listener(chunk);
+  }
+}
+
 function createHarness(overrides: HarnessOverrides = {}): {
   deps: ViewDependencies;
   writes: string[];
@@ -71,17 +101,20 @@ function createHarness(overrides: HarnessOverrides = {}): {
   logs: unknown[][];
   signals: Map<NodeJS.Signals, () => void | Promise<void>>;
   sockets: FakeWebSocket[];
+  stdin: FakeStdin;
 } {
   const writes: string[] = [];
   const errors: unknown[][] = [];
   const logs: unknown[][] = [];
   const signals = new Map<NodeJS.Signals, () => void | Promise<void>>();
   const sockets: FakeWebSocket[] = [];
+  const stdin = new FakeStdin();
 
   const deps: ViewDependencies = {
     readConnectionFile: vi.fn(() => overrides.connectionFile ?? null),
     getDefaultStateDir: vi.fn(() => overrides.defaultStateDir ?? '/tmp/fake/.agentworkforce/relay'),
     env: overrides.env ?? {},
+    stdin,
     createWebSocket: vi.fn((url: string, headers: Record<string, string>) => {
       const socket = new FakeWebSocket(url, headers);
       sockets.push(socket);
@@ -115,7 +148,7 @@ function createHarness(overrides: HarnessOverrides = {}): {
     stdoutIsTty: overrides.stdoutIsTty ?? false,
   };
 
-  return { deps, writes, errors, logs, signals, sockets };
+  return { deps, writes, errors, logs, signals, sockets, stdin };
 }
 
 afterEach(() => {
@@ -475,6 +508,28 @@ describe('runViewSession', () => {
 
     await sessionPromise;
     expect(writes).toEqual(['\x1b[?1049hSCREEN', 'out', 'more']);
+  });
+
+  it('consumes local input in raw mode so alternate-scroll reports are not echoed', async () => {
+    const { deps, sockets, stdin } = createHarness({
+      connectionFile: { url: 'http://localhost:3889' },
+    });
+
+    const sessionPromise = runViewSession('Alice', {}, deps);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stdin.setRawMode).toHaveBeenCalledWith(true);
+    expect(stdin.resume).toHaveBeenCalledOnce();
+
+    // These are the bytes a terminal produces for mouse-wheel movement when
+    // alternate-scroll is enabled. View must consume them rather than let
+    // cooked stdin echo them as `^[[0A` and `^[[0B`.
+    stdin.emitData(Buffer.from('\x1b[0A\x1b[0B'));
+    expect(sockets[0].closed).toBe(false);
+
+    stdin.emitData(Buffer.from([0x03]));
+    await expect(sessionPromise).resolves.toBe(0);
+    expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(stdin.pause).toHaveBeenCalledOnce();
   });
 
   it('exits cleanly on SIGINT without surfacing an error', async () => {

--- a/packages/cli/src/cli/lib/attach-view.ts
+++ b/packages/cli/src/cli/lib/attach-view.ts
@@ -63,6 +63,23 @@ export interface ViewSignalRegistrar {
   (signal: NodeJS.Signals, handler: () => void | Promise<void>): void | (() => void);
 }
 
+/**
+ * Stdin surface used by view. Unlike drive and passthrough, view deliberately
+ * consumes and discards input: it is read-only, but taking stdin out of cooked
+ * echo mode prevents a terminal's mouse/focus reports from being painted as
+ * literal escape characters when a TUI has enabled them.
+ */
+export interface ViewStdin {
+  setRawMode?: (mode: boolean) => unknown;
+  isTTY?: boolean;
+  isRaw?: boolean;
+  resume(): unknown;
+  pause(): unknown;
+  on(event: 'data', listener: (chunk: Buffer) => void): unknown;
+  off?(event: 'data', listener: (chunk: Buffer) => void): unknown;
+  removeListener?(event: 'data', listener: (chunk: Buffer) => void): unknown;
+}
+
 export interface ViewDependencies {
   /** Reads `<state-dir>/connection.json` and returns parsed JSON, or null. */
   readConnectionFile: (stateDir: string) => unknown;
@@ -70,6 +87,8 @@ export interface ViewDependencies {
   getDefaultStateDir: () => string;
   /** Environment variables (so tests can inject). */
   env: NodeJS.ProcessEnv;
+  /** Local input, held in raw mode and discarded for the read-only session. */
+  stdin: ViewStdin;
   /** Factory for the WebSocket — overridden in tests with a mock. */
   createWebSocket: ViewWebSocketFactory;
   /** Where the PTY chunks get written. Defaults to `process.stdout.write`. */
@@ -125,6 +144,7 @@ function withDefaults(overrides: Partial<ViewDependencies> = {}): ViewDependenci
     readConnectionFile: readConnectionFileFromDisk,
     getDefaultStateDir: defaultStateDir,
     env: process.env,
+    stdin: process.stdin,
     createWebSocket: (url, headers) => new WebSocket(url, { headers }) as ViewWebSocket,
     writeChunk: writer.write,
     disposeWriter: writer.dispose,
@@ -396,6 +416,7 @@ export async function runViewSession(
 
   return new Promise<number>((resolve) => {
     let settled = false;
+    let rawModeWasSet = false;
     const cleanupSignals: Array<() => void> = [];
     // Subscribe-first: buffer live `worker_stream` chunks until the snapshot
     // is painted and reconciled, so no output around attach time is lost and
@@ -409,6 +430,36 @@ export async function runViewSession(
     const writeAgentOutput = (chunk: string): void => {
       const filtered = inputModeFilter.push(chunk);
       if (filtered.length > 0) deps.writeChunk(filtered);
+    };
+    // `view` never forwards stdin. Still consume it in raw mode so mouse,
+    // focus, and alternate-scroll reports cannot be cooked-mode echoed into
+    // the viewer as visible `^[[0A` / `^[[0B` garbage. Ctrl+C must be handled
+    // here because raw mode disables the terminal driver's SIGINT handling.
+    const stdinDataHandler = (chunk: Buffer): void => {
+      if (chunk.includes(0x03)) finish(0);
+    };
+    const teardownStdin = (): void => {
+      try {
+        if (deps.stdin.off) {
+          deps.stdin.off('data', stdinDataHandler);
+        } else if (deps.stdin.removeListener) {
+          deps.stdin.removeListener('data', stdinDataHandler);
+        }
+      } catch {
+        // best effort
+      }
+      try {
+        if (rawModeWasSet && typeof deps.stdin.setRawMode === 'function') {
+          deps.stdin.setRawMode(false);
+        }
+      } catch {
+        // best effort
+      }
+      try {
+        deps.stdin.pause();
+      } catch {
+        // best effort
+      }
     };
     const finish = (code: number) => {
       if (settled) return;
@@ -434,6 +485,7 @@ export async function runViewSession(
       } catch {
         // best effort
       }
+      teardownStdin();
       // Drop the writer's pending queue and unhook its drain listener so no
       // buffered chunk flushes to stdout after detach.
       deps.disposeWriter?.();
@@ -485,6 +537,20 @@ export async function runViewSession(
     };
 
     const socket = deps.createWebSocket(wsUrl, headers);
+
+    // Do this before rendering the snapshot: a source TUI may have enabled
+    // mouse or alternate-scroll already, and raw input is the final safeguard
+    // even if an unusual escape sequence evades the output filter.
+    try {
+      if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false && !deps.stdin.isRaw) {
+        deps.stdin.setRawMode(true);
+        rawModeWasSet = true;
+      }
+      deps.stdin.resume();
+      deps.stdin.on('data', stdinDataHandler);
+    } catch {
+      // Read-only viewing still works on non-TTY or unusual stdin surfaces.
+    }
 
     for (const signal of ['SIGINT', 'SIGTERM'] as const) {
       const cleanup = deps.onSignal(signal, () => finish(0));


### PR DESCRIPTION
## Summary
- consume and discard local stdin during read-only `attach --mode view` sessions
- prevent terminal alternate-scroll reports from being echoed as visible escape characters
- retain Ctrl-C detach behavior and restore stdin on exit

## Root cause
`view` left stdin in cooked echo mode. When a terminal had alternate-scroll enabled, wheel events were emitted as arrow-key escape sequences and displayed in the viewer.

## Validation
- `npx vitest run packages/cli/src/cli/lib/attach-view.test.ts`
- ESLint for the changed files
- `npx tsc --noEmit -p packages/cli/tsconfig.json`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

