### PR TITLE
test(fleet): use load-compatible relaycast engine

### DIFF
--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -58,18 +58,16 @@ jobs:
       - name: Checkout relay
         uses: actions/checkout@v4
 
-      # The relaycast engine lives in a separate repo. This E2E now drives the
-      # node-provider model (broker registers as the `broker` provider carrying a
-      # `provider` identity + capacity `kind`), so it REQUIRES the node-provider
-      # engine (relaycast#243/#244, released as 6.0.0) — a pre-provider engine
-      # rejects the `provider` field and no node comes online. Pinned to the
-      # v6.0.0 release tag's commit so CI runs the same engine the published
-      # packages came from (the roster-snapshot/Bearer-auth compat is included).
+      # The relaycast engine lives in a separate repo. This E2E drives the
+      # node-provider model and heartbeats whose load may be unreported for
+      # unbounded providers. Keep the pin on a released engine that supports the
+      # complete wire shape: older engines reject an omitted/null `load` and
+      # silently stop applying active-agent heartbeat updates (relaycast#307).
       - name: Checkout relaycast engine (node-provider model)
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: 58a93422a5a5dc568f2eaffc0ad55fe656a78288 # relaycast v6.0.1 (node-provider engine + self-host write gate, trigger/reschedule node-scoped fixes)
+          ref: eb7563ffcf0e54698c23363c5753060f99d37dd3 # relaycast v7.0.0 (node providers + unreported-load heartbeat compatibility)
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/tests/e2e/fleet/README.md
+++ b/tests/e2e/fleet/README.md
@@ -10,7 +10,8 @@ Boots a **real** stack and drives the fleet control wire end-to-end:
 Unlike the unit suites (in-process adapter / fake broker WS), this exercises the
 actual broker `node_control` connection, including the `Authorization: Bearer`
 node-token handshake and the `agent.register` token-authority reply — the two
-engine⇄broker mismatches this E2E surfaced (fixed in relaycast#194).
+engine⇄broker mismatches this E2E surfaced (fixed in relaycast#194), plus the
+omitted/null heartbeat-load compatibility added in relaycast#307.
 
 ## Scenario matrix
 
@@ -55,14 +56,14 @@ engine⇄broker mismatches this E2E surfaced (fixed in relaycast#194).
 ```bash
 npm run build:core                                   # relay CLI + fleet + harness-driver
 cargo build --release --bin agent-relay-broker       # broker
-RELAYCAST_ENGINE_DIR=/path/to/relaycast \            # must carry relaycast#194's compat fixes
+RELAYCAST_ENGINE_DIR=/path/to/relaycast \            # must carry relaycast#194 and #307 compat fixes
 BROKER_BINARY_PATH="$PWD/target/release/agent-relay-broker" \
   npm run test:e2e
 ```
 
 The suite **skips cleanly** (never fails) when prerequisites are missing — the
 default `npm test` does not run it. The `Fleet E2E` GitHub Actions workflow
-provisions the engine (pinned to the relaycast#194 SHA) + broker and runs the
+provisions a released compatible engine (including relaycast#194 and #307) + broker and runs the
 full matrix; the matrix itself is ~2 minutes, the wall-clock is build-dominated.
 
 ## Isolation notes

--- a/tests/e2e/fleet/fleet-e2e.test.ts
+++ b/tests/e2e/fleet/fleet-e2e.test.ts
@@ -710,15 +710,15 @@ describe.skipIf(!pre.ok)('bounded durable mailbox', () => {
     const dm = await sendDm(engine, sender, 'ttl-recipient', 'will expire');
     expect(dm.status).toBeLessThan(300);
 
-    // Reading with ?status=dead_lettered triggers the TTL sweep (the route sweeps
-    // on every read), which dead-letters the row AND fans delivery.failed to the
-    // sender. Poll past the TTL.
+    // Expiry is scheduled maintenance rather than read-coupled work. The Node
+    // adapter sweeps every 15s, dead-lettering the row and fanning
+    // delivery.failed to the sender. Poll beyond one full maintenance interval.
     const dead = await waitFor(
       async () => {
         const all = await listDeliveries(engine, recipient, 'dead_lettered');
         return all.find((d) => d.status === 'dead_lettered') ?? null;
       },
-      { label: 'message dead-lettered', timeoutMs: 15_000, intervalMs: 400 }
+      { label: 'message dead-lettered', timeoutMs: 25_000, intervalMs: 400 }
     );
     expect(dead.status).toBe('dead_lettered');
 
@@ -729,7 +729,7 @@ describe.skipIf(!pre.ok)('bounded durable mailbox', () => {
     });
     expect(failed).toMatchObject({ target_agent_name: 'ttl-recipient' });
     senderWs.close();
-  }, 25_000);
+  }, 35_000);
 
   // Overflow reject-new is enforced by `belowDepthCapSql` (counts queued+delivered
   // per agent) at delivery-write time, and the sender is notified via the realtime

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -694,8 +694,8 @@ export async function sendDm(
   });
 }
 
-/** List an agent's own deliveries. Reading triggers the engine's TTL sweep, so
- * polling this is how the mailbox TTL dead-letter becomes observable. */
+/** List an agent's own deliveries. Polling makes a mailbox TTL transition
+ * observable after the engine's scheduled expiry maintenance runs. */
 export async function listDeliveries(
   engine: EngineHandle,
   agentToken: string,


### PR DESCRIPTION
## Summary
- pin Fleet E2E to released relaycast v7.0.0, which accepts omitted/null heartbeat `load`
- keep the active-agent and least-loaded placement assertions unchanged
- update the mailbox TTL fixture for relaycast scheduled expiry maintenance without weakening dead-letter or sender-notification checks

## Root cause
`0b43dbe3` (post-#1445) fails against the old v6.0.1 engine because an unbounded broker-provider heartbeat omits `load`; that engine stops applying the heartbeat, so `active_agents` never advances. `1ae49812` (pre-#1445) passes. This is the same wire contract covered by relaycast#307 and requires the server release before the relay release.

## Verification
- `1ae49812`: Fleet E2E exit 0 (27 passed, 4 skipped)
- `0b43dbe3`: Fleet E2E exit 1 (heartbeat/load failures)
- updated branch full Fleet E2E: exit 0 twice (27 passed, 4 skipped each)
- focused TTL E2E: exit 0
- Prettier check: exit 0
- `git diff --check`: exit 0