### PR TITLE
fix(skills): correct using-agent-relay drift and stale MCP names in sdk rule

### DIFF
--- a/.agents/skills/using-agent-relay/SKILL.md
+++ b/.agents/skills/using-agent-relay/SKILL.md
@@ -77,6 +77,7 @@ Do not use older category-expanded names such as
 | `send_dm`             | Send a direct message to one agent                 |
 | `send_group_dm`       | Create a group DM and send the first message       |
 | `post_message`        | Post to a channel                                  |
+| `list_dms`            | List your direct-message conversations             |
 | `list_messages`       | Read channel history                               |
 | `reply_to_thread`     | Reply to an existing message                       |
 | `get_message_thread`  | Read a thread                                      |
@@ -198,38 +199,63 @@ remove_agent(name: "reviewer-1", reason: "Review accepted")
 
 ## Current CLI Reference
 
-Startup and status commands are intentionally omitted from these agent-facing
-examples. Published Agent Relay versions through 11.3.0 can print live
-workspace credentials when those commands run in a transcribed session. Upgrade
-to Agent Relay 11.3.1 or later before running them there.
+Prefer the MCP tools above for messaging. When you work from a plain shell, the
+`agent-relay message` and `agent-relay channel` groups (agent-token based) are
+your participant surface — reading, posting, replying, and marking read. The
+`agent-relay node` group is broker lifecycle and debug only.
 
-These are the current CLI forms for local broker and SDK-backed messaging
-operations:
+Export your credentials once instead of repeating them as flags. Command-line
+arguments are visible to other processes on the machine (`ps`), and they land in
+shell history and CI logs:
 
 ```bash
-agent-relay status
+export RELAY_WORKSPACE_KEY=rk_live_...
+export RELAY_AGENT_TOKEN=at_live_...
+export RELAY_BASE_URL=https://cast.agentrelay.com   # only to override the default
+```
+
+Messaging (agent token; these are how a participant reads and replies):
+
+```bash
+agent-relay message inbox check
+agent-relay message inbox mark_read msg_123
+agent-relay message dm send Lead "ACK: I am online."
+agent-relay message dm list "$CONVERSATION_ID"   # persistent DM history (unlike unread-only inbox check)
+agent-relay message post general "Status update"
+agent-relay message list general
+agent-relay message reply msg_123 "Thread reply"
+agent-relay message get_thread msg_123
+agent-relay channel list
+```
+
+Workspace identity:
+
+```bash
+agent-relay agent register Worker
+agent-relay agent list
+```
+
+Local broker lifecycle and debug (lifecycle only — read replies through the
+`message` group above, never `node tail`):
+
+```bash
+agent-relay status                       # workspace + cloud + broker overview
+agent-relay node up --background --verbose
+agent-relay node status --wait-for 10
 agent-relay node agent list
 agent-relay node agent spawn claude --name Worker --task "Use https://agentrelay.com/skill and ACK over Relay."
-agent-relay node tail --agent Worker
 agent-relay node agent attach Worker --mode view
 agent-relay node agent release Worker
-
-agent-relay agent register Worker --workspace-key rk_live_...
-agent-relay agent list --workspace-key rk_live_...
-agent-relay message inbox check --workspace-key rk_live_... --token at_live_...
-agent-relay message dm send Lead "ACK: I am online." --workspace-key rk_live_... --token at_live_...
-agent-relay message post general "Status update" --workspace-key rk_live_... --token at_live_...
-agent-relay message list general --workspace-key rk_live_... --token at_live_...
-agent-relay message reply msg_123 "Thread reply" --workspace-key rk_live_... --token at_live_...
+agent-relay node tail --agent Worker    # worker output/TTY, not durable messages
+agent-relay node tail                   # broker debug events (unfiltered), not messages
 ```
 
-Use environment variables instead of flags when available:
+These lifecycle commands live under `agent-relay node …`. The old flat
+`agent-relay local …` group still works as a hidden, deprecated alias (it prints
+a removal warning) — prefer `node`.
 
