### PR TITLE
fix(mcp): stop a cleared enrollment reporting as a failed persist

### DIFF
--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -593,6 +593,10 @@ describe('createAgentRelayMcpServer', () => {
     // `node up` mentioned it.
     expect(result.structuredContent.message).toContain('node_abc');
     expect(result.structuredContent.message).toContain('relay cloud enroll');
+    // A cleared enrollment means the write SUCCEEDED. Reporting it through the
+    // persistence-failure wording would tell the caller the key never landed.
+    expect(result.structuredContent.message).toContain('persisted for this project');
+    expect(result.structuredContent.message).not.toContain('could not be persisted');
   });
 
   it('registers submit_result when a spawned-agent result callback is configured', async () => {

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -499,11 +499,15 @@ function registerAgentRelayTools(
       } else {
         setSession({ workspaceKey: key });
       }
+      // Two distinct outcomes, never conflated: the write failed, or the write
+      // succeeded and dropped this project's enrolled fleet node. Reporting the
+      // second as the first would tell the caller the key had not persisted.
       let persistenceWarning: string | undefined;
+      let clearedEnrollmentWarning: string | undefined;
       try {
         // Joining a different workspace drops this project's enrolled fleet
         // node; surface that here instead of at the next `node up`.
-        persistenceWarning = describeClearedEnrollment(persistWorkspaceSession({ workspaceKey: key }));
+        clearedEnrollmentWarning = describeClearedEnrollment(persistWorkspaceSession({ workspaceKey: key }));
       } catch (error) {
         const persistenceError = error instanceof Error ? error.message : String(error);
         persistenceWarning =
@@ -517,7 +521,9 @@ function registerAgentRelayTools(
       const activeMessage = switchingWorkspace
         ? 'Workspace key set. Call "register_agent" to join this workspace.'
         : 'Workspace key set.';
-      const message = persistenceWarning ? `${activeMessage} ${persistenceWarning}` : persistedMessage;
+      const message = persistenceWarning
+        ? `${activeMessage} ${persistenceWarning}`
+        : [persistedMessage, clearedEnrollmentWarning].filter(Boolean).join(' ');
       return textContent(message);
     }
   );


### PR DESCRIPTION
Follow-up to #1439, which merged at `f8c644838` while this last review finding was still being fixed. Everything else from that PR is in `main`; this is the one commit that missed the merge.

## The bug

#1439 made MCP `set_workspace_key` report a cleared fleet-node enrollment through the `warning` string it already used for persistence failures. Reusing one variable for two outcomes made the success case take the failure branch:

```ts
const message = persistenceWarning ? `${activeMessage} ${persistenceWarning}` : persistedMessage;
```

A cleared enrollment means `persistWorkspaceSession` **succeeded**. Selecting `activeMessage` answered *"Workspace key set."* — the wording that exists specifically to say the key did **not** persist — while the key had in fact persisted and the only thing that happened was the enrolled node being dropped.

The tool's own description, updated in the same PR, promised the opposite: that the message states whether the key was persisted.

Caught by CodeRabbit on #1439 ([comment](https://github.com/AgentWorkforce/relay/pull/1439#discussion_r3727343899)); the finding is correct and the bug was mine.

## The fix

The two outcomes are tracked separately:

- write **failed** → active-not-persisted wording plus the failure detail, unchanged
- write **succeeded** and cleared an enrollment → persisted wording followed by the clearing notice
- write succeeded and cleared nothing → persisted wording alone, unchanged

## Test bar

`reports an enrolled fleet node dropped by joining another workspace` now asserts both halves, including the *absence* of the failure wording. Mutation-checked by restoring the conflated single-variable form:

```
× reports an enrolled fleet node dropped by joining another workspace
  → 3 failed | 24 passed
restored → 2 failed | 25 passed
```

The 2 remaining are pre-existing on `main` (telemetry machine-id), unrelated and present before this branch.

## Gates

- `npm run typecheck` — exit 0
- `npx vitest run` — 1760 passed, 16 skipped, 5 failed
- `npm run format:check` — clean

The 5 failures are the same pre-existing `main` failures documented on #1439: `telemetry/client.test.ts` (2), `agent-relay-mcp.startup.test.ts` (2), `packages/cloud/src/auth.test.ts` (1).

Refs #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

