### PR TITLE
fix(verify): make Slack delivery work in the cloud sandbox

### DIFF
--- a/workflows/audit-feature-manifest.ts
+++ b/workflows/audit-feature-manifest.ts
@@ -84,6 +84,23 @@ NIGHTCTO_EVIDENCE_URL="$(printenv NIGHTCTO_EVIDENCE_URL || true)"
 NIGHTCTO_EVIDENCE_TOKEN="$(printenv NIGHTCTO_EVIDENCE_TOKEN || true)"
 CLOUD_API_URL="$(printenv CLOUD_API_URL || true)"
 CLOUD_API_TOKEN="$(printenv CLOUD_API_TOKEN || true)"
+# The cloud sandbox injects CLOUD_API_ACCESS_TOKEN, not CLOUD_API_TOKEN (see
+# the launcher's env bundle), but @relayflows/slack-primitive only reads
+# CLOUD_API_TOKEN. Without this bridge every scheduled run fails Slack
+# delivery with auth_token_missing. github-primitive already falls back the
+# same way (RELAY_CLOUD_API_TOKEN -> CLOUD_API_ACCESS_TOKEN); slack does not.
+if [ -z "$CLOUD_API_TOKEN" ]; then
+  CLOUD_API_TOKEN="$(printenv RELAY_CLOUD_API_TOKEN || true)"
+fi
+if [ -z "$CLOUD_API_TOKEN" ]; then
+  CLOUD_API_TOKEN="$(printenv CLOUD_API_ACCESS_TOKEN || true)"
+fi
+
+# These are read by the node children this workflow writes and runs (the Slack
+# post script), so they must be exported, not just assigned. Plain assignment
+# left the child seeing only the original process env, which silently defeated
+# the fallback above.
+export CLOUD_API_URL CLOUD_API_TOKEN
 RELAY_CLI="$(printenv RELAY_CLI || true)"
 VERIFY_ENVIRONMENT="$(printenv VERIFY_ENVIRONMENT || true)"
 if [ -z "$POSTHOG_HOST" ]; then POSTHOG_HOST="https://i.agentrelay.com"; fi

--- a/workflows/verify-features.ts
+++ b/workflows/verify-features.ts
@@ -118,6 +118,23 @@ NIGHTCTO_EVIDENCE_URL="$(printenv NIGHTCTO_EVIDENCE_URL || true)"
 NIGHTCTO_EVIDENCE_TOKEN="$(printenv NIGHTCTO_EVIDENCE_TOKEN || true)"
 CLOUD_API_URL="$(printenv CLOUD_API_URL || true)"
 CLOUD_API_TOKEN="$(printenv CLOUD_API_TOKEN || true)"
+# The cloud sandbox injects CLOUD_API_ACCESS_TOKEN, not CLOUD_API_TOKEN (see
+# the launcher's env bundle), but @relayflows/slack-primitive only reads
+# CLOUD_API_TOKEN. Without this bridge every scheduled run fails Slack
+# delivery with auth_token_missing. github-primitive already falls back the
+# same way (RELAY_CLOUD_API_TOKEN -> CLOUD_API_ACCESS_TOKEN); slack does not.
+if [ -z "$CLOUD_API_TOKEN" ]; then
+  CLOUD_API_TOKEN="$(printenv RELAY_CLOUD_API_TOKEN || true)"
+fi
+if [ -z "$CLOUD_API_TOKEN" ]; then
+  CLOUD_API_TOKEN="$(printenv CLOUD_API_ACCESS_TOKEN || true)"
+fi
+
+# These are read by the node children this workflow writes and runs (the Slack
+# post script), so they must be exported, not just assigned. Plain assignment
+# left the child seeing only the original process env, which silently defeated
+# the fallback above.
+export CLOUD_API_URL CLOUD_API_TOKEN
 VERIFY_ENVIRONMENT="$(printenv VERIFY_ENVIRONMENT || true)"
 if [ -z "$POSTHOG_HOST" ]; then POSTHOG_HOST="https://i.agentrelay.com"; fi
 if [ -z "$VERIFY_ENVIRONMENT" ]; then VERIFY_ENVIRONMENT="sandbox"; fi


### PR DESCRIPTION
## Why

Deploying the nightly schedule (#1392) surfaced two defects that only appear in the cloud sandbox, so no local run — including my own stub-server verification — would have caught them.

## 1. The sandbox's token variable has a different name

`packages/core/src/bootstrap/launcher.ts` in `../cloud` injects:

```
CLOUD_API_URL, CLOUD_API_ACCESS_TOKEN, CLOUD_API_REFRESH_TOKEN, …
```

but `@relayflows/slack-primitive` reads only `CLOUD_API_TOKEN`:

```ts
const cloudApiToken = nonEmpty(config.cloudApiToken) ?? nonEmpty(env.CLOUD_API_TOKEN) ?? '';
```

So every scheduled run would have failed Slack delivery with `auth_token_missing`. `@relayflows/github-primitive` already knows about this and falls back `RELAY_CLOUD_API_TOKEN → CLOUD_API_ACCESS_TOKEN → WORKSPACE_TOKEN`; the Slack primitive simply doesn't. The workflow now bridges it with the same precedence.

## 2. The variables were never exported

`ENV_DEFAULTS` *assigned* the cloud variables but didn't export them. The Slack post runs in a node child process, which therefore saw only the original process env — so the fallback in (1) would have had no effect even once added.

This one is worth calling out: my earlier verification of the Slack path against a stub server passed **only because that test set `CLOUD_API_TOKEN` directly**. It would not have worked in the sandbox. A green signal that didn't prove the thing it appeared to prove — the exact failure mode this whole workflow exists to catch, reproduced in my own test.

## Verification

Stub server, all three paths:

| Env | Result |
|---|---|
| `CLOUD_API_ACCESS_TOKEN` only (sandbox shape) | `SLACK_POSTED` · stub saw `Bearer access-tok` |
| `CLOUD_API_TOKEN` only (no regression) | `SLACK_POSTED` · stub saw `Bearer direct-tok` |
| Neither | `SLACK_ERROR auth_token_missing` + payload echoed, still loud |

Both workflows `Validation: PASS`, all step bodies pass `sh -n`, prettier clean.

## Deployment note

The live schedule `29fe661b` currently runs the #1392 content, which has this gap — tonight's 03:00 UTC run will produce its verdict and the relay-native `#relay-health` report normally, but Slack delivery will print `SLACK_UNDELIVERED` with the payload in the run log rather than posting to `C0AEKNLDNKW`. I'll re-deploy the schedule from main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

