### PR TITLE
fix(cli): render non-Error failures instead of `[object Object]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A CLI failure raised as a non-`Error` value — e.g. a protocol-shaped `{ status: 401 }` rejection from a broker client — now prints its message, status, and code instead of `[object Object]`, and an `Error` with an empty message no longer exits silently with no output at all. The top-level handler, the `node agent attach` paths, and the broker failure mapper share the formatter, which redacts credentials in the values it serializes.
+- A CLI command that fails with a non-`Error` value now reports it. A protocol-shaped rejection such as `{ status: 401 }` from a broker client printed `[object Object]`, and an `Error` with an empty message printed nothing at all; both now surface the message, status, and code, with credentials redacted. Applies to the top-level failure handler, `node agent attach`, and broker request failures.
 - `agent-relay integration webhook create` now works. It took a `<url>` argument and sent `{ url, event }`, but `POST /v1/webhooks` accepts `{ channel, name? }` and returns the URL — so every invocation failed with `channel is required`. It now takes `<channel>` with an optional `--name`, matching `create-inbound`, which posts to the same endpoint.
 - `@agent-relay/sdk` `RelayCreateWebhookInput` declared a required `url` and an `event`, neither of which the endpoint accepts. It is now `{ channel, name? }`. Code passing `url`/`event` was already failing at runtime.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A CLI failure raised as a non-`Error` value — e.g. a protocol-shaped `{ status: 401 }` rejection from a broker client — now prints its message, status, and code instead of `[object Object]`, and an `Error` with an empty message no longer exits silently with no output at all. The top-level handler, the `node agent attach` paths, and the broker failure mapper share the formatter, which redacts credentials in the values it serializes.
 - `agent-relay integration webhook create` now works. It took a `<url>` argument and sent `{ url, event }`, but `POST /v1/webhooks` accepts `{ channel, name? }` and returns the URL — so every invocation failed with `channel is required`. It now takes `<channel>` with an optional `--name`, matching `create-inbound`, which posts to the same endpoint.
 - `@agent-relay/sdk` `RelayCreateWebhookInput` declared a required `url` and an `event`, neither of which the endpoint accepts. It is now `{ channel, name? }`. Code passing `url`/`event` was already failing at runtime.
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { runAiSdkSidecarMain } from '@agent-relay/harnesses';
 
 import { runCli } from './bootstrap.js';
+import { describeError } from './lib/describe-error.js';
 
 export * from './bootstrap.js';
 
@@ -25,10 +26,9 @@ if (isEntrypoint()) {
   main.catch((err) => {
     // Commander will have already printed a helpful message for parse errors.
     // For other top-level failures, surface them to stderr and exit non-zero.
-    const message = err instanceof Error ? err.message : String(err);
-    if (message) {
-      process.stderr.write(`${message}\n`);
-    }
+    // `describeError` keeps a non-Error rejection (e.g. `{ status: 401 }` from
+    // a broker client) readable instead of collapsing it to `[object Object]`.
+    process.stderr.write(`${describeError(err)}\n`);
     process.exit(1);
   });
 }

--- a/packages/cli/src/cli/lib/attach-broker.ts
+++ b/packages/cli/src/cli/lib/attach-broker.ts
@@ -1,6 +1,7 @@
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
 
 import type { BrokerConnection } from './broker-connection.js';
+import { describeError } from './describe-error.js';
 
 export type {
   InboundDeliveryMode,
@@ -40,5 +41,5 @@ export function mapBrokerSdkFailure(error: unknown): BrokerSdkFailure {
     typeof (error as { status: unknown }).status === 'number'
       ? (error as { status: number }).status
       : 0;
-  return { status, message: error instanceof Error ? error.message : String(error) };
+  return { status, message: describeError(error) };
 }

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -86,6 +86,7 @@ import {
   type PtyInputStreamOptions,
   type PtyInputWriteResult,
 } from '../lib/attach-broker.js';
+import { describeError } from './describe-error.js';
 import { createPredictiveEcho, type CreatePredictiveEchoOptions } from './predictive-echo-screen.js';
 import type { PredictiveEcho } from '@agent-relay/harness-driver';
 
@@ -926,7 +927,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
           // event loop on every keystroke.
           void stream.send(decoded).catch((err: unknown) => {
             if (settled) return;
-            const message = err instanceof Error ? err.message : String(err);
+            const message = describeError(err);
             deps.log(`[drive] input stream send failed: ${message}`);
             // The keystroke never reached the PTY — drop any optimistic echo
             // for it so the screen doesn't show input the agent didn't get.
@@ -1126,7 +1127,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
         }
       } catch (err: unknown) {
         if (settled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const message = describeError(err);
         deps.error(`[drive] could not open PTY input stream: ${message}`);
         finish(1);
       }
@@ -1163,7 +1164,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
         }
       } catch (err: unknown) {
         if (settled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const message = describeError(err);
         deps.error(`[drive] could not take terminal input: ${message}`);
         finish(1);
       }
@@ -1214,7 +1215,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
         try {
           await predictiveEcho.seed(snapshotBytes);
         } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = describeError(err);
           deps.log(`[drive] could not seed predictive echo: ${message}`);
           finish(1);
           return;

--- a/packages/cli/src/cli/lib/attach-native.ts
+++ b/packages/cli/src/cli/lib/attach-native.ts
@@ -16,6 +16,7 @@ import {
   type BrokerConnection,
 } from './broker-connection.js';
 import { createBrokerClient } from './attach-broker.js';
+import { describeError } from './describe-error.js';
 
 export type NativeAttachMode = 'view' | 'drive' | 'passthrough';
 
@@ -146,7 +147,7 @@ export async function attachNative(
   try {
     brokerCursor = await client.currentEventSeq();
   } catch (error) {
-    deps.output.stderr(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    deps.output.stderr(`Error: ${describeError(error)}\n`);
     client.disconnect();
     return 1;
   }
@@ -255,7 +256,7 @@ export async function attachNative(
             }
           })
           .catch((error: unknown) => {
-            deps.output.stderr(`Input failed: ${error instanceof Error ? error.message : String(error)}\n`);
+            deps.output.stderr(`Input failed: ${describeError(error)}\n`);
           })
           .then(() => undefined);
         commandChain = pendingCommand.catch(() => undefined);
@@ -279,7 +280,7 @@ export async function attachNative(
     await Promise.allSettled(pendingCommands);
     return 0;
   } catch (error) {
-    deps.output.stderr(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    deps.output.stderr(`Error: ${describeError(error)}\n`);
     return 1;
   } finally {
     stopped = true;

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -64,6 +64,7 @@ import {
   resizeWorker,
   type InboundDeliveryMode,
 } from './attach-drive.js';
+import { describeError } from './describe-error.js';
 import { createPredictiveEcho, type CreatePredictiveEchoOptions } from './predictive-echo-screen.js';
 import type { PredictiveEcho } from '@agent-relay/harness-driver';
 
@@ -560,7 +561,7 @@ export async function runPassthroughSession(
         if (decoded.length > 0) {
           void stream.send(decoded).catch((err: unknown) => {
             if (settled) return;
-            const message = err instanceof Error ? err.message : String(err);
+            const message = describeError(err);
             deps.log(`[passthrough] input stream send failed: ${message}`);
             // The keystroke never reached the PTY — drop any optimistic echo
             // for it so the screen doesn't show input the agent didn't get.
@@ -740,7 +741,7 @@ export async function runPassthroughSession(
         }
       } catch (err: unknown) {
         if (settled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const message = describeError(err);
         deps.error(`[passthrough] could not open PTY input stream: ${message}`);
         finish(1);
       }
@@ -775,7 +776,7 @@ export async function runPassthroughSession(
         }
       } catch (err: unknown) {
         if (settled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const message = describeError(err);
         deps.error(`[passthrough] could not take terminal input: ${message}`);
         finish(1);
       }
@@ -825,7 +826,7 @@ export async function runPassthroughSession(
         try {
           await predictiveEcho.seed(snapshotBytes);
         } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = describeError(err);
           deps.log(`[passthrough] could not seed predictive echo: ${message}`);
           finish(1);
           return;

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   classifyBrokerStartError,
   classifyBrokerStartStage,
-  describeError,
+  describeErrorWithCause,
   isBundledBunExecutableEntrypoint,
   readNodeDeliveryStatus,
   resolveNodeIdentityFromSession,
@@ -34,9 +34,9 @@ describe('isBundledBunExecutableEntrypoint', () => {
   });
 });
 
-describe('describeError', () => {
+describe('describeErrorWithCause', () => {
   it('returns plain message for a bare Error', () => {
-    expect(describeError(new Error('boom'))).toBe('boom');
+    expect(describeErrorWithCause(new Error('boom'))).toBe('boom');
   });
 
   it('unwraps the Node fetch failed cause and surfaces the network code', () => {
@@ -46,7 +46,7 @@ describe('describeError', () => {
     });
     const err = new TypeError('fetch failed', { cause });
 
-    const result = describeError(err);
+    const result = describeErrorWithCause(err);
     expect(result).toContain('fetch failed');
     expect(result).toContain('ECONNREFUSED');
     expect(result).toContain('127.0.0.1');
@@ -58,15 +58,15 @@ describe('describeError', () => {
     });
     const err = new TypeError('fetch failed', { cause });
 
-    const result = describeError(err);
+    const result = describeErrorWithCause(err);
     expect(result).toContain('ENOTFOUND');
     expect(result).toContain('agentrelay.com');
   });
 
   it('handles non-Error values without throwing', () => {
-    expect(describeError('something went wrong')).toBe('something went wrong');
-    expect(describeError(undefined)).toBe('undefined');
-    expect(describeError(null)).toBe('null');
+    expect(describeErrorWithCause('something went wrong')).toBe('something went wrong');
+    expect(describeErrorWithCause(undefined)).toBe('undefined');
+    expect(describeErrorWithCause(null)).toBe('null');
   });
 
   it('caps the cause-chain walk so a cycle cannot loop forever', () => {
@@ -75,7 +75,7 @@ describe('describeError', () => {
     a.cause = b;
     b.cause = a;
     // Just needs to terminate — the assertion is the absence of a hang.
-    expect(typeof describeError(a)).toBe('string');
+    expect(typeof describeErrorWithCause(a)).toBe('string');
   });
 });
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -21,6 +21,7 @@ import {
   type NodeDefinitionDescriptor,
   type RunningNodeProviderChild,
 } from './node-provider-child.js';
+import { describeError } from './describe-error.js';
 import { maskSecret } from './redact.js';
 import { startReflexCapture, type RunningReflexCapture } from './reflex-capture.js';
 import { projectWorkspaceKeyPath, writeProjectWorkspaceKey } from './project-workspace-key.js';
@@ -152,7 +153,7 @@ export function readBrokerConnection(dataDir: string): BrokerConnection | null {
 }
 
 function toErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return describeError(err);
 }
 
 /** Emit a `[verbose]`-prefixed step marker via `deps.log` when `--verbose` is set. */
@@ -258,6 +259,9 @@ function errorCode(err: unknown): string | undefined {
 /**
  * Extract a human-meaningful detail string from an error, walking `err.cause`.
  *
+ * The broker-start specialization of {@link describeError}: it starts from the
+ * shared description and appends the cause chain's detail and error codes.
+ *
  * Node's native `fetch()` throws `TypeError: fetch failed` for any network
  * problem and stuffs the real reason (ECONNREFUSED, ENOTFOUND, AbortError,
  * UND_ERR_CONNECT_TIMEOUT, …) into `err.cause`. Without unwrapping, every
@@ -265,7 +269,7 @@ function errorCode(err: unknown): string | undefined {
  *
  * Exported for testing.
  */
-export function describeError(err: unknown): string {
+export function describeErrorWithCause(err: unknown): string {
   const top = toErrorMessage(err);
   if (!(err instanceof Error) || !err.cause) return top;
 
@@ -1392,7 +1396,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
         env: deps.env,
       });
     } catch (err: unknown) {
-      deps.error(`Failed to start broker in background: ${describeError(err)}`);
+      deps.error(`Failed to start broker in background: ${describeErrorWithCause(err)}`);
       deps.exit(1);
       return;
     }
@@ -1666,7 +1670,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     if (isBrokerAlreadyRunningError(message)) {
       reportAlreadyRunningError(message, paths.dataDir, deps);
     } else {
-      deps.error(`Failed to start broker: ${describeError(err)}`);
+      deps.error(`Failed to start broker: ${describeErrorWithCause(err)}`);
     }
     deps.exit(1);
   }

--- a/packages/cli/src/cli/lib/core-maintenance.ts
+++ b/packages/cli/src/cli/lib/core-maintenance.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { CoreDependencies, CoreFileSystem } from '../commands/core.js';
 import { track } from '../telemetry/index.js';
 import { readBrokerConnection } from './broker-lifecycle.js';
+import { describeError } from './describe-error.js';
 import { errorClassName } from './telemetry-helpers.js';
 
 const SNIPPET_MARKER_START_PREFIX = '<!-- prpm:snippet:start @agent-relay/agent-relay-snippet@';
@@ -17,7 +18,7 @@ const DEFAULT_ZED_SERVER_NAME = 'Agent Relay';
 const INSTALL_DIR_NAMES = ['.agentworkforce/relay', '.agent-relay'] as const;
 
 function toErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return describeError(err);
 }
 
 /**

--- a/packages/cli/src/cli/lib/describe-error.test.ts
+++ b/packages/cli/src/cli/lib/describe-error.test.ts
@@ -37,6 +37,29 @@ describe('describeError', () => {
     expect(described).toContain('[redacted]');
   });
 
+  it('redacts a credential echoed back inside the message text', () => {
+    // A server error payload is free to quote whatever was sent to it, and that
+    // text is lifted out whole — key-name redaction cannot reach it.
+    expect(describeError({ status: 401, message: 'invalid key rk_live_abcdefghij1234' })).toBe(
+      'invalid key rk_live_…1234 (status 401)'
+    );
+    expect(describeError(new Error('enroll failed for nt_live_0123456789abcdef'))).toBe(
+      'enroll failed for nt_live_…cdef'
+    );
+  });
+
+  it('keeps JSON-hostile members readable', () => {
+    // JSON.stringify throws on BigInt; the old fallback answered [object Object].
+    expect(describeError({ status: 429, retryAfter: 30n })).toBe('{"status":429,"retryAfter":"30n"}');
+
+    const throwingGetter = {
+      get status(): number {
+        throw new Error('nope');
+      },
+    };
+    expect(describeError(throwingGetter)).toBe('[unserializable Object]');
+  });
+
   it('tolerates cycles and truncates oversized payloads', () => {
     const cyclic: Record<string, unknown> = { status: 500 };
     cyclic.self = cyclic;

--- a/packages/cli/src/cli/lib/describe-error.test.ts
+++ b/packages/cli/src/cli/lib/describe-error.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeError } from './describe-error.js';
+
+describe('describeError', () => {
+  it('renders an Error as its message', () => {
+    expect(describeError(new Error('broker refused the attach'))).toBe('broker refused the attach');
+  });
+
+  it('falls back to name and cause when an Error has no message', () => {
+    expect(describeError(new Error(''))).toBe('Error');
+    const named = new Error('');
+    named.name = 'AttachError';
+    expect(describeError(named)).toBe('AttachError');
+    expect(describeError(new Error('', { cause: new Error('socket hang up') }))).toBe(
+      'Error: socket hang up'
+    );
+  });
+
+  it('keeps a protocol-shaped rejection readable instead of [object Object]', () => {
+    expect(describeError({ status: 401 })).toBe('{"status":401}');
+    expect(describeError({ status: 401, code: 'unauthorized', message: 'invalid workspace key' })).toBe(
+      'invalid workspace key (status 401, code unauthorized)'
+    );
+    expect(describeError({ error: 'invalid api key', status: 403 })).toBe('invalid api key (status 403)');
+  });
+
+  it('unwraps a nested error object', () => {
+    expect(describeError({ error: { message: 'node offline' }, code: 'node_unreachable' })).toBe(
+      'node offline (code node_unreachable)'
+    );
+  });
+
+  it('redacts credentials in the JSON fallback', () => {
+    const described = describeError({ status: 401, workspaceKey: 'rk_live_supersecret' });
+    expect(described).not.toContain('rk_live_supersecret');
+    expect(described).toContain('[redacted]');
+  });
+
+  it('tolerates cycles and truncates oversized payloads', () => {
+    const cyclic: Record<string, unknown> = { status: 500 };
+    cyclic.self = cyclic;
+    expect(describeError(cyclic)).toContain('[circular]');
+
+    const huge = describeError({ status: 500, blob: 'x'.repeat(5000) });
+    expect(huge.length).toBeLessThanOrEqual(501);
+    expect(huge.endsWith('…')).toBe(true);
+  });
+
+  it('renders primitives and empty values without going blank', () => {
+    expect(describeError('connection reset')).toBe('connection reset');
+    expect(describeError(404)).toBe('404');
+    expect(describeError(null)).toBe('null');
+    expect(describeError(undefined)).toBe('undefined');
+    expect(describeError('')).toBe('Unknown error');
+    expect(describeError({})).toBe('{}');
+  });
+
+  it('never returns the useless [object Object] rendering', () => {
+    for (const value of [{ status: 401 }, {}, Object.create(null), [{ status: 401 }]]) {
+      expect(describeError(value)).not.toBe('[object Object]');
+    }
+  });
+});

--- a/packages/cli/src/cli/lib/describe-error.ts
+++ b/packages/cli/src/cli/lib/describe-error.ts
@@ -8,6 +8,11 @@
  * visible so the backstop formatter never destroys the diagnosis.
  */
 
+// Imported from the `redact` leaf, not the package barrel: this module is
+// reachable from the CLI entrypoint and from small libs, and the barrel drags
+// in the whole cloud surface (auth, workflows, child-process spawning).
+import { redactCredentialValues } from '@agent-relay/cloud/redact';
+
 import { redactSecrets } from './redact.js';
 
 /** Longest JSON fallback we will print before truncating. */
@@ -24,14 +29,19 @@ const UNKNOWN = 'Unknown error';
  *
  * - `Error` → its `message`, or its `name`/`cause` when the message is empty
  * - object → `message`/`error` text plus `status`/`code` context, else compact
- *   credential-redacted JSON
+ *   JSON with credential-named fields redacted
  * - primitive → `String(value)`
+ *
+ * Every branch's output passes through {@link redactCredentialValues}: a server
+ * error payload is free to echo the credential that was sent to it, so the text
+ * we lift out of `message`/`error` needs the same value-pattern masking the rest
+ * of the CLI's error output gets.
  *
  * @param value - The caught or rejected value.
  * @returns A non-empty, single-line description. Never `[object Object]`.
  */
 export function describeError(value: unknown): string {
-  const described = describe(value, 0).trim();
+  const described = redactCredentialValues(describe(value, 0)).trim();
   return described === '' ? UNKNOWN : described;
 }
 
@@ -103,10 +113,32 @@ function toText(value: unknown): string | null {
 function toCompactJson(value: unknown): string {
   let json: string | undefined;
   try {
-    json = JSON.stringify(redactSecrets(value));
+    json = JSON.stringify(redactSecrets(value), jsonSafeReplacer);
   } catch {
     json = undefined;
   }
-  if (json === undefined) return Object.prototype.toString.call(value);
+  if (json === undefined) return unserializableTag(value);
   return json.length > MAX_JSON_LENGTH ? `${json.slice(0, MAX_JSON_LENGTH)}…` : json;
+}
+
+/**
+ * Keep members `JSON.stringify` refuses or drops — it throws on `BigInt` and
+ * silently omits functions and symbols, either of which would turn a readable
+ * payload back into a useless one.
+ */
+function jsonSafeReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') return `${value}n`;
+  if (typeof value === 'function') return `[Function: ${value.name || 'anonymous'}]`;
+  if (typeof value === 'symbol') return value.toString();
+  return value;
+}
+
+/**
+ * Name a value we could not serialize at all (a throwing getter, say). Falls
+ * back to the constructor or tag rather than `[object Object]`, which is the
+ * exact rendering this module exists to eliminate.
+ */
+function unserializableTag(value: unknown): string {
+  const name = (value as { constructor?: { name?: string } } | null)?.constructor?.name;
+  return `[unserializable ${name || Object.prototype.toString.call(value).slice(8, -1)}]`;
 }

--- a/packages/cli/src/cli/lib/describe-error.ts
+++ b/packages/cli/src/cli/lib/describe-error.ts
@@ -1,0 +1,112 @@
+/**
+ * Human-readable rendering for values caught in a `catch` or a rejected
+ * promise.
+ *
+ * `String(err)` collapses a protocol-shaped rejection such as `{ status: 401 }`
+ * into `[object Object]`, which is how a clear attach authorization failure
+ * reached users as garbage. {@link describeError} keeps the useful fields
+ * visible so the backstop formatter never destroys the diagnosis.
+ */
+
+import { redactSecrets } from './redact.js';
+
+/** Longest JSON fallback we will print before truncating. */
+const MAX_JSON_LENGTH = 500;
+
+/** How far to follow `cause` / nested `error` values. */
+const MAX_DEPTH = 2;
+
+/** Last resort when a value carries no describable text at all. */
+const UNKNOWN = 'Unknown error';
+
+/**
+ * Describe an unknown thrown or rejected value as a single-line string.
+ *
+ * - `Error` → its `message`, or its `name`/`cause` when the message is empty
+ * - object → `message`/`error` text plus `status`/`code` context, else compact
+ *   credential-redacted JSON
+ * - primitive → `String(value)`
+ *
+ * @param value - The caught or rejected value.
+ * @returns A non-empty, single-line description. Never `[object Object]`.
+ */
+export function describeError(value: unknown): string {
+  const described = describe(value, 0).trim();
+  return described === '' ? UNKNOWN : described;
+}
+
+function describe(value: unknown, depth: number): string {
+  if (value === null || value === undefined) return String(value);
+  if (value instanceof Error) return describeErrorInstance(value, depth);
+  if (typeof value === 'function') return `[Function: ${value.name || 'anonymous'}]`;
+  if (typeof value !== 'object') return String(value);
+  return describeObject(value, depth);
+}
+
+function describeErrorInstance(error: Error, depth: number): string {
+  const message = error.message.trim();
+  if (message) return message;
+  // An Error with an empty message printed as nothing at all — just as opaque
+  // as `[object Object]`. Fall back to whatever else identifies it.
+  const name = error.name.trim();
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause !== undefined && depth < MAX_DEPTH) {
+    const described = describe(cause, depth + 1).trim();
+    if (described) return name ? `${name}: ${described}` : described;
+  }
+  return name || 'Error';
+}
+
+function describeObject(value: object, depth: number): string {
+  if (Array.isArray(value)) return toCompactJson(value);
+  const record = value as Record<string, unknown>;
+  const text = describeText(record, depth);
+  // No text field to lead with — the compact JSON already carries `status`,
+  // `code`, and whatever else the thrower attached, so print that instead of
+  // restating a subset of it.
+  if (!text) return toCompactJson(value);
+  const context = describeContext(record);
+  return context ? `${text} (${context})` : text;
+}
+
+/** Pull the leading human message out of a protocol-shaped rejection. */
+function describeText(record: Record<string, unknown>, depth: number): string | null {
+  const message = toText(record.message);
+  if (message) return message;
+  if (typeof record.error === 'string') return record.error.trim() || null;
+  if (record.error && typeof record.error === 'object' && depth < MAX_DEPTH) {
+    return describe(record.error, depth + 1).trim() || null;
+  }
+  return null;
+}
+
+/** `status` / `code` rendered as trailing context for the message. */
+function describeContext(record: Record<string, unknown>): string {
+  const parts: string[] = [];
+  const status = toText(record.status);
+  if (status) parts.push(`status ${status}`);
+  const code = toText(record.code);
+  if (code) parts.push(`code ${code}`);
+  return parts.join(', ');
+}
+
+function toText(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() || null;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+/**
+ * Serialize a value for display: credentials redacted, cycles tolerated, and
+ * truncated so a large payload cannot flood the terminal.
+ */
+function toCompactJson(value: unknown): string {
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(redactSecrets(value));
+  } catch {
+    json = undefined;
+  }
+  if (json === undefined) return Object.prototype.toString.call(value);
+  return json.length > MAX_JSON_LENGTH ? `${json.slice(0, MAX_JSON_LENGTH)}…` : json;
+}

--- a/packages/cli/src/cli/lib/index.ts
+++ b/packages/cli/src/cli/lib/index.ts
@@ -1,3 +1,4 @@
 export { createRuntimeClient, spawnAgentWithClient } from './client-factory.js';
+export { describeError } from './describe-error.js';
 export { formatRelativeTime, parseSince, formatTableRow } from './formatting.js';
 export { stripJsonComments, readJsonWithComments, writeJson } from './jsonc.js';

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createLogger } from '@agent-relay/utils';
 
 import type { CoreDependencies, SpawnedProcess } from '../commands/core.js';
+import { describeError } from './describe-error.js';
 
 /**
  * Credentials handed to an out-of-process node provider, mirroring the env
@@ -644,7 +645,7 @@ function extractChildFailure(err: unknown): string {
   if (trimmed) {
     return trimmed;
   }
-  return err instanceof Error ? err.message : String(err);
+  return describeError(err);
 }
 
 /**

--- a/packages/cli/src/cli/mcp/action-tools.ts
+++ b/packages/cli/src/cli/mcp/action-tools.ts
@@ -7,6 +7,7 @@ import {
   actionToolInputSchema,
   serializableActionDescriptor,
 } from './action-schema.js';
+import { describeError } from '../lib/describe-error.js';
 import { jsonContent, jsonResult } from './tool-results.js';
 import type { AgentClientLike, SessionState } from './types.js';
 
@@ -35,7 +36,7 @@ function asInputRecord(input: unknown): Record<string, unknown> | undefined {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return describeError(error);
 }
 
 /**

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/audit.d.ts",
       "import": "./dist/audit.js"
     },
+    "./redact": {
+      "types": "./dist/redact.d.ts",
+      "import": "./dist/redact.js"
+    },
     "./workspace-key": {
       "types": "./dist/workspace-key.d.ts",
       "import": "./dist/workspace-key.js"


### PR DESCRIPTION
## Summary

Fixes #1383.

`packages/cli/src/cli/index.ts` rendered top-level rejections with `err instanceof Error ? err.message : String(err)`. A non-`Error` rejection — a protocol-shaped object like `{ status: 401 }` from a broker client — printed `[object Object]` and nothing else. An `Error` with an empty message printed *nothing at all*, since the handler only wrote when the string was truthy.

Adds `describeError(unknown): string` (`packages/cli/src/cli/lib/describe-error.ts`):

- `Error` → its `message`; when the message is empty, its `name`, or `name: <cause>` when it carries a `cause`
- object → the `message`/`error` text plus `status`/`code` context (`invalid workspace key (status 401, code unauthorized)`), else compact JSON (`{"status":401}`)
- primitive → `String(value)`; never returns an empty string, never returns `[object Object]`

The JSON fallback runs through the existing `redactSecrets`, so a rejection payload carrying a workspace key or token cannot leak into stderr, and it truncates at 500 chars so a large payload can't flood the terminal. Cycles render as `[circular]` rather than throwing.

Call sites updated:

- the top-level catch in `cli/index.ts`
- `attach-broker.ts` `mapBrokerSdkFailure`, which is where the reported attach 401 turned into `[object Object]` as the failure *message* that callers then printed
- the `node agent attach` paths (`attach-native.ts`, `attach-drive.ts`, `attach-passthrough.ts`)
- the per-module `toErrorMessage`/`errorMessage`/`extractChildFailure` helpers (`core-maintenance.ts`, `broker-lifecycle.ts`, `mcp/action-tools.ts`, `node-provider-child.ts`)

`broker-lifecycle.ts` already exported a `describeError` — the cause-chain walker that unwraps `TypeError: fetch failed` into `ECONNREFUSED` etc. It's the broker-start specialization, so it's renamed to `describeErrorWithCause` and now builds on the shared formatter (gaining non-`Error` handling for free).

On the issue's root-cause companion: the broker client paths already reject with typed `HarnessDriverProtocolError`s throughout `@agent-relay/harness-driver` (HTTP failures, WS input-stream failures, timeouts, closes), and I found no site in this repo that throws or rejects with a bare object. So this ships the backstop formatter only; if the `{ status: 401 }` value originated outside these paths, the formatter now surfaces enough detail to identify where.

## Test Plan

- [x] Tests added/updated — `packages/cli/src/cli/lib/describe-error.test.ts` covers Error/empty-message/cause, protocol-shaped objects, nested `error` objects, credential redaction, cycles, truncation, primitives, and an explicit "never renders `[object Object]`" case
- [x] `npx vitest run packages/cli` — 879 passed, 11 skipped, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings (only pre-existing complexity/naming warnings)

## Screenshots

n/a


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKFr7pXffb5LVaP5pjo8bG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

