### PR TITLE
fix(cli): protect attach input mode transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `agent-relay agent attach --mode drive|passthrough` now takes raw input before replaying terminal state and restores an inherited raw mode on detach, preventing mouse-report escape characters and parent-TUI input regressions.
+- `agent-relay agent attach --mode drive|passthrough` now takes raw input before replaying terminal state and preserves inherited raw mode on detach, preventing mouse-report escape characters and parent-TUI input regressions.
 
 ## [11.0.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay agent attach --mode drive|passthrough` now takes raw input before replaying terminal state and restores an inherited raw mode on detach, preventing mouse-report escape characters and parent-TUI input regressions.
 
 ## [11.0.1] - 2026-07-22
 

--- a/packages/cli/src/cli/lib/attach-drive.test.ts
+++ b/packages/cli/src/cli/lib/attach-drive.test.ts
@@ -424,7 +424,19 @@ function createHarness(opts: FetchScript = {}): {
     ownershipReassertMs: opts.ownershipReassertMs ?? 0,
   };
 
-  return { deps, stdin, terminal, sockets, writes, errors, logs, signals, fetchLog, inputStreams, predictiveEcho: opts.predictiveEcho };
+  return {
+    deps,
+    stdin,
+    terminal,
+    sockets,
+    writes,
+    errors,
+    logs,
+    signals,
+    fetchLog,
+    inputStreams,
+    predictiveEcho: opts.predictiveEcho,
+  };
 }
 
 afterEach(() => {

--- a/packages/cli/src/cli/lib/attach-drive.test.ts
+++ b/packages/cli/src/cli/lib/attach-drive.test.ts
@@ -162,6 +162,23 @@ class FakeInputStream implements CliPtyInputStream {
   }
 }
 
+class FakePredictiveEcho {
+  readonly seeded: string[] = [];
+  readonly inputs: string[] = [];
+
+  async seed(data: string): Promise<void> {
+    this.seeded.push(data);
+  }
+
+  async onServerOutput(): Promise<void> {}
+  onUserInput(forward: Buffer): void {
+    this.inputs.push(forward.toString('utf-8'));
+  }
+  rollback(): void {}
+  onResize(): void {}
+  reset(): void {}
+}
+
 /** Routed fetch — keyed on `${method} ${pathSuffix}`. */
 type FetchRoute = (init?: RequestInit) => Promise<Response>;
 
@@ -187,6 +204,7 @@ interface FetchScript {
   /** Ownership re-assert interval (ms). Defaults to disabled (0) in tests so
    *  the keep-alive timer doesn't interfere; the re-assert test sets it small. */
   ownershipReassertMs?: number;
+  predictiveEcho?: FakePredictiveEcho;
 }
 
 function createHarness(opts: FetchScript = {}): {
@@ -200,6 +218,7 @@ function createHarness(opts: FetchScript = {}): {
   signals: Map<NodeJS.Signals, () => void | Promise<void>>;
   fetchLog: Array<{ url: string; method: string; body?: unknown; headers: Record<string, string> }>;
   inputStreams: FakeInputStream[];
+  predictiveEcho?: FakePredictiveEcho;
 } {
   const writes: string[] = [];
   const errors: unknown[][] = [];
@@ -397,6 +416,7 @@ function createHarness(opts: FetchScript = {}): {
       inputStreams.push(stream);
       return stream;
     }),
+    createPredictiveEcho: opts.predictiveEcho ? () => opts.predictiveEcho ?? null : undefined,
     // Immediate, deterministic status repaints in tests (no coalescing timer).
     statusRepaintCoalesceMs: 0,
     // Disable the ownership re-assert timer by default so it can't perturb
@@ -404,7 +424,7 @@ function createHarness(opts: FetchScript = {}): {
     ownershipReassertMs: opts.ownershipReassertMs ?? 0,
   };
 
-  return { deps, stdin, terminal, sockets, writes, errors, logs, signals, fetchLog, inputStreams };
+  return { deps, stdin, terminal, sockets, writes, errors, logs, signals, fetchLog, inputStreams, predictiveEcho: opts.predictiveEcho };
 }
 
 afterEach(() => {
@@ -614,6 +634,54 @@ describe('runDriveSession', () => {
 
     const sessionPromise = runDriveSession('Alice', {}, deps);
     await openSocket(sockets);
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+  });
+
+  it('keeps Ctrl+C available while a raw-mode snapshot is pending', async () => {
+    let releaseSnapshot!: () => void;
+    const snapshotPending = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const { deps, sockets, stdin, inputStreams } = createHarness();
+    deps.captureAndRenderSnapshot = vi.fn(async () => {
+      await snapshotPending;
+      return { status: 'ok' };
+    }) as DriveDependencies['captureAndRenderSnapshot'];
+
+    const sessionPromise = runDriveSession('Alice', {}, deps);
+    await openSocket(sockets);
+    expect(stdin.isRaw).toBe(true);
+
+    stdin.type(Buffer.from('\x1b[0A'));
+    stdin.type(Buffer.from([0x03]));
+    await expect(sessionPromise).resolves.toBe(0);
+    expect(inputStreams[0].writes).toEqual([]);
+    releaseSnapshot();
+  });
+
+  it('waits for predictive echo seeding before forwarding initial input', async () => {
+    let releaseSeed!: () => void;
+    const seedPending = new Promise<void>((resolve) => {
+      releaseSeed = resolve;
+    });
+    const predictiveEcho = new FakePredictiveEcho();
+    predictiveEcho.seed = vi.fn(() => seedPending);
+    const { deps, sockets, stdin, inputStreams } = createHarness({ predictiveEcho });
+
+    const sessionPromise = runDriveSession('Alice', {}, deps);
+    await openSocket(sockets);
+    stdin.type(Buffer.from('before'));
+    expect(inputStreams[0].writes).toEqual([]);
+    expect(predictiveEcho.inputs).toEqual([]);
+
+    releaseSeed();
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setImmediate(resolve));
+    stdin.type(Buffer.from('after'));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(inputStreams[0].writes).toEqual(['after']);
+    expect(predictiveEcho.inputs).toEqual(['after']);
+
     stdin.type(Buffer.from([0x03]));
     await sessionPromise;
   });

--- a/packages/cli/src/cli/lib/attach-drive.test.ts
+++ b/packages/cli/src/cli/lib/attach-drive.test.ts
@@ -57,6 +57,7 @@ class FakeWebSocket implements DriveWebSocket {
 
 class FakeStdin implements DriveStdin {
   isTTY = true;
+  isRaw = false;
   setRawMode = vi.fn<(mode: boolean) => unknown>(() => undefined);
   resume = vi.fn(() => undefined);
   pause = vi.fn(() => undefined);
@@ -66,6 +67,7 @@ class FakeStdin implements DriveStdin {
   constructor() {
     this.setRawMode = vi.fn((mode: boolean) => {
       this.rawModeCalls.push(mode);
+      this.isRaw = mode;
       return undefined;
     });
   }
@@ -601,6 +603,32 @@ describe('runDriveSession', () => {
       expected_mode: 'manual_flush',
       expected_revision: '1',
     });
+  });
+
+  it('takes stdin raw before replaying a TUI snapshot', async () => {
+    const { deps, sockets, stdin } = createHarness();
+    deps.captureAndRenderSnapshot = vi.fn(async () => {
+      expect(stdin.isRaw).toBe(true);
+      return { status: 'ok' };
+    }) as DriveDependencies['captureAndRenderSnapshot'];
+
+    const sessionPromise = runDriveSession('Alice', {}, deps);
+    await openSocket(sockets);
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+  });
+
+  it('preserves an already-raw stdin on detach', async () => {
+    const { deps, sockets, stdin } = createHarness();
+    stdin.isRaw = true;
+
+    const sessionPromise = runDriveSession('Alice', {}, deps);
+    await openSocket(sockets);
+    expect(stdin.rawModeCalls).toEqual([]);
+
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+    expect(stdin.rawModeCalls).toEqual([]);
   });
 
   it('aborts before opening the WS when the broker rejects the mode flip', async () => {

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -105,6 +105,7 @@ export interface DriveSignalRegistrar {
 export interface DriveStdin {
   setRawMode?: (mode: boolean) => unknown;
   isTTY?: boolean;
+  isRaw?: boolean;
   resume(): unknown;
   pause(): unknown;
   on(event: 'data', listener: (chunk: Buffer) => void): unknown;
@@ -979,7 +980,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
 
     const socket = deps.createWebSocket(wsUrl, headers);
 
-    const openInputStreamAndTakeStdin = async (): Promise<void> => {
+    const openInputStreamAndSetRawMode = async (): Promise<void> => {
       try {
         inputStream = deps.openInputStream(connection, name);
         await inputStream.waitUntilOpen();
@@ -987,10 +988,21 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           closeInputStream();
           return;
         }
-        if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false) {
+        if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false && !deps.stdin.isRaw) {
           deps.stdin.setRawMode(true);
           rawModeWasSet = true;
         }
+      } catch (err: unknown) {
+        if (settled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`[drive] could not open PTY input stream: ${message}`);
+        finish(1);
+      }
+    };
+
+    const takeStdin = (): void => {
+      try {
+        if (settled) return;
         deps.stdin.resume();
         deps.stdin.on('data', stdinDataHandler);
         // Subscribe to local-terminal resize events at the same point
@@ -1021,17 +1033,18 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
       } catch (err: unknown) {
         if (settled) return;
         const message = err instanceof Error ? err.message : String(err);
-        deps.error(`[drive] could not open PTY input stream: ${message}`);
+        deps.error(`[drive] could not take terminal input: ${message}`);
         finish(1);
       }
     };
 
-    // Runs once the event WS is subscribed: paint the snapshot, seed
-    // predictive echo, reconcile buffered live output against the snapshot
-    // offset, forward the initial resize (now that we're subscribed, so its
-    // SIGWINCH repaint lands in the live stream instead of a dead zone before
-    // subscription), then open the input stream and take over stdin.
+    // Runs once the event WS is subscribed. Take over stdin before replaying
+    // the snapshot: a source TUI can enable mouse/focus/alternate-scroll
+    // reporting in that replay, and cooked-mode stdin would echo those reports
+    // as visible escape text until the later input-stream setup completed.
     const onSubscribed = async (): Promise<void> => {
+      await openInputStreamAndSetRawMode();
+      if (settled) return;
       const snapshot = await deps.captureAndRenderSnapshot(
         { url: connection.url, apiKey: connection.apiKey },
         name,
@@ -1073,10 +1086,10 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
       trackResize(initialResize);
       await initialResize;
       if (settled) return;
-      // Open the SDK input stream before taking over stdin. A failed stream
-      // should not leave the user's terminal in raw mode with nowhere to
-      // send bytes.
-      await openInputStreamAndTakeStdin();
+      // Input forwarding starts only after predictive echo has been seeded by
+      // the snapshot. Raw mode was already enabled above, so terminal reports
+      // could not echo during the setup window.
+      takeStdin();
     };
 
     // Hand off from the early restore handlers (installed before the awaited

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -789,7 +789,16 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
     };
 
     // ---- stdin handling ----
+    let stdinReady = false;
     const stdinDataHandler = (chunk: Buffer): void => {
+      // Raw mode starts before snapshot replay so terminal input reports cannot
+      // echo. Until the predictive echo model is seeded, discard all input
+      // except Ctrl+C: forwarding stale mouse/focus reports (or echoing user
+      // input against an unseeded screen) would be worse than dropping it.
+      if (!stdinReady) {
+        if (chunk.includes(0x03)) finish(0);
+        return;
+      }
       const outcome = parser.feed(chunk);
       if (outcome.forward.length > 0) {
         const stream = inputStream;
@@ -988,6 +997,11 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           closeInputStream();
           return;
         }
+        // Register the temporary input handler before raw mode. Ctrl+C is an
+        // ordinary byte in raw mode, so this keeps detach available while a
+        // snapshot fetch or initial resize is still pending.
+        deps.stdin.resume();
+        deps.stdin.on('data', stdinDataHandler);
         if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false && !deps.stdin.isRaw) {
           deps.stdin.setRawMode(true);
           rawModeWasSet = true;
@@ -1003,8 +1017,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
     const takeStdin = (): void => {
       try {
         if (settled) return;
-        deps.stdin.resume();
-        deps.stdin.on('data', stdinDataHandler);
+        stdinReady = true;
         // Subscribe to local-terminal resize events at the same point
         // we take over stdin so the lifecycles match — both go away in
         // `teardownStdin` on any exit path.
@@ -1069,7 +1082,17 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           );
           break;
       }
-      if (predictiveEcho) void predictiveEcho.seed(snapshotBytes);
+      if (predictiveEcho) {
+        try {
+          await predictiveEcho.seed(snapshotBytes);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          deps.log(`[drive] could not seed predictive echo: ${message}`);
+          finish(1);
+          return;
+        }
+        if (settled) return;
+      }
       terminalRows = pickInitialTerminalRows(state.initialLocalSize, snapshot.rows);
       // Track the snapshot bytes for boundary state before the first repaint.
       statusController.observeOutput(snapshotBytes);

--- a/packages/cli/src/cli/lib/attach-passthrough.test.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.test.ts
@@ -528,6 +528,54 @@ describe('runPassthroughSession', () => {
     expect(stdin.rawModeCalls).toEqual([true, false]);
   });
 
+  it('keeps Ctrl+C available while a raw-mode snapshot is pending', async () => {
+    let releaseSnapshot!: () => void;
+    const snapshotPending = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const { deps, sockets, stdin, inputStreams } = createHarness();
+    deps.captureAndRenderSnapshot = vi.fn(async () => {
+      await snapshotPending;
+      return { status: 'ok' };
+    }) as PassthroughDependencies['captureAndRenderSnapshot'];
+
+    const sessionPromise = runPassthroughSession('Alice', {}, deps);
+    await openSocket(sockets);
+    expect(stdin.isRaw).toBe(true);
+
+    stdin.type(Buffer.from('\x1b[0A'));
+    stdin.type(Buffer.from([0x03]));
+    await expect(sessionPromise).resolves.toBe(0);
+    expect(inputStreams[0].writes).toEqual([]);
+    releaseSnapshot();
+  });
+
+  it('waits for predictive echo seeding before forwarding initial input', async () => {
+    let releaseSeed!: () => void;
+    const seedPending = new Promise<void>((resolve) => {
+      releaseSeed = resolve;
+    });
+    const predictiveEcho = new FakePredictiveEcho();
+    predictiveEcho.seed = vi.fn(() => seedPending);
+    const { deps, sockets, stdin, inputStreams } = createHarness({ predictiveEcho });
+
+    const sessionPromise = runPassthroughSession('Alice', {}, deps);
+    await openSocket(sockets);
+    stdin.type(Buffer.from('before'));
+    expect(inputStreams[0].writes).toEqual([]);
+    expect(predictiveEcho.inputs).toEqual([]);
+
+    releaseSeed();
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setImmediate(resolve));
+    stdin.type(Buffer.from('after'));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(inputStreams[0].writes).toEqual(['after']);
+    expect(predictiveEcho.inputs).toEqual(['after']);
+
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+  });
+
   it('takes stdin raw before replaying a TUI snapshot', async () => {
     const { deps, sockets, stdin } = createHarness();
     deps.captureAndRenderSnapshot = vi.fn(async () => {

--- a/packages/cli/src/cli/lib/attach-passthrough.test.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.test.ts
@@ -57,6 +57,7 @@ class FakeWebSocket implements PassthroughWebSocket {
 
 class FakeStdin implements PassthroughStdin {
   isTTY = true;
+  isRaw = false;
   setRawMode = vi.fn<(mode: boolean) => unknown>(() => undefined);
   resume = vi.fn(() => undefined);
   pause = vi.fn(() => undefined);
@@ -66,6 +67,7 @@ class FakeStdin implements PassthroughStdin {
   constructor() {
     this.setRawMode = vi.fn((mode: boolean) => {
       this.rawModeCalls.push(mode);
+      this.isRaw = mode;
       return undefined;
     });
   }
@@ -524,6 +526,32 @@ describe('runPassthroughSession', () => {
       { mode: 'auto_inject', expected_mode: 'auto_inject', expected_revision: '1' },
     ]);
     expect(stdin.rawModeCalls).toEqual([true, false]);
+  });
+
+  it('takes stdin raw before replaying a TUI snapshot', async () => {
+    const { deps, sockets, stdin } = createHarness();
+    deps.captureAndRenderSnapshot = vi.fn(async () => {
+      expect(stdin.isRaw).toBe(true);
+      return { status: 'ok' };
+    }) as PassthroughDependencies['captureAndRenderSnapshot'];
+
+    const sessionPromise = runPassthroughSession('Alice', {}, deps);
+    await openSocket(sockets);
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+  });
+
+  it('preserves an already-raw stdin on detach', async () => {
+    const { deps, sockets, stdin } = createHarness();
+    stdin.isRaw = true;
+
+    const sessionPromise = runPassthroughSession('Alice', {}, deps);
+    await openSocket(sockets);
+    expect(stdin.rawModeCalls).toEqual([]);
+
+    stdin.type(Buffer.from([0x03]));
+    await sessionPromise;
+    expect(stdin.rawModeCalls).toEqual([]);
   });
 
   it('flips to auto_inject even when the worker was in manual_flush mode on attach, then restores on detach', async () => {

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -84,6 +84,7 @@ export interface PassthroughSignalRegistrar {
 export interface PassthroughStdin {
   setRawMode?: (mode: boolean) => unknown;
   isTTY?: boolean;
+  isRaw?: boolean;
   resume(): unknown;
   pause(): unknown;
   on(event: 'data', listener: (chunk: Buffer) => void): unknown;
@@ -611,7 +612,7 @@ export async function runPassthroughSession(
 
     const socket = deps.createWebSocket(wsUrl, headers);
 
-    const openInputStreamAndTakeStdin = async (): Promise<void> => {
+    const openInputStreamAndSetRawMode = async (): Promise<void> => {
       try {
         inputStream = deps.openInputStream(connection, name);
         await inputStream.waitUntilOpen();
@@ -619,10 +620,21 @@ export async function runPassthroughSession(
           closeInputStream();
           return;
         }
-        if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false) {
+        if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false && !deps.stdin.isRaw) {
           deps.stdin.setRawMode(true);
           rawModeWasSet = true;
         }
+      } catch (err: unknown) {
+        if (settled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`[passthrough] could not open PTY input stream: ${message}`);
+        finish(1);
+      }
+    };
+
+    const takeStdin = (): void => {
+      try {
+        if (settled) return;
         deps.stdin.resume();
         deps.stdin.on('data', stdinDataHandler);
         unsubscribeResize = deps.terminal.onResize(resizeHandler);
@@ -651,16 +663,18 @@ export async function runPassthroughSession(
       } catch (err: unknown) {
         if (settled) return;
         const message = err instanceof Error ? err.message : String(err);
-        deps.error(`[passthrough] could not open PTY input stream: ${message}`);
+        deps.error(`[passthrough] could not take terminal input: ${message}`);
         finish(1);
       }
     };
 
-    // Runs once the event WS is subscribed: paint the snapshot, seed
-    // predictive echo, reconcile buffered live output, forward the initial
-    // resize (now that we're subscribed, so its SIGWINCH repaint lands in the
-    // live stream rather than a dead zone), then take over stdin.
+    // Runs once the event WS is subscribed. Take over stdin before replaying
+    // the snapshot: a source TUI can enable mouse/focus/alternate-scroll
+    // reporting in that replay, and cooked-mode stdin would echo those reports
+    // as visible escape text until the later input-stream setup completed.
     const onSubscribed = async (): Promise<void> => {
+      await openInputStreamAndSetRawMode();
+      if (settled) return;
       const snapshot = await deps.captureAndRenderSnapshot(
         { url: connection.url, apiKey: connection.apiKey },
         name,
@@ -702,7 +716,10 @@ export async function runPassthroughSession(
       trackResize(initialResize);
       await initialResize;
       if (settled) return;
-      await openInputStreamAndTakeStdin();
+      // Input forwarding starts only after predictive echo has been seeded by
+      // the snapshot. Raw mode was already enabled above, so terminal reports
+      // could not echo during the setup window.
+      takeStdin();
     };
 
     // Hand off from the early restore handlers to the fuller loop handlers.

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -445,7 +445,16 @@ export async function runPassthroughSession(
       paintStatus();
     };
 
+    let stdinReady = false;
     const stdinDataHandler = (chunk: Buffer): void => {
+      // Raw mode starts before snapshot replay so terminal input reports cannot
+      // echo. Until the predictive echo model is seeded, discard all input
+      // except Ctrl+C: forwarding stale mouse/focus reports (or echoing user
+      // input against an unseeded screen) would be worse than dropping it.
+      if (!stdinReady) {
+        if (chunk.includes(0x03)) finish(0);
+        return;
+      }
       const outcome = parser.feed(chunk);
       if (outcome.forward.length > 0) {
         const stream = inputStream;
@@ -620,6 +629,11 @@ export async function runPassthroughSession(
           closeInputStream();
           return;
         }
+        // Register the temporary input handler before raw mode. Ctrl+C is an
+        // ordinary byte in raw mode, so this keeps detach available while a
+        // snapshot fetch or initial resize is still pending.
+        deps.stdin.resume();
+        deps.stdin.on('data', stdinDataHandler);
         if (typeof deps.stdin.setRawMode === 'function' && deps.stdin.isTTY !== false && !deps.stdin.isRaw) {
           deps.stdin.setRawMode(true);
           rawModeWasSet = true;
@@ -635,8 +649,7 @@ export async function runPassthroughSession(
     const takeStdin = (): void => {
       try {
         if (settled) return;
-        deps.stdin.resume();
-        deps.stdin.on('data', stdinDataHandler);
+        stdinReady = true;
         unsubscribeResize = deps.terminal.onResize(resizeHandler);
         // Periodic ownership re-assert (see `ownershipReassertMs`): keeps the
         // single-resizer lease alive on an idle-but-live session; the broker
@@ -699,7 +712,17 @@ export async function runPassthroughSession(
           );
           break;
       }
-      if (predictiveEcho) void predictiveEcho.seed(snapshotBytes);
+      if (predictiveEcho) {
+        try {
+          await predictiveEcho.seed(snapshotBytes);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          deps.log(`[passthrough] could not seed predictive echo: ${message}`);
+          finish(1);
+          return;
+        }
+        if (settled) return;
+      }
       terminalRows = pickInitialTerminalRows(initialLocalSize, snapshot.rows);
       // Track the snapshot bytes for boundary state before the first repaint.
       statusController.observeOutput(snapshotBytes);


### PR DESCRIPTION
## Summary

- takes `drive` and `passthrough` stdin raw before replaying a watched terminal's snapshot
- preserves an inherited raw stdin state instead of forcing cooked mode on detach
- adds regression coverage for snapshot ordering and nested-TUI input restoration

## Root cause

Interactive attach modes replayed terminal state before owning stdin. A watched TUI could enable mouse or alternate-scroll reporting during that window, causing the terminal driver to echo generated input reports as visible escape characters. Both modes also unconditionally restored cooked input, disrupting callers that were already using raw mode.

## Validation

- `npx vitest run packages/cli/src/cli/lib/attach-drive.test.ts packages/cli/src/cli/lib/attach-passthrough.test.ts`
- `npx eslint packages/cli/src/cli/lib/attach-drive.ts packages/cli/src/cli/lib/attach-drive.test.ts packages/cli/src/cli/lib/attach-passthrough.ts packages/cli/src/cli/lib/attach-passthrough.test.ts`
- `npx tsc --noEmit -p packages/cli/tsconfig.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

