### PR TITLE
feat: add pretty node agent list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
+
+### Added
+
+- `relay node agent list --pretty` now provides a compact agent view with each agent's name, CLI/model, state, and relative last activity time.
 
 ### Fixed
 

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -131,6 +131,27 @@ describe('local agent subtree', () => {
     expect(formatPrettyAgentList([], new Date())).toBe('No agents running.');
   });
 
+  it('removes terminal control sequences from broker-provided cells', () => {
+    const [, , row] = formatPrettyAgentList(
+      [
+        {
+          name: 'Lead\x1b[2J\nAgent',
+          runtime: 'pty',
+          cli: 'codex\nunsafe',
+          model: 'gpt-5\x1b[0m',
+          channels: [],
+          current_state: 'working',
+          last_activity_at: '2026-07-22T17:00:00.000Z',
+        },
+      ],
+      new Date('2026-07-22T17:00:00.000Z')
+    ).split('\n');
+
+    expect(row).toContain('Lead�Agent');
+    expect(row).toContain('codex�unsafe / gpt-5');
+    expect(row).not.toContain('\x1b');
+  });
+
   it('spawn forwards task-exit lifecycle options', async () => {
     const { program, client } = harness();
     await program.parseAsync(

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -9,7 +9,11 @@ vi.mock('@agent-relay/harness-driver', () => ({
   },
 }));
 
-import { registerLocalAgentCommands, type LocalAgentDependencies } from './local-agent.js';
+import {
+  formatPrettyAgentList,
+  registerLocalAgentCommands,
+  type LocalAgentDependencies,
+} from './local-agent.js';
 
 function harness(overrides: Partial<LocalAgentDependencies> = {}) {
   const client = {
@@ -74,10 +78,57 @@ describe('local agent subtree', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
-  it('list queries the broker', async () => {
-    const { program, client } = harness();
+  it('list queries the broker and keeps JSON as the default output', async () => {
+    const { program, client, log } = harness();
     await program.parseAsync(['local', 'agent', 'list'], { from: 'user' });
     expect(client.listAgents).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('[\n  {\n    "name": "lead"\n  }\n]');
+  });
+
+  it('list --pretty shows the compact human-readable view', async () => {
+    const { program, log } = harness({
+      connect: vi.fn(
+        async () =>
+          ({
+            listAgents: vi.fn(async () => [
+              {
+                name: 'Lead',
+                runtime: 'pty' as const,
+                cli: 'codex',
+                model: 'gpt-5.4',
+                channels: [],
+                current_state: 'working' as const,
+                last_activity_at: '2026-07-22T16:59:57.000Z',
+              },
+            ]),
+          }) as never
+      ),
+      now: () => new Date('2026-07-22T17:00:00.000Z'),
+    });
+
+    await program.parseAsync(['local', 'agent', 'list', '--pretty'], { from: 'user' });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Lead  codex / gpt-5.4  ● working  now'));
+  });
+
+  it('formats agent state and activity time for the pretty list', () => {
+    expect(
+      formatPrettyAgentList(
+        [
+          {
+            name: 'Review',
+            runtime: 'pty',
+            cli: 'claude',
+            channels: [],
+            current_state: 'blocked_on_send',
+            last_activity_at: '2026-07-22T16:58:00.000Z',
+          },
+          { name: 'Worker', runtime: 'headless', channels: [], current_state: 'idle' },
+        ],
+        new Date('2026-07-22T17:00:00.000Z')
+      )
+    ).toMatch(/Review\s+claude\s+◐ waiting\s+2 minutes ago/);
+    expect(formatPrettyAgentList([], new Date())).toBe('No agents running.');
   });
 
   it('spawn forwards task-exit lifecycle options', async () => {

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
+import type { ListAgent } from '@agent-relay/harness-driver';
 import type { HarnessRuntime } from '@agent-relay/harnesses';
 
 import { classifyTask, composeTeam, buildDirectorPrompt } from '../../auto/index.js';
@@ -86,6 +87,7 @@ export interface LocalAgentDependencies {
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
   exit: ExitFn;
+  now: () => Date;
 }
 
 function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAgentDependencies {
@@ -100,6 +102,7 @@ function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAge
     log: (...args: unknown[]) => console.log(...args),
     error: (...args: unknown[]) => console.error(...args),
     exit: defaultExit,
+    now: () => new Date(),
     ...overrides,
   } as LocalAgentDependencies;
   deps.connectLocal ??= async (_cwd: string, options: LocalAgentMessageBrokerOptions) => {
@@ -117,6 +120,69 @@ function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAge
     return createBrokerClient(connection, deps.fetch);
   };
   return deps;
+}
+
+const AGENT_STATE_DISPLAY: Record<
+  NonNullable<ListAgent['current_state']>,
+  { symbol: string; label: string }
+> = {
+  working: { symbol: '●', label: 'working' },
+  idle: { symbol: '○', label: 'idle' },
+  blocked_on_send: { symbol: '◐', label: 'waiting' },
+};
+
+function formatRelativeTime(value: string | undefined, now: Date): string {
+  if (!value) return 'unknown';
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return 'unknown';
+
+  const seconds = Math.max(0, Math.floor((now.getTime() - timestamp) / 1_000));
+  if (seconds < 5) return 'now';
+  if (seconds < 60) return `${seconds} seconds ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+/** Render a compact terminal view while retaining JSON as the script-friendly default. */
+export function formatPrettyAgentList(agents: ListAgent[], now: Date): string {
+  if (agents.length === 0) return 'No agents running.';
+
+  const rows = agents.map((agent) => {
+    const state = agent.current_state ? AGENT_STATE_DISPLAY[agent.current_state] : undefined;
+    return {
+      name: agent.name,
+      cliModel: [agent.cli ?? agent.provider ?? agent.runtime, agent.model].filter(Boolean).join(' / '),
+      state: state ? `${state.symbol} ${state.label}` : '· unknown',
+      lastActive: formatRelativeTime(agent.last_activity_at, now),
+    };
+  });
+  const columns = [
+    { header: 'NAME', values: rows.map((row) => row.name) },
+    { header: 'CLI / MODEL', values: rows.map((row) => row.cliModel) },
+    { header: 'STATE', values: rows.map((row) => row.state) },
+    { header: 'LAST ACTIVE', values: rows.map((row) => row.lastActive) },
+  ];
+  const widths = columns.map((column) =>
+    Math.max(column.header.length, ...column.values.map((value) => value.length))
+  );
+  const formatRow = (values: string[]) =>
+    values
+      .map((value, index) => value.padEnd(widths[index]!))
+      .join('  ')
+      .trimEnd();
+
+  return [
+    formatRow(columns.map((column) => column.header)),
+    formatRow(columns.map((_, index) => '-'.repeat(widths[index]!))),
+    ...rows.map((row) => formatRow([row.name, row.cliModel, row.state, row.lastActive])),
+  ].join('\n');
 }
 
 async function run(
@@ -241,9 +307,11 @@ export function registerLocalAgentCommands(
   agent
     .command('list')
     .description('List agents running on the local broker')
-    .action(async () => {
+    .option('--pretty', 'Show a compact human-readable list')
+    .action(async (opts: { pretty?: boolean }) => {
       await run(deps, async (client) => {
-        deps.log(JSON.stringify(await client.listAgents(), null, 2));
+        const agents = await client.listAgents();
+        deps.log(opts.pretty ? formatPrettyAgentList(agents, deps.now()) : JSON.stringify(agents, null, 2));
       });
     });
 

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -3,6 +3,7 @@ import type { Command } from 'commander';
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
 import type { ListAgent } from '@agent-relay/harness-driver';
 import type { HarnessRuntime } from '@agent-relay/harnesses';
+import { stripAnsiFast } from '@agent-relay/utils';
 
 import { classifyTask, composeTeam, buildDirectorPrompt } from '../../auto/index.js';
 import { createBrokerClient } from '../lib/attach-broker.js';
@@ -150,6 +151,12 @@ function formatRelativeTime(value: string | undefined, now: Date): string {
   return `${days} day${days === 1 ? '' : 's'} ago`;
 }
 
+/** Keep broker-provided text from escaping its table cell or controlling the terminal. */
+function sanitizeTerminalCell(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return stripAnsiFast(value).replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, '�');
+}
+
 /** Render a compact terminal view while retaining JSON as the script-friendly default. */
 export function formatPrettyAgentList(agents: ListAgent[], now: Date): string {
   if (agents.length === 0) return 'No agents running.';
@@ -157,10 +164,12 @@ export function formatPrettyAgentList(agents: ListAgent[], now: Date): string {
   const rows = agents.map((agent) => {
     const state = agent.current_state ? AGENT_STATE_DISPLAY[agent.current_state] : undefined;
     return {
-      name: agent.name,
-      cliModel: [agent.cli ?? agent.provider ?? agent.runtime, agent.model].filter(Boolean).join(' / '),
-      state: state ? `${state.symbol} ${state.label}` : '· unknown',
-      lastActive: formatRelativeTime(agent.last_activity_at, now),
+      name: sanitizeTerminalCell(agent.name),
+      cliModel: sanitizeTerminalCell(
+        [agent.cli ?? agent.provider ?? agent.runtime, agent.model].filter(Boolean).join(' / ')
+      ),
+      state: sanitizeTerminalCell(state ? `${state.symbol} ${state.label}` : '· unknown'),
+      lastActive: sanitizeTerminalCell(formatRelativeTime(agent.last_activity_at, now)),
     };
   });
   const columns = [


### PR DESCRIPTION
## Summary

Adds `relay node agent list --pretty` for a compact, human-readable view of local broker agents.

- Shows name, CLI/model, symbolic state, and relative last activity time.
- Keeps JSON as the default output for scripts.
- Covers default JSON output, pretty output, state formatting, relative times, and empty lists.

## Validation

- `npx vitest run packages/cli/src/cli/commands/local-agent.test.ts`
- `cd packages/cli && npx tsc --noEmit`
- `cd packages/cli && npm run lint` (existing warnings only)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

