### PR TITLE
Resident lead seat: relay agent under chief; relay roster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,13 @@ Your trajectory helps others understand:
 Future agents can query past trajectories to learn from your decisions.
 
 <!-- prpm:snippet:end @agent-workforce/trail-snippet@1.1.2 -->
+
+## Resident lead
+
+The resident `relay` agent is this repo's lead. Reports to **chief**
+(Will → chief → relay; no engineering department is seated yet). One
+writer: the resident is sole writer of this repo while online; delegates
+use worktrees off origin/main (others — including Khaliq and bots — work
+this repo in parallel). Session start: this file, `git log --oneline -15`,
+relay inbox. ACK / progress / DONE with evidence on every assignment.
+Publishing (npm, crates, GitHub releases) is gated on chief green-light.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,3 +263,22 @@ use worktrees off origin/main (others — including Khaliq and bots — work
 this repo in parallel). Session start: this file, `git log --oneline -15`,
 relay inbox. ACK / progress / DONE with evidence on every assignment.
 Publishing (npm, crates, GitHub releases) is gated on chief green-light.
+
+### Standing board (2026-07-29 — delete entries as they close)
+
+- Telemetry identity-leak cluster: merged as PR #1363; CLI stayed 11.2.0
+  (no release cut yet — release-train needs chief green-light).
+- Secrets fix train (issue #1379): PR A = #1380 (CLI output/error masking,
+  key off argv) + required companion relayfile#380 which must merge and
+  release FIRST (relayfile scrapes raw secrets from CLI output and error
+  text). PR B (Rust file modes) and PR C (--mcp-config argv→file; must
+  also update .claude/rules/mcp-injection.md) are unstarted — full spec
+  in #1379. #1380 unblocks the fleet-wide credential rotation.
+- Open issue batch: #1378 (fresh `node up` silently mints a workspace),
+  #1381 (teams.json per-agent model pinning gap; `claude:opus` doc syntax
+  is dead), #1382 (attach pairs broker URL/key from different sources;
+  delete chief's orgchart env-unset workaround when fixed), #1383
+  (non-Error rejections render as `[object Object]`).
+- Also pending: 64 dependabot alerts on main (1 critical); skills repo
+  relay-team/relay-pipeline/relay-fanout SKILL.mds still instruct printing
+  raw observer URLs — unsatisfiable once #1380 lands.

--- a/teams.json
+++ b/teams.json
@@ -1,0 +1,12 @@
+{
+  "team": "relay",
+  "autoSpawn": true,
+  "agents": [
+    {
+      "name": "relay",
+      "cli": "claude",
+      "role": "resident lead — relay (core product)",
+      "task": "Read CLAUDE.md fully (including the Resident lead section) and follow its guidance plus the session-start ritual: CLAUDE.md, recent git log, relay inbox. You are the resident relay repo lead: stay online, answer DMs from chief and Will, never self-remove. Assignments arrive by DM from chief; ACK on start, DONE with evidence. Publishing releases needs chief green-light."
+    }
+  ]
+}

--- a/teams.json
+++ b/teams.json
@@ -4,7 +4,7 @@
   "agents": [
     {
       "name": "relay",
-      "cli": "claude",
+      "cli": "codex",
       "role": "resident lead — relay (core product)",
       "task": "Read CLAUDE.md fully (including the Resident lead section) and follow its guidance plus the session-start ritual: CLAUDE.md, recent git log, relay inbox. You are the resident relay repo lead: stay online, answer DMs from chief and Will, never self-remove. Assignments arrive by DM from chief; ACK on start, DONE with evidence. Publishing releases needs chief green-light."
     }


### PR DESCRIPTION
Seats the resident relay lead in the org files: AGENTS.md declares the relay agent under chief, and teams.json carries the relay roster entry.

Authored by Will locally (was sitting unpushed on the local main checkout); moved to a branch so main stays PR-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

