### PR TITLE
Stop silently discarding agent metadata on registration and spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `register_agent` now writes supplied `metadata` or `persona` instead of silently discarding it when returning a cached token, and its new `verify_metadata` option reports whether the write actually persisted.
 - Spawned agents now launch Agent Relay MCP through an installed local `agent-relay` executable instead of cold `npx` resolution.
 - Spawn now fails before start with an actionable error when no usable Agent Relay MCP executable is available.
 

--- a/packages/cli/src/cli/agent-relay-mcp.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.test.ts
@@ -37,6 +37,271 @@ describe('registerAgentWithRebind', () => {
     });
   });
 
+  const IDENTITY = {
+    organization: 'AgentWorkforce',
+    project: 'chief-delegation-governance',
+    workstream: 'dispatch-contract',
+    role: 'lead',
+    reportsTo: 'chief-khaliq',
+  };
+
+  const strictSession = () => ({
+    workspaceKey: 'rk_live_test',
+    agentToken: 'at_live_existing',
+    agentName: 'WorkerA',
+    agents: new Map([['WorkerA', { agentName: 'WorkerA', agentToken: 'at_live_existing' }]]),
+  });
+
+  /**
+   * A relay that actually stores what it is given, so a test can read the
+   * record back instead of trusting that the call was made. Asserting only
+   * "registerOrRotate was called with metadata" would repeat the mistake this
+   * whole change is about: the parameter being passed is not the field
+   * landing. `persists: false` models the broken platform.
+   */
+  function fakeRelay({ persists = true }: { persists?: boolean } = {}) {
+    // The platform writes its own block; a verifier must ignore it.
+    const records = new Map<string, Record<string, unknown>>([['WorkerA', { fleet: { nodeId: 'node_x' } }]]);
+    const registerOrRotate = vi.fn(async (input: any) => {
+      if (persists && input.metadata) {
+        records.set(input.name, { ...records.get(input.name), ...input.metadata });
+      }
+      return { id: 'agent_123', name: input.name, token: 'at_live_rotated', status: 'online' };
+    });
+    const list = vi.fn(async () => [...records].map(([name, metadata]) => ({ name, metadata })));
+    return { agents: { registerOrRotate, list }, records };
+  }
+
+  it('writes supplied metadata through and proves it landed on the record', async () => {
+    // The short-circuit exists to avoid handing back a dead token. It must not
+    // also swallow a write: a caller supplying metadata is asking for the
+    // agent record to change, and returning a cached token discarded that
+    // silently — success, no warnings, record untouched.
+    const relay = fakeRelay();
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: IDENTITY,
+      verifyMetadata: true,
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(relay.agents.registerOrRotate).toHaveBeenCalledOnce();
+
+    // The round trip, not just the call: read the record back and assert the
+    // fields are actually there.
+    const [record] = (await relay.agents.list()).filter((a) => a.name === 'WorkerA');
+    expect(record.metadata).toMatchObject(IDENTITY);
+    expect(record.metadata.fleet, 'must not clobber platform keys').toEqual({ nodeId: 'node_x' });
+
+    expect(payload.metadata_verified).toBe(true);
+    expect(payload.warnings).toEqual([]);
+  });
+
+  it('verifies nested metadata even when the platform re-serializes keys in a different order', async () => {
+    // `metadata` accepts nested objects (z.record(z.string(), z.unknown())),
+    // and the platform is free to re-serialize a stored record with keys in a
+    // different order than the caller sent them — JSON round-tripping makes
+    // no ordering guarantee. A comparison via JSON.stringify would treat this
+    // as a mismatch and report `metadata_verified: false` on a registration
+    // that actually succeeded: a verifier failing on success, the exact
+    // defect class it exists to catch. This test fails against that
+    // implementation and passes against an order-insensitive one.
+    const supplied = {
+      context: { role: 'lead', team: 'delegation-governance' },
+    };
+    const storedWithDifferentKeyOrder = {
+      fleet: { nodeId: 'node_x' },
+      context: { team: 'delegation-governance', role: 'lead' },
+    };
+    const relay = {
+      agents: {
+        registerOrRotate: vi.fn(async (input: any) => ({
+          id: 'agent_123',
+          name: input.name,
+          token: 'at_live_rotated',
+          status: 'online',
+        })),
+        list: vi.fn(async () => [{ name: 'WorkerA', metadata: storedWithDifferentKeyOrder }]),
+      },
+    };
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: supplied,
+      verifyMetadata: true,
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(payload.metadata_verified).toBe(true);
+    expect(payload.warnings).toEqual([]);
+  });
+
+  it('still catches a genuine nested mismatch under the order-insensitive comparison', async () => {
+    // The order-insensitive switch (isDeepStrictEqual) must not become a
+    // rubber stamp: same shape, a value that is actually different rather
+    // than reordered, must still fail verification. Proving the positive arm
+    // (reordered-but-equal passes) discriminates says nothing about whether
+    // this control arm (genuinely different still fails) does too — an
+    // overly lenient comparison could pass both by accident.
+    const supplied = {
+      context: { role: 'lead', team: 'delegation-governance' },
+    };
+    const storedWithDifferentValue = {
+      fleet: { nodeId: 'node_x' },
+      context: { role: 'worker', team: 'delegation-governance' },
+    };
+    const relay = {
+      agents: {
+        registerOrRotate: vi.fn(async (input: any) => ({
+          id: 'agent_123',
+          name: input.name,
+          token: 'at_live_rotated',
+          status: 'online',
+        })),
+        list: vi.fn(async () => [{ name: 'WorkerA', metadata: storedWithDifferentValue }]),
+      },
+    };
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: supplied,
+      verifyMetadata: true,
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(payload.metadata_verified).toBe(false);
+    expect(payload.warnings).toHaveLength(1);
+    expect(payload.warnings[0]).toContain('context');
+  });
+
+  it('says so loudly when the platform accepts metadata and does not persist it', async () => {
+    // This is the exact defect being fixed, reproduced: the write is accepted,
+    // the response looks like success, and the record is untouched. A
+    // passthrough that fails this way is worse than none, because it looks
+    // like it worked. It must never again be reported as a clean success.
+    const relay = fakeRelay({ persists: false });
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: IDENTITY,
+      verifyMetadata: true,
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(payload.metadata_verified).toBe(false);
+    expect(payload.warnings).toHaveLength(1);
+    expect(payload.warnings[0]).toContain('was not persisted');
+    expect(payload.warnings[0]).toContain('organization');
+    expect(payload.warnings[0]).toContain('Treat this registration as unattributed');
+  });
+
+  it('reports unverified rather than throwing when the record cannot be read back', async () => {
+    // The registration itself succeeded; claiming it failed would be its own
+    // kind of lie. But it must not be reported as verified either.
+    const relay = fakeRelay();
+    relay.agents.list = vi.fn(async () => {
+      throw new Error('workspace unreachable');
+    }) as never;
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: IDENTITY,
+      verifyMetadata: true,
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(payload.token).toBe('at_live_rotated');
+    expect(payload.metadata_verified).toBe(false);
+    expect(payload.warnings[0]).toContain('could not read the record back');
+    expect(payload.warnings[0]).toContain('workspace unreachable');
+  });
+
+  it('writes a supplied persona through, and claims no metadata verification', async () => {
+    const relay = fakeRelay();
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      persona: 'Accountable lead for chief-delegation-governance',
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(relay.agents.registerOrRotate).toHaveBeenCalledOnce();
+    // No metadata was supplied, so there is nothing to verify and no read-back
+    // cost is paid.
+    expect(relay.agents.list).not.toHaveBeenCalled();
+    expect(payload.metadata_verified).toBeUndefined();
+  });
+
+  it("reports 'unchecked' rather than success when nobody verified the write", async () => {
+    // Verification costs a workspace listing, so the per-spawn `{model}` hint
+    // does not pay for it. But "nobody looked" must not be reported as "it is
+    // there" — collapsing those two is the same error as the silent discard.
+    const relay = fakeRelay({ persists: false });
+
+    const payload = await registerAgentWithRebind({
+      session: strictSession(),
+      setSession: vi.fn(),
+      getRelay: () => relay as never,
+      name: 'WorkerA',
+      metadata: { model: 'gpt-5' },
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(payload.metadata_verified).toBe('unchecked');
+    expect(relay.agents.list).not.toHaveBeenCalled();
+    // Not a warning: nothing is known to be wrong. The claim is simply scoped.
+    expect(payload.warnings).toEqual([]);
+  });
+
+  it('still short-circuits when the caller only wants a token', async () => {
+    // The original behaviour has to survive: a bare re-registration with no
+    // write to make should not rotate the token for nothing.
+    const registerOrRotate = vi.fn();
+
+    const payload = await registerAgentWithRebind({
+      session: {
+        workspaceKey: 'rk_live_test',
+        agentToken: 'at_live_existing',
+        agentName: 'WorkerA',
+        agents: new Map([['WorkerA', { agentName: 'WorkerA', agentToken: 'at_live_existing' }]]),
+      },
+      setSession: vi.fn(),
+      getRelay: () => ({ agents: { registerOrRotate } }) as never,
+      name: 'WorkerA',
+      strictAgentName: true,
+      preferredAgentName: 'WorkerA',
+    });
+
+    expect(registerOrRotate).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({ token: 'at_live_existing' });
+  });
+
   it('re-registers when the strict-named identity was dropped from the agents map', async () => {
     // After an `agent_token_invalid` recovery, the active token is null and
     // the identity is missing from session.agents. The short-circuit must

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -244,6 +245,12 @@ type RegisterAgentWithRebindArgs = {
   type?: AgentType;
   persona?: string;
   metadata?: Record<string, unknown>;
+  /**
+   * Read the agent record back and confirm the supplied metadata persisted.
+   * Costs a workspace listing, so callers writing durable identity opt in and
+   * the per-spawn `{model}` hint does not pay for it.
+   */
+  verifyMetadata?: boolean;
   strictAgentName?: boolean;
   preferredAgentName?: string | null;
   forcedAgentType?: AgentType;
@@ -469,6 +476,7 @@ export async function registerAgentWithRebind({
   type,
   persona,
   metadata,
+  verifyMetadata,
   strictAgentName,
   preferredAgentName,
   forcedAgentType,
@@ -491,7 +499,16 @@ export async function registerAgentWithRebind({
     );
   }
 
-  if (session.agentToken && effectiveName && strictAgentName) {
+  // A caller supplying metadata or a persona is asking for a write, not for a
+  // token. The short-circuit below hands back a cached token without calling
+  // upstream, which silently discarded that write: the call returned success
+  // with no warnings and the agent record was never touched. Anything that
+  // reads identity off the record — the fleet dashboard, an org chart, a
+  // delegation gate — then sees nothing and falls back to guessing from the
+  // agent's name. Fall through so the write actually happens.
+  const wantsRecordWrite = metadata !== undefined || persona !== undefined;
+
+  if (session.agentToken && effectiveName && strictAgentName && !wantsRecordWrite) {
     // If the session tracks per-identity agents, only short-circuit when the
     // strict-named identity is still registered. After an `agent_token_invalid`
     // recovery the entry is dropped from the map, which lets this fall through
@@ -518,9 +535,39 @@ export async function registerAgentWithRebind({
   const reboundName = result.name?.trim() ? result.name : effectiveName;
   setSession({ agentToken: result.token, agentName: reboundName });
 
+  // A registration response carries {id, name, token, status, createdAt} and
+  // nothing else — `normalizeAgentRegistration` drops everything not in that
+  // shape. So the response cannot tell a caller whether its metadata landed,
+  // which is precisely why the discard this fixes went unnoticed: success and
+  // silent-failure are the same bytes.
+  //
+  // `metadata_verified` closes that gap without ever claiming more than is
+  // known. It is machine-readable so a dispatcher writing durable identity can
+  // fail closed on it — a passthrough that quietly does nothing is a worse bug
+  // than no passthrough, because it looks like it worked.
+  //
+  // Verification costs a full workspace listing, so it is opt-in rather than
+  // automatic: `add_agent` sends `metadata: {model}` on every spawn as a
+  // broker hint, and making each of those refetch every agent in the workspace
+  // would be a bad trade. Unverified is reported as the literal string
+  // 'unchecked' rather than omitted or defaulted to false — "nobody looked" is
+  // a different claim from "it is not there", and collapsing them is the same
+  // class of error as the silent discard itself.
+  let metadataVerified: boolean | 'unchecked' | undefined;
+  if (metadata) {
+    if (verifyMetadata) {
+      const verification = await verifyMetadataLanded(relay, reboundName, metadata);
+      metadataVerified = verification.verified;
+      if (!verification.verified) warnings.push(verification.warning);
+    } else {
+      metadataVerified = 'unchecked';
+    }
+  }
+
   return {
     ...result,
     registered_name: reboundName,
+    ...(metadataVerified === undefined ? {} : { metadata_verified: metadataVerified }),
     warnings,
   };
 }
@@ -606,6 +653,61 @@ async function invokeVerifiedPersonaSpawn(
   const commands = new AgentRelay({ agentToken, baseUrl }).messaging.commands;
   const invocation = await commands.invoke('spawn', actionInput);
   return waitForPersonaSpawn(commands, invocation);
+}
+
+/**
+ * Read the agent record back and confirm the supplied metadata is on it.
+ *
+ * Compares only the keys the caller sent; the platform adds its own (a `fleet`
+ * block, for one) and those are none of our business. A read that fails is
+ * reported as unverified rather than thrown — the registration itself
+ * succeeded, and claiming otherwise would be its own kind of lie.
+ */
+async function verifyMetadataLanded(
+  relay: RelayCastLike,
+  name: string,
+  metadata: Record<string, unknown>
+): Promise<{ verified: boolean; warning: string }> {
+  const keys = Object.keys(metadata);
+  if (keys.length === 0) return { verified: true, warning: '' };
+
+  let agents: unknown[];
+  try {
+    agents = await relay.agents.list();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      verified: false,
+      warning: `Registered "${name}", but could not read the record back to confirm metadata landed: ${detail}`,
+    };
+  }
+
+  const record = agents.find((agent) => (agent as { name?: string } | null)?.name === name) as
+    | { metadata?: Record<string, unknown> }
+    | undefined;
+
+  if (!record) {
+    return {
+      verified: false,
+      warning: `Registered "${name}", but the agent is not in the workspace listing, so its metadata could not be confirmed.`,
+    };
+  }
+
+  // Order-insensitive: `metadata` is a caller-supplied Record that can nest
+  // objects, and JSON.stringify comparison would false-negative a value the
+  // platform re-serialized with a different key order — reporting a verifier
+  // failure on a registration that actually succeeded.
+  const stored = record.metadata ?? {};
+  const missing = keys.filter((key) => !isDeepStrictEqual(stored[key], metadata[key]));
+  if (missing.length === 0) return { verified: true, warning: '' };
+
+  return {
+    verified: false,
+    warning:
+      `Registered "${name}", but the metadata was not persisted: ${missing.join(', ')} ` +
+      `${missing.length === 1 ? 'is' : 'are'} missing or different on the record. ` +
+      `Treat this registration as unattributed.`,
+  };
 }
 
 function registerAgentRelayTools(
@@ -760,11 +862,19 @@ function registerAgentRelayTools(
           .record(z.string(), z.unknown())
           .optional()
           .describe('Key-value metadata to attach to the agent'),
+        verify_metadata: z
+          .boolean()
+          .optional()
+          .describe(
+            'Read the agent record back and confirm the metadata persisted. Costs a ' +
+              'workspace listing. Use when writing durable identity you intend to rely on; ' +
+              'the response reports metadata_verified as true, false, or "unchecked".'
+          ),
       },
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ name, type, persona, metadata }: any) => {
+    async ({ name, type, persona, metadata, verify_metadata }: any) => {
       const payload = await registerAgentWithRebind({
         session: getSession(),
         setSession,
@@ -773,6 +883,7 @@ function registerAgentRelayTools(
         type,
         persona,
         metadata,
+        verifyMetadata: verify_metadata,
         strictAgentName,
         preferredAgentName: preferredAgentName ?? null,
         forcedAgentType,


### PR DESCRIPTION
Delegation identity — `organization`, `project`, `workstream`, `role`, `reportsTo` — belongs on the Relaycast agent record, where any consumer can read it. The record already has a first-class `metadata` bag, and the fleet spawn path already writes `metadata.fleet` into it (451 of 745 agents in one live workspace carry non-empty metadata). Identity cannot get there by either available route, so consumers fall back to inferring a hierarchy from the agent's name.

That fallback is a guess, and for a multi-token project slug it is not even a recoverable one — nothing in `chief-delegation-governance-dispatch-contract-worker` marks where the project ends and the workstream begins. A consumer splitting at the first hyphen reads `cloud-chief-yc-demo-delivery-lead` as project `cloud`.

## Two independent gaps

**1. `register_agent` accepted `metadata` and threw it away.**

`registerAgentWithRebind` short-circuits when strict worker identity is on and the session already holds a token for that name, returning the cached token without ever calling `registerOrRotate`. The short-circuit is right about tokens and wrong about writes — a caller supplying `metadata` or `persona` is asking for the *record* to change, and got back success, no warnings, and an untouched record.

**Verified against installed relay CLI 11.2.0 before writing any code.** A call carrying a full identity bag returned `{name, token, registered_name, warnings: []}`; reading the record back afterwards showed only the platform's own `metadata.fleet`. A silent discard on a documented parameter is worse than a rejection, because the caller has no way to notice.

Now a supplied `metadata` or `persona` falls through to the write. The token-only path is unchanged and still short-circuits, so a bare re-registration does not rotate a token for nothing.

**2. The fleet `spawn` action could not carry metadata at all.**

Its input schema has no metadata parameter, so identity cannot be supplied at spawn even in principle. Added and forwarded — this is what lets an agent record carry its identity from birth rather than depending on a follow-up write that may never land.

Together these make the durable path reachable: a dispatcher can stamp a worker at spawn, and an agent can correct its own record afterwards.

## Why this matters beyond one dashboard

Without it there is no route by which a dispatcher can attribute a worker it spawned. Chief's delegation gate (AgentWorkforce/chief#24) currently compensates with a local ledger that the Cloud dashboard cannot read — it closes the loop on one side only. This PR is what removes the need for that compensation.

## Tests

`packages/cli/src/cli/agent-relay-mcp.test.ts` — write-through on metadata, write-through on persona, and that the token-only short-circuit survives unchanged.
`packages/cli/src/cli/agent-relay-mcp.startup.test.ts` — spawn forwards identity metadata into the action input.

Two pre-existing failures in `agent-relay-mcp.startup.test.ts` are unrelated and reproduce on an unmodified checkout (24 passed / 2 failed at baseline; 34 passed / same 2 failed with this change). They assert on telemetry context and pick up local machine configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

