### PR TITLE
feat(cli): add `agent-relay observer` to mint read-only follow-along links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- `agent-relay observer` mints a scoped, read-only observer token and prints the observer URL built from it, so sharing a live follow-along view no longer requires hand-rolling a `POST /v1/observer-tokens` call. Defaults to a 24-hour token with agent DMs excluded; `--channels`, `--include-dms`, and `--expires` widen it, and `observer list` / `observer revoke <id>` manage existing tokens.
+- `get_observer_url` MCP tool does the same for an orchestrating agent, so a lead can hand the user a follow-along link without shelling out.
+- `@agent-relay/sdk` exports `createObserverToken`, `listObserverTokens`, and `revokeObserverToken`.
 
 ## [11.8.0] - 2026-08-19
 

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -1008,6 +1008,9 @@ function registerAgentRelayTools(
       const session = getSession();
       requireWorkspaceKey(session);
       const lifetimeHours = expires_in_hours ?? 24;
+      // Resolve the dashboard URL BEFORE minting: an invalid RELAY_OBSERVER_URL
+      // would otherwise leave a live token behind that this call never returns.
+      const observerBase = resolveObserverBaseUrl(undefined);
       const token = await createObserverToken({
         workspaceKey: session.workspaceKey as string,
         name: `observer-mcp-${Math.random().toString(36).slice(2, 10)}`,
@@ -1023,7 +1026,7 @@ function registerAgentRelayTools(
         throw new Error('Observer token created, but the response did not include token material.');
       }
       return jsonContent({
-        url: observerUrl(resolveObserverBaseUrl(undefined), token.token),
+        url: observerUrl(observerBase, token.token),
         tokenId: token.id,
         expiresAt: token.expiresAt,
         includesDms: include_dms === true,

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -16,6 +16,7 @@ import {
   AgentRelay,
   RELAYCAST_SDK_VERSION,
   createAgentClient,
+  createObserverToken,
   createRealtimeClient,
   createWorkspaceClient,
   isInvalidAgentTokenError,
@@ -31,6 +32,7 @@ import { attributableReleaseReason } from './lib/release-reason.js';
 import { initTelemetry, shutdown as shutdownTelemetry } from './telemetry/index.js';
 import { RealtimeResourceBridge, SubscriptionManager, registerResourceDefinitions } from './mcp/resources.js';
 import { jsonContent, jsonResult, textContent } from './mcp/tool-results.js';
+import { observerUrl, resolveObserverBaseUrl } from './lib/observer-url.js';
 import {
   createWorkspace,
   extractWorkspaceKey,
@@ -965,6 +967,63 @@ function registerAgentRelayTools(
       requireWorkspaceKey(getSession());
       const agents = await getRelay().agents.list(status ? { status } : undefined);
       return jsonContent({ agents });
+    }
+  );
+
+  server.registerTool(
+    'get_observer_url',
+    {
+      title: 'Get Observer URL',
+      description:
+        'Mint a scoped, read-only observer link so a human can follow this workspace live. ' +
+        'Use this whenever the user asks to watch, follow along with, or see the agent conversation. ' +
+        'Returns a URL backed by a read-only observer token that expires — NEVER build an observer ' +
+        'URL from the workspace key, which is an administrative credential.',
+      inputSchema: {
+        channels: z
+          .array(z.string())
+          .optional()
+          .describe('Restrict the view to these channels. Omit to show every channel.'),
+        include_dms: z
+          .boolean()
+          .optional()
+          .describe('Include agent DM traffic. Defaults to false (channels only).'),
+        expires_in_hours: z
+          .number()
+          .int()
+          .min(1)
+          .max(2160)
+          .optional()
+          .describe('Token lifetime in hours. Defaults to 24.'),
+      },
+      outputSchema: jsonResult,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ channels, include_dms, expires_in_hours }: any) => {
+      const session = getSession();
+      requireWorkspaceKey(session);
+      const lifetimeHours = expires_in_hours ?? 24;
+      const token = await createObserverToken({
+        workspaceKey: session.workspaceKey as string,
+        name: `observer-mcp-${Math.random().toString(36).slice(2, 10)}`,
+        description: 'Minted by the get_observer_url MCP tool for read-only follow-along',
+        filters: {
+          includeDms: include_dms === true,
+          ...(channels?.length ? { channelNames: channels } : {}),
+        },
+        expiresAt: new Date(Date.now() + lifetimeHours * 3_600_000).toISOString(),
+        ...(baseUrl ? { baseUrl } : {}),
+      });
+      if (!token.token) {
+        throw new Error('Observer token created, but the response did not include token material.');
+      }
+      return jsonContent({
+        url: observerUrl(resolveObserverBaseUrl(undefined), token.token),
+        tokenId: token.id,
+        expiresAt: token.expiresAt,
+        includesDms: include_dms === true,
+        ...(channels?.length ? { channels } : {}),
+      });
     }
   );
 

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -997,7 +997,12 @@ function registerAgentRelayTools(
           .describe('Token lifetime in hours. Defaults to 24.'),
       },
       outputSchema: jsonResult,
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async ({ channels, include_dms, expires_in_hours }: any) => {
       const session = getSession();

--- a/packages/cli/src/cli/bootstrap.test.ts
+++ b/packages/cli/src/cli/bootstrap.test.ts
@@ -91,6 +91,10 @@ const expectedLeafCommands = [
   'workspace switch',
   'workspace restore',
   'workspace rebind',
+  // observer (the bare `observer` mint action is asserted separately — it is a
+  // group with a default action, so the leaf walk does not reach it)
+  'observer list',
+  'observer revoke',
   // workspace agents
   'agent register',
   'agent rotate',
@@ -218,6 +222,7 @@ describe('bootstrap CLI', () => {
         'reflex',
         'session',
         'status',
+        'observer',
         'version',
         'update',
         'uninstall',
@@ -246,6 +251,24 @@ describe('bootstrap CLI', () => {
         'on',
         'rm',
       ])
+    );
+  });
+
+  it('registers `observer` as a runnable command, not just a group', () => {
+    // `observer` carries both a default action (mint a link) and subcommands
+    // (list/revoke), so the leaf-path walk in the inventory test below skips
+    // it. Assert the action directly — otherwise the primary command could be
+    // dropped and every other assertion would still pass.
+    // The action's behaviour is covered in commands/observer.test.ts, which
+    // parses a bare `observer` and asserts a token is minted.
+    const program = createProgram();
+    const observer = program.commands.find((command) => command.name() === 'observer');
+    expect(observer).toBeDefined();
+    expect(observer?.commands.map((command) => command.name()).sort()).toEqual(['list', 'revoke']);
+    // The mint options live on the group itself, which is what makes a bare
+    // `agent-relay observer` runnable.
+    expect(observer?.options.map((option) => option.long)).toEqual(
+      expect.arrayContaining(['--channels', '--include-dms', '--expires'])
     );
   });
 

--- a/packages/cli/src/cli/bootstrap.ts
+++ b/packages/cli/src/cli/bootstrap.ts
@@ -41,6 +41,7 @@ import { registerLocalWorkflowCommands } from './commands/local-workflow.js';
 import { registerCloudCommands } from './commands/cloud.js';
 import { registerReflexCommands } from './commands/reflex.js';
 import { registerWorkspaceCommands } from './commands/workspace.js';
+import { registerObserverCommands } from './commands/observer.js';
 import { registerAgentCommands } from './commands/agent.js';
 import { registerChannelCommands } from './commands/channel.js';
 import { registerMessageCommands } from './commands/message.js';
@@ -414,6 +415,7 @@ export function createProgram(options: { name?: string } = {}): Command {
   registerCloudCommands(program);
   registerReflexCommands(program);
   registerWorkspaceCommands(program);
+  registerObserverCommands(program);
   registerAgentCommands(program);
   registerChannelCommands(program);
   registerMessageCommands(program);

--- a/packages/cli/src/cli/commands/observer.test.ts
+++ b/packages/cli/src/cli/commands/observer.test.ts
@@ -1,0 +1,159 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerObserverCommands, type ObserverCommandDependencies } from './observer.js';
+import { observerUrl, resolveObserverBaseUrl } from '../lib/observer-url.js';
+
+class ExitSignal extends Error {
+  constructor(public readonly code: number) {
+    super(`exit:${code}`);
+  }
+}
+
+const WORKSPACE_KEY = 'rk_live_workspacekey000000';
+const FIXED_NOW = Date.parse('2026-08-03T00:00:00.000Z');
+
+function createdToken(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ot_abc123',
+    name: 'observer-cli-deadbeef',
+    scopes: ['stream:read', 'messages:read'],
+    status: 'active',
+    expiresAt: '2026-08-04T00:00:00.000Z',
+    createdAt: '2026-08-03T00:00:00.000Z',
+    token: 'ot_live_secrettokenmaterial',
+    ...overrides,
+  };
+}
+
+function setup(overrides: Partial<ObserverCommandDependencies> = {}) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const createObserverToken = vi.fn(async () => createdToken());
+  const listObserverTokens = vi.fn(async () => []);
+  const revokeObserverToken = vi.fn(async () => {});
+
+  const program = new Command();
+  program.exitOverride();
+  registerObserverCommands(program, {
+    log: (...args: unknown[]) => logs.push(args.join(' ')),
+    error: (...args: unknown[]) => errors.push(args.join(' ')),
+    exit: (code: number) => {
+      throw new ExitSignal(code);
+    },
+    createObserverToken: createObserverToken as never,
+    listObserverTokens: listObserverTokens as never,
+    revokeObserverToken: revokeObserverToken as never,
+    now: () => FIXED_NOW,
+    randomSuffix: () => 'deadbeef',
+    ...overrides,
+  });
+
+  return { program, logs, errors, createObserverToken, listObserverTokens, revokeObserverToken };
+}
+
+describe('agent-relay observer', () => {
+  beforeEach(() => {
+    process.env.RELAY_WORKSPACE_KEY = WORKSPACE_KEY;
+    delete process.env.RELAY_OBSERVER_URL;
+    delete process.env.RELAY_BASE_URL;
+  });
+
+  it('mints a scoped token and prints an observer URL carrying the token, not the workspace key', async () => {
+    const { program, logs, createObserverToken } = setup();
+
+    await program.parseAsync(['observer'], { from: 'user' });
+
+    const [call] = createObserverToken.mock.calls as unknown as [[Record<string, unknown>]];
+    expect(call[0].workspaceKey).toBe(WORKSPACE_KEY);
+    // Default posture: DMs excluded, no channel narrowing, 24h lifetime.
+    expect(call[0].filters).toEqual({ includeDms: false });
+    expect(call[0].expiresAt).toBe(new Date(FIXED_NOW + 24 * 3_600_000).toISOString());
+
+    const url = logs[0];
+    expect(url).toBe('https://agentrelay.com/observer?key=ot_live_secrettokenmaterial');
+    // The whole point: the administrative credential never reaches the output.
+    expect(logs.join('\n')).not.toContain(WORKSPACE_KEY);
+  });
+
+  it('narrows to channels and includes DMs when asked', async () => {
+    const { program, createObserverToken } = setup();
+
+    await program.parseAsync(
+      ['observer', '--channels', '#general, build ,general', '--include-dms', '--expires', '7d'],
+      { from: 'user' }
+    );
+
+    const [call] = createObserverToken.mock.calls as unknown as [[Record<string, unknown>]];
+    // Leading `#` stripped and duplicates collapsed.
+    expect(call[0].filters).toEqual({ includeDms: true, channelNames: ['general', 'build'] });
+    expect(call[0].expiresAt).toBe(new Date(FIXED_NOW + 7 * 86_400_000).toISOString());
+  });
+
+  it('rejects a bare-number expiry rather than guessing a unit', async () => {
+    const { program } = setup();
+
+    await expect(
+      program.parseAsync(['observer', '--expires', '24'], { from: 'user' })
+    ).rejects.toThrow(/30m, 24h, or 7d/);
+  });
+
+  it('fails loudly when the engine returns no token material', async () => {
+    const { program, errors } = setup({
+      createObserverToken: vi.fn(async () => createdToken({ token: undefined })) as never,
+    });
+
+    await expect(program.parseAsync(['observer'], { from: 'user' })).rejects.toBeInstanceOf(
+      ExitSignal
+    );
+    expect(errors.join('\n')).toContain('did not include token material');
+  });
+
+  it('list never prints token material', async () => {
+    const { program, logs } = setup({
+      listObserverTokens: vi.fn(async () => [
+        createdToken({ token: undefined, lastUsedAt: null }),
+      ]) as never,
+    });
+
+    await program.parseAsync(['observer', 'list'], { from: 'user' });
+
+    expect(logs.join('\n')).toContain('ot_abc123');
+    expect(logs.join('\n')).not.toContain('ot_live_');
+  });
+
+  it('revokes by id', async () => {
+    const { program, revokeObserverToken, logs } = setup();
+
+    await program.parseAsync(['observer', 'revoke', 'ot_abc123'], { from: 'user' });
+
+    const [call] = revokeObserverToken.mock.calls as unknown as [[Record<string, unknown>]];
+    expect(call[0]).toMatchObject({ workspaceKey: WORKSPACE_KEY, id: 'ot_abc123' });
+    expect(logs.join('\n')).toContain('Revoked ot_abc123.');
+  });
+});
+
+describe('observer URL construction', () => {
+  it('refuses to build a URL from a workspace key', () => {
+    expect(() => observerUrl('https://agentrelay.com/observer', WORKSPACE_KEY)).toThrow(
+      /scoped observer token/
+    );
+  });
+
+  it('prefers an explicit URL, then RELAY_OBSERVER_URL, then the hosted default', () => {
+    const env = { RELAY_OBSERVER_URL: 'https://observer.relaycast.dev' } as NodeJS.ProcessEnv;
+    expect(resolveObserverBaseUrl('https://example.test/observer', env)).toBe(
+      'https://example.test/observer'
+    );
+    expect(resolveObserverBaseUrl(undefined, env)).toBe('https://observer.relaycast.dev');
+    expect(resolveObserverBaseUrl(undefined, {} as NodeJS.ProcessEnv)).toBe(
+      'https://agentrelay.com/observer'
+    );
+  });
+
+  it('rejects a malformed observer URL instead of emitting a broken link', () => {
+    expect(() => resolveObserverBaseUrl('not-a-url', {} as NodeJS.ProcessEnv)).toThrow(
+      /Invalid observer URL/
+    );
+  });
+});

--- a/packages/cli/src/cli/commands/observer.test.ts
+++ b/packages/cli/src/cli/commands/observer.test.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { registerObserverCommands, type ObserverCommandDependencies } from './observer.js';
 import { observerUrl, resolveObserverBaseUrl } from '../lib/observer-url.js';
@@ -33,9 +33,10 @@ function setup(overrides: Partial<ObserverCommandDependencies> = {}) {
   const listObserverTokens = vi.fn(async () => []);
   const revokeObserverToken = vi.fn(async () => {});
 
-  const program = new Command();
-  program.exitOverride();
-  registerObserverCommands(program, {
+  // Build the dep set once and hand back exactly what was registered, so a test
+  // that overrides a mock inspects the same instance the command called rather
+  // than the untouched default.
+  const deps = {
     log: (...args: unknown[]) => logs.push(args.join(' ')),
     error: (...args: unknown[]) => errors.push(args.join(' ')),
     exit: (code: number) => {
@@ -47,16 +48,33 @@ function setup(overrides: Partial<ObserverCommandDependencies> = {}) {
     now: () => FIXED_NOW,
     randomSuffix: () => 'deadbeef',
     ...overrides,
-  });
+  };
 
-  return { program, logs, errors, createObserverToken, listObserverTokens, revokeObserverToken };
+  const program = new Command();
+  program.exitOverride();
+  registerObserverCommands(program, deps);
+
+  return {
+    program,
+    logs,
+    errors,
+    createObserverToken: deps.createObserverToken as unknown as ReturnType<typeof vi.fn>,
+    listObserverTokens: deps.listObserverTokens as unknown as ReturnType<typeof vi.fn>,
+    revokeObserverToken: deps.revokeObserverToken as unknown as ReturnType<typeof vi.fn>,
+  };
 }
 
 describe('agent-relay observer', () => {
   beforeEach(() => {
-    process.env.RELAY_WORKSPACE_KEY = WORKSPACE_KEY;
-    delete process.env.RELAY_OBSERVER_URL;
-    delete process.env.RELAY_BASE_URL;
+    // Stub rather than assign: a direct `process.env` mutation outlives this
+    // suite and leaks a workspace key into every test file that runs after it.
+    vi.stubEnv('RELAY_WORKSPACE_KEY', WORKSPACE_KEY);
+    vi.stubEnv('RELAY_OBSERVER_URL', '');
+    vi.stubEnv('RELAY_BASE_URL', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('mints a scoped token and prints an observer URL carrying the token, not the workspace key', async () => {
@@ -118,6 +136,46 @@ describe('agent-relay observer', () => {
     expect(logs.join('\n')).not.toContain('ot_live_');
   });
 
+  it('honours flags on subcommands even though the parent declares the same names', async () => {
+    // Regression: Commander binds a repeated option to the ancestor that
+    // declared it first, so reading the subcommand's local opts returned {} and
+    // silently dropped both --json and --workspace-key.
+    const { program, logs, listObserverTokens } = setup({
+      listObserverTokens: vi.fn(async () => [createdToken({ token: undefined })]) as never,
+    });
+
+    await program.parseAsync(
+      ['observer', 'list', '--json', '--workspace-key', 'rk_live_explicitkey00000'],
+      { from: 'user' }
+    );
+
+    const [call] = listObserverTokens.mock.calls as unknown as [[Record<string, unknown>]];
+    expect(call[0].workspaceKey).toBe('rk_live_explicitkey00000');
+    expect(() => JSON.parse(logs.join('\n'))).not.toThrow();
+  });
+
+  it('validates the observer URL before minting, so a bad config leaves no live token', async () => {
+    const { program, errors, createObserverToken } = setup();
+
+    await expect(
+      program.parseAsync(['observer', '--observer-url', 'data:text/html,x'], { from: 'user' })
+    ).rejects.toBeInstanceOf(ExitSignal);
+
+    expect(errors.join('\n')).toContain('must be http or https');
+    // The important half: no token was created before the failure.
+    expect(createObserverToken).not.toHaveBeenCalled();
+  });
+
+  it('collapses duplicate channels before applying the cap', async () => {
+    const { program, createObserverToken } = setup();
+    const many = Array.from({ length: 60 }, () => 'general').join(',');
+
+    await program.parseAsync(['observer', '--channels', many], { from: 'user' });
+
+    const [call] = createObserverToken.mock.calls as unknown as [[Record<string, unknown>]];
+    expect(call[0].filters).toEqual({ includeDms: false, channelNames: ['general'] });
+  });
+
   it('revokes by id', async () => {
     const { program, revokeObserverToken, logs } = setup();
 
@@ -150,6 +208,17 @@ describe('observer URL construction', () => {
   it('rejects a malformed observer URL instead of emitting a broken link', () => {
     expect(() => resolveObserverBaseUrl('not-a-url', {} as NodeJS.ProcessEnv)).toThrow(
       /Invalid observer URL/
+    );
+  });
+
+  it('rejects non-http(s) schemes, which would carry the token somewhere unintended', () => {
+    for (const bad of ['data:text/html,x', 'javascript:alert(1)', 'file:///etc/passwd', 'ftp://h/p']) {
+      expect(() => resolveObserverBaseUrl(bad, {} as NodeJS.ProcessEnv)).toThrow(
+        /must be http or https/
+      );
+    }
+    expect(resolveObserverBaseUrl('http://localhost:3000/observer', {} as NodeJS.ProcessEnv)).toBe(
+      'http://localhost:3000/observer'
     );
   });
 });

--- a/packages/cli/src/cli/commands/observer.test.ts
+++ b/packages/cli/src/cli/commands/observer.test.ts
@@ -93,9 +93,9 @@ describe('agent-relay observer', () => {
   it('rejects a bare-number expiry rather than guessing a unit', async () => {
     const { program } = setup();
 
-    await expect(
-      program.parseAsync(['observer', '--expires', '24'], { from: 'user' })
-    ).rejects.toThrow(/30m, 24h, or 7d/);
+    await expect(program.parseAsync(['observer', '--expires', '24'], { from: 'user' })).rejects.toThrow(
+      /30m, 24h, or 7d/
+    );
   });
 
   it('fails loudly when the engine returns no token material', async () => {
@@ -103,17 +103,13 @@ describe('agent-relay observer', () => {
       createObserverToken: vi.fn(async () => createdToken({ token: undefined })) as never,
     });
 
-    await expect(program.parseAsync(['observer'], { from: 'user' })).rejects.toBeInstanceOf(
-      ExitSignal
-    );
+    await expect(program.parseAsync(['observer'], { from: 'user' })).rejects.toBeInstanceOf(ExitSignal);
     expect(errors.join('\n')).toContain('did not include token material');
   });
 
   it('list never prints token material', async () => {
     const { program, logs } = setup({
-      listObserverTokens: vi.fn(async () => [
-        createdToken({ token: undefined, lastUsedAt: null }),
-      ]) as never,
+      listObserverTokens: vi.fn(async () => [createdToken({ token: undefined, lastUsedAt: null })]) as never,
     });
 
     await program.parseAsync(['observer', 'list'], { from: 'user' });

--- a/packages/cli/src/cli/commands/observer.test.ts
+++ b/packages/cli/src/cli/commands/observer.test.ts
@@ -144,10 +144,9 @@ describe('agent-relay observer', () => {
       listObserverTokens: vi.fn(async () => [createdToken({ token: undefined })]) as never,
     });
 
-    await program.parseAsync(
-      ['observer', 'list', '--json', '--workspace-key', 'rk_live_explicitkey00000'],
-      { from: 'user' }
-    );
+    await program.parseAsync(['observer', 'list', '--json', '--workspace-key', 'rk_live_explicitkey00000'], {
+      from: 'user',
+    });
 
     const [call] = listObserverTokens.mock.calls as unknown as [[Record<string, unknown>]];
     expect(call[0].workspaceKey).toBe('rk_live_explicitkey00000');
@@ -213,9 +212,7 @@ describe('observer URL construction', () => {
 
   it('rejects non-http(s) schemes, which would carry the token somewhere unintended', () => {
     for (const bad of ['data:text/html,x', 'javascript:alert(1)', 'file:///etc/passwd', 'ftp://h/p']) {
-      expect(() => resolveObserverBaseUrl(bad, {} as NodeJS.ProcessEnv)).toThrow(
-        /must be http or https/
-      );
+      expect(() => resolveObserverBaseUrl(bad, {} as NodeJS.ProcessEnv)).toThrow(/must be http or https/);
     }
     expect(resolveObserverBaseUrl('http://localhost:3000/observer', {} as NodeJS.ProcessEnv)).toBe(
       'http://localhost:3000/observer'

--- a/packages/cli/src/cli/commands/observer.ts
+++ b/packages/cli/src/cli/commands/observer.ts
@@ -1,0 +1,219 @@
+/**
+ * `agent-relay observer` — mint a scoped, read-only observer link.
+ *
+ * The engine rejects a workspace key (`rk_live_`) on the realtime endpoint, and
+ * a workspace key is an administrative credential that has no business in a URL
+ * or a terminal transcript. This command mints a scoped `ot_live_` token instead
+ * and prints the observer URL built from it, so "let a human follow along" is a
+ * single command rather than a hand-rolled API call.
+ */
+
+import type { Command } from 'commander';
+import { InvalidArgumentError } from 'commander';
+
+import {
+  createObserverToken,
+  listObserverTokens,
+  revokeObserverToken,
+  type RelayObserverToken,
+} from '@agent-relay/sdk';
+
+import {
+  DEFAULT_OBSERVER_EXPIRES,
+  DEFAULT_OBSERVER_URL,
+  observerUrl,
+  resolveObserverBaseUrl,
+} from '../lib/observer-url.js';
+import { printJson, runSdk, withSdkDefaults, type SdkCommandDeps } from '../lib/sdk-command.js';
+import { resolveBaseUrl, resolveWorkspaceKey } from '../lib/sdk-client.js';
+
+const MAX_CHANNEL_FILTERS = 50;
+
+export interface ObserverCommandDependencies extends SdkCommandDeps {
+  createObserverToken: typeof createObserverToken;
+  listObserverTokens: typeof listObserverTokens;
+  revokeObserverToken: typeof revokeObserverToken;
+  /** Injected so tests get deterministic token names and expiry timestamps. */
+  now: () => number;
+  randomSuffix: () => string;
+}
+
+function withObserverDefaults(
+  overrides: Partial<ObserverCommandDependencies> = {}
+): ObserverCommandDependencies {
+  return {
+    ...withSdkDefaults(overrides),
+    createObserverToken,
+    listObserverTokens,
+    revokeObserverToken,
+    now: () => Date.now(),
+    randomSuffix: () => Math.random().toString(36).slice(2, 10),
+    ...overrides,
+  };
+}
+
+/**
+ * Parse a `30m` / `24h` / `7d` duration into milliseconds. Bare digits are
+ * rejected rather than guessed at — `--expires 24` is far more likely to mean
+ * hours than milliseconds, and silently picking either would be wrong.
+ */
+export function parseDuration(value: string): number {
+  const match = /^(\d+)([mhd])$/.exec(value.trim());
+  if (!match) {
+    throw new InvalidArgumentError('Expected a duration like 30m, 24h, or 7d.');
+  }
+  const amount = Number(match[1]);
+  if (amount <= 0) {
+    throw new InvalidArgumentError('Expected a positive duration.');
+  }
+  const unitMs = { m: 60_000, h: 3_600_000, d: 86_400_000 }[match[2] as 'm' | 'h' | 'd'];
+  const total = amount * unitMs;
+  // The engine caps nothing here, but a token outliving the workspace is a
+  // liability rather than a convenience.
+  if (total > 90 * 86_400_000) {
+    throw new InvalidArgumentError('Expected a duration of 90d or less.');
+  }
+  return total;
+}
+
+function parseChannels(value: string): string[] {
+  const names = value
+    .split(',')
+    .map((name) => name.trim().replace(/^#/, ''))
+    .filter(Boolean);
+  if (names.length === 0) {
+    throw new InvalidArgumentError('Expected at least one channel name.');
+  }
+  if (names.length > MAX_CHANNEL_FILTERS) {
+    throw new InvalidArgumentError(`Expected at most ${MAX_CHANNEL_FILTERS} channel names.`);
+  }
+  return [...new Set(names)];
+}
+
+/**
+ * Credentials shared by every observer subcommand. `baseUrl` is spread rather
+ * than passed as `undefined` because the SDK options treat an explicit
+ * `undefined` and an absent key differently.
+ */
+function connection(options: Record<string, unknown>): { workspaceKey: string; baseUrl?: string } {
+  const baseUrl = resolveBaseUrl({ baseUrl: options.baseUrl as string | undefined });
+  return {
+    workspaceKey: resolveWorkspaceKey({
+      workspaceKey: options.workspaceKey as string | undefined,
+    }),
+    ...(baseUrl ? { baseUrl } : {}),
+  };
+}
+
+function describeToken(token: RelayObserverToken): Record<string, unknown> {
+  return {
+    id: token.id,
+    name: token.name,
+    status: token.status,
+    expiresAt: token.expiresAt,
+    createdAt: token.createdAt,
+    ...(token.lastUsedAt === undefined ? {} : { lastUsedAt: token.lastUsedAt }),
+  };
+}
+
+export function registerObserverCommands(
+  program: Command,
+  overrides: Partial<ObserverCommandDependencies> = {}
+): void {
+  const deps = withObserverDefaults(overrides);
+  const env = process.env;
+
+  const group = program
+    .command('observer')
+    .description('Mint a read-only observer link so a human can follow this workspace');
+
+  group
+    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option('--base-url <url>', 'Override the engine API base URL (defaults to RELAY_BASE_URL)')
+    .option('--observer-url <url>', `Observer dashboard URL (defaults to ${DEFAULT_OBSERVER_URL})`)
+    .option('--name <name>', 'Token name (defaults to a generated unique name)')
+    .option('--channels <names>', 'Restrict to a comma-separated list of channels', parseChannels)
+    .option('--include-dms', 'Include agent DM traffic (excluded by default)')
+    .option('--expires <duration>', `Token lifetime, e.g. 30m, 24h, 7d (default ${DEFAULT_OBSERVER_EXPIRES})`, parseDuration)
+    .option('--json', 'Output the token metadata and URL as JSON')
+    .action(async (options: Record<string, unknown>) => {
+      await runSdk(deps, async () => {
+        const lifetimeMs = (options.expires as number | undefined) ?? parseDuration(DEFAULT_OBSERVER_EXPIRES);
+        const name =
+          (options.name as string | undefined)?.trim() || `observer-cli-${deps.randomSuffix()}`;
+
+        const token = await deps.createObserverToken({
+          ...connection(options),
+          name,
+          description: 'Minted by `agent-relay observer` for read-only follow-along',
+          filters: {
+            includeDms: options.includeDms === true,
+            ...(options.channels ? { channelNames: options.channels as string[] } : {}),
+          },
+          expiresAt: new Date(deps.now() + lifetimeMs).toISOString(),
+        });
+
+        if (!token.token) {
+          throw new Error('Observer token created, but the response did not include token material.');
+        }
+
+        const url = observerUrl(
+          resolveObserverBaseUrl(options.observerUrl as string | undefined, env),
+          token.token
+        );
+
+        if (options.json) {
+          printJson(deps, { ...describeToken(token), url });
+          return;
+        }
+
+        deps.log(url);
+        deps.log('');
+        deps.log(`Read-only. Expires ${token.expiresAt ?? 'never'}.`);
+        deps.log(
+          options.includeDms === true
+            ? 'Includes agent DMs.'
+            : 'Channels only — agent DMs are excluded.'
+        );
+        deps.log(`Revoke with: agent-relay observer revoke ${token.id}`);
+      });
+    });
+
+  group
+    .command('list')
+    .description('List observer tokens for this workspace (token material is never shown)')
+    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option('--base-url <url>', 'Override the engine API base URL')
+    .option('--json', 'Output as JSON')
+    .action(async (options: Record<string, unknown>) => {
+      await runSdk(deps, async () => {
+        const tokens = await deps.listObserverTokens(connection(options));
+
+        if (options.json) {
+          printJson(deps, tokens.map(describeToken));
+          return;
+        }
+
+        if (tokens.length === 0) {
+          deps.log('No observer tokens.');
+          return;
+        }
+        for (const token of tokens) {
+          deps.log(`${token.id}  ${token.status}  expires ${token.expiresAt ?? 'never'}  ${token.name}`);
+        }
+      });
+    });
+
+  group
+    .command('revoke')
+    .description('Revoke an observer token by id')
+    .argument('<id>', 'Observer token id')
+    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option('--base-url <url>', 'Override the engine API base URL')
+    .action(async (id: string, options: Record<string, unknown>) => {
+      await runSdk(deps, async () => {
+        await deps.revokeObserverToken({ ...connection(options), id });
+        deps.log(`Revoked ${id}.`);
+      });
+    });
+}

--- a/packages/cli/src/cli/commands/observer.ts
+++ b/packages/cli/src/cli/commands/observer.ts
@@ -128,19 +128,25 @@ export function registerObserverCommands(
     .description('Mint a read-only observer link so a human can follow this workspace');
 
   group
-    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option(
+      '--workspace-key <key>',
+      'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)'
+    )
     .option('--base-url <url>', 'Override the engine API base URL (defaults to RELAY_BASE_URL)')
     .option('--observer-url <url>', `Observer dashboard URL (defaults to ${DEFAULT_OBSERVER_URL})`)
     .option('--name <name>', 'Token name (defaults to a generated unique name)')
     .option('--channels <names>', 'Restrict to a comma-separated list of channels', parseChannels)
     .option('--include-dms', 'Include agent DM traffic (excluded by default)')
-    .option('--expires <duration>', `Token lifetime, e.g. 30m, 24h, 7d (default ${DEFAULT_OBSERVER_EXPIRES})`, parseDuration)
+    .option(
+      '--expires <duration>',
+      `Token lifetime, e.g. 30m, 24h, 7d (default ${DEFAULT_OBSERVER_EXPIRES})`,
+      parseDuration
+    )
     .option('--json', 'Output the token metadata and URL as JSON')
     .action(async (options: Record<string, unknown>) => {
       await runSdk(deps, async () => {
         const lifetimeMs = (options.expires as number | undefined) ?? parseDuration(DEFAULT_OBSERVER_EXPIRES);
-        const name =
-          (options.name as string | undefined)?.trim() || `observer-cli-${deps.randomSuffix()}`;
+        const name = (options.name as string | undefined)?.trim() || `observer-cli-${deps.randomSuffix()}`;
 
         const token = await deps.createObserverToken({
           ...connection(options),
@@ -171,9 +177,7 @@ export function registerObserverCommands(
         deps.log('');
         deps.log(`Read-only. Expires ${token.expiresAt ?? 'never'}.`);
         deps.log(
-          options.includeDms === true
-            ? 'Includes agent DMs.'
-            : 'Channels only — agent DMs are excluded.'
+          options.includeDms === true ? 'Includes agent DMs.' : 'Channels only — agent DMs are excluded.'
         );
         deps.log(`Revoke with: agent-relay observer revoke ${token.id}`);
       });
@@ -182,7 +186,10 @@ export function registerObserverCommands(
   group
     .command('list')
     .description('List observer tokens for this workspace (token material is never shown)')
-    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option(
+      '--workspace-key <key>',
+      'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)'
+    )
     .option('--base-url <url>', 'Override the engine API base URL')
     .option('--json', 'Output as JSON')
     .action(async (options: Record<string, unknown>) => {
@@ -208,7 +215,10 @@ export function registerObserverCommands(
     .command('revoke')
     .description('Revoke an observer token by id')
     .argument('<id>', 'Observer token id')
-    .option('--workspace-key <key>', 'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)')
+    .option(
+      '--workspace-key <key>',
+      'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)'
+    )
     .option('--base-url <url>', 'Override the engine API base URL')
     .action(async (id: string, options: Record<string, unknown>) => {
       await runSdk(deps, async () => {

--- a/packages/cli/src/cli/commands/observer.ts
+++ b/packages/cli/src/cli/commands/observer.ts
@@ -84,10 +84,14 @@ function parseChannels(value: string): string[] {
   if (names.length === 0) {
     throw new InvalidArgumentError('Expected at least one channel name.');
   }
-  if (names.length > MAX_CHANNEL_FILTERS) {
+  // Collapse duplicates before enforcing the cap: `--channels a,a,a` is one
+  // filter, and rejecting it for exceeding a limit it never reaches would be
+  // surprising.
+  const unique = [...new Set(names)];
+  if (unique.length > MAX_CHANNEL_FILTERS) {
     throw new InvalidArgumentError(`Expected at most ${MAX_CHANNEL_FILTERS} channel names.`);
   }
-  return [...new Set(names)];
+  return unique;
 }
 
 /**
@@ -148,6 +152,12 @@ export function registerObserverCommands(
         const lifetimeMs = (options.expires as number | undefined) ?? parseDuration(DEFAULT_OBSERVER_EXPIRES);
         const name = (options.name as string | undefined)?.trim() || `observer-cli-${deps.randomSuffix()}`;
 
+        // Resolve the dashboard URL BEFORE minting. A bad `--observer-url` or
+        // `RELAY_OBSERVER_URL` would otherwise mint a live 24-hour token and
+        // then throw before printing it, leaving an active credential the
+        // caller never saw.
+        const observerBase = resolveObserverBaseUrl(options.observerUrl as string | undefined, env);
+
         const token = await deps.createObserverToken({
           ...connection(options),
           name,
@@ -163,10 +173,7 @@ export function registerObserverCommands(
           throw new Error('Observer token created, but the response did not include token material.');
         }
 
-        const url = observerUrl(
-          resolveObserverBaseUrl(options.observerUrl as string | undefined, env),
-          token.token
-        );
+        const url = observerUrl(observerBase, token.token);
 
         if (options.json) {
           printJson(deps, { ...describeToken(token), url });
@@ -192,7 +199,12 @@ export function registerObserverCommands(
     )
     .option('--base-url <url>', 'Override the engine API base URL')
     .option('--json', 'Output as JSON')
-    .action(async (options: Record<string, unknown>) => {
+    .action(async (_options: Record<string, unknown>, command: Command) => {
+      // The parent `observer` group declares the same flag names, and Commander
+      // resolves a repeated option onto the ancestor that declared it first — so
+      // the local opts object here is empty and `--json` / `--workspace-key`
+      // would be silently dropped. Read the merged view instead.
+      const options = command.optsWithGlobals() as Record<string, unknown>;
       await runSdk(deps, async () => {
         const tokens = await deps.listObserverTokens(connection(options));
 
@@ -220,7 +232,9 @@ export function registerObserverCommands(
       'Workspace key (defaults to RELAY_WORKSPACE_KEY or the active workspace)'
     )
     .option('--base-url <url>', 'Override the engine API base URL')
-    .action(async (id: string, options: Record<string, unknown>) => {
+    .action(async (id: string, _options: Record<string, unknown>, command: Command) => {
+      // See the note on `observer list` — read merged options, not local ones.
+      const options = command.optsWithGlobals() as Record<string, unknown>;
       await runSdk(deps, async () => {
         await deps.revokeObserverToken({ ...connection(options), id });
         deps.log(`Revoked ${id}.`);

--- a/packages/cli/src/cli/lib/observer-url.ts
+++ b/packages/cli/src/cli/lib/observer-url.ts
@@ -28,12 +28,21 @@ export function resolveObserverBaseUrl(
   env: NodeJS.ProcessEnv = process.env
 ): string {
   const value = explicit?.trim() || env.RELAY_OBSERVER_URL?.trim() || DEFAULT_OBSERVER_URL;
+  let parsed: URL;
   try {
     // Fail here rather than emitting a malformed link the caller only discovers
     // after pasting it somewhere public.
-    new URL(value);
+    parsed = new URL(value);
   } catch {
     throw new Error(`Invalid observer URL: ${value}`);
+  }
+  // The token is appended to this URL's query string, so the scheme decides
+  // where a live credential ends up. `new URL` happily accepts `data:`,
+  // `javascript:`, and arbitrary custom schemes; restrict to the two that
+  // actually address an observer dashboard so a bad `RELAY_OBSERVER_URL`
+  // cannot turn the generated link into a token-exfiltration vector.
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`Observer URL must be http or https: ${value}`);
   }
   return value;
 }

--- a/packages/cli/src/cli/lib/observer-url.ts
+++ b/packages/cli/src/cli/lib/observer-url.ts
@@ -1,0 +1,57 @@
+/**
+ * Observer dashboard URL construction, shared by the `observer` command group
+ * and the `get_observer_url` MCP tool so both produce identical links.
+ *
+ * The credential rides in the `?key=` query string because that is what the
+ * observer dashboard reads. That is precisely why the value must always be a
+ * scoped, read-only `ot_live_` token and never a workspace key: query strings
+ * land in browser history, referrer headers, and proxy logs.
+ */
+
+/** Where the hosted observer dashboard lives. */
+export const DEFAULT_OBSERVER_URL = 'https://agentrelay.com/observer';
+
+/** Default token lifetime for a link meant to be pasted into chat. */
+export const DEFAULT_OBSERVER_EXPIRES = '24h';
+
+/**
+ * Resolve the observer dashboard base URL: explicit flag, then
+ * `RELAY_OBSERVER_URL` (for self-hosted or staging dashboards), then the
+ * hosted default.
+ *
+ * @param explicit - Value passed on the command line, if any
+ * @param env - Environment to read `RELAY_OBSERVER_URL` from
+ * @returns A validated absolute URL
+ */
+export function resolveObserverBaseUrl(
+  explicit: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const value = explicit?.trim() || env.RELAY_OBSERVER_URL?.trim() || DEFAULT_OBSERVER_URL;
+  try {
+    // Fail here rather than emitting a malformed link the caller only discovers
+    // after pasting it somewhere public.
+    new URL(value);
+  } catch {
+    throw new Error(`Invalid observer URL: ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Build the observer URL for a token.
+ *
+ * @param baseUrl - Observer dashboard base URL
+ * @param token - Scoped `ot_live_` observer token
+ * @returns The full observer URL
+ */
+export function observerUrl(baseUrl: string, token: string): string {
+  if (!token.startsWith('ot_live_')) {
+    // A workspace key in this position would be an administrative credential in
+    // a shareable URL — the exact failure this command exists to prevent.
+    throw new Error('Observer URLs require a scoped observer token (ot_live_...).');
+  }
+  const url = new URL(baseUrl);
+  url.searchParams.set('key', token);
+  return url.toString();
+}

--- a/packages/sdk/src/__tests__/thin-client.test.ts
+++ b/packages/sdk/src/__tests__/thin-client.test.ts
@@ -7,6 +7,7 @@ const relaycastMocks = vi.hoisted(() => {
   const relayCastInstances: Array<{
     config: Record<string, unknown>;
     as: Mock;
+    observerTokens: { create: Mock; list: Mock; revoke: Mock };
     agents: { list: Mock; registerOrRotate: Mock; spawn: Mock; release: Mock };
   }> = [];
   const wsClientInstances: Array<Record<string, unknown>> = [];
@@ -32,6 +33,19 @@ const relaycastMocks = vi.hoisted(() => {
     const instance = {
       config,
       as,
+      observerTokens: {
+        create: vi.fn(async (data: Record<string, unknown>) => ({
+          id: 'ot_1',
+          name: data.name,
+          scopes: data.scopes,
+          status: 'active',
+          expiresAt: data.expiresAt ?? null,
+          createdAt: '2026-08-03T00:00:00.000Z',
+          token: 'ot_live_material',
+        })),
+        list: vi.fn(async () => [{ id: 'ot_1', name: 'a', status: 'active' }]),
+        revoke: vi.fn(async () => undefined),
+      },
       agents: {
         list: vi.fn(async () => [{ name: 'A' }]),
         registerOrRotate: vi.fn(async () => ({ name: 'A', token: 'at_live_a', extra_field: 1 })),
@@ -67,10 +81,14 @@ vi.mock('@relaycast/sdk', async (importOriginal) => {
 });
 
 import {
+  RELAY_OBSERVER_SCOPES,
   createAgentClient,
+  createObserverToken,
   createRealtimeClient,
   createWorkspace,
   createWorkspaceClient,
+  listObserverTokens,
+  revokeObserverToken,
 } from '../messaging/thin-client.js';
 
 beforeEach(() => {
@@ -255,5 +273,51 @@ describe('createWorkspace', () => {
     await createWorkspace('Test');
 
     expect(relaycastMocks.createWorkspace).toHaveBeenCalledWith('Test', {});
+  });
+});
+
+describe('observer tokens', () => {
+  it('defaults to every read scope with DMs excluded', async () => {
+    const token = await createObserverToken({
+      workspaceKey: 'rk_live_test',
+      name: 'observer-cli-1',
+    });
+
+    const instance = relaycastMocks.relayCastInstances[0];
+    expect(instance.config).toEqual({ apiKey: 'rk_live_test' });
+    const [payload] = instance.observerTokens.create.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.scopes).toEqual([...RELAY_OBSERVER_SCOPES]);
+    // `stream:read` is what makes the token usable on the realtime endpoint.
+    expect(payload.scopes).toContain('stream:read');
+    // Recorded explicitly rather than left to the server default, so the
+    // token's stored filters show the decision.
+    expect(payload.filters).toEqual({ includeDms: false });
+    expect(token.token).toBe('ot_live_material');
+  });
+
+  it('passes channel and DM narrowing through', async () => {
+    await createObserverToken({
+      workspaceKey: 'rk_live_test',
+      name: 'observer-cli-2',
+      filters: { channelNames: ['general'], includeDms: true },
+      expiresAt: '2026-08-04T00:00:00.000Z',
+      scopes: ['stream:read', 'messages:read'],
+    });
+
+    const instance = relaycastMocks.relayCastInstances[0];
+    const [payload] = instance.observerTokens.create.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      scopes: ['stream:read', 'messages:read'],
+      filters: { includeDms: true, channelNames: ['general'] },
+      expiresAt: '2026-08-04T00:00:00.000Z',
+    });
+  });
+
+  it('lists and revokes through the workspace client', async () => {
+    await listObserverTokens({ workspaceKey: 'rk_live_test' });
+    expect(relaycastMocks.relayCastInstances[0].observerTokens.list).toHaveBeenCalled();
+
+    await revokeObserverToken({ workspaceKey: 'rk_live_test', id: 'ot_1' });
+    expect(relaycastMocks.relayCastInstances[1].observerTokens.revoke).toHaveBeenCalledWith('ot_1');
   });
 });

--- a/packages/sdk/src/messaging/thin-client.ts
+++ b/packages/sdk/src/messaging/thin-client.ts
@@ -279,9 +279,7 @@ export async function createObserverToken(
     // token's stored filters record the decision rather than an absence.
     filters: {
       includeDms: options.filters?.includeDms === true,
-      ...(options.filters?.channelNames?.length
-        ? { channelNames: options.filters.channelNames }
-        : {}),
+      ...(options.filters?.channelNames?.length ? { channelNames: options.filters.channelNames } : {}),
       ...(options.filters?.agentIds?.length ? { agentIds: options.filters.agentIds } : {}),
     },
     ...(options.expiresAt === undefined ? {} : { expiresAt: options.expiresAt }),

--- a/packages/sdk/src/messaging/thin-client.ts
+++ b/packages/sdk/src/messaging/thin-client.ts
@@ -176,6 +176,142 @@ export interface RelayRealtimeClientOptions extends RelaycastTelemetryOptions {
   baseUrl?: string;
 }
 
+/**
+ * Read scopes granted to an observer token minted by {@link createObserverToken}.
+ *
+ * Mirrors the engine's `OBSERVER_SCOPES`. `stream:read` is what makes the token
+ * usable on the workspace realtime endpoint (`GET /v1/ws`) — the engine rejects
+ * a workspace key there, so a token without it can read REST but never streams.
+ */
+export const RELAY_OBSERVER_SCOPES = [
+  'stream:read',
+  'messages:read',
+  'threads:read',
+  'dms:read',
+  'channels:read',
+  'search:read',
+  'agents:read',
+  'nodes:read',
+  'deliveries:read',
+  'activity:read',
+  'files:read',
+  'reactions:read',
+] as const;
+
+export type RelayObserverScope = (typeof RELAY_OBSERVER_SCOPES)[number];
+
+/** Visibility filters narrowing what an observer token can see. */
+export interface RelayObserverTokenFilters {
+  /** Restrict to these channel names. Omit for every channel in the workspace. */
+  channelNames?: string[];
+  /** Include agent DM traffic. Off unless explicitly requested. */
+  includeDms?: boolean;
+  /** Restrict to events involving these agent ids. */
+  agentIds?: string[];
+}
+
+export interface RelayCreateObserverTokenOptions extends RelaycastTelemetryOptions {
+  /** Workspace key (`rk_live_...`) — only a workspace key may mint observer tokens. */
+  workspaceKey: string;
+  /** Token name. Must be unique within the workspace. */
+  name: string;
+  description?: string;
+  /** Defaults to every read scope in {@link RELAY_OBSERVER_SCOPES}. */
+  scopes?: readonly RelayObserverScope[];
+  filters?: RelayObserverTokenFilters;
+  /** ISO-8601 expiry. The engine rejects a timestamp in the past. */
+  expiresAt?: string;
+  baseUrl?: string;
+}
+
+/** Observer token metadata. `token` is present only on the create response. */
+export interface RelayObserverToken {
+  id: string;
+  name: string;
+  scopes: RelayObserverScope[];
+  status: string;
+  expiresAt: string | null;
+  createdAt: string;
+  lastUsedAt?: string | null;
+  /** Raw `ot_live_...` material. Returned once, at creation, and never again. */
+  token?: string;
+}
+
+/**
+ * The observer-token slice of the workspace client. Declared structurally so
+ * tests can substitute a fake without standing up a `RelayCast` instance.
+ */
+type ObserverTokenClient = {
+  observerTokens: {
+    create(data: Record<string, unknown>): Promise<RelayObserverToken>;
+    list(): Promise<RelayObserverToken[]>;
+    revoke(id: string): Promise<void>;
+  };
+};
+
+function observerTokenClient(
+  workspaceKey: string,
+  options: { baseUrl?: string } & RelaycastTelemetryOptions
+): ObserverTokenClient {
+  return new RelayCast(clientConfig(workspaceKey, options)) as unknown as ObserverTokenClient;
+}
+
+/**
+ * Mint a scoped, read-only observer token for a workspace.
+ *
+ * This is the supported way to let a human follow a workspace without handing
+ * out the workspace key: the returned `ot_live_...` is accepted everywhere the
+ * observer dashboard accepts a credential, but it cannot send messages, spawn
+ * agents, or administer the workspace.
+ *
+ * @param options - Workspace key, token name, and optional scope/filter/expiry narrowing
+ * @returns The created token, including the raw material in `token`
+ */
+export async function createObserverToken(
+  options: RelayCreateObserverTokenOptions
+): Promise<RelayObserverToken> {
+  const client = observerTokenClient(options.workspaceKey, options);
+  return client.observerTokens.create({
+    name: options.name,
+    ...(options.description === undefined ? {} : { description: options.description }),
+    scopes: [...(options.scopes ?? RELAY_OBSERVER_SCOPES)],
+    // `include_dms` defaults to false server-side, but send it explicitly so the
+    // token's stored filters record the decision rather than an absence.
+    filters: {
+      includeDms: options.filters?.includeDms === true,
+      ...(options.filters?.channelNames?.length
+        ? { channelNames: options.filters.channelNames }
+        : {}),
+      ...(options.filters?.agentIds?.length ? { agentIds: options.filters.agentIds } : {}),
+    },
+    ...(options.expiresAt === undefined ? {} : { expiresAt: options.expiresAt }),
+  });
+}
+
+/**
+ * List observer-token metadata for a workspace. Raw token material is never
+ * returned — only the creating call ever sees it.
+ *
+ * @param options - Workspace key, optional base URL and telemetry overrides
+ * @returns Token metadata, without `token`
+ */
+export async function listObserverTokens(
+  options: { workspaceKey: string; baseUrl?: string } & RelaycastTelemetryOptions
+): Promise<RelayObserverToken[]> {
+  return observerTokenClient(options.workspaceKey, options).observerTokens.list();
+}
+
+/**
+ * Revoke an observer token by id. The token stops working immediately.
+ *
+ * @param options - Workspace key, token id, optional base URL and telemetry overrides
+ */
+export async function revokeObserverToken(
+  options: { workspaceKey: string; id: string; baseUrl?: string } & RelaycastTelemetryOptions
+): Promise<void> {
+  await observerTokenClient(options.workspaceKey, options).observerTokens.revoke(options.id);
+}
+
 export interface RelayCreateWorkspaceOptions extends Omit<RelaycastTelemetryOptions, 'originActor'> {
   baseUrl?: string;
 }

--- a/plugins/codex-relay-skill/SKILL.md
+++ b/plugins/codex-relay-skill/SKILL.md
@@ -30,11 +30,13 @@ Every relay-connected Codex agent must complete these steps IN ORDER before subs
 2. **Register as an agent.** Call `register_agent` with your agent name and `type: "agent"`. Use `RELAY_AGENT_NAME` from the environment if set, otherwise derive a name from the task context (e.g., `lead`, `auth-worker`).
 
 3. **Keep workspace credentials out of output.** Never print the workspace key
-   or construct an observer URL from it. If the user asks to follow the
-   conversation, explain that observation requires a separately provisioned,
-   read-only observer token (`ot_live_...`) delivered through an explicit
-   secret handoff. Do not print the token or place it in a URL query string;
-   when no scoped observer token is available, omit the observer link.
+   or construct an observer URL from it — it is an administrative credential.
+   When the user asks to follow the conversation, run `agent-relay observer`
+   and print the URL it returns. That mints a scoped, read-only token
+   (`ot_live_...`) that expires in 24 hours and excludes agent DMs, so the link
+   is safe to share. Narrow it further with `--channels`, widen it with
+   `--include-dms` or `--expires`, and revoke it with
+   `agent-relay observer revoke <id>`.
 
 4. **Check the relay inbox.** Call `check_inbox` to see if there are any pending messages or task assignments.
 

--- a/plugins/gemini-relay-extension/GEMINI.md
+++ b/plugins/gemini-relay-extension/GEMINI.md
@@ -8,10 +8,12 @@ Never print a workspace key or construct an observer URL from one. Workspace
 keys have administrative authority and do not belong in terminal transcripts
 or URL query strings.
 
-If the user asks to follow the conversation, explain that observation requires
-a separately provisioned, read-only observer token (`ot_live_...`). The token
-must be delivered through an explicit secret handoff, not printed by the agent.
-When no scoped observer token has been provisioned, omit the observer link.
+When the user asks to follow the conversation, run `agent-relay observer` and
+print the URL it returns. It mints a scoped, read-only observer token
+(`ot_live_...`) — expiring in 24 hours and excluding agent DMs by default — and
+builds the link from that instead of the workspace key. Use `--channels` to
+narrow the view, `--include-dms` or `--expires` to widen it, and
+`agent-relay observer revoke <id>` to cut it off early.
 
 ## Delegating to Sub-Agents
 


### PR DESCRIPTION
## Summary

Letting a human watch a workspace live had no supported path, so the guidance we ship told agents not to offer one.

The engine rejects a workspace key on the realtime endpoint (`GET /v1/ws`) and accepts only a scoped `ot_live_` observer token. But nothing in the CLI or MCP server minted one — grepping `packages/cli/src` for "observer" returned exactly one hit, `cloud-room.ts:197`, which *rejects* observer tokens. The only real routes were a hand-rolled `POST /v1/observer-tokens` or pasting an admin key into the dashboard login so it mints one server-side.

So `plugins/codex-relay-skill/SKILL.md` and `plugins/gemini-relay-extension/GEMINI.md` (from #1405) said observation "requires a separately provisioned, read-only observer token" and to "omit the observer link" when none exists. Correct about the danger, but with no reachable happy path it means nobody ever gets a link. Meanwhile the skills repo's `relay-team` / `relay-fanout` / `relay-pipeline` skills mandate the opposite — printing the raw `rk_live_` key in a URL, "This is mandatory" — which is the thing #1380 is meant to stop. This PR gives all of them one satisfiable answer.

### What's added

- **`agent-relay observer`** — mints a scoped token and prints the observer URL built from it. `observer list` and `observer revoke <id>` manage existing tokens.
- **`get_observer_url` MCP tool** — same thing for an orchestrating agent, so a lead can hand the user a link without shelling out.
- **SDK exports** — `createObserverToken`, `listObserverTokens`, `revokeObserverToken` from `@agent-relay/sdk`.

The frontend already works: `RelaySessionProvider.tsx:29` in relaycast accepts `ot_live_` in `?key=` exactly like `rk_live_`, so a scoped token is a drop-in URL replacement with no dashboard change.

### Defaults, and why they differ from the dashboard's

The observer dashboard already auto-mints a token on workspace-key login (`observer-dashboard/src/lib/observer-token.ts`): 30-day expiry, `include_dms: true`. That is right for a token backing a browser session behind an httpOnly cookie. It is wrong for a token printed as a URL and pasted into chat, so this command defaults to **24 hours with agent DMs excluded**, widened explicitly:

```bash
agent-relay observer                            # 24h, channels only
agent-relay observer --channels build,review    # narrow further
agent-relay observer --include-dms --expires 7d # widen deliberately
agent-relay observer revoke ot_abc123
```

**These two defaults are the main judgement calls in this PR** — easy to change if you'd rather match the dashboard.

`observerUrl()` throws on any credential that isn't an `ot_live_` token, so the workspace-key-in-a-URL failure this command exists to prevent can't be reintroduced by a later caller.

Also updates the Codex skill and Gemini extension text to point at the command rather than describing the link as unobtainable.

### Review fixes (552944f)

Five findings, all confirmed and fixed:

- **Subcommand flags were silently dropped.** `observer list` / `revoke` read only their local option object, but Commander binds a repeated option to the ancestor that declared it first. Reproduced directly — the child's local opts are `{}`, so both `--json` **and** `--workspace-key` were ignored. Now reads `optsWithGlobals()`.
- **Non-http(s) observer URLs were accepted.** The token rides in the query string, so a `data:`/custom-scheme value would carry a live credential somewhere unintended. Restricted to http/https (plain http kept for local dashboards).
- **Token was minted before the URL was validated**, in both the CLI and the MCP tool — an invalid `RELAY_OBSERVER_URL` left a live 24-hour token behind and then threw before returning it. URL now resolved first.
- **`--channels` enforced its cap before deduping**, so `a,a,a,…` could be rejected for a limit it never reached.
- **Tests mutated `process.env` directly**, leaking a workspace key into every later test file. Now `vi.stubEnv` + `vi.unstubAllEnvs`.

Fixing these also surfaced a bug in the test harness itself: `setup()` returned its default mocks rather than the overrides actually registered, so an overridden mock could never be asserted against. Fixed, with four new regression tests.

## Test Plan

- [x] Rebased onto current main (11.4.0 → 11.8.0); resolved conflicts in `CHANGELOG.md` and `bootstrap.test.ts`
- [x] `packages/cli/src/cli/commands/observer.test.ts` — **13 tests**, including regressions for all four behavioural fixes above
- [x] `packages/sdk/src/__tests__/thin-client.test.ts` — 3 tests covering the SDK helper's own scope/filter defaults, which the CLI tests stub out
- [x] `packages/cli` suite — 1222 passed, 11 skipped
- [x] `npm run typecheck` clean (exit 0)
- [x] Reproduced the Commander option-scoping bug in isolation before fixing it, rather than trusting the report
- [x] 6 failures in `node-definition-loader.bun.test.ts` are **pre-existing** — verified identical failures on a clean `origin/main` worktree (Bun isn't installed in this environment)
- [x] `bootstrap.test.ts` inventory updated. `observer` is a group with a default action, so the leaf-path walk skips it — added an explicit assertion so the primary command can't be dropped silently
- [ ] Manual run against a live workspace — not run; no credentials here. Worth one `agent-relay observer` before merge to confirm the minted token opens the dashboard

## Screenshots

n/a