### PR TITLE
fix(agent): keep delayed Slack receipts retryable

### DIFF
--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -982,23 +982,45 @@ describe('relay-feature-guardian delayed Slack receipts', () => {
   });
 
   it('keeps a delayed receipt retryable and replays the stable key without a second Slack post', async () => {
-    const formerFatalError = 'Slack post failed: no timestamp returned for feature broker-status';
+    const capabilityFeatures = [
+      manifestFeatures[0]!,
+      {
+        id: 'capabilities-register',
+        name: 'Register Capabilities',
+        cli: 'relay capabilities register',
+        description: 'Registers broker capabilities.',
+        tier: 1,
+      },
+    ];
+    const capabilityState: ProgressState = {
+      kind: 'relay-feature-guardian:progress',
+      version: 3,
+      generation: 1,
+      checkedIds: ['broker-up'],
+      cycleStartedAt: '2026-07-18T10:26:47.981Z',
+      totalFeatures: capabilityFeatures.length,
+      lastPost: { featureId: 'broker-up', ts: '17843701.029509' },
+    };
+    const formerFatalError = 'Slack post failed: no timestamp returned for feature capabilities-register';
     const transport = new LateReceiptReplaySlackTransport();
     const restore = bindPreviewTransport(transport);
-    const { ctx, files } = exactStateContext(JSON.stringify(progressState(1)));
+    const { ctx, files } = exactStateContext(
+      JSON.stringify(capabilityState),
+      renderManifest(capabilityFeatures)
+    );
     try {
       await expect(guardian.handler(ctx, { type: 'cron.tick' } as never)).resolves.toBeUndefined();
       expect(JSON.parse(files.get(CYCLE_STATE_PATH) ?? '{}').checkedIds).toEqual(['broker-up']);
       expect(ctx.log).toHaveBeenCalledWith('warn', 'relay-feature-guardian.post-receipt-pending', {
         channel: 'C0AEKNLDNKW',
-        feature: 'broker-status',
+        feature: 'capabilities-register',
         path: expect.any(String),
       });
       expect(JSON.stringify(vi.mocked(ctx.log).mock.calls)).not.toContain(formerFatalError);
 
       await expect(guardian.handler(ctx, { type: 'cron.tick' } as never)).resolves.toBeUndefined();
       const state = JSON.parse(files.get(CYCLE_STATE_PATH) ?? '{}') as ProgressState;
-      expect(state.checkedIds).toEqual(['broker-up', 'broker-status']);
+      expect(state.checkedIds).toEqual(['broker-up', 'capabilities-register']);
       expect(state.lastPost?.ts).toBe('1710000001.000100');
       expect(transport.providerCreates).toBe(1);
       expect(transport.attempts).toHaveLength(2);

--- a/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.test.ts
@@ -220,14 +220,16 @@ class DelayedSlackTransport extends IdempotentSlackTransport {
   }
 }
 
-class ReceiptlessSlackTransport extends IdempotentSlackTransport {
+class LateReceiptReplaySlackTransport extends IdempotentSlackTransport {
+  private readonly receiptlessKeys = new Set<string>();
+
   override async write(request: RelayTransportWriteRequest): Promise<WritebackResult> {
-    this.attempts.push(request);
-    return {
-      path: '/slack/draft.json',
-      absolutePath: '/slack/draft.json',
-      receipt: { id: 'mountcmd-without-provider-ts' },
-    };
+    const result = await super.write(request);
+    const body = request.body as { idempotencyKey?: string };
+    const key = body.idempotencyKey ?? `unkeyed:${this.attempts.length}`;
+    if (this.receiptlessKeys.has(key)) return result;
+    this.receiptlessKeys.add(key);
+    return { ...result, receipt: { id: 'mountcmd-without-provider-ts' } };
   }
 }
 
@@ -979,19 +981,28 @@ describe('relay-feature-guardian delayed Slack receipts', () => {
     }
   });
 
-  it('rejects and never advances on a receipt-shaped draft without provider ts', async () => {
-    const transport = new ReceiptlessSlackTransport();
+  it('keeps a delayed receipt retryable and replays the stable key without a second Slack post', async () => {
+    const formerFatalError = 'Slack post failed: no timestamp returned for feature broker-status';
+    const transport = new LateReceiptReplaySlackTransport();
     const restore = bindPreviewTransport(transport);
     const { ctx, files } = exactStateContext(JSON.stringify(progressState(1)));
     try {
-      await expect(guardian.handler(ctx, { type: 'cron.tick' } as never)).rejects.toThrow(
-        'Slack post failed: no timestamp returned for feature broker-status'
-      );
+      await expect(guardian.handler(ctx, { type: 'cron.tick' } as never)).resolves.toBeUndefined();
       expect(JSON.parse(files.get(CYCLE_STATE_PATH) ?? '{}').checkedIds).toEqual(['broker-up']);
-      expect(ctx.log).toHaveBeenCalledWith('error', 'relay-feature-guardian.post-failed', {
+      expect(ctx.log).toHaveBeenCalledWith('warn', 'relay-feature-guardian.post-receipt-pending', {
         channel: 'C0AEKNLDNKW',
         feature: 'broker-status',
+        path: expect.any(String),
       });
+      expect(JSON.stringify(vi.mocked(ctx.log).mock.calls)).not.toContain(formerFatalError);
+
+      await expect(guardian.handler(ctx, { type: 'cron.tick' } as never)).resolves.toBeUndefined();
+      const state = JSON.parse(files.get(CYCLE_STATE_PATH) ?? '{}') as ProgressState;
+      expect(state.checkedIds).toEqual(['broker-up', 'broker-status']);
+      expect(state.lastPost?.ts).toBe('1710000001.000100');
+      expect(transport.providerCreates).toBe(1);
+      expect(transport.attempts).toHaveLength(2);
+      expect(transport.attempts[0]?.body).toMatchObject(transport.attempts[1]?.body as object);
     } finally {
       restore();
     }

--- a/.agentworkforce/agents/relay-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relay-feature-guardian/agent.ts
@@ -792,8 +792,16 @@ export async function runGuardian(
   }
   const ts = deliveredSlackTs(result);
   if (!ts) {
-    ctx.log('error', 'relay-feature-guardian.post-failed', { channel, feature: feature.id });
-    throw new Error(`Slack post failed: no timestamp returned for feature ${feature.id}`);
+    // A successful helper return means the draft was admitted, not that the
+    // provider receipt is already visible. Leave the exact checkpoint alone so
+    // the next tick replays the stable idempotency key instead of turning an
+    // eventually-consistent receipt into a terminal handler failure.
+    ctx.log('warn', 'relay-feature-guardian.post-receipt-pending', {
+      channel,
+      feature: feature.id,
+      path: result.path,
+    });
+    return;
   }
 
   // Checkpoint immediately after the confirmed provider receipt. The stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay agent attach --mode drive|passthrough` now takes raw input before replaying terminal state and preserves inherited raw mode on detach, preventing mouse-report escape characters and parent-TUI input regressions.
+- `relay-feature-guardian` now treats an admitted Slack write without a provider receipt as a retry-pending warning, retaining its checkpoint and idempotency key instead of failing the guardian run.
 
 ## [11.0.1] - 2026-07-22
 


### PR DESCRIPTION
## Summary
- treat a successful Relayfile write with no provider timestamp as receipt-pending, not a terminal handler failure
- leave the progress checkpoint unchanged so the next tick replays the existing stable idempotency key
- cover late receipt replay and assert a single provider-side create in the idempotent transport

## Root cause
The write helper can return after the draft is admitted but before the provider receipt is visible. The guardian previously translated that success-without-receipt state into Slack post failed: no timestamp returned for feature capabilities-register, even though provider completion could still arrive later.

Relayfile v0.10.36 fixes one underlying accepted-operation 404 receipt visibility defect, but it is not deployed to the running snapshot and it does not remove the helper independent 15-second receipt deadline. This PR fixes the residual agent-side classification bug.

## Red / green
Exact acceptance red, observed Node v20.20.1: with the production no-timestamp branch restored and the final fixture, 1 failed / 33 passed; exact cause Slack post failed: no timestamp returned for feature capabilities-register at agent.ts:796.

CI-correct local verification at 9f16f237215d49aa3d90f9444fb180feb04868ed, observed Node v22.14.0 / npm 10.9.2 as pinned by .github/workflows/test.yml:
- npx vitest run .agentworkforce/agents/relay-feature-guardian/agent.test.ts: 34 passed
- npm run typecheck: passed

The clean install reports existing transitive engine warnings for dependencies requiring newer Node 22 minors than the workflow pin; install and both gates pass. No live agent run, deploy, merge, or production mutation was performed.