-```bash
-RELAY_WORKSPACE_KEY=rk_live_...
-RELAY_AGENT_TOKEN=at_live_...
-RELAY_BASE_URL=https://gateway.relaycast.dev
-```
+Every command above accepts explicit `--workspace-key` / `--token` / `--base-url`
+flags too, but only reach for them when you cannot set the environment.
 
 ## Common Mistakes
 

--- a/.agents/skills/using-agent-relay/SKILL.md
+++ b/.agents/skills/using-agent-relay/SKILL.md
@@ -254,8 +254,12 @@ These lifecycle commands live under `agent-relay node …`. The old flat
 `agent-relay local …` group still works as a hidden, deprecated alias (it prints
 a removal warning) — prefer `node`.
 
-Every command above accepts explicit `--workspace-key` / `--token` / `--base-url`
-flags too, but only reach for them when you cannot set the environment.
+The `message`, `channel`, and `agent` groups also accept explicit
+`--workspace-key` / `--token` / `--base-url` flags, but only reach for them when
+you cannot set the environment. The `node` group does **not** take those — it
+talks to the local broker over its own `--broker-url` / `--api-key` /
+`--state-dir` flags (`RELAY_BROKER_URL`, `RELAY_BROKER_API_KEY`), and the
+`--workspace-key` on `node up` is a different flag with a different meaning.
 
 ## Common Mistakes
 

--- a/.claude/rules/sdk.md
+++ b/.claude/rules/sdk.md
@@ -53,10 +53,14 @@ The SDK uses subpath exports:
 
 ## Communication Protocol
 
-- **Primary**: MCP tools (`mcp__agent-relay__send_dm`,
-  `mcp__agent-relay__post_message`, `mcp__agent-relay__check_inbox`,
-  `mcp__agent-relay__list_agents`, `mcp__agent-relay__add_agent`,
-  `mcp__agent-relay__remove_agent`)
+- **Primary**: MCP tools. The canonical names are flat — `send_dm`,
+  `check_inbox`, `post_message`, `list_agents`, `add_agent`, `remove_agent`.
+  A client may decorate them with the configured server key, so Claude Code
+  users typically see `mcp__agent-relay__send_dm` while Codex and opencode see
+  the bare name.
+- Do **not** use the older category-expanded forms
+  (`mcp__relaycast__message_dm_send`, `relaycast.message.dm.send`,
+  `message.post`). They are not registered by `agent-relay mcp`.
 
 ## No Storage Layer
 

--- a/.claude/skills/using-agent-relay/SKILL.md
+++ b/.claude/skills/using-agent-relay/SKILL.md
@@ -77,6 +77,7 @@ Do not use older category-expanded names such as
 | `send_dm`             | Send a direct message to one agent                 |
 | `send_group_dm`       | Create a group DM and send the first message       |
 | `post_message`        | Post to a channel                                  |
+| `list_dms`            | List your direct-message conversations             |
 | `list_messages`       | Read channel history                               |
 | `reply_to_thread`     | Reply to an existing message                       |
 | `get_message_thread`  | Read a thread                                      |
@@ -198,38 +199,63 @@ remove_agent(name: "reviewer-1", reason: "Review accepted")
 
 ## Current CLI Reference
 
-Startup and status commands are intentionally omitted from these agent-facing
-examples. Published Agent Relay versions through 11.3.0 can print live
-workspace credentials when those commands run in a transcribed session. Upgrade
-to Agent Relay 11.3.1 or later before running them there.
+Prefer the MCP tools above for messaging. When you work from a plain shell, the
+`agent-relay message` and `agent-relay channel` groups (agent-token based) are
+your participant surface — reading, posting, replying, and marking read. The
+`agent-relay node` group is broker lifecycle and debug only.
 
