### PR TITLE
chore: relay resident seat runs claude opus

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -4,7 +4,7 @@
   "agents": [
     {
       "name": "relay",
-      "cli": "codex",
+      "cli": "claude --model opus",
       "role": "resident lead — relay (core product)",
       "task": "Read CLAUDE.md fully (including the Resident lead section) and follow its guidance plus the session-start ritual: CLAUDE.md, recent git log, relay inbox. You are the resident relay repo lead: stay online, answer DMs from chief and Will, never self-remove. Assignments arrive by DM from chief; ACK on start, DONE with evidence. Publishing releases needs chief green-light."
     }


### PR DESCRIPTION
The relay resident lead seat runs on the claude harness with the opus model, matching the cmo/cpo/cso residents.

`teams.json` declares `"cli": "claude --model opus"`, so a broker restart or autoSpawn brings the seat back on claude rather than codex. The live seat was already moved to claude opus by in-place surgery (`node agent release` + `node agent spawn claude --model opus --name relay`) during the codex quota outage; this makes the roster match the running fleet.

Role and task text are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

