### PR TITLE
fix(broker): treat blank nested sessionRef as absent in bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Spawned agents now stamp a `Session-Id:` git trailer on commits when the dispatcher supplies a session reference, enabling auditors to trace each commit back to the session that produced it.
 
+### Fixed
+
+- Broker bridge now treats a blank/whitespace-only nested `sessionRef` inside `metadata.attestation` as absent; a valid top-level `session_ref` correctly fills the field instead of being silently suppressed.
+
 ## [11.5.1] - 2026-08-10
 
 ### Added

--- a/crates/broker/src/relaycast/bridge.rs
+++ b/crates/broker/src/relaycast/bridge.rs
@@ -184,10 +184,19 @@ pub fn broker_payload_from_action(
         // present.  Only an already-attested spawn gains a Session-Id trailer;
         // an un-attested spawn has no hook installed so there is nothing to
         // stamp.
+        //
+        // Use the same blank-value guard as spawner.rs `is_valid_attestation_value`:
+        // a nested `sessionRef` that is `None` or blank (all whitespace) is treated
+        // as absent so a valid top-level alias still reaches the hook.
         if let (Some(ref mut attestation), Some(sid)) =
             (&mut spawn.metadata.attestation, session_id)
         {
-            if attestation.session_ref.is_none() {
+            let nested_is_blank = attestation
+                .session_ref
+                .as_deref()
+                .map(str::trim)
+                .map_or(true, |v| v.is_empty());
+            if nested_is_blank {
                 attestation.session_ref = Some(sid);
             }
         }
@@ -1118,6 +1127,49 @@ mod tests {
             attestation.session_ref.as_deref(),
             Some("ai-hist:claudecode-camel-rescue"),
             "whitespace-only session_id must not suppress valid sessionId alias"
+        );
+    }
+
+    /// A blank/whitespace-only `sessionRef` inside `metadata.attestation` must be
+    /// treated as absent so a valid top-level `session_ref` can fill the field.
+    /// The `nested_is_blank` guard in `broker_payload_from_action` handles this;
+    /// a plain `is_none()` check would silently suppress the top-level value.
+    #[test]
+    fn blank_nested_session_ref_is_treated_as_absent() {
+        let (_, payload) = map_action(
+            &json!({
+                "type": "action.invoked",
+                "action_name": "spawn",
+                "invocation_id": "inv_blank_nested",
+                "caller_name": "147298826957365248",
+            }),
+            json!({
+                "name": "WorkerBlankNested",
+                "cli": "claude",
+                "session_ref": "ai-hist:claudecode-top-level-wins",
+                "metadata": {
+                    "attestation": {
+                        "jti": "jti-blank-nested",
+                        "agentId": "agent_blank_nested",
+                        "sponsorId": "sponsor_blank_nested",
+                        "sessionRef": "   "
+                    }
+                }
+            }),
+        )
+        .expect("should map spawn with blank nested sessionRef");
+
+        let crate::types::BrokerCommandPayload::Spawn(params) = payload else {
+            panic!("expected spawn payload");
+        };
+        let attestation = params
+            .metadata
+            .attestation
+            .expect("attestation must be present");
+        assert_eq!(
+            attestation.session_ref.as_deref(),
+            Some("ai-hist:claudecode-top-level-wins"),
+            "blank nested sessionRef must be treated as absent; top-level session_ref must fill the field"
         );
     }
 

--- a/crates/broker/src/relaycast/bridge.rs
+++ b/crates/broker/src/relaycast/bridge.rs
@@ -195,7 +195,7 @@ pub fn broker_payload_from_action(
                 .session_ref
                 .as_deref()
                 .map(str::trim)
-                .map_or(true, |v| v.is_empty());
+                .is_none_or(|v| v.is_empty());
             if nested_is_blank {
                 attestation.session_ref = Some(sid);
             }


### PR DESCRIPTION
## Summary

Follow-up to #1477 addressing one post-merge coderabbit finding.

- `attestation.session_ref.is_none()` in `broker_payload_from_action` did not cover the case where the nested `sessionRef` inside `metadata.attestation` is a blank/whitespace string (e.g. `"   "`). A dispatcher that sends `{"sessionRef":"  "}` inside the attestation block would suppress a valid top-level `session_ref`, leaving the `Session-Id` commit trailer unset.
- Replaces bare `is_none()` with the same blank-aware check used by `spawner.rs::is_valid_attestation_value`: trims the nested value and treats an empty result as absent, allowing the top-level alias to fill the field.
- Adds `blank_nested_session_ref_is_treated_as_absent` test to cover this branch directly.

## Test plan

- [ ] `cargo test -p agent-relay-broker --lib -- relaycast::bridge::tests::blank` → 3 tests pass (blank_nested, blank_session_ref_falls_through, blank_session_id_falls_through)
- [ ] Full suite: `cargo test -p agent-relay-broker --lib` → 895 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

