### PR TITLE
chore: ignore generated agent runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ pnpm-debug.log*
 # Relay runtime artifacts
 *.sock
 *.pid
+.agent-runs/
+INCIDENT-*.md
 
 # Local test artifacts
 .agent-relay-test-*/


### PR DESCRIPTION
## What changed

- Ignore `.agent-runs/` runtime state.
- Ignore generated `INCIDENT-*.md` recovery artifacts.

## Why

The repo already ignored logs, `.npm-cache`, and broker state under
`.agentworkforce/relay/`, but these two generated artifact classes could still
appear as untracked product-repo content.

The broader `.agentworkforce/` tree remains trackable because this repository
intentionally versions product assets and required trajectory records there.

## Validation

- `git check-ignore -v` confirms all required runtime samples are ignored.
- `git check-ignore` confirms `.agentworkforce/trajectories/` remains trackable.
- `git ls-files` found no tracked `.agent-runs/`, `.npm-cache/`,
  `INCIDENT-*.md`, or `*.log` artifacts.
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

