### PR TITLE
chore: exclude relay-feature-guardian from the changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1830,6 +1830,16 @@ jobs:
             const text = title.toLowerCase();
             if (type === 'chore' && (scope === 'release' || scope === 'prerelease')) return true;
             if (scope === 'trajectories' || scope === 'comments') return true;
+            // relay-feature-guardian is an internal Slack feature-check agent, not a
+            // user-facing Relay surface — keep its changes out of the release changelog.
+            if (scope === 'feature-guardian' || scope === 'relay-feature-guardian') return true;
+            if (text.includes('relay-feature-guardian')) return true;
+            if (
+              files.length > 0 &&
+              files.every(file => file.startsWith('.agentworkforce/agents/relay-feature-guardian/'))
+            ) {
+              return true;
+            }
             if (text.includes('compact trajectories')) return true;
             if (text.includes('record ') && text.includes('trajectory')) return true;
             if (text.includes('address pr review')) return true;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,11 @@ Do not add web-only changes to the changelog. Omit unpublished or withdrawn
 versions as release headings; move their shipped user-visible changes into the
 corrected published release.
 
+Do not add `relay-feature-guardian` changes to the changelog. It is an internal
+Slack feature-check agent (`.agentworkforce/agents/relay-feature-guardian/`),
+not a user-facing Relay surface, so its fixes never belong in the release
+narrative. The release workflow also skips these commits automatically.
+
 ## .trajectories Must Be Tracked
 
 **CRITICAL: Never add `.agentworkforce/trajectories/` to `.gitignore`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay agent attach --mode drive|passthrough` now takes raw input before replaying terminal state and preserves inherited raw mode on detach, preventing mouse-report escape characters and parent-TUI input regressions.
-- `relay-feature-guardian` now treats an admitted Slack write without a provider receipt as a retry-pending warning, retaining its checkpoint and idempotency key instead of failing the guardian run.
 
 ## [11.0.1] - 2026-07-22
 
@@ -66,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay cloud enroll --workspace` now validates and resolves Cloud UUIDs and unified `rw_` IDs before minting, and reports unresolvable identifiers instead of mislabeling them as permission failures.
-- `relay-feature-guardian` now picker-gates its Slack mirror to the configured output channel, moves checks off the fleet's shared Claude subscription, and surfaces failed posts as failed runs instead of silently reporting success.
 
 ## [10.6.5] - 2026-07-19
 
@@ -85,7 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `agent-relay integration` now discovers relayfile control-plane capabilities before sending API v3 headers, fails fast with upgrade and restart guidance for incompatible daemons, and safely replaces stale daemons when a compatible binary is installed.
 - `AgentRelaySDK` now maps Relaycast lifecycle states onto its existing Swift presence states, so root-package consumers compile with Relaycast 6.1 and later while package-local builds remain compatible with 6.0.5.
-- `relay-feature-guardian` now limits read mirrors to the feature manifest and workspace memory while keeping Slack write-only to its configured output channel, and advances its exact, revision-safe cycle checkpoint only after a bounded wait returns a real Slack receipt while safely reconciling retired manifest features.
 - `agent-relay-broker` and `@agent-relay/utils` now preserve mise/asdf/rtx-style CLI shims when spawning provider workers, so Codex, Claude, Gemini, and other agent CLIs installed via a version manager receive their own permission flags (e.g. `--dangerously-bypass-approvals-and-sandbox`) instead of the manager binary rejecting them.
 
 ## [10.6.3] - 2026-07-17


### PR DESCRIPTION
## Summary

`relay-feature-guardian` is an internal Slack feature-check agent (`.agentworkforce/agents/relay-feature-guardian/`), not a user-facing Relay surface, yet its fixes had been landing in the cross-package release changelog. This removes the existing entries and stops future ones.

## Changes

- **`CHANGELOG.md`** — delete the three curated bullets describing the guardian agent (under `[11.0.2]`, `[10.6.6]`, `[10.6.4]`).
- **`.github/workflows/publish.yml`** — the release changelog generator's `shouldSkip()` now drops any commit that is scoped to `feature-guardian`/`relay-feature-guardian`, mentions `relay-feature-guardian` in its title, or touches only files under `.agentworkforce/agents/relay-feature-guardian/`.
- **`AGENTS.md`** (symlinked from `CLAUDE.md`) — document that guardian changes never belong in the user-facing release changelog.

## Notes

- The guardian was never an *author* auto-writing entries — it was the *subject* of hand-curated `[Unreleased]` bullets. The doc rule stops the common curated path; the workflow filter is the automated backstop for the commit-fallback path.
- Embedded generator script re-verified with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