-These are the current CLI forms for local broker and SDK-backed messaging
-operations:
+Export your credentials once instead of repeating them as flags. Command-line
+arguments are visible to other processes on the machine (`ps`), and they land in
+shell history and CI logs:
 
 ```bash
-agent-relay status
+export RELAY_WORKSPACE_KEY=rk_live_...
+export RELAY_AGENT_TOKEN=at_live_...
+export RELAY_BASE_URL=https://cast.agentrelay.com   # only to override the default
+```
+
+Messaging (agent token; these are how a participant reads and replies):
+
+```bash
+agent-relay message inbox check
+agent-relay message inbox mark_read msg_123
+agent-relay message dm send Lead "ACK: I am online."
+agent-relay message dm list "$CONVERSATION_ID"   # persistent DM history (unlike unread-only inbox check)
+agent-relay message post general "Status update"
+agent-relay message list general
+agent-relay message reply msg_123 "Thread reply"
+agent-relay message get_thread msg_123
+agent-relay channel list
+```
+
+Workspace identity:
+
+```bash
+agent-relay agent register Worker
+agent-relay agent list
+```
+
+Local broker lifecycle and debug (lifecycle only — read replies through the
+`message` group above, never `node tail`):
+
+```bash
+agent-relay status                       # workspace + cloud + broker overview
+agent-relay node up --background --verbose
+agent-relay node status --wait-for 10
 agent-relay node agent list
 agent-relay node agent spawn claude --name Worker --task "Use https://agentrelay.com/skill and ACK over Relay."
-agent-relay node tail --agent Worker
 agent-relay node agent attach Worker --mode view
 agent-relay node agent release Worker
-
-agent-relay agent register Worker --workspace-key rk_live_...
-agent-relay agent list --workspace-key rk_live_...
-agent-relay message inbox check --workspace-key rk_live_... --token at_live_...
-agent-relay message dm send Lead "ACK: I am online." --workspace-key rk_live_... --token at_live_...
-agent-relay message post general "Status update" --workspace-key rk_live_... --token at_live_...
-agent-relay message list general --workspace-key rk_live_... --token at_live_...
-agent-relay message reply msg_123 "Thread reply" --workspace-key rk_live_... --token at_live_...
+agent-relay node tail --agent Worker    # worker output/TTY, not durable messages
+agent-relay node tail                   # broker debug events (unfiltered), not messages
 ```
 
-Use environment variables instead of flags when available:
+These lifecycle commands live under `agent-relay node …`. The old flat
+`agent-relay local …` group still works as a hidden, deprecated alias (it prints
+a removal warning) — prefer `node`.
 
-```bash
-RELAY_WORKSPACE_KEY=rk_live_...
-RELAY_AGENT_TOKEN=at_live_...
-RELAY_BASE_URL=https://gateway.relaycast.dev
-```
+Every command above accepts explicit `--workspace-key` / `--token` / `--base-url`
+flags too, but only reach for them when you cannot set the environment.
 
 ## Common Mistakes
 

--- a/.claude/skills/using-agent-relay/SKILL.md
+++ b/.claude/skills/using-agent-relay/SKILL.md
@@ -254,8 +254,12 @@ These lifecycle commands live under `agent-relay node …`. The old flat
 `agent-relay local …` group still works as a hidden, deprecated alias (it prints
 a removal warning) — prefer `node`.
 
-Every command above accepts explicit `--workspace-key` / `--token` / `--base-url`
-flags too, but only reach for them when you cannot set the environment.
+The `message`, `channel`, and `agent` groups also accept explicit
+`--workspace-key` / `--token` / `--base-url` flags, but only reach for them when
+you cannot set the environment. The `node` group does **not** take those — it
+talks to the local broker over its own `--broker-url` / `--api-key` /
+`--state-dir` flags (`RELAY_BROKER_URL`, `RELAY_BROKER_API_KEY`), and the
+`--workspace-key` on `node up` is a different flag with a different meaning.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary

