### PR TITLE
feat(broker): forward the anonymous distinct id to relaycast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The broker now sends its anonymous telemetry id (`X-Agent-Relay-Distinct-Id`) and origin actor with its Relaycast requests, so hosted usage can be attributed to an install instead of only to a workspace. Nothing is sent when telemetry is opted out.
+- The broker now sends its anonymous telemetry id (`X-Agent-Relay-Distinct-Id`) and origin actor with its Relaycast requests, so hosted usage can be attributed to an install instead of only to a workspace. The id header is omitted when telemetry is opted out; requests and origin actor are unaffected.
+
+### Fixed
+
+- The broker now reads its telemetry preference and machine-id files from `AGENT_RELAY_DATA_DIR` when set, matching the CLI. It previously only read `~/.agentworkforce/relay/telemetry.json`, so an opt-out written by `agent-relay telemetry disable` under a configured data directory was ignored.
 
 ## [11.1.1] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Changed
+
+- The broker now sends its anonymous telemetry id (`X-Agent-Relay-Distinct-Id`) and origin actor with its Relaycast requests, so hosted usage can be attributed to an install instead of only to a workspace. Nothing is sent when telemetry is opted out.
 
 ## [11.1.1] - 2026-07-23
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -20,6 +20,8 @@ Telemetry allows us to better identify bugs and gain visibility on usage pattern
 
 Agent Relay uses an anonymous, hashed machine ID to correlate events. No personally identifiable information is collected.
 
