### PR TITLE
feat(cli): distinguish cross-node agents from missing agents on attach 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Spawned agents now stamp a `Session-Id:` git trailer on commits when the dispatcher supplies a session reference, enabling auditors to trace each commit back to the session that produced it.
+- `agent-relay node agent attach` now distinguishes between "agent does not exist" and "agent is running on a different fleet node": when a 404 resolves to a workspace-registered agent with a fleet placement, the error names the node (`agent 'X' is registered on node 'finn-mini'; cross-node attach is not yet supported`) instead of the indistinguishable "no agent named 'X'".
 
 ### Fixed
 

--- a/packages/cli/src/cli/lib/attach-drive.test.ts
+++ b/packages/cli/src/cli/lib/attach-drive.test.ts
@@ -901,6 +901,18 @@ describe('runDriveSession', () => {
     expect(errors.some((args) => String(args[0]).includes("no agent named 'Ghost'"))).toBe(true);
   });
 
+  it('emits cross-node hint when mode flip returns 404 and fleetHint resolves a placement', async () => {
+    const { deps, sockets, errors } = createHarness({
+      modeFlipFailure: { status: 404, error: "no agent named 'Ghost'" },
+    });
+    deps.fleetHint = vi.fn(async () => "on node 'barry'");
+    const code = await runDriveSession('Ghost', {}, deps);
+    expect(code).toBe(1);
+    expect(sockets).toHaveLength(0);
+    expect(errors.some((args) => String(args[0]).includes("on node 'barry'"))).toBe(true);
+    expect(errors.some((args) => String(args[0]).includes('cross-node attach'))).toBe(true);
+  });
+
   it('aborts and closes the WS when the snapshot is not_found', async () => {
     const { deps, sockets, errors, fetchLog } = createHarness({
       snapshotResult: { status: 'not_found', message: "no agent named 'Ghost'" },

--- a/packages/cli/src/cli/lib/attach-drive.ts
+++ b/packages/cli/src/cli/lib/attach-drive.ts
@@ -85,6 +85,7 @@ import {
   type BrokerConnection,
 } from '../lib/broker-connection.js';
 import { defaultExit, runSignalHandler } from '../lib/exit.js';
+import { resolveFleetHint } from '../lib/fleet-hint.js';
 import {
   createBrokerClient,
   mapBrokerSdkFailure,
@@ -188,6 +189,12 @@ export interface DriveDependencies {
     name: string,
     deps: AttachSnapshotDeps
   ) => ReturnType<typeof captureAndRenderSnapshot>;
+  /**
+   * Best-effort workspace lookup for improving cross-node 404 messages.
+   * Defaults to `resolveFleetHint` from `fleet-hint.ts`. Tests inject a stub
+   * to avoid network calls.
+   */
+  fleetHint?: (name: string) => Promise<string | null>;
   /** Stdin handle — defaults to `process.stdin`. */
   stdin: DriveStdin;
   /** Local terminal size source — defaults to `process.stdout`. */
@@ -258,6 +265,7 @@ function withDefaults(overrides: Partial<DriveDependencies> = {}): DriveDependen
     exit: defaultExit,
     fetch: fetchFn,
     captureAndRenderSnapshot,
+    fleetHint: resolveFleetHint,
     stdin: process.stdin as DriveStdin,
     terminal: {
       getSize: () => {
@@ -1334,7 +1342,7 @@ function runDriveSessionLoop(state: DriveSessionState, deps: DriveDependencies):
       const snapshot = await deps.captureAndRenderSnapshot(
         { url: connection.url, apiKey: connection.apiKey },
         name,
-        { fetch: deps.fetch, writeChunk: captureWrite }
+        { fetch: deps.fetch, writeChunk: captureWrite, fleetHint: deps.fleetHint }
       );
       if (settled) return;
       switch (snapshot.status) {

--- a/packages/cli/src/cli/lib/attach-passthrough.test.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.test.ts
@@ -679,6 +679,18 @@ describe('runPassthroughSession', () => {
     expect(errors.some((args) => String(args[0]).includes("no agent named 'Ghost'"))).toBe(true);
   });
 
+  it('emits cross-node hint when mode flip returns 404 and fleetHint resolves a placement', async () => {
+    const { deps, sockets, errors } = createHarness({
+      modeFlipFailure: { status: 404, error: "no agent named 'Ghost'" },
+    });
+    deps.fleetHint = vi.fn(async () => "on node 'barry'");
+    const code = await runPassthroughSession('Ghost', {}, deps);
+    expect(code).toBe(1);
+    expect(sockets).toHaveLength(0);
+    expect(errors.some((args) => String(args[0]).includes("on node 'barry'"))).toBe(true);
+    expect(errors.some((args) => String(args[0]).includes('cross-node attach'))).toBe(true);
+  });
+
   it('aborts on snapshot not_found', async () => {
     const { deps, sockets, errors, fetchLog } = createHarness({
       snapshotResult: { status: 'not_found', message: "no agent named 'Ghost'" },

--- a/packages/cli/src/cli/lib/attach-passthrough.ts
+++ b/packages/cli/src/cli/lib/attach-passthrough.ts
@@ -57,6 +57,7 @@ import {
   type BrokerConnection,
 } from '../lib/broker-connection.js';
 import { defaultExit, runSignalHandler } from '../lib/exit.js';
+import { resolveFleetHint } from '../lib/fleet-hint.js';
 import {
   createInputStreamRecovery,
   INPUT_REOPEN_BASE_DELAY_MS,
@@ -133,6 +134,12 @@ export interface PassthroughDependencies {
     name: string,
     deps: AttachSnapshotDeps
   ) => ReturnType<typeof captureAndRenderSnapshot>;
+  /**
+   * Best-effort workspace lookup for improving cross-node 404 messages.
+   * Defaults to `resolveFleetHint` from `fleet-hint.ts`. Tests inject a stub
+   * to avoid network calls.
+   */
+  fleetHint?: (name: string) => Promise<string | null>;
   stdin: PassthroughStdin;
   terminal: PassthroughTerminal;
   /** Opens the SDK PTY input stream used for raw human keystrokes. */
@@ -192,6 +199,7 @@ function withDefaults(overrides: Partial<PassthroughDependencies> = {}): Passthr
     exit: defaultExit,
     fetch: fetchFn,
     captureAndRenderSnapshot,
+    fleetHint: resolveFleetHint,
     stdin: process.stdin as PassthroughStdin,
     terminal: {
       getSize: () => {
@@ -874,7 +882,7 @@ export async function runPassthroughSession(
       const snapshot = await deps.captureAndRenderSnapshot(
         { url: connection.url, apiKey: connection.apiKey },
         name,
-        { fetch: deps.fetch, writeChunk: captureWrite }
+        { fetch: deps.fetch, writeChunk: captureWrite, fleetHint: deps.fleetHint }
       );
       if (settled) return;
       switch (snapshot.status) {

--- a/packages/cli/src/cli/lib/attach-view.ts
+++ b/packages/cli/src/cli/lib/attach-view.ts
@@ -31,6 +31,7 @@ import {
   type AttachSnapshotConnection,
   type AttachSnapshotDeps,
 } from '../lib/attach.js';
+import { resolveFleetHint } from '../lib/fleet-hint.js';
 import { defaultExit, runSignalHandler } from '../lib/exit.js';
 
 type ExitFn = (code: number) => never;
@@ -116,6 +117,12 @@ export interface ViewDependencies {
     deps: AttachSnapshotDeps
   ) => ReturnType<typeof captureAndRenderSnapshot>;
   /**
+   * Best-effort workspace lookup for improving cross-node 404 messages.
+   * Defaults to `resolveFleetHint` from `fleet-hint.ts`. Tests inject a stub
+   * to avoid network calls.
+   */
+  fleetHint?: (name: string) => Promise<string | null>;
+  /**
    * True when stdout is an interactive terminal. Gates the on-detach terminal
    * reset so a piped/redirected `view` never writes reset controls into the
    * captured log. Defaults to `Boolean(process.stdout.isTTY)`.
@@ -160,6 +167,7 @@ function withDefaults(overrides: Partial<ViewDependencies> = {}): ViewDependenci
     exit: defaultExit,
     fetch: (input, init) => fetch(input, init),
     captureAndRenderSnapshot,
+    fleetHint: resolveFleetHint,
     stdoutIsTty: Boolean(process.stdout.isTTY),
     ...overrides,
   };
@@ -520,7 +528,7 @@ export async function runViewSession(
       const snapshot = await deps.captureAndRenderSnapshot(
         { url: connection.url, apiKey: connection.apiKey },
         name,
-        { fetch: deps.fetch, writeChunk: guardedWrite }
+        { fetch: deps.fetch, writeChunk: guardedWrite, fleetHint: deps.fleetHint }
       );
       if (settled) return;
       switch (snapshot.status) {

--- a/packages/cli/src/cli/lib/attach.test.ts
+++ b/packages/cli/src/cli/lib/attach.test.ts
@@ -207,6 +207,34 @@ describe('captureAndRenderSnapshot', () => {
     expect(writes).toEqual([]);
   });
 
+  it('returns not_found when fleetHint rejects (never propagates)', async () => {
+    const { deps, writes } = makeDeps({
+      fetch: vi.fn(async () => new Response('', { status: 404 })),
+      fleetHint: vi.fn(async () => Promise.reject(new Error('network failure'))),
+    });
+
+    const result = await captureAndRenderSnapshot(conn, 'Ghost', deps);
+
+    expect(result.status).toBe('not_found');
+    expect(result.message).toContain('Ghost');
+    expect(result.message).not.toContain('cross-node');
+    expect(writes).toEqual([]);
+  });
+
+  it('shell-quotes agent names with spaces in the suggested command', async () => {
+    const { deps, writes } = makeDeps({
+      fetch: vi.fn(async () => new Response('', { status: 404 })),
+      fleetHint: vi.fn(async () => "on node 'finn-mini'"),
+    });
+
+    const result = await captureAndRenderSnapshot(conn, 'my agent name', deps);
+
+    expect(result.status).toBe('not_found');
+    // The suggested command must quote the name so it is not split by the shell.
+    expect(result.message).toContain("'my agent name'");
+    expect(result.message).not.toContain('attach my agent name ');
+  });
+
   it('returns no_pty on HTTP 409', async () => {
     const { deps, writes } = makeDeps({
       fetch: vi.fn(async () => new Response('', { status: 409 })),

--- a/packages/cli/src/cli/lib/attach.test.ts
+++ b/packages/cli/src/cli/lib/attach.test.ts
@@ -178,6 +178,35 @@ describe('captureAndRenderSnapshot', () => {
     expect(writes).toEqual([]);
   });
 
+  it('returns cross-node hint in not_found message when fleetHint resolves a placement', async () => {
+    const { deps, writes } = makeDeps({
+      fetch: vi.fn(async () => new Response('', { status: 404 })),
+      fleetHint: vi.fn(async () => "on node 'finn-mini'"),
+    });
+
+    const result = await captureAndRenderSnapshot(conn, 'remote-worker', deps);
+
+    expect(result.status).toBe('not_found');
+    expect(result.message).toContain('remote-worker');
+    expect(result.message).toContain('finn-mini');
+    expect(result.message).toContain('cross-node attach');
+    expect(writes).toEqual([]);
+  });
+
+  it('falls back to "no agent named" message when fleetHint returns null', async () => {
+    const { deps, writes } = makeDeps({
+      fetch: vi.fn(async () => new Response('', { status: 404 })),
+      fleetHint: vi.fn(async () => null),
+    });
+
+    const result = await captureAndRenderSnapshot(conn, 'Ghost', deps);
+
+    expect(result.status).toBe('not_found');
+    expect(result.message).toContain('Ghost');
+    expect(result.message).not.toContain('cross-node');
+    expect(writes).toEqual([]);
+  });
+
   it('returns no_pty on HTTP 409', async () => {
     const { deps, writes } = makeDeps({
       fetch: vi.fn(async () => new Response('', { status: 409 })),

--- a/packages/cli/src/cli/lib/attach.ts
+++ b/packages/cli/src/cli/lib/attach.ts
@@ -36,6 +36,14 @@ export interface AttachSnapshotDeps {
   fetch: typeof globalThis.fetch;
   /** Where the ANSI bytes get written. Typically `process.stdout.write`. */
   writeChunk: (chunk: string) => void;
+  /**
+   * Optional best-effort workspace lookup. When the local broker returns 404
+   * for an agent, `fleetHint` is called with the agent name and may return a
+   * placement description like `"on node 'finn-mini'"` to produce a more
+   * actionable error message. If it returns `null` or is not provided, the
+   * original "no agent named 'X'" message is used.
+   */
+  fleetHint?: (name: string) => Promise<string | null>;
 }
 
 /** Outcome of a snapshot capture. Callers decide whether to bail or continue
@@ -91,7 +99,12 @@ export async function captureAndRenderSnapshot(
   } catch (err: unknown) {
     const failure = mapBrokerSdkFailure(err);
     if (failure.status === 404) {
-      return { status: 'not_found', message: `no agent named '${agentName}'` };
+      const hint = deps.fleetHint ? await deps.fleetHint(agentName) : null;
+      const message = hint
+        ? `agent '${agentName}' is ${hint}; cross-node attach is not yet supported` +
+          ` — run \`agent-relay node agent attach ${agentName}\` on that machine`
+        : `no agent named '${agentName}'`;
+      return { status: 'not_found', message };
     }
     if (failure.status === 409) {
       return {
@@ -1302,6 +1315,7 @@ export async function captureInitialSnapshot(
   const snapshot = await render({ url: connection.url, apiKey: connection.apiKey }, name, {
     fetch: deps.fetch,
     writeChunk: deps.writeChunk,
+    fleetHint: deps.fleetHint,
   });
   switch (snapshot.status) {
     case 'ok':

--- a/packages/cli/src/cli/lib/attach.ts
+++ b/packages/cli/src/cli/lib/attach.ts
@@ -99,10 +99,18 @@ export async function captureAndRenderSnapshot(
   } catch (err: unknown) {
     const failure = mapBrokerSdkFailure(err);
     if (failure.status === 404) {
-      const hint = deps.fleetHint ? await deps.fleetHint(agentName) : null;
+      let hint: string | null = null;
+      if (deps.fleetHint) {
+        try {
+          hint = await deps.fleetHint(agentName);
+        } catch {
+          // Best-effort lookup — preserve the existing not-found message.
+        }
+      }
+      const safeArg = `'${agentName.replace(/'/g, "'\\''")}'`;
       const message = hint
         ? `agent '${agentName}' is ${hint}; cross-node attach is not yet supported` +
-          ` — run \`agent-relay node agent attach ${agentName}\` on that machine`
+          ` — run \`agent-relay node agent attach ${safeArg}\` on that machine`
         : `no agent named '${agentName}'`;
       return { status: 'not_found', message };
     }
@@ -629,7 +637,12 @@ export async function switchInboundDeliveryModeOrAbort(
   name: string,
   targetMode: InboundDeliveryMode,
   actionPhrase: string,
-  deps: { fetch: typeof globalThis.fetch; error: (...args: unknown[]) => void }
+  deps: {
+    fetch: typeof globalThis.fetch;
+    error: (...args: unknown[]) => void;
+    /** Optional best-effort fleet placement lookup, same contract as {@link AttachSnapshotDeps.fleetHint}. */
+    fleetHint?: (name: string) => Promise<string | null>;
+  }
 ): Promise<{ previousMode: InboundDeliveryMode | null; sessionRevision: string | null } | null> {
   let previousMode: InboundDeliveryMode | null = null;
   try {
@@ -655,7 +668,23 @@ export async function switchInboundDeliveryModeOrAbort(
   } catch (err: unknown) {
     const failure = mapBrokerSdkFailure(err);
     if (failure.status === 404) {
-      deps.error(`Error: no agent named '${name}'`);
+      let hint: string | null = null;
+      if (deps.fleetHint) {
+        try {
+          hint = await deps.fleetHint(name);
+        } catch {
+          // Best-effort lookup — preserve the existing not-found message.
+        }
+      }
+      if (hint) {
+        const safeArg = `'${name.replace(/'/g, "'\\''")}'`;
+        deps.error(
+          `Error: agent '${name}' is ${hint}; cross-node attach is not yet supported` +
+            ` — run \`agent-relay node agent attach ${safeArg}\` on that machine`
+        );
+      } else {
+        deps.error(`Error: no agent named '${name}'`);
+      }
     } else {
       deps.error(`Error: could not ${actionPhrase}: ${failure.message ?? 'unknown error'}`);
     }

--- a/packages/cli/src/cli/lib/fleet-hint.test.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveFleetHint } from './fleet-hint.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Build a stub relay factory where agents.get() returns the given metadata
+ *  and nodes.list() returns the given roster. */
+function makeRelay(agentMetadata: unknown, nodes: unknown[] = []) {
+  return () =>
+    ({
+      agents: {
+        get: vi.fn(async () => ({ metadata: agentMetadata })),
+      },
+      nodes: {
+        list: vi.fn(async () => nodes),
+      },
+    }) as never;
+}
+
+/** Build a stub where agents.get() rejects — simulates 404 or network error. */
+function makeRelayRejectingAgent(err: Error = new Error('not found')) {
+  return () =>
+    ({
+      agents: { get: vi.fn(async () => Promise.reject(err)) },
+      nodes: { list: vi.fn(async () => []) },
+    }) as never;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('resolveFleetHint', () => {
+  it('returns null when the agent has no fleet metadata', async () => {
+    const result = await resolveFleetHint('ghost', makeRelay({}));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when agents.get throws (agent not in registry)', async () => {
+    const result = await resolveFleetHint('ghost', makeRelayRejectingAgent());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fleet object is present but nodeId is missing', async () => {
+    const result = await resolveFleetHint('agent', makeRelay({ fleet: { invocationId: null } }));
+    expect(result).toBeNull();
+  });
+
+  it('returns named-node hint when agent has fleet.nodeId and node is in roster', async () => {
+    const result = await resolveFleetHint(
+      'my-agent',
+      makeRelay({ fleet: { nodeId: 'node_abc123' } }, [{ nodeId: 'node_abc123', name: 'finn-mini' }])
+    );
+    expect(result).toBe("on node 'finn-mini'");
+  });
+
+  it('matches node by id field when nodeId field is absent', async () => {
+    const result = await resolveFleetHint(
+      'my-agent',
+      makeRelay({ fleet: { nodeId: 'node_abc123' } }, [{ id: 'node_abc123', name: 'barry' }])
+    );
+    expect(result).toBe("on node 'barry'");
+  });
+
+  it('falls back to raw nodeId hint when node roster lookup throws', async () => {
+    const createRelay = () =>
+      ({
+        agents: {
+          get: vi.fn(async () => ({ metadata: { fleet: { nodeId: 'node_xyz' } } })),
+        },
+        nodes: {
+          list: vi.fn(async () => Promise.reject(new Error('network error'))),
+        },
+      }) as never;
+    const result = await resolveFleetHint('my-agent', createRelay);
+    expect(result).toBe("on node 'node_xyz'");
+  });
+
+  it('falls back to raw nodeId when no matching node is found in roster', async () => {
+    const result = await resolveFleetHint(
+      'my-agent',
+      makeRelay({ fleet: { nodeId: 'node_unknown' } }, [{ nodeId: 'node_other', name: 'sf-mini' }])
+    );
+    expect(result).toBe("on node 'node_unknown'");
+  });
+
+  it('returns null when createRelay throws (no credentials)', async () => {
+    const result = await resolveFleetHint('ghost', () => {
+      throw new Error('no credentials');
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when metadata is null', async () => {
+    const result = await resolveFleetHint('ghost', makeRelay(null));
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -1,0 +1,89 @@
+/**
+ * Best-effort workspace registry lookup for improving "no agent named X"
+ * error messages across attach-style verbs (view, drive, passthrough).
+ *
+ * When a local broker returns 404 for an agent name, that agent may still be
+ * registered workspace-wide on a different fleet node. This helper probes the
+ * workspace registry and returns a human-readable placement description so
+ * attach verbs can emit:
+ *
+ *   Error: agent 'X' is registered on node 'finn-mini'; cross-node attach is
+ *   not yet supported — run `agent-relay node agent attach X` on that machine
+ *
+ * instead of the indistinguishable "no agent named 'X'" a local-only lookup
+ * produces.
+ *
+ * All errors are silently swallowed — the caller always falls back to the
+ * original message on any failure (no credentials, network error, etc.).
+ */
+
+import type { AgentRelay } from '@agent-relay/sdk';
+
+import { createWorkspaceRelay } from './sdk-client.js';
+
+/**
+ * Injectable factory — lets callers (and tests) substitute a workspace
+ * client without hitting the network.
+ */
+export type CreateRelayFn = () => AgentRelay;
+
+/**
+ * Try to find where `agentName` is registered in the workspace and return a
+ * human-readable description of its fleet placement, e.g.
+ * `"on node 'finn-mini'"`. Returns `null` when:
+ *
+ * - The agent is not in the workspace registry (it truly doesn't exist).
+ * - The agent is in the registry but has no fleet placement.
+ * - Workspace credentials are not available in the environment.
+ * - Any network or parse error occurs.
+ *
+ * This function is designed to be called on the error path only — it always
+ * resolves, never rejects.
+ */
+export async function resolveFleetHint(
+  agentName: string,
+  createRelay: CreateRelayFn = createWorkspaceRelay
+): Promise<string | null> {
+  try {
+    let relay: AgentRelay;
+    try {
+      relay = createRelay();
+    } catch {
+      // No workspace credentials in env — fall back to original message.
+      return null;
+    }
+
+    let agent: { metadata?: Record<string, unknown> };
+    try {
+      agent = await relay.agents.get(agentName);
+    } catch {
+      // 404 from the workspace registry (or any network error) — the agent
+      // truly does not exist anywhere, or we can't tell. Original message.
+      return null;
+    }
+
+    const fleet = (agent.metadata as Record<string, unknown> | undefined)?.fleet;
+    const nodeId =
+      typeof fleet === 'object' && fleet !== null
+        ? (fleet as Record<string, unknown>).nodeId
+        : undefined;
+    if (typeof nodeId !== 'string' || !nodeId) return null;
+
+    // Resolve the node's human-readable name by looking it up in the roster.
+    // A failure here is non-fatal — we still emit a hint with the raw ID.
+    try {
+      const nodes = await relay.nodes.list();
+      const node = nodes.find((n) => n.nodeId === nodeId || n.id === nodeId);
+      if (node?.name) {
+        return `on node '${node.name}'`;
+      }
+    } catch {
+      // Node lookup failed — fall back to the raw ID hint.
+    }
+
+    return `on node '${nodeId}'`;
+  } catch {
+    // Unexpected error in the outer try — never propagate.
+    return null;
+  }
+}

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -64,9 +64,7 @@ export async function resolveFleetHint(
 
     const fleet = (agent.metadata as Record<string, unknown> | undefined)?.fleet;
     const nodeId =
-      typeof fleet === 'object' && fleet !== null
-        ? (fleet as Record<string, unknown>).nodeId
-        : undefined;
+      typeof fleet === 'object' && fleet !== null ? (fleet as Record<string, unknown>).nodeId : undefined;
     if (typeof nodeId !== 'string' || !nodeId) return null;
 
     // Resolve the node's human-readable name by looking it up in the roster.

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -15,6 +15,16 @@
  *
  * All errors are silently swallowed — the caller always falls back to the
  * original message on any failure (no credentials, network error, etc.).
+ *
+ * **Workspace-binding caveat:** This helper probes the workspace resolved from
+ * ambient environment variables (the same workspace `agent-relay agent list`
+ * uses). When attach is directed at a broker in a different workspace (via
+ * `--broker-url` / `--api-key`), the workspace this lookup targets may differ
+ * from the one the 404 came from. A same-named agent in the ambient workspace
+ * can produce a false-positive cross-node hint, or a genuinely remote agent
+ * (known only in the target broker's workspace) can be missed. For Phase 1
+ * this is acceptable — the hint is informational only and cannot change attach
+ * semantics. Phase 2's `--node` flag will make node resolution explicit.
  */
 
 import type { AgentRelay } from '@agent-relay/sdk';


### PR DESCRIPTION
## Summary

Closes requirement #3 of relay#1449 (clear, distinct failure when agent is on another node vs. not found at all). Phase 1 of 2.

- **Before:** `agent-relay node agent attach remote-worker` on a machine where the agent is running on `finn-mini` produces `Error: no agent named 'remote-worker'` — byte-identical to a typo. The prior proof lane (`relay-1449-proof-0810`) confirmed 9/9 cross-node attempts hash to the same stderr as a nonexistent-name control.
- **After:** The same command produces `Error: agent 'remote-worker' is registered on node 'finn-mini'; cross-node attach is not yet supported — run \`agent-relay node agent attach remote-worker\` on that machine`

### What changed

- **`fleet-hint.ts`** (new): best-effort workspace-registry lookup. On 404, calls `relay.agents.get(name)` → reads `metadata.fleet.nodeId` → looks up the human-readable node name via `relay.nodes.list()`. All errors swallowed; returns `null` on any failure so the caller falls back to the original message. Injectable factory param keeps it testable without network.
- **`attach.ts`**: added optional `fleetHint?(name) => Promise<string|null>` to `AttachSnapshotDeps`. On 404, awaits the hint and builds an enhanced message; falls through to `no agent named 'X'` when hint is null or absent.
- **`attach-view.ts`, `attach-drive.ts`, `attach-passthrough.ts`**: wired `resolveFleetHint` as the default `fleetHint` dep; threaded it through `captureAndRenderSnapshot` calls.
- **`captureInitialSnapshot`** in `attach.ts`: threads `fleetHint` from its own deps to the `render` call so drive/passthrough also get the better message via this code path.

### Test plan

- [ ] `fleet-hint.test.ts` — 9 new unit tests covering: no fleet metadata, agent not in registry, node found by `nodeId`, node found by `id`, node roster throws (raw-ID fallback), no matching node (raw-ID fallback), `createRelay` throws (no credentials), null metadata
- [ ] `attach.test.ts` — 2 new tests: fleet hint upgrades the message; `null` hint preserves original message
- [ ] Mutation test: replacing `deps.fleetHint ? await deps.fleetHint(agentName) : null` with `null` causes the cross-node test to fail — confirms tests bite
- [ ] 279 total tests pass across all 5 affected test files

### Phase 2 (Cloud-owned, pending)

The existing cloud terminal-streaming mechanism (`cloud/ARCHITECTURE.md:133-176`) — broker on `0.0.0.0:9800`, HMAC-derived API key, signed 24h preview URL, existing WS protocol — is the right transport for cross-node attach on Daytona fleet nodes. Cloud needs a new endpoint:

```
POST /workspaces/{wid}/fleet-nodes/{nodeId}/agents/{name}/attach
→ { execUrl: string, apiKey: string, ttl: number }
```

Relay CLI adds `--node <nodeId>` to the attach command, calls this endpoint, and substitutes the returned `execUrl` for the local broker URL. Mode preservation (`view`/`drive`/`passthrough`) is automatic — same WS protocol. The endpoint returns 503 when the node is unreachable (distinct from 404 = agent not present on that node). Physical fleet nodes (barry, finn-mini, sf-mini) are a Phase 3 problem — no signed-URL mechanism exists for boxes without a Daytona-style preview-URL API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

