### PR TITLE
fix: preserve unbounded heartbeat compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Agent Relay `spawn` MCP tool accepts an AgentWorkforce `persona` id or path instead of a raw CLI, routes it to a `spawn:persona` fleet node, and waits for broker registration plus harness readiness before reporting success. `@agent-relay/fleet` documents the corresponding `defineWorkforcePersonaSpawnNode` setup.
 
+### Fixed
+
+- Fleet node heartbeats remain compatible with deployed Relaycast engines when capacity is unbounded, so active-agent counts and liveness continue updating while nullable load reporting rolls out separately.
+
 ## [11.4.3] - 2026-08-09
 
 ### Fixed
@@ -35,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fleet node heartbeats no longer report unbounded capacity as `load: 0`; `load` is omitted when `max_agents` is `0` and remains a measured `[0,1]` utilization ratio when a finite agent limit is configured.
 - `agent-relay node up` resolves its installed broker through canonical package-manager links and Relay's user install directories, so mise-managed and minimal-`PATH` launches no longer fail when the broker binary is already installed.
 - `agent-relay node up` warns instead of silently ignoring stored Cloud fleet enrollments when the project workspace pin has no enrolled node id. That combination started the broker in the pinned workspace while the node never heartbeat, leaving the Cloud dashboard and `agent-relay fleet nodes` showing different rosters with no error from either.
 - `agent-relay cloud enroll` records the enrolled node on the project workspace pin, so `node up` in that repo serves the node it just enrolled. A pin that already names a different node is reported and left untouched rather than repointed.

--- a/crates/broker/src/fleet_wire.rs
+++ b/crates/broker/src/fleet_wire.rs
@@ -169,9 +169,10 @@ pub struct NodeHeartbeat {
     pub max_agents: u32,
     pub version: String,
     // Capacity utilization is undefined for an unbounded provider
-    // (`max_agents == 0`). Omit it instead of reporting a false idle `0`.
-    // Requires the Relaycast engine to accept an omitted/null `load` before
-    // this broker version is deployed (relaycast#307).
+    // (`max_agents == 0`). The wire type accepts an omitted/null value for the
+    // coordinated relaycast#307 rollout, but producers must keep sending the
+    // legacy numeric value until compatible engines are deployed; older engines
+    // reject the entire heartbeat when `load` is absent.
     #[serde(
         default,
         deserialize_with = "deserialize_optional_finite_nonnegative_f64",

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -464,7 +464,11 @@ impl FleetLoadSnapshot {
     /// time server-side as the single source of truth for liveness.
     fn heartbeat(&self, node: &NodeRegister) -> NodeHeartbeat {
         let load = if self.max_agents == 0 {
-            None
+            // Relaycast releases before relaycast#307 require a numeric load.
+            // Keep emitting the legacy value until the engine accepts an
+            // omitted/null load; otherwise it rejects the whole heartbeat and
+            // loses the authoritative active_agents and liveness updates too.
+            Some(0.0)
         } else {
             Some((self.active_agents as f64 / self.max_agents as f64).clamp(0.0, 1.0))
         };
@@ -3546,7 +3550,7 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_reports_only_measured_capacity_load() {
+    fn heartbeat_keeps_unbounded_load_backward_compatible() {
         let register = build_node_register(
             &test_manifest(),
             "node-default",
@@ -3569,7 +3573,11 @@ mod tests {
             handlers_live: true,
         }
         .heartbeat(&register);
-        assert_eq!(unbounded.load, None);
+        assert_eq!(unbounded.load, Some(0.0));
+
+        let value = serde_json::to_value(BrokerToRelaycast::NodeHeartbeat(unbounded)).unwrap();
+        assert_eq!(value["load"], 0.0);
+        assert_eq!(value["active_agents"], 25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep nullable `node.heartbeat.load` decoding in place for the coordinated Relaycast rollout
- temporarily emit legacy numeric `load: 0` when `max_agents == 0`, so deployed Relaycast engines accept the whole heartbeat
- add a producer serialization regression test covering `load` and `active_agents`
- correct the changelog: remove the unshipped claim from 11.4.2 and describe the compatibility fix under Unreleased

## Root cause

Relay #1445 began omitting `load` for unbounded providers. Fleet E2E pins Relaycast v6.0.1, which rejects heartbeats without a numeric `load`. Spawn and brief delivery still complete, but the entire heartbeat is discarded, so `active_agents` and load never update. This is the same wire-contract boundary addressed by Relaycast PR #307; it is a product compatibility defect, not a stale harness assertion.

The decisive comparison used the same local Node 22.14.0, Relaycast commit `58a9342`, and release broker build:

- `1ae49812` (post-#1464, pre-#1445): Fleet E2E exit 0, 14/14 passed
- `0b43dbe3` (post-both): Fleet E2E exit 1, 12/14 passed; five-agent heartbeat and least-loaded placement both timed out with `last=null`

## Validation

- patched Fleet E2E against pinned Relaycast v6.0.1: 3 consecutive passes / 0 failures, exit codes `0, 0, 0`, 14/14 each
- full broker suite: exit 0; 868 unit tests passed, 4 ignored; all broker integration tests passed
- focused heartbeat tests: exit 0; 5 passed
- `cargo fmt --all -- --check`: exit 0
- `git diff --check`: exit 0

## Release sequencing

Relaycast PR #307 must merge and deploy before Relay can safely switch unbounded heartbeat load back to omitted/null. Until then, numeric emission preserves active-agent and liveness updates across currently deployed engines without weakening Fleet E2E.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