> **Re-verified against main at `32c36b89`** (after #1422 merged). All four issues below are still present on main, so this PR is still needed and still correct. Details in the test plan.

Both vendored copies of `using-agent-relay` (`.claude/skills/` and `.agents/skills/`) had drifted in four ways. Main has since fixed one of them:

| Issue | Status on current main |
|---|---|
| MCP tool prefix documented as `mcp__relaycast__send_dm` | ✅ **fixed on main** — no longer part of this PR |
| Dead 11.3.0 security warning suppressing working content | ❌ still present, fixed here |
| `RELAY_BASE_URL` example is the legacy `gateway.relaycast.dev` | ❌ still present, fixed here |
| `list_dms` missing from the tool table | ❌ still missing, fixed here |
| Credentials passed as argv in 7 examples | ❌ still present, fixed here |

### The dead warning

The CLI reference omits every startup and status command, justified by:

> *"Published Agent Relay versions through 11.3.0 can print live workspace credentials … Upgrade to Agent Relay 11.3.1 or later."*

Main is on **11.8.0**. The warning describes a defect fixed several minor versions ago while still hiding commands agents need. Removed, and the suppressed commands restored.

### The other two

`gateway.relaycast.dev` is the legacy host — the default in this repo and in relaycast is `cast.agentrelay.com`. And `list_dms` was missing from the tool table even though `orchestrating-agent-relay` tells agents to use exactly that tool to re-read consumed DM history.

Main's newer injection-mode guidance (`mode: "wait"` vs `"steer"`, `get_message_readers`) is preserved intact — the CLI Reference section was rebuilt on top of main's file rather than replacing it.

### From review

- **Credentials moved out of argv.** Seven examples passed `--workspace-key rk_live_... --token at_live_...` as arguments. Those are visible to other processes via `ps` and land in shell history and CI logs — the same exposure class #1380 is closing. The examples now export the documented environment variables once and run bare.
- **`<conversationId>` → `"$CONVERSATION_ID"`.** Angle brackets are shell redirection, so the old example could not be pasted as written.
- **Credential-flag note scoped correctly.** A later review caught that the closing note claimed *every* command accepts `--workspace-key` / `--token` / `--base-url`. Verified against a build of the current CLI — the `node` group takes none of them (`node agent list` has only `--pretty`/`--status`; `node tail`, `node agent release`, `node agent spawn` have no connection flags at all), uses its own `--broker-url` / `--api-key` / `--state-dir` model, and `node up --workspace-key` is a *different* flag with a different meaning. As written it would have sent an agent to add flags that error out.

### `.claude/rules/sdk.md`

Main corrected the prefix here too, but this keeps the fuller wording: it also names the canonical flat tool names (`send_dm`, `check_inbox`, …) and warns off the category-expanded forms (`mcp__relaycast__message_dm_send`) that `using-agent-relay` already tells agents not to use — none of which `agent-relay mcp` registers.

### The structural problem — tracked in #1588

Six skills exist in three copies with three different contents. This PR fixes one and deliberately leaves the rest, because the fix is structural rather than another manual sync.

This PR is itself the evidence: main improved the vendored copy while the published one sat still, so "which copy is canonical" **reversed mid-PR**. Had the original sync landed, it would have deleted main's improvements. #1588 has the full drift table and the options.

## Test Plan

Re-verified end to end against main at `32c36b89`:

- [x] Branch contains current main (`git merge-base --is-ancestor` passes) — no rebase needed
- [x] Confirmed all four issues are **still present on main**, so the PR still does something: 11.3.0 warning present, `gateway.relaycast.dev` present, `list_dms` absent, 7 argv-credential examples
- [x] Confirmed the branch fixes all four, in **both** copies, and that the two copies are byte-identical
- [x] Confirmed main's newer content survives the rebuild: `mode: "steer"` guidance, `get_message_readers`, and main's own MCP-prefix fix
- [x] **Every command in the rewritten CLI reference verified against a build of the current CLI** — all 19 resolve (`message inbox check`/`mark_read`, `message dm send`/`list`, `message post`/`list`/`reply`/`get_thread`, `channel list`, `agent register`/`list`, `status`, `node up`/`status`/`tail`, `node agent list`/`spawn`/`attach`/`release`)
- [x] Confirmed `local` is still routable and still hidden from help, as the text claims
- [x] Confirmed the three documented env vars are the ones `sdk-client.ts` actually reads, and that `cast.agentrelay.com` is still the default
- [x] `npm run typecheck` clean (exit 0); `bootstrap.test.ts` + `observer.test.ts` — 28 passed
- [x] `npx prettier --check` clean on all three files
- [x] CI green — non-skipped checks all pass (build/test jobs are correctly skipped by the path filter for a docs-only change)
- [x] Removed `package-lock.json` churn that an `npm install` swept into a commit during verification; diff is back to the intended 3 files
- [ ] Tests added/updated — n/a, documentation and agent-instruction files with no code or build dependency

## Screenshots

n/a