### PR TITLE
fix(cli): pin relayflows dependency exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `agent-relay cloud whoami` prints the organization and workspace IDs alongside their names.
+- `agent-relay` pins `@relayflows/cli` exactly, so each Relay release resolves one reviewed workflow dependency tree instead of changing with later compatible Relayflows publishes.
 
 ## [11.3.1] - 2026-07-31
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13591,7 +13591,7 @@
         "@agent-relay/utils": "11.2.0",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@relayfile/client": "^0.10.27",
-        "@relayflows/cli": "^1.0.1",
+        "@relayflows/cli": "1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
         "dotenv": "^17.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "@agent-relay/utils": "11.3.1",
     "@modelcontextprotocol/sdk": "^1.23.0",
     "@relayfile/client": "^0.10.27",
-    "@relayflows/cli": "^1.0.1",
+    "@relayflows/cli": "1.0.1",
     "@xterm/headless": "^6.0.0",
     "commander": "^12.1.0",
     "dotenv": "^17.2.3",

--- a/packages/cli/src/cli/entrypoint.test.ts
+++ b/packages/cli/src/cli/entrypoint.test.ts
@@ -124,4 +124,12 @@ describe('CLI entrypoints', () => {
 
     expect(packageJson.bin?.['agent-relay']).toBe('dist/cli/index.js');
   });
+
+  it('pins relayflows so an Agent Relay release has a reproducible workflow dependency tree', () => {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies?.['@relayflows/cli']).toMatch(/^\d+\.\d+\.\d+$/);
+  });
 });


### PR DESCRIPTION
## Summary

- replace the `@relayflows/cli` caret range with the exact version already resolved by this repository (`1.0.1`)
- add a regression requiring a plain SemVer dependency
- record the install-reproducibility change in the pending Minor changelog

Companion to AgentWorkforce/relayflows#25 and AgentWorkforce/relayflows#27.

## Security sequencing

This pin is a reproducibility control, **not the leak remediation by itself**. Every currently published Relayflows version checked, including `1.0.1`, contains the first-run observer-key leak. The leak closes only after the Relayflows fix is reviewed and published, followed by an explicit bump of this pin to that safe release. Until then, this PR must not be described as an all-clear.

The installed tree on the machine that runs Agent Relay must be checked after that bump, dependencies included. A clean package tarball cannot establish closure because `npm pack` omits `node_modules`.

## Verification

- clean `npm ci` accepts the exact package/lock declaration
- `npx vitest run packages/cli/src/cli/entrypoint.test.ts` — 5/5 passed
- `npm run build:core && npm run build:cli`
- `git diff --check`

No packages were published and no release was created.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