+When Agent Relay talks to Relaycast Cloud, it sends that same anonymous ID with its requests (the `X-Agent-Relay-Distinct-Id` header) so server-side usage can be attributed to an install rather than to a workspace alone. It is not sent when telemetry is disabled by any of the methods below.
+
 **Note**: This list is regularly audited to ensure its accuracy.
 
 ## What is NOT collected?

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use futures_util::{Sink, SinkExt, StreamExt};
-use relaycast::AGENT_RELAY_DISTINCT_ID_HEADER;
+use relaycast::{AGENT_RELAY_DISTINCT_ID_HEADER, ORIGIN_ACTOR_HEADER};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, oneshot};
@@ -1492,15 +1492,13 @@ async fn run_connected_once(
     // handshake. Both are best-effort: a header that won't parse is skipped, it
     // never fails the connection.
     if let Ok(value) = crate::telemetry::BROKER_ORIGIN_ACTOR.parse() {
-        request
-            .headers_mut()
-            .insert("x-relaycast-origin-actor", value);
+        request.headers_mut().insert(ORIGIN_ACTOR_HEADER, value);
     }
     if let Some(distinct_id) = crate::telemetry::agent_relay_distinct_id() {
         if let Ok(value) = distinct_id.parse() {
             request
                 .headers_mut()
-                .insert("x-agent-relay-distinct-id", value);
+                .insert(AGENT_RELAY_DISTINCT_ID_HEADER, value);
         }
     }
 

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use futures_util::{Sink, SinkExt, StreamExt};
+use relaycast::AGENT_RELAY_DISTINCT_ID_HEADER;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, oneshot};
@@ -254,7 +255,7 @@ pub(crate) async fn mint_node_token(
     // final iteration returns the last error instead of sleeping again.
     #[allow(clippy::needless_range_loop)]
     for attempt in 0..=CREATE_NODE_RETRY_BACKOFFS_MS.len() {
-        let response = match client
+        let mut builder = client
             .post(&url)
             .bearer_auth(workspace_key)
             .header("X-SDK-Version", crate::util::version::broker_version())
@@ -266,11 +267,11 @@ pub(crate) async fn mint_node_token(
             .header(
                 "X-Relaycast-Origin-Actor",
                 crate::telemetry::BROKER_ORIGIN_ACTOR,
-            )
-            .json(&request)
-            .send()
-            .await
-        {
+            );
+        if let Some(distinct_id) = crate::telemetry::agent_relay_distinct_id() {
+            builder = builder.header(AGENT_RELAY_DISTINCT_ID_HEADER, distinct_id);
+        }
+        let response = match builder.json(&request).send().await {
             Ok(response) => response,
             Err(error) => {
                 let mint_error = CreateNodeMintError::Http(error);
@@ -1484,6 +1485,22 @@ async fn run_connected_once(
         Err(error) => {
             tracing::warn!(target = "relay_broker::fleet", error = %error, "invalid fleet node token header");
             return ControlRunResult::Disconnected;
+        }
+    }
+
+    // Telemetry attribution for the node session the gateway opens off this
+    // handshake. Both are best-effort: a header that won't parse is skipped, it
+    // never fails the connection.
+    if let Ok(value) = crate::telemetry::BROKER_ORIGIN_ACTOR.parse() {
+        request
+            .headers_mut()
+            .insert("x-relaycast-origin-actor", value);
+    }
+    if let Some(distinct_id) = crate::telemetry::agent_relay_distinct_id() {
+        if let Ok(value) = distinct_id.parse() {
+            request
+                .headers_mut()
+                .insert("x-agent-relay-distinct-id", value);
         }
     }
 

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -858,6 +858,9 @@ fn auth_http_status(err: &anyhow::Error) -> Option<StatusCode> {
 fn build_relay_client(api_key: &str, base_url: Option<&str>) -> Result<RelayCast> {
     let mut opts =
         RelayCastOptions::new(api_key).with_origin_actor(crate::telemetry::BROKER_ORIGIN_ACTOR);
+    if let Some(distinct_id) = crate::telemetry::agent_relay_distinct_id() {
+        opts = opts.with_agent_relay_distinct_id(distinct_id);
+    }
     if let Some(base_url) = base_url {
         opts = opts.with_base_url(base_url);
     }

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -781,6 +781,9 @@ async fn mute_self_channel(agent_client: &AgentClient, channel: &str) {
 fn build_relay_client(api_key: &str, base_url: Option<&str>) -> Option<RelayCast> {
     let mut opts =
         RelayCastOptions::new(api_key).with_origin_actor(crate::telemetry::BROKER_ORIGIN_ACTOR);
+    if let Some(distinct_id) = crate::telemetry::agent_relay_distinct_id() {
+        opts = opts.with_agent_relay_distinct_id(distinct_id);
+    }
     if let Some(base_url) = base_url {
         opts = opts.with_base_url(base_url);
     }

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -474,6 +474,51 @@ pub(crate) fn orchestrator_harness_opt() -> Option<&'static str> {
 /// `agent-relay-cli/agent/<harness>`. See cloud/plans/origin-actor.md.
 pub(crate) const BROKER_ORIGIN_ACTOR: &str = "agent-relay-cli/cli";
 
+/// Env var carrying the anonymous distinct id, exported by the agent-relay CLI
+/// so the broker and every spawned agent report as the same machine.
+const AGENT_RELAY_DISTINCT_ID_ENV: &str = "AGENT_RELAY_DISTINCT_ID";
+
+/// Anonymous machine id forwarded to relaycast as `X-Agent-Relay-Distinct-Id`,
+/// or `None` when the user has opted out of telemetry.
+///
+/// Relaycast's server-side product events key on this when present (see the
+/// engine's `emitServerEvent`), which is what lets a workspace-create or an
+/// agent-registration be attributed back to an install. Without it every
+/// broker-driven server event is keyed by workspace id alone, so "how many
+/// distinct installs are using this" is unanswerable.
+///
+/// Prefer the CLI-exported env var so the CLI, the broker, and the agents it
+/// spawns all report one id; fall back to the same hashed machine id the
+/// telemetry client uses, for a broker started outside the CLI. This is the
+/// same anonymous value already sent with the broker's own PostHog events —
+/// never a hostname, account, or path. Resolved once per process.
+pub(crate) fn agent_relay_distinct_id() -> Option<&'static str> {
+    static CACHE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            resolve_distinct_id(
+                TelemetryClient::check_enabled(),
+                env_nonempty(AGENT_RELAY_DISTINCT_ID_ENV),
+                || load_or_create_machine_id().map(|id| anonymous_id(&id)),
+            )
+        })
+        .as_deref()
+}
+
+/// Policy half of [`agent_relay_distinct_id`], split out so the opt-out
+/// behaviour is testable without touching process-wide env or the cache.
+/// `machine_id` is lazy: an opted-out broker must not even derive one.
+fn resolve_distinct_id(
+    enabled: bool,
+    env_value: Option<String>,
+    machine_id: impl FnOnce() -> Option<String>,
+) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+    env_value.or_else(machine_id)
+}
+
 /// Build the `origin_actor` path for a spawned agent:
 /// `agent-relay-cli/agent/<harness>[@<model>]`. The model (when the broker knows
 /// it from the spawn request) is appended so server telemetry can segment by
@@ -1136,6 +1181,33 @@ mod tests {
         );
         assert_eq!(sanitize_orchestrator_harness("bad\nvalue"), None);
         assert_eq!(sanitize_orchestrator_harness(""), None);
+    }
+
+    #[test]
+    fn resolve_distinct_id_is_none_when_telemetry_is_disabled() {
+        // Opted out: neither the exported id nor a derived machine id may leak.
+        let mut derived = false;
+        let resolved = resolve_distinct_id(false, Some("abc123".to_string()), || {
+            derived = true;
+            Some("machine".to_string())
+        });
+        assert_eq!(resolved, None);
+        assert!(!derived, "machine id must not be derived when opted out");
+    }
+
+    #[test]
+    fn resolve_distinct_id_prefers_the_exported_env_value() {
+        let resolved = resolve_distinct_id(true, Some("abc123".to_string()), || {
+            Some("machine".to_string())
+        });
+        assert_eq!(resolved, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn resolve_distinct_id_falls_back_to_the_machine_id() {
+        let resolved = resolve_distinct_id(true, None, || Some("machine".to_string()));
+        assert_eq!(resolved, Some("machine".to_string()));
+        assert_eq!(resolve_distinct_id(true, None, || None), None);
     }
 
     #[test]

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -7,9 +7,12 @@
 //!   - Set `AGENT_RELAY_TELEMETRY_DISABLED=1` (or `true`)
 //!   - Set `DO_NOT_TRACK=1` (cross-tool convention, https://consoledonottrack.com)
 //!   - Or write `{"enabled": false}` to `~/.agentworkforce/relay/telemetry.json`
+//!     (or `$AGENT_RELAY_DATA_DIR/telemetry.json` when that is set — the same
+//!     file `agent-relay telemetry disable` writes)
 
 use std::path::PathBuf;
 
+use relaycast::sanitize_agent_relay_distinct_id;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -207,8 +210,33 @@ struct TelemetryPrefs {
     notified_at: Option<String>,
 }
 
+/// Override for both the preference file and the machine-id file, matching the
+/// TypeScript CLI (`telemetry/config.ts`, `telemetry/machine-id.ts`). When set,
+/// `agent-relay telemetry disable` writes the opt-out there — so the broker has
+/// to read it from the same place or it would ignore an explicit opt-out.
+const DATA_DIR_ENV: &str = "AGENT_RELAY_DATA_DIR";
+
+fn data_dir_override() -> Option<PathBuf> {
+    env_nonempty(DATA_DIR_ENV).map(PathBuf::from)
+}
+
+/// Resolve a telemetry data file: the `AGENT_RELAY_DATA_DIR` override wins,
+/// otherwise the platform default. Pure, so the precedence is testable without
+/// mutating process-wide env from a parallel test.
+fn data_file_path(
+    override_dir: Option<PathBuf>,
+    default_dir: Option<PathBuf>,
+    file_name: &str,
+) -> Option<PathBuf> {
+    override_dir.or(default_dir).map(|dir| dir.join(file_name))
+}
+
 fn prefs_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".agentworkforce/relay").join("telemetry.json"))
+    data_file_path(
+        data_dir_override(),
+        dirs::home_dir().map(|h| h.join(".agentworkforce/relay")),
+        "telemetry.json",
+    )
 }
 
 fn load_prefs() -> TelemetryPrefs {
@@ -238,15 +266,20 @@ fn save_prefs(prefs: &TelemetryPrefs) {
 // ---------------------------------------------------------------------------
 
 fn machine_id_path() -> Option<PathBuf> {
-    // Use ~/.local/share regardless of platform (matches the spec and
-    // the Node.js SDK convention).
-    dirs::home_dir().map(|h| {
-        h.join(".local")
-            .join("share")
-            .join("agentworkforce")
-            .join("relay")
-            .join("machine-id")
-    })
+    // `AGENT_RELAY_DATA_DIR` wins, then ~/.local/share regardless of platform
+    // (matches the spec and the Node.js SDK convention). Both halves mirror the
+    // CLI's `getMachineIdPath()`, so the CLI and the broker derive the same id
+    // from the same file instead of minting two ids for one machine.
+    data_file_path(
+        data_dir_override(),
+        dirs::home_dir().map(|h| {
+            h.join(".local")
+                .join("share")
+                .join("agentworkforce")
+                .join("relay")
+        }),
+        "machine-id",
+    )
 }
 
 fn load_or_create_machine_id() -> Option<String> {
@@ -508,6 +541,12 @@ pub(crate) fn agent_relay_distinct_id() -> Option<&'static str> {
 /// Policy half of [`agent_relay_distinct_id`], split out so the opt-out
 /// behaviour is testable without touching process-wide env or the cache.
 /// `machine_id` is lazy: an opted-out broker must not even derive one.
+///
+/// The resolved value is sanitized against the SDK's wire contract before any
+/// caller builds a header from it. The env var is caller-supplied, and an
+/// invalid one (a newline, a non-ASCII character) would otherwise be handed to
+/// `RequestBuilder::header`, which stores the conversion error and fails the
+/// request on every retry — optional telemetry must never break connectivity.
 fn resolve_distinct_id(
     enabled: bool,
     env_value: Option<String>,
@@ -516,7 +555,7 @@ fn resolve_distinct_id(
     if !enabled {
         return None;
     }
-    env_value.or_else(machine_id)
+    sanitize_agent_relay_distinct_id(env_value.or_else(machine_id))
 }
 
 /// Build the `origin_actor` path for a spawned agent:
@@ -1208,6 +1247,50 @@ mod tests {
         let resolved = resolve_distinct_id(true, None, || Some("machine".to_string()));
         assert_eq!(resolved, Some("machine".to_string()));
         assert_eq!(resolve_distinct_id(true, None, || None), None);
+    }
+
+    #[test]
+    fn resolve_distinct_id_drops_a_header_invalid_env_value() {
+        // A caller-supplied value that can't be a header value must be dropped,
+        // not forwarded — reqwest would store the conversion error and fail the
+        // request on every retry. Matches the TS contract, which sends no header
+        // at all rather than falling back when the env value is malformed.
+        for bad in ["abc\ndef", "naïve", "has space"] {
+            assert_eq!(
+                resolve_distinct_id(true, Some(bad.to_string()), || Some("machine".to_string())),
+                None,
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn data_file_path_prefers_the_configured_data_dir() {
+        // `agent-relay telemetry disable` writes the opt-out to
+        // AGENT_RELAY_DATA_DIR when set, so the broker must read it from there.
+        assert_eq!(
+            data_file_path(
+                Some(PathBuf::from("/custom/dir")),
+                Some(PathBuf::from("/home/u/.agentworkforce/relay")),
+                "telemetry.json",
+            ),
+            Some(PathBuf::from("/custom/dir/telemetry.json"))
+        );
+    }
+
+    #[test]
+    fn data_file_path_falls_back_to_the_platform_default() {
+        assert_eq!(
+            data_file_path(
+                None,
+                Some(PathBuf::from("/home/u/.agentworkforce/relay")),
+                "telemetry.json"
+            ),
+            Some(PathBuf::from(
+                "/home/u/.agentworkforce/relay/telemetry.json"
+            ))
+        );
+        assert_eq!(data_file_path(None, None, "telemetry.json"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The broker sends `X-Relaycast-Origin-Actor` on its relaycast traffic but never `X-Agent-Relay-Distinct-Id`. Relaycast's `emitServerEvent` keys on that header when present (`distinctId: clientDistinctId ?? workspaceId`), so without it every server event the broker drives — node sessions, agent registration, messages, actions — is attributed to a workspace id alone. That makes "how many distinct installs created a workspace" and "how many are still active a week later" unanswerable server-side, even though the broker already computes exactly the id needed.

The TypeScript SDK already forwards it (`packages/cloud/src/telemetry-headers.ts`), and the Rust SDK already supports it (`with_agent_relay_distinct_id`, pinned `relaycast = "=6.0.0"`) — the broker just never passed one.

### Changes

- **`telemetry.rs`** — new process-wide `agent_relay_distinct_id()`:
  - Prefers the CLI-exported `AGENT_RELAY_DISTINCT_ID`, so the CLI, the broker, and the agents it spawns all report as one machine.
  - Falls back to the same hashed machine id the telemetry client uses, for a broker started outside the CLI.
  - Returns `None` whenever telemetry is opted out (`AGENT_RELAY_TELEMETRY_DISABLED`, `DO_NOT_TRACK`, or the prefs file), reusing the existing `check_enabled()` so there's one opt-out policy.
  - The machine id is derived lazily, so an opted-out broker never even computes one.
  - Policy is split into a pure `resolve_distinct_id` so the opt-out behavior is unit-testable without touching process env or the cache.
- **`relaycast/auth.rs`, `relaycast/ws.rs`** — pass it into `RelayCastOptions`.
- **`node_control.rs`** — send it on the node-token mint (`POST /v1/nodes`) and on the `/v1/node/ws` handshake. The handshake also now carries the origin actor, which it was missing entirely — without it the node session events the gateway emits off that handshake are all attributed to `unknown`. Both header inserts are best-effort and never fail the connection.

The value is the same anonymous hashed id already sent with the broker's own PostHog events — never a hostname, account, or path. `TELEMETRY.md` is updated to say it's forwarded to Relaycast Cloud, and that it isn't sent when telemetry is disabled.

Pairs with [relaycast-cloud#46](https://github.com/AgentWorkforce/relaycast-cloud/pull/46), which adds the node session events this attribution feeds.

## Test Plan

- [x] Tests added/updated — three unit tests on `resolve_distinct_id` covering the opt-out (asserting the machine id isn't even derived), the env-var preference, and the machine-id fallback
- [x] `cargo test -p agent-relay-broker --lib telemetry` — 24 passing
- [x] `cargo clippy -p agent-relay-broker --all-targets` — no new warnings (the 3 reported are pre-existing, in files this PR doesn't touch)
- [x] `cargo fmt --check` clean

## Screenshots

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxUMkEa2foSTbw88sqEFWA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

