### PR TITLE
feat(cli): attach terminals through fleet nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-relay node agent attach --node <node>` now opens a short-lived, authenticated terminal session for both physical and Daytona fleet nodes. It reuses the established view, drive, and passthrough clients through a loopback-only broker-compatible adapter; PTY bytes travel on a separate bounded outbound terminal WebSocket, while `--ssh-host` remains the explicit SSH fallback.
 - `agent-relay node agent attach --ssh-host <host>` now provides an explicit SSH fallback for physical fleet nodes without exporting the remote broker or its API key; `--node` remains reserved for canonical fleet-native attach.
 - Spawned agents now stamp a `Session-Id:` git trailer on commits when the dispatcher supplies a session reference, enabling auditors to trace each commit back to the session that produced it.
 - `agent-relay node agent attach` now distinguishes between "agent does not exist" and "agent is running on a different fleet node": when a 404 resolves to a workspace-registered agent with a fleet placement, the error names the node (`agent 'X' is registered on node 'finn-mini'; cross-node attach is not yet supported`) instead of the indistinguishable "no agent named 'X'".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `agent-relay node agent attach --node <node>` now opens a short-lived, authenticated terminal session for both physical and Daytona fleet nodes. It reuses the established view, drive, and passthrough clients through a loopback-only broker-compatible adapter; PTY bytes travel on a separate bounded outbound terminal WebSocket, while `--ssh-host` remains the explicit SSH fallback.
-- `agent-relay node agent attach --ssh-host <host>` now provides an explicit SSH fallback for physical fleet nodes without exporting the remote broker or its API key; `--node` remains reserved for canonical fleet-native attach.
+- `agent-relay node agent attach --node <node>` now opens an authenticated terminal session for physical and Daytona fleet nodes, preserving view, drive, and passthrough modes.
+- `agent-relay node agent attach --ssh-host <host>` now provides an explicit SSH fallback for physical fleet nodes without exporting the remote broker or its API key.
 - Spawned agents now stamp a `Session-Id:` git trailer on commits when the dispatcher supplies a session reference, enabling auditors to trace each commit back to the session that produced it.
 - `agent-relay node agent attach` now distinguishes between "agent does not exist" and "agent is running on a different fleet node": when a 404 resolves to a workspace-registered agent with a fleet placement, the error names the node (`agent 'X' is registered on node 'finn-mini'; cross-node attach is not yet supported`) instead of the indistinguishable "no agent named 'X'".
 

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) mod swarm;
 pub(crate) mod swarm_tui;
 #[allow(dead_code)]
 pub(crate) mod telemetry;
+pub(crate) mod terminal_control;
 #[allow(dead_code)]
 pub(crate) mod types;
 pub(crate) mod util;

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::terminal_control::TerminalToCloud;
 use relaycast::{
     CreateObserverTokenRequest, ObserverScope, ObserverToken, ObserverTokenFilters, RelayError,
 };
@@ -260,6 +261,10 @@ impl BrokerRuntime {
         let resize_owners = &mut self.resize_owners;
         let delivery_states = &mut self.delivery_states;
         let agent_result_tokens = &mut self.agent_result_tokens;
+        let terminal_control_tx = &self.terminal_control_tx;
+        let terminal_sessions = &mut self.terminal_sessions;
+        let terminal_snapshot_requests = &mut self.terminal_snapshot_requests;
+        let terminal_input_requests = &mut self.terminal_input_requests;
         let dedup = &mut self.dedup;
         let recent_thread_messages = &mut self.recent_thread_messages;
         let delivery_retry_interval = self.delivery_retry_interval;
@@ -825,6 +830,27 @@ impl BrokerRuntime {
                         fail_pending_requests_for_worker(pending_requests, &name, "agent_released");
                         resize_owners.remove(&name);
                         pty_observability.remove(&name);
+                        let terminal_session_ids: Vec<String> = terminal_sessions
+                            .iter()
+                            .filter(|(_, session)| session.agent == name)
+                            .map(|(session_id, _)| session_id.clone())
+                            .collect();
+                        for session_id in terminal_session_ids {
+                            terminal_sessions.remove(&session_id);
+                            terminal_snapshot_requests
+                                .retain(|_, pending| pending.session_id != session_id);
+                            terminal_input_requests
+                                .retain(|_, pending| pending.session_id != session_id);
+                            if let Err(error) = terminal_control_tx.try_send(
+                                TerminalControlCommand::Send(TerminalToCloud::Closed {
+                                    session_id: session_id.clone(),
+                                    code: Some("agent_released".into()),
+                                    message: Some("terminal worker was released".into()),
+                                }),
+                            ) {
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while closing released worker session");
+                            }
+                        }
                         delivery_states.remove(&name);
                         agent_result_tokens.retain(|_, agent| agent != &name);
                         state.agents.remove(&name);

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1,3 +1,4 @@
+use super::fleet::try_send_terminal;
 use super::*;
 use crate::terminal_control::TerminalToCloud;
 use relaycast::{
@@ -841,14 +842,15 @@ impl BrokerRuntime {
                                 .retain(|_, pending| pending.session_id != session_id);
                             terminal_input_requests
                                 .retain(|_, pending| pending.session_id != session_id);
-                            if let Err(error) = terminal_control_tx.try_send(
-                                TerminalControlCommand::Send(TerminalToCloud::Closed {
+                            if !try_send_terminal(
+                                terminal_control_tx,
+                                TerminalToCloud::Closed {
                                     session_id: session_id.clone(),
                                     code: Some("agent_released".into()),
                                     message: Some("terminal worker was released".into()),
-                                }),
+                                },
                             ) {
-                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while closing released worker session");
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while closing released worker session");
                             }
                         }
                         delivery_states.remove(&name);

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -482,12 +482,16 @@ impl BrokerRuntime {
         {
             tracing::debug!(error = %error, "failed to send fleet control shutdown signal");
         }
-        if let Err(error) = self
+        // A terminal client can be awaiting a full event queue while its own
+        // bounded command queue is full. Shutdown must never await that cycle:
+        // process teardown closes the task/socket if this best-effort enqueue
+        // cannot fit immediately.
+        if self
             .terminal_control_tx
-            .send(TerminalControlCommand::Shutdown)
-            .await
+            .try_send(TerminalControlCommand::Shutdown)
+            .is_err()
         {
-            tracing::debug!(error = %error, "failed to send terminal control shutdown signal");
+            tracing::debug!("terminal control shutdown signal could not be queued immediately");
         }
         // Persist any still-pending deliveries so the next start can
         // redeliver them; only remove the file when nothing is pending.

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -204,6 +204,15 @@ pub(crate) struct BrokerRuntime {
     pub(super) node_delivery_connected: bool,
     pub(super) fleet_event_rx: mpsc::Receiver<FleetControlEvent>,
     pub(super) fleet_control_open: bool,
+    /// Independent outbound terminal lane. It never shares the node-control
+    /// socket, keeping high-volume PTY bytes away from heartbeats/actions.
+    pub(super) terminal_control_tx: mpsc::Sender<TerminalControlCommand>,
+    pub(super) terminal_event_rx: mpsc::Receiver<TerminalControlEvent>,
+    pub(super) terminal_control_open: bool,
+    pub(super) terminal_sessions: HashMap<String, TerminalSession>,
+    /// Worker snapshot RPCs parked for terminal opens. These are kept outside
+    /// the HTTP request map because their reply belongs on the terminal lane.
+    pub(super) terminal_snapshot_requests: HashMap<String, String>,
     pub(super) fleet_delivery_book: FleetDeliveryBook,
     pub(super) fleet_max_agents: u32,
     pub(super) fleet_inventory: HashMap<WorkerName, InventoryAgent>,
@@ -259,8 +268,15 @@ enum RuntimeEvent {
     Stdin(std::io::Result<Option<String>>),
     Relaycast(Option<WorkspaceInboundMessage>),
     Fleet(Option<FleetControlEvent>),
+    Terminal(Option<TerminalControlEvent>),
     Worker(Option<WorkerEvent>),
     MaintenanceTick,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct TerminalSession {
+    pub(super) agent: WorkerName,
+    pub(super) mode: TerminalMode,
 }
 
 impl BrokerRuntime {
@@ -277,6 +293,7 @@ impl BrokerRuntime {
                 result = self.sdk_lines.next_line(), if self.stdin_open => RuntimeEvent::Stdin(result),
                 message = self.ws_inbound_rx.recv(), if self.relaycast_open => RuntimeEvent::Relaycast(message),
                 event = self.fleet_event_rx.recv(), if self.fleet_control_open => RuntimeEvent::Fleet(event),
+                event = self.terminal_event_rx.recv(), if self.terminal_control_open => RuntimeEvent::Terminal(event),
                 event = self.worker_event_rx.recv(), if self.worker_events_open => RuntimeEvent::Worker(event),
                 _ = self.reap_tick.tick() => RuntimeEvent::MaintenanceTick,
             };
@@ -314,6 +331,12 @@ impl BrokerRuntime {
                 }
                 RuntimeEvent::Fleet(None) => {
                     self.fleet_control_open = false;
+                }
+                RuntimeEvent::Terminal(Some(event)) => {
+                    self.handle_terminal_control_event(event).await;
+                }
+                RuntimeEvent::Terminal(None) => {
+                    self.terminal_control_open = false;
                 }
                 RuntimeEvent::Worker(Some(event)) => {
                     self.handle_worker_event(event).await;
@@ -437,6 +460,13 @@ impl BrokerRuntime {
             .await
         {
             tracing::debug!(error = %error, "failed to send fleet control shutdown signal");
+        }
+        if let Err(error) = self
+            .terminal_control_tx
+            .send(TerminalControlCommand::Shutdown)
+            .await
+        {
+            tracing::debug!(error = %error, "failed to send terminal control shutdown signal");
         }
         // Persist any still-pending deliveries so the next start can
         // redeliver them; only remove the file when nothing is pending.

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -212,7 +212,10 @@ pub(crate) struct BrokerRuntime {
     pub(super) terminal_sessions: HashMap<String, TerminalSession>,
     /// Worker snapshot RPCs parked for terminal opens. These are kept outside
     /// the HTTP request map because their reply belongs on the terminal lane.
-    pub(super) terminal_snapshot_requests: HashMap<String, String>,
+    pub(super) terminal_snapshot_requests: HashMap<String, TerminalSnapshotRequest>,
+    /// PTY writes are acknowledged only after the worker drainer confirms
+    /// them; this map correlates that response back to its terminal session.
+    pub(super) terminal_input_requests: HashMap<String, TerminalInputRequest>,
     pub(super) fleet_delivery_book: FleetDeliveryBook,
     pub(super) fleet_max_agents: u32,
     pub(super) fleet_inventory: HashMap<WorkerName, InventoryAgent>,
@@ -277,6 +280,19 @@ enum RuntimeEvent {
 pub(super) struct TerminalSession {
     pub(super) agent: WorkerName,
     pub(super) mode: TerminalMode,
+    /// PTY output is withheld until the initial ANSI grid has been delivered,
+    /// so a client always receives `terminal.ready` before stream chunks.
+    pub(super) ready: bool,
+}
+
+pub(super) struct TerminalSnapshotRequest {
+    pub(super) session_id: String,
+    pub(super) deadline: Instant,
+}
+
+pub(super) struct TerminalInputRequest {
+    pub(super) session_id: String,
+    pub(super) deadline: Instant,
 }
 
 impl BrokerRuntime {

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -283,6 +283,11 @@ pub(super) struct TerminalSession {
     /// PTY output is withheld until the initial ANSI grid has been delivered,
     /// so a client always receives `terminal.ready` before stream chunks.
     pub(super) ready: bool,
+    /// Output observed while the snapshot RPC is in flight. It is forwarded
+    /// after `terminal.ready`; per-stream offsets let the client discard bytes
+    /// already represented by the snapshot without losing later bytes.
+    pub(super) pending_output: Vec<(String, Option<u64>)>,
+    pub(super) pending_output_bytes: usize,
 }
 
 pub(super) struct TerminalSnapshotRequest {

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -6,7 +6,12 @@ use crate::{
         RelaycastToBroker, FLEET_WIRE_VERSION,
     },
     node_control::{delivery_ack, handler_unavailable_result, DeliveryDecision},
+    terminal_control::{
+        TerminalControlCommand, TerminalControlEvent, TerminalFromCloud, TerminalMode,
+        TerminalToCloud,
+    },
 };
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 const FLEET_AGENT_REGISTER_TIMEOUT: Duration = Duration::from_secs(30);
 const VERIFIED_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(90);
@@ -67,6 +72,214 @@ fn plan_fleet_delivery(decision: DeliveryDecision) -> FleetDeliveryPlan {
 }
 
 impl BrokerRuntime {
+    pub(super) async fn handle_terminal_control_event(&mut self, event: TerminalControlEvent) {
+        match event {
+            TerminalControlEvent::Connected => {
+                tracing::info!(
+                    target = "relay_broker::terminal",
+                    "fleet terminal transport connected"
+                );
+            }
+            TerminalControlEvent::Disconnected => {
+                tracing::warn!(
+                    target = "relay_broker::terminal",
+                    "fleet terminal transport disconnected; sessions await reconnect"
+                );
+            }
+            TerminalControlEvent::Message(TerminalFromCloud::Open {
+                session_id,
+                agent,
+                mode,
+            }) => {
+                let agent_name = WorkerName::new(agent.clone());
+                let runtime = self
+                    .workers
+                    .workers
+                    .get(&agent_name)
+                    .map(|handle| handle.spec.runtime.clone());
+                match runtime {
+                    None => self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "agent_not_found".to_string(),
+                        message: format!("no worker named '{agent}'"),
+                    }),
+                    Some(AgentRuntime::Headless) => self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "unsupported_runtime".to_string(),
+                        message: format!("worker '{agent}' is headless and has no PTY"),
+                    }),
+                    Some(AgentRuntime::Pty) => {
+                        self.terminal_sessions.insert(
+                            session_id.clone(),
+                            TerminalSession {
+                                agent: agent_name.clone(),
+                                mode,
+                            },
+                        );
+                        // Request the grid asynchronously. The response is routed
+                        // from worker_events to the terminal lane, so this never
+                        // stalls heartbeat/action processing behind a PTY snapshot.
+                        let request_id = format!("terminal_snapshot_{}", Uuid::new_v4().simple());
+                        match self
+                            .workers
+                            .send_to_worker(
+                                agent_name.as_str(),
+                                "snapshot_pty",
+                                Some(RequestId::new(request_id.clone())),
+                                json!({ "format": "ansi" }),
+                            )
+                            .await
+                        {
+                            Ok(()) => {
+                                self.terminal_snapshot_requests
+                                    .insert(request_id, session_id);
+                            }
+                            Err(error) => self.send_terminal(TerminalToCloud::Error {
+                                session_id,
+                                code: "snapshot_failed".into(),
+                                message: error.to_string(),
+                            }),
+                        }
+                    }
+                }
+            }
+            TerminalControlEvent::Message(TerminalFromCloud::Input {
+                session_id,
+                data_base64,
+            }) => {
+                let Some(session) = self.terminal_sessions.get(&session_id).cloned() else {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "session_not_found".into(),
+                        message: "terminal session is not active".into(),
+                    });
+                    return;
+                };
+                if session.mode == TerminalMode::View {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "read_only".into(),
+                        message: "view sessions do not accept input".into(),
+                    });
+                    return;
+                }
+                let bytes = match BASE64.decode(data_base64.as_bytes()) {
+                    Ok(bytes) if bytes.len() <= 64 * 1024 => bytes,
+                    _ => {
+                        self.send_terminal(TerminalToCloud::Error {
+                            session_id,
+                            code: "invalid_input".into(),
+                            message: "terminal input must be bounded base64 UTF-8".into(),
+                        });
+                        return;
+                    }
+                };
+                let data = match String::from_utf8(bytes) {
+                    Ok(data) => data,
+                    Err(_) => {
+                        self.send_terminal(TerminalToCloud::Error {
+                            session_id,
+                            code: "invalid_input".into(),
+                            message: "terminal input must be UTF-8".into(),
+                        });
+                        return;
+                    }
+                };
+                let bytes_written = data.len();
+                match self
+                    .workers
+                    .send_to_worker(
+                        session.agent.as_str(),
+                        "write_pty",
+                        None,
+                        json!({ "data": data }),
+                    )
+                    .await
+                {
+                    Ok(()) => self.send_terminal(TerminalToCloud::InputAck {
+                        session_id,
+                        bytes_written,
+                    }),
+                    Err(error) => self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "input_failed".into(),
+                        message: error.to_string(),
+                    }),
+                }
+            }
+            TerminalControlEvent::Message(TerminalFromCloud::Resize {
+                session_id,
+                rows,
+                cols,
+            }) => {
+                let Some(session) = self.terminal_sessions.get(&session_id).cloned() else {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "session_not_found".into(),
+                        message: "terminal session is not active".into(),
+                    });
+                    return;
+                };
+                if session.mode == TerminalMode::View {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "read_only".into(),
+                        message: "view sessions do not resize the PTY".into(),
+                    });
+                    return;
+                }
+                if let Err(error) = self
+                    .workers
+                    .send_to_worker(
+                        session.agent.as_str(),
+                        "resize_pty",
+                        None,
+                        json!({ "rows": rows, "cols": cols }),
+                    )
+                    .await
+                {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "resize_failed".into(),
+                        message: error.to_string(),
+                    });
+                }
+            }
+            TerminalControlEvent::Message(TerminalFromCloud::Close { session_id }) => {
+                self.terminal_sessions.remove(&session_id);
+                self.terminal_snapshot_requests
+                    .retain(|_, pending_session| pending_session != &session_id);
+                self.send_terminal(TerminalToCloud::Closed {
+                    session_id,
+                    code: None,
+                    message: None,
+                });
+            }
+        }
+    }
+
+    /// Attempts a bounded enqueue onto the dedicated terminal lane. On
+    /// saturation we tear down the affected session instead of accumulating
+    /// unbounded PTY output or delaying control traffic.
+    pub(super) fn send_terminal(&mut self, message: TerminalToCloud) {
+        let session_id = match &message {
+            TerminalToCloud::Ready { session_id, .. }
+            | TerminalToCloud::Output { session_id, .. }
+            | TerminalToCloud::InputAck { session_id, .. }
+            | TerminalToCloud::Error { session_id, .. }
+            | TerminalToCloud::Closed { session_id, .. } => session_id.clone(),
+        };
+        if let Err(error) = self
+            .terminal_control_tx
+            .try_send(TerminalControlCommand::Send(message))
+        {
+            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed; ending session");
+            self.terminal_sessions.remove(&session_id);
+            self.terminal_snapshot_requests
+                .retain(|_, pending_session| pending_session != &session_id);
+        }
+    }
+
     pub(super) async fn handle_fleet_control_event(&mut self, event: FleetControlEvent) {
         match event {
             FleetControlEvent::Connected => {

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -19,6 +19,28 @@ const TERMINAL_INPUT_MAX_BYTES: usize = 64 * 1024;
 const TERMINAL_INPUT_MAX_BASE64_BYTES: usize = TERMINAL_INPUT_MAX_BYTES * 4 / 3 + 4;
 const TERMINAL_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 const TERMINAL_INPUT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+// Terminal worker writes share the broker event loop with fleet control and
+// worker lifecycle events. A wedged PTY must fail only its own attach instead
+// of awaiting an unbounded pipe write in that loop.
+const TERMINAL_WORKER_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
+const TERMINAL_INPUT_MAX_IN_FLIGHT_PER_SESSION: usize = 16;
+// Relaycast currently limits a node to 32 terminal sessions. Keep that many
+// slots free from high-volume frames so every affected session can still get a
+// terminal.closed notification when the output lane applies backpressure.
+const TERMINAL_CLOSE_RESERVE: usize = 32;
+
+pub(super) fn try_send_terminal(
+    terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
+    message: TerminalToCloud,
+) -> bool {
+    let is_close = matches!(&message, TerminalToCloud::Closed { .. });
+    if !is_close && terminal_control_tx.capacity() <= TERMINAL_CLOSE_RESERVE {
+        return false;
+    }
+    terminal_control_tx
+        .try_send(TerminalControlCommand::Send(message))
+        .is_ok()
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct PendingVerifiedSpawn {
@@ -135,17 +157,18 @@ impl BrokerRuntime {
                         // from worker_events to the terminal lane, so this never
                         // stalls heartbeat/action processing behind a PTY snapshot.
                         let request_id = format!("terminal_snapshot_{}", Uuid::new_v4().simple());
-                        match self
-                            .workers
-                            .send_to_worker(
+                        match tokio::time::timeout(
+                            TERMINAL_WORKER_WRITE_TIMEOUT,
+                            self.workers.send_to_worker(
                                 agent_name.as_str(),
                                 "snapshot_pty",
                                 Some(RequestId::new(request_id.clone())),
                                 json!({ "format": "ansi" }),
-                            )
-                            .await
+                            ),
+                        )
+                        .await
                         {
-                            Ok(()) => {
+                            Ok(Ok(())) => {
                                 self.terminal_snapshot_requests.insert(
                                     request_id,
                                     TerminalSnapshotRequest {
@@ -154,13 +177,19 @@ impl BrokerRuntime {
                                     },
                                 );
                             }
-                            Err(error) => {
-                                self.terminal_sessions.remove(&session_id);
-                                self.send_terminal(TerminalToCloud::Error {
+                            Ok(Err(error)) => {
+                                self.fail_terminal_session(
                                     session_id,
-                                    code: "snapshot_failed".into(),
-                                    message: error.to_string(),
-                                });
+                                    "snapshot_failed",
+                                    error.to_string(),
+                                );
+                            }
+                            Err(_) => {
+                                self.fail_terminal_session(
+                                    session_id,
+                                    "snapshot_timeout",
+                                    "terminal snapshot write timed out".into(),
+                                );
                             }
                         }
                     }
@@ -224,18 +253,33 @@ impl BrokerRuntime {
                         return;
                     }
                 };
+                if self
+                    .terminal_input_requests
+                    .values()
+                    .filter(|pending| pending.session_id == session_id)
+                    .count()
+                    >= TERMINAL_INPUT_MAX_IN_FLIGHT_PER_SESSION
+                {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "input_backpressure".into(),
+                        message: "terminal input acknowledgement backlog is full".into(),
+                    });
+                    return;
+                }
                 let request_id = format!("terminal_input_{}", Uuid::new_v4().simple());
-                match self
-                    .workers
-                    .send_to_worker(
+                match tokio::time::timeout(
+                    TERMINAL_WORKER_WRITE_TIMEOUT,
+                    self.workers.send_to_worker(
                         session.agent.as_str(),
                         "write_pty",
                         Some(RequestId::new(request_id.clone())),
                         json!({ "data": data }),
-                    )
-                    .await
+                    ),
+                )
+                .await
                 {
-                    Ok(()) => {
+                    Ok(Ok(())) => {
                         self.terminal_input_requests.insert(
                             request_id,
                             TerminalInputRequest {
@@ -244,11 +288,14 @@ impl BrokerRuntime {
                             },
                         );
                     }
-                    Err(error) => self.send_terminal(TerminalToCloud::Error {
+                    Ok(Err(error)) => {
+                        self.fail_terminal_session(session_id, "input_failed", error.to_string())
+                    }
+                    Err(_) => self.fail_terminal_session(
                         session_id,
-                        code: "input_failed".into(),
-                        message: error.to_string(),
-                    }),
+                        "input_timeout",
+                        "terminal input write timed out".into(),
+                    ),
                 }
             }
             TerminalControlEvent::Message(TerminalFromCloud::Resize {
@@ -280,21 +327,26 @@ impl BrokerRuntime {
                     });
                     return;
                 }
-                if let Err(error) = self
-                    .workers
-                    .send_to_worker(
+                match tokio::time::timeout(
+                    TERMINAL_WORKER_WRITE_TIMEOUT,
+                    self.workers.send_to_worker(
                         session.agent.as_str(),
                         "resize_pty",
                         None,
                         json!({ "rows": rows, "cols": cols }),
-                    )
-                    .await
+                    ),
+                )
+                .await
                 {
-                    self.send_terminal(TerminalToCloud::Error {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        self.fail_terminal_session(session_id, "resize_failed", error.to_string())
+                    }
+                    Err(_) => self.fail_terminal_session(
                         session_id,
-                        code: "resize_failed".into(),
-                        message: error.to_string(),
-                    });
+                        "resize_timeout",
+                        "terminal resize write timed out".into(),
+                    ),
                 }
             }
             TerminalControlEvent::Message(TerminalFromCloud::Close { session_id }) => {
@@ -323,17 +375,45 @@ impl BrokerRuntime {
             | TerminalToCloud::Error { session_id, .. }
             | TerminalToCloud::Closed { session_id, .. } => session_id.clone(),
         };
-        if let Err(error) = self
-            .terminal_control_tx
-            .try_send(TerminalControlCommand::Send(message))
-        {
-            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed; ending session");
+        let is_close = matches!(&message, TerminalToCloud::Closed { .. });
+        if !try_send_terminal(&self.terminal_control_tx, message) {
+            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed; ending session");
             self.terminal_sessions.remove(&session_id);
             self.terminal_snapshot_requests
                 .retain(|_, pending| pending.session_id != session_id);
             self.terminal_input_requests
                 .retain(|_, pending| pending.session_id != session_id);
+            if !is_close
+                && !try_send_terminal(
+                    &self.terminal_control_tx,
+                    TerminalToCloud::Closed {
+                        session_id: session_id.clone(),
+                        code: Some("output_backpressure".into()),
+                        message: Some("terminal output queue is full".into()),
+                    },
+                )
+            {
+                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal close could not be queued after backpressure");
+            }
         }
+    }
+
+    fn fail_terminal_session(&mut self, session_id: String, code: &str, message: String) {
+        self.terminal_sessions.remove(&session_id);
+        self.terminal_snapshot_requests
+            .retain(|_, pending| pending.session_id != session_id);
+        self.terminal_input_requests
+            .retain(|_, pending| pending.session_id != session_id);
+        self.send_terminal(TerminalToCloud::Error {
+            session_id: session_id.clone(),
+            code: code.into(),
+            message: message.clone(),
+        });
+        self.send_terminal(TerminalToCloud::Closed {
+            session_id,
+            code: Some(code.into()),
+            message: Some(message),
+        });
     }
 
     pub(super) async fn handle_fleet_control_event(&mut self, event: FleetControlEvent) {
@@ -1579,6 +1659,46 @@ mod tests {
             plan_fleet_delivery(DeliveryDecision::IdentityReject),
             FleetDeliveryPlan::RejectWithoutAck
         );
+    }
+
+    #[test]
+    fn terminal_close_reserve_survives_output_backpressure() {
+        let (tx, mut rx) = mpsc::channel(TERMINAL_CLOSE_RESERVE + 1);
+        assert!(try_send_terminal(
+            &tx,
+            TerminalToCloud::Output {
+                session_id: "session-a".into(),
+                chunk: "x".into(),
+                offset: None,
+            },
+        ));
+        assert!(
+            !try_send_terminal(
+                &tx,
+                TerminalToCloud::Output {
+                    session_id: "session-a".into(),
+                    chunk: "y".into(),
+                    offset: None,
+                },
+            ),
+            "non-final terminal traffic must preserve close capacity"
+        );
+        assert!(try_send_terminal(
+            &tx,
+            TerminalToCloud::Closed {
+                session_id: "session-a".into(),
+                code: Some("output_backpressure".into()),
+                message: Some("queue full".into()),
+            },
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(TerminalControlCommand::Send(TerminalToCloud::Output { .. }))
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(TerminalControlCommand::Send(TerminalToCloud::Closed { .. }))
+        ));
     }
 
     #[test]

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -87,8 +87,16 @@ impl BrokerRuntime {
             TerminalControlEvent::Disconnected => {
                 tracing::warn!(
                     target = "relay_broker::terminal",
-                    "fleet terminal transport disconnected; sessions await reconnect"
+                    sessions = self.terminal_sessions.len(),
+                    "fleet terminal transport disconnected; clearing sessions for cloud resync"
                 );
+                // Relaycast re-opens live terminal sessions when this dedicated
+                // lane reconnects. Drop the old connection's state now so input
+                // and snapshot replies cannot be routed into a server-side
+                // session that was invalidated with the old websocket.
+                self.terminal_sessions.clear();
+                self.terminal_snapshot_requests.clear();
+                self.terminal_input_requests.clear();
             }
             TerminalControlEvent::Message(TerminalFromCloud::Open {
                 session_id,
@@ -119,6 +127,8 @@ impl BrokerRuntime {
                                 agent: agent_name.clone(),
                                 mode,
                                 ready: false,
+                                pending_output: Vec::new(),
+                                pending_output_bytes: 0,
                             },
                         );
                         // Request the grid asynchronously. The response is routed

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -15,6 +15,10 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 const FLEET_AGENT_REGISTER_TIMEOUT: Duration = Duration::from_secs(30);
 const VERIFIED_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(90);
+const TERMINAL_INPUT_MAX_BYTES: usize = 64 * 1024;
+const TERMINAL_INPUT_MAX_BASE64_BYTES: usize = TERMINAL_INPUT_MAX_BYTES * 4 / 3 + 4;
+const TERMINAL_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
+const TERMINAL_INPUT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub(super) struct PendingVerifiedSpawn {
@@ -114,6 +118,7 @@ impl BrokerRuntime {
                             TerminalSession {
                                 agent: agent_name.clone(),
                                 mode,
+                                ready: false,
                             },
                         );
                         // Request the grid asynchronously. The response is routed
@@ -131,14 +136,22 @@ impl BrokerRuntime {
                             .await
                         {
                             Ok(()) => {
-                                self.terminal_snapshot_requests
-                                    .insert(request_id, session_id);
+                                self.terminal_snapshot_requests.insert(
+                                    request_id,
+                                    TerminalSnapshotRequest {
+                                        session_id,
+                                        deadline: Instant::now() + TERMINAL_SNAPSHOT_TIMEOUT,
+                                    },
+                                );
                             }
-                            Err(error) => self.send_terminal(TerminalToCloud::Error {
-                                session_id,
-                                code: "snapshot_failed".into(),
-                                message: error.to_string(),
-                            }),
+                            Err(error) => {
+                                self.terminal_sessions.remove(&session_id);
+                                self.send_terminal(TerminalToCloud::Error {
+                                    session_id,
+                                    code: "snapshot_failed".into(),
+                                    message: error.to_string(),
+                                });
+                            }
                         }
                     }
                 }
@@ -163,8 +176,24 @@ impl BrokerRuntime {
                     });
                     return;
                 }
+                if !session.ready {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "session_not_ready".into(),
+                        message: "terminal snapshot is not ready".into(),
+                    });
+                    return;
+                }
+                if data_base64.len() > TERMINAL_INPUT_MAX_BASE64_BYTES {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "invalid_input".into(),
+                        message: "terminal input must be bounded base64 UTF-8".into(),
+                    });
+                    return;
+                }
                 let bytes = match BASE64.decode(data_base64.as_bytes()) {
-                    Ok(bytes) if bytes.len() <= 64 * 1024 => bytes,
+                    Ok(bytes) if bytes.len() <= TERMINAL_INPUT_MAX_BYTES => bytes,
                     _ => {
                         self.send_terminal(TerminalToCloud::Error {
                             session_id,
@@ -185,21 +214,26 @@ impl BrokerRuntime {
                         return;
                     }
                 };
-                let bytes_written = data.len();
+                let request_id = format!("terminal_input_{}", Uuid::new_v4().simple());
                 match self
                     .workers
                     .send_to_worker(
                         session.agent.as_str(),
                         "write_pty",
-                        None,
+                        Some(RequestId::new(request_id.clone())),
                         json!({ "data": data }),
                     )
                     .await
                 {
-                    Ok(()) => self.send_terminal(TerminalToCloud::InputAck {
-                        session_id,
-                        bytes_written,
-                    }),
+                    Ok(()) => {
+                        self.terminal_input_requests.insert(
+                            request_id,
+                            TerminalInputRequest {
+                                session_id,
+                                deadline: Instant::now() + TERMINAL_INPUT_ACK_TIMEOUT,
+                            },
+                        );
+                    }
                     Err(error) => self.send_terminal(TerminalToCloud::Error {
                         session_id,
                         code: "input_failed".into(),
@@ -228,6 +262,14 @@ impl BrokerRuntime {
                     });
                     return;
                 }
+                if !session.ready {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "session_not_ready".into(),
+                        message: "terminal snapshot is not ready".into(),
+                    });
+                    return;
+                }
                 if let Err(error) = self
                     .workers
                     .send_to_worker(
@@ -248,7 +290,9 @@ impl BrokerRuntime {
             TerminalControlEvent::Message(TerminalFromCloud::Close { session_id }) => {
                 self.terminal_sessions.remove(&session_id);
                 self.terminal_snapshot_requests
-                    .retain(|_, pending_session| pending_session != &session_id);
+                    .retain(|_, pending| pending.session_id != session_id);
+                self.terminal_input_requests
+                    .retain(|_, pending| pending.session_id != session_id);
                 self.send_terminal(TerminalToCloud::Closed {
                     session_id,
                     code: None,
@@ -276,7 +320,9 @@ impl BrokerRuntime {
             tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed; ending session");
             self.terminal_sessions.remove(&session_id);
             self.terminal_snapshot_requests
-                .retain(|_, pending_session| pending_session != &session_id);
+                .retain(|_, pending| pending.session_id != session_id);
+            self.terminal_input_requests
+                .retain(|_, pending| pending.session_id != session_id);
         }
     }
 

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -246,6 +246,9 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         (!resolved_node_name.trim().is_empty()).then_some(resolved_node_name.as_str()),
     );
     let fleet_ws_url = relaycast::node_control_ws_url(configured_base.as_deref());
+    // Keep terminal traffic on a physically separate websocket. Do not append
+    // terminal frames to the heartbeat/action control endpoint.
+    let terminal_ws_url = fleet_ws_url.replacen("/v1/node/ws", "/v1/node/terminal/ws", 1);
     let broker_version = format!("relay-broker/{}", crate::util::version::broker_version());
     // The broker enrolls as a relaycast node and delivers/injects solely over
     // /v1/node/ws. A node token is required to open that connection: prefer an
@@ -303,6 +306,13 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
     });
     let (fleet_control_tx, fleet_control_rx) = mpsc::channel::<FleetControlCommand>(256);
     let (fleet_event_tx, fleet_event_rx) = mpsc::channel::<FleetControlEvent>(256);
+    // The terminal queue is deliberately bounded. A wedged remote attach must
+    // fail its session rather than accumulating unbounded PTY output in the
+    // broker or starving node control.
+    let (terminal_control_tx, terminal_control_rx) =
+        mpsc::channel::<crate::terminal_control::TerminalControlCommand>(256);
+    let (terminal_event_tx, terminal_event_rx) =
+        mpsc::channel::<crate::terminal_control::TerminalControlEvent>(256);
     let node_delivery_token_present = node_token.is_some();
     tokio::spawn(crate::node_control::run_node_control_client(
         crate::node_control::FleetControlConfig {
@@ -316,6 +326,14 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         },
         fleet_control_rx,
         fleet_event_tx,
+    ));
+    tokio::spawn(crate::terminal_control::run_terminal_control_client(
+        crate::terminal_control::TerminalControlConfig {
+            ws_url: terminal_ws_url,
+            session_token: session_node_token.clone(),
+        },
+        terminal_control_rx,
+        terminal_event_tx,
     ));
     // Register this node unconditionally on connect (no sidecar required). This
     // is the only command that flips the control client out of its idle state
@@ -659,6 +677,11 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         node_delivery_connected: false,
         fleet_event_rx,
         fleet_control_open: true,
+        terminal_control_tx,
+        terminal_event_rx,
+        terminal_control_open: true,
+        terminal_sessions: HashMap::new(),
+        terminal_snapshot_requests: HashMap::new(),
         fleet_delivery_book: FleetDeliveryBook::default(),
         // Seed the live capacity with the configured max so heartbeats/load
         // updates keep reporting it (they overwrite load.max_agents from this

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -248,7 +248,10 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
     let fleet_ws_url = relaycast::node_control_ws_url(configured_base.as_deref());
     // Keep terminal traffic on a physically separate websocket. Do not append
     // terminal frames to the heartbeat/action control endpoint.
-    let terminal_ws_url = fleet_ws_url.replacen("/v1/node/ws", "/v1/node/terminal/ws", 1);
+    let terminal_ws_url = fleet_ws_url
+        .strip_suffix("/v1/node/ws")
+        .map(|base| format!("{base}/v1/node/terminal/ws"))
+        .context("fleet control URL must end with /v1/node/ws to derive the terminal URL")?;
     let broker_version = format!("relay-broker/{}", crate::util::version::broker_version());
     // The broker enrolls as a relaycast node and delivers/injects solely over
     // /v1/node/ws. A node token is required to open that connection: prefer an
@@ -309,10 +312,13 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
     // The terminal queue is deliberately bounded. A wedged remote attach must
     // fail its session rather than accumulating unbounded PTY output in the
     // broker or starving node control.
+    // Terminal bytes have a burstier profile than control actions. Keep this
+    // lane bounded, but give a short PTY burst room without impacting the
+    // independent control queue.
     let (terminal_control_tx, terminal_control_rx) =
-        mpsc::channel::<crate::terminal_control::TerminalControlCommand>(256);
+        mpsc::channel::<crate::terminal_control::TerminalControlCommand>(1024);
     let (terminal_event_tx, terminal_event_rx) =
-        mpsc::channel::<crate::terminal_control::TerminalControlEvent>(256);
+        mpsc::channel::<crate::terminal_control::TerminalControlEvent>(1024);
     let node_delivery_token_present = node_token.is_some();
     tokio::spawn(crate::node_control::run_node_control_client(
         crate::node_control::FleetControlConfig {
@@ -682,6 +688,7 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         terminal_control_open: true,
         terminal_sessions: HashMap::new(),
         terminal_snapshot_requests: HashMap::new(),
+        terminal_input_requests: HashMap::new(),
         fleet_delivery_book: FleetDeliveryBook::default(),
         // Seed the live capacity with the configured max so heartbeats/load
         // updates keep reporting it (they overwrite load.max_agents from this

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::terminal_control::TerminalToCloud;
 
 impl BrokerRuntime {
     pub(super) async fn handle_maintenance_tick(&mut self) {
@@ -26,11 +27,57 @@ impl BrokerRuntime {
         let delivery_states = &mut self.delivery_states;
         let resize_owners = &mut self.resize_owners;
         let agent_result_tokens = &mut self.agent_result_tokens;
+        let terminal_control_tx = &self.terminal_control_tx;
+        let terminal_sessions = &mut self.terminal_sessions;
+        let terminal_snapshot_requests = &mut self.terminal_snapshot_requests;
+        let terminal_input_requests = &mut self.terminal_input_requests;
         let delivery_retry_interval = self.delivery_retry_interval;
         let shutdown = &self.shutdown;
         let default_workspace = &self.default_workspace;
 
         let now = Instant::now();
+
+        // A worker can disappear before answering `snapshot_pty`. Bound these
+        // terminal-only RPCs so their sessions cannot remain live forever.
+        let expired_terminal_snapshots: Vec<(String, String)> = terminal_snapshot_requests
+            .iter()
+            .filter(|(_, pending)| pending.deadline <= now)
+            .map(|(request_id, pending)| (request_id.clone(), pending.session_id.clone()))
+            .collect();
+        for (request_id, session_id) in expired_terminal_snapshots {
+            terminal_snapshot_requests.remove(&request_id);
+            if terminal_sessions.remove(&session_id).is_some() {
+                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+                    TerminalToCloud::Error {
+                        session_id: session_id.clone(),
+                        code: "snapshot_timeout".into(),
+                        message: "terminal snapshot timed out".into(),
+                    },
+                )) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting snapshot timeout");
+                }
+            }
+        }
+        let expired_terminal_inputs: Vec<(String, String)> = terminal_input_requests
+            .iter()
+            .filter(|(_, pending)| pending.deadline <= now)
+            .map(|(request_id, pending)| (request_id.clone(), pending.session_id.clone()))
+            .collect();
+        for (request_id, session_id) in expired_terminal_inputs {
+            terminal_input_requests.remove(&request_id);
+            if terminal_sessions.contains_key(&session_id) {
+                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+                    TerminalToCloud::Error {
+                        session_id: session_id.clone(),
+                        code: "input_timeout".into(),
+                        message: "terminal input acknowledgement timed out".into(),
+                    },
+                )) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting input timeout");
+                    terminal_sessions.remove(&session_id);
+                }
+            }
+        }
 
         // Time out worker request/response calls whose worker never
         // responded. Common cause: worker crashed between us sending
@@ -210,6 +257,25 @@ impl BrokerRuntime {
                 );
             }
             pty_observability.remove(name);
+            let terminal_session_ids: Vec<String> = terminal_sessions
+                .iter()
+                .filter(|(_, session)| session.agent == *name)
+                .map(|(session_id, _)| session_id.clone())
+                .collect();
+            for session_id in terminal_session_ids {
+                terminal_sessions.remove(&session_id);
+                terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
+                terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
+                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+                    TerminalToCloud::Closed {
+                        session_id: session_id.clone(),
+                        code: Some("agent_exited".into()),
+                        message: Some("terminal worker exited".into()),
+                    },
+                )) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while closing exited worker session");
+                }
+            }
             // Record crash in insights
             let (category, description) =
                 crate::crash_insights::CrashInsights::analyze(*code, signal.as_deref());

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -1,3 +1,4 @@
+use super::fleet::try_send_terminal;
 use super::*;
 use crate::terminal_control::TerminalToCloud;
 
@@ -47,14 +48,26 @@ impl BrokerRuntime {
         for (request_id, session_id) in expired_terminal_snapshots {
             terminal_snapshot_requests.remove(&request_id);
             if terminal_sessions.remove(&session_id).is_some() {
-                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+                terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
+                if !try_send_terminal(
+                    terminal_control_tx,
                     TerminalToCloud::Error {
                         session_id: session_id.clone(),
                         code: "snapshot_timeout".into(),
                         message: "terminal snapshot timed out".into(),
                     },
-                )) {
-                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting snapshot timeout");
+                ) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while reporting snapshot timeout");
+                }
+                if !try_send_terminal(
+                    terminal_control_tx,
+                    TerminalToCloud::Closed {
+                        session_id: session_id.clone(),
+                        code: Some("snapshot_timeout".into()),
+                        message: Some("terminal snapshot timed out".into()),
+                    },
+                ) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal close could not be queued after snapshot timeout");
                 }
             }
         }
@@ -65,16 +78,31 @@ impl BrokerRuntime {
             .collect();
         for (request_id, session_id) in expired_terminal_inputs {
             terminal_input_requests.remove(&request_id);
-            if terminal_sessions.contains_key(&session_id) {
-                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+            // A timed-out write may still reach the PTY after cancellation. End
+            // the whole session before reporting it so a retry cannot duplicate
+            // user keystrokes against that uncertain write.
+            if terminal_sessions.remove(&session_id).is_some() {
+                terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
+                terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
+                if !try_send_terminal(
+                    terminal_control_tx,
                     TerminalToCloud::Error {
                         session_id: session_id.clone(),
                         code: "input_timeout".into(),
                         message: "terminal input acknowledgement timed out".into(),
                     },
-                )) {
-                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting input timeout");
-                    terminal_sessions.remove(&session_id);
+                ) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while reporting input timeout");
+                }
+                if !try_send_terminal(
+                    terminal_control_tx,
+                    TerminalToCloud::Closed {
+                        session_id: session_id.clone(),
+                        code: Some("input_timeout".into()),
+                        message: Some("terminal input acknowledgement timed out".into()),
+                    },
+                ) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal close could not be queued after input timeout");
                 }
             }
         }
@@ -266,14 +294,15 @@ impl BrokerRuntime {
                 terminal_sessions.remove(&session_id);
                 terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
                 terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
-                if let Err(error) = terminal_control_tx.try_send(TerminalControlCommand::Send(
+                if !try_send_terminal(
+                    terminal_control_tx,
                     TerminalToCloud::Closed {
                         session_id: session_id.clone(),
                         code: Some("agent_exited".into()),
                         message: Some("terminal worker exited".into()),
                     },
-                )) {
-                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while closing exited worker session");
+                ) {
+                    tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while closing exited worker session");
                 }
             }
             // Record crash in insights

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -43,6 +43,7 @@ use crate::{
     },
     replay_buffer::{ReplayBuffer, DEFAULT_REPLAY_CAPACITY},
     telemetry::{ActionSource, TelemetryClient, TelemetryEvent},
+    terminal_control::{TerminalControlCommand, TerminalControlEvent, TerminalMode},
     types::{
         AgentResultMcpConfig, InboundDeliveryDispatch, InboundDeliveryMode, InboundDeliveryState,
         PendingRelayMessage, RelaycastDeliveryReceipt,

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -3,6 +3,8 @@ use super::*;
 use crate::terminal_control::{TerminalControlCommand, TerminalToCloud};
 use crate::worker::AgentWorkState;
 
+const TERMINAL_PENDING_OUTPUT_MAX_BYTES: usize = 1024 * 1024;
+
 fn publish_terminal_output(
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     terminal_sessions: &mut HashMap<String, TerminalSession>,
@@ -13,11 +15,28 @@ fn publish_terminal_output(
     if terminal_sessions.is_empty() {
         return;
     }
-    let session_ids: Vec<String> = terminal_sessions
-        .iter()
-        .filter(|(_, session)| session.ready && session.agent == *name)
-        .map(|(session_id, _)| session_id.clone())
-        .collect();
+    let chunk_bytes = chunk.len();
+    let mut session_ids = Vec::new();
+    let mut saturated_sessions = Vec::new();
+    for (session_id, session) in terminal_sessions.iter_mut() {
+        if session.agent != *name {
+            continue;
+        }
+        if !session.ready {
+            if session.pending_output_bytes + chunk_bytes > TERMINAL_PENDING_OUTPUT_MAX_BYTES {
+                saturated_sessions.push(session_id.clone());
+            } else {
+                session.pending_output.push((chunk.clone(), offset));
+                session.pending_output_bytes += chunk_bytes;
+            }
+            continue;
+        }
+        session_ids.push(session_id.clone());
+    }
+    for session_id in saturated_sessions {
+        tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal snapshot wait exceeded bounded output buffer; ending session");
+        terminal_sessions.remove(&session_id);
+    }
     for session_id in session_ids {
         if let Err(error) =
             terminal_control_tx.try_send(TerminalControlCommand::Send(TerminalToCloud::Output {
@@ -952,8 +971,26 @@ impl BrokerRuntime {
                                 tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while sending snapshot; ending session");
                                 terminal_sessions.remove(&session_id);
                             } else if snapshot_ready {
-                                if let Some(session) = terminal_sessions.get_mut(&session_id) {
-                                    session.ready = true;
+                                let pending_output =
+                                    if let Some(session) = terminal_sessions.get_mut(&session_id) {
+                                        session.ready = true;
+                                        session.pending_output_bytes = 0;
+                                        std::mem::take(&mut session.pending_output)
+                                    } else {
+                                        Vec::new()
+                                    };
+                                for (chunk, offset) in pending_output {
+                                    if let Err(error) = terminal_control_tx.try_send(
+                                        TerminalControlCommand::Send(TerminalToCloud::Output {
+                                            session_id: session_id.clone(),
+                                            chunk,
+                                            offset,
+                                        }),
+                                    ) {
+                                        tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while flushing buffered output; ending session");
+                                        terminal_sessions.remove(&session_id);
+                                        break;
+                                    }
                                 }
                             } else if snapshot_failed {
                                 terminal_sessions.remove(&session_id);

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -10,9 +10,12 @@ fn publish_terminal_output(
     chunk: String,
     offset: Option<u64>,
 ) {
+    if terminal_sessions.is_empty() {
+        return;
+    }
     let session_ids: Vec<String> = terminal_sessions
         .iter()
-        .filter(|(_, session)| session.agent == *name)
+        .filter(|(_, session)| session.ready && session.agent == *name)
         .map(|(session_id, _)| session_id.clone())
         .collect();
     for session_id in session_ids {
@@ -458,6 +461,7 @@ impl BrokerRuntime {
         let terminal_control_tx = &self.terminal_control_tx;
         let terminal_sessions = &mut self.terminal_sessions;
         let terminal_snapshot_requests = &mut self.terminal_snapshot_requests;
+        let terminal_input_requests = &mut self.terminal_input_requests;
 
         match worker_event {
             WorkerEvent::Message {
@@ -827,11 +831,65 @@ impl BrokerRuntime {
                         }
                         let _ = send_event(sdk_out_tx, agent_event).await;
                     } else if msg_type.ends_with("_response") {
+                        let terminal_input_session_id = value
+                            .get("request_id")
+                            .and_then(Value::as_str)
+                            .and_then(|request_id| terminal_input_requests.remove(request_id))
+                            .map(|request| request.session_id);
                         let terminal_session_id = value
                             .get("request_id")
                             .and_then(Value::as_str)
-                            .and_then(|request_id| terminal_snapshot_requests.remove(request_id));
-                        if let Some(session_id) = terminal_session_id {
+                            .and_then(|request_id| terminal_snapshot_requests.remove(request_id))
+                            .map(|request| request.session_id);
+                        if let Some(session_id) = terminal_input_session_id {
+                            if !terminal_sessions.contains_key(&session_id) {
+                                return;
+                            }
+                            let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+                            let message = if msg_type != "write_pty_response" {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: "input_failed".into(),
+                                    message:
+                                        "terminal input returned an unexpected worker response"
+                                            .into(),
+                                }
+                            } else if let Some(error) = payload.get("error") {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: error
+                                        .get("code")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("input_failed")
+                                        .to_string(),
+                                    message: error
+                                        .get("message")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("terminal input failed")
+                                        .to_string(),
+                                }
+                            } else if let Some(bytes_written) =
+                                payload.get("bytes_written").and_then(Value::as_u64)
+                            {
+                                TerminalToCloud::InputAck {
+                                    session_id: session_id.clone(),
+                                    bytes_written: usize::try_from(bytes_written)
+                                        .unwrap_or(usize::MAX),
+                                }
+                            } else {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: "input_failed".into(),
+                                    message: "terminal input response was malformed".into(),
+                                }
+                            };
+                            if let Err(error) =
+                                terminal_control_tx.try_send(TerminalControlCommand::Send(message))
+                            {
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting PTY input result; ending session");
+                                terminal_sessions.remove(&session_id);
+                            }
+                        } else if let Some(session_id) = terminal_session_id {
                             if !terminal_sessions.contains_key(&session_id) {
                                 return;
                             }
@@ -858,7 +916,7 @@ impl BrokerRuntime {
                                         .unwrap_or("terminal snapshot failed")
                                         .to_string(),
                                 }
-                            } else if let (Some(screen), Some(rows), Some(cols), Some(offset)) = (
+                            } else if let (Some(screen), Some(rows), Some(cols)) = (
                                 payload.get("screen").and_then(Value::as_str),
                                 payload
                                     .get("rows")
@@ -868,14 +926,16 @@ impl BrokerRuntime {
                                     .get("cols")
                                     .and_then(Value::as_u64)
                                     .and_then(|value| u16::try_from(value).ok()),
-                                payload.get("offset").and_then(Value::as_u64),
                             ) {
                                 TerminalToCloud::Ready {
                                     session_id: session_id.clone(),
                                     screen: screen.to_string(),
                                     rows,
                                     cols,
-                                    offset,
+                                    offset: payload
+                                        .get("offset")
+                                        .and_then(Value::as_u64)
+                                        .unwrap_or(0),
                                 }
                             } else {
                                 TerminalToCloud::Error {
@@ -884,10 +944,18 @@ impl BrokerRuntime {
                                     message: "terminal snapshot response was malformed".into(),
                                 }
                             };
+                            let snapshot_ready = matches!(&message, TerminalToCloud::Ready { .. });
+                            let snapshot_failed = matches!(&message, TerminalToCloud::Error { .. });
                             if let Err(error) =
                                 terminal_control_tx.try_send(TerminalControlCommand::Send(message))
                             {
                                 tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while sending snapshot; ending session");
+                                terminal_sessions.remove(&session_id);
+                            } else if snapshot_ready {
+                                if let Some(session) = terminal_sessions.get_mut(&session_id) {
+                                    session.ready = true;
+                                }
+                            } else if snapshot_failed {
                                 terminal_sessions.remove(&session_id);
                             }
                         } else {
@@ -926,39 +994,38 @@ impl BrokerRuntime {
                         if is_pty {
                             publish_pty_busy(pty_observability, hosted_agent_event_tx, &name);
                         }
-                        let mut stream_event = json!({
-                            "kind": "worker_stream",
-                            "name": name,
-                            "stream": value.get("payload").and_then(|p| p.get("stream")).cloned().unwrap_or(Value::String("stdout".to_string())),
-                            "chunk": value.get("payload").and_then(|p| p.get("chunk")).cloned().unwrap_or(Value::String(String::new())),
-                        });
-                        // Forward the per-worker stream offset when present so
-                        // attaching clients can correlate the live stream with
-                        // a snapshot. Absent for headless workers (no grid).
-                        if let Some(offset) =
-                            value.get("payload").and_then(|p| p.get("offset")).cloned()
-                        {
-                            if let Some(obj) = stream_event.as_object_mut() {
-                                obj.insert("offset".to_string(), offset);
-                            }
-                        }
-                        let chunk = value
-                            .get("payload")
+                        let payload = value.get("payload");
+                        let chunk = payload
                             .and_then(|payload| payload.get("chunk"))
                             .and_then(Value::as_str)
                             .unwrap_or_default()
                             .to_string();
-                        let offset = value
-                            .get("payload")
+                        let offset = payload
                             .and_then(|payload| payload.get("offset"))
                             .and_then(Value::as_u64);
-                        publish_terminal_output(
-                            terminal_control_tx,
-                            terminal_sessions,
-                            &name,
-                            chunk,
-                            offset,
-                        );
+                        let mut stream_event = json!({
+                            "kind": "worker_stream",
+                            "name": name,
+                            "stream": payload.and_then(|p| p.get("stream")).cloned().unwrap_or(Value::String("stdout".to_string())),
+                            "chunk": chunk.clone(),
+                        });
+                        // Forward the per-worker stream offset when present so
+                        // attaching clients can correlate the live stream with
+                        // a snapshot. Absent for headless workers (no grid).
+                        if let Some(offset) = offset {
+                            if let Some(obj) = stream_event.as_object_mut() {
+                                obj.insert("offset".to_string(), Value::from(offset));
+                            }
+                        }
+                        if !chunk.is_empty() {
+                            publish_terminal_output(
+                                terminal_control_tx,
+                                terminal_sessions,
+                                &name,
+                                chunk,
+                                offset,
+                            );
+                        }
                         let _ = send_event(sdk_out_tx, stream_event).await;
                     } else if msg_type == "harness_started" {
                         // A running child process proves liveness but not that

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -12,7 +12,8 @@ fn publish_terminal_output(
 ) {
     let session_ids: Vec<String> = terminal_sessions
         .iter()
-        .filter_map(|(session_id, session)| (session.agent == *name).then(|| session_id.clone()))
+        .filter(|(_, session)| session.agent == *name)
+        .map(|(session_id, _)| session_id.clone())
         .collect();
     for session_id in session_ids {
         if let Err(error) =

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -1,6 +1,32 @@
 use super::fleet::{refresh_fleet_inventory_session_ref, verified_spawn_ready_result};
 use super::*;
+use crate::terminal_control::{TerminalControlCommand, TerminalToCloud};
 use crate::worker::AgentWorkState;
+
+fn publish_terminal_output(
+    terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
+    terminal_sessions: &mut HashMap<String, TerminalSession>,
+    name: &WorkerName,
+    chunk: String,
+    offset: Option<u64>,
+) {
+    let session_ids: Vec<String> = terminal_sessions
+        .iter()
+        .filter_map(|(session_id, session)| (session.agent == *name).then(|| session_id.clone()))
+        .collect();
+    for session_id in session_ids {
+        if let Err(error) =
+            terminal_control_tx.try_send(TerminalControlCommand::Send(TerminalToCloud::Output {
+                session_id: session_id.clone(),
+                chunk: chunk.clone(),
+                offset,
+            }))
+        {
+            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal output queue full or closed; ending session");
+            terminal_sessions.remove(&session_id);
+        }
+    }
+}
 
 fn enqueue_pty_event(
     states: &mut HashMap<WorkerName, PtyObservabilityState>,
@@ -428,6 +454,9 @@ impl BrokerRuntime {
         let fleet_control_tx = &self.fleet_control_tx;
         let fleet_inventory = &mut self.fleet_inventory;
         let delivery_states = &self.delivery_states;
+        let terminal_control_tx = &self.terminal_control_tx;
+        let terminal_sessions = &mut self.terminal_sessions;
+        let terminal_snapshot_requests = &mut self.terminal_snapshot_requests;
 
         match worker_event {
             WorkerEvent::Message {
@@ -797,27 +826,92 @@ impl BrokerRuntime {
                         }
                         let _ = send_event(sdk_out_tx, agent_event).await;
                     } else if msg_type.ends_with("_response") {
-                        // Generic worker request/response dispatch.
-                        // Any frame whose `type` ends in
-                        // `_response` is routed by `request_id`
-                        // into the matching parked `oneshot` in
-                        // `pending_requests`. The pending entry
-                        // owns the format/error decoding logic
-                        // via `worker_request::fulfil_response_frame`.
-                        let routed =
-                            worker_request::fulfil_response_frame(pending_requests, &value);
-                        if !routed {
-                            let req_id = value
-                                .get("request_id")
-                                .and_then(Value::as_str)
-                                .unwrap_or("<missing>");
-                            tracing::debug!(
-                                target = "agent_relay::broker",
-                                worker = %name,
-                                msg_type = %msg_type,
-                                request_id = %req_id,
-                                "worker response with no pending caller — dropping"
-                            );
+                        let terminal_session_id = value
+                            .get("request_id")
+                            .and_then(Value::as_str)
+                            .and_then(|request_id| terminal_snapshot_requests.remove(request_id));
+                        if let Some(session_id) = terminal_session_id {
+                            if !terminal_sessions.contains_key(&session_id) {
+                                return;
+                            }
+                            let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+                            let message = if msg_type != "snapshot_response" {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: "snapshot_failed".into(),
+                                    message:
+                                        "terminal snapshot returned an unexpected worker response"
+                                            .into(),
+                                }
+                            } else if let Some(error) = payload.get("error") {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: error
+                                        .get("code")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("snapshot_failed")
+                                        .to_string(),
+                                    message: error
+                                        .get("message")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("terminal snapshot failed")
+                                        .to_string(),
+                                }
+                            } else if let (Some(screen), Some(rows), Some(cols), Some(offset)) = (
+                                payload.get("screen").and_then(Value::as_str),
+                                payload
+                                    .get("rows")
+                                    .and_then(Value::as_u64)
+                                    .and_then(|value| u16::try_from(value).ok()),
+                                payload
+                                    .get("cols")
+                                    .and_then(Value::as_u64)
+                                    .and_then(|value| u16::try_from(value).ok()),
+                                payload.get("offset").and_then(Value::as_u64),
+                            ) {
+                                TerminalToCloud::Ready {
+                                    session_id: session_id.clone(),
+                                    screen: screen.to_string(),
+                                    rows,
+                                    cols,
+                                    offset,
+                                }
+                            } else {
+                                TerminalToCloud::Error {
+                                    session_id: session_id.clone(),
+                                    code: "snapshot_failed".into(),
+                                    message: "terminal snapshot response was malformed".into(),
+                                }
+                            };
+                            if let Err(error) =
+                                terminal_control_tx.try_send(TerminalControlCommand::Send(message))
+                            {
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while sending snapshot; ending session");
+                                terminal_sessions.remove(&session_id);
+                            }
+                        } else {
+                            // Generic worker request/response dispatch.
+                            // Any frame whose `type` ends in
+                            // `_response` is routed by `request_id`
+                            // into the matching parked `oneshot` in
+                            // `pending_requests`. The pending entry
+                            // owns the format/error decoding logic
+                            // via `worker_request::fulfil_response_frame`.
+                            let routed =
+                                worker_request::fulfil_response_frame(pending_requests, &value);
+                            if !routed {
+                                let req_id = value
+                                    .get("request_id")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or("<missing>");
+                                tracing::debug!(
+                                    target = "agent_relay::broker",
+                                    worker = %name,
+                                    msg_type = %msg_type,
+                                    request_id = %req_id,
+                                    "worker response with no pending caller — dropping"
+                                );
+                            }
                         }
                     } else if msg_type == "worker_stream" {
                         let is_pty = workers
@@ -847,6 +941,23 @@ impl BrokerRuntime {
                                 obj.insert("offset".to_string(), offset);
                             }
                         }
+                        let chunk = value
+                            .get("payload")
+                            .and_then(|payload| payload.get("chunk"))
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string();
+                        let offset = value
+                            .get("payload")
+                            .and_then(|payload| payload.get("offset"))
+                            .and_then(Value::as_u64);
+                        publish_terminal_output(
+                            terminal_control_tx,
+                            terminal_sessions,
+                            &name,
+                            chunk,
+                            offset,
+                        );
                         let _ = send_event(sdk_out_tx, stream_event).await;
                     } else if msg_type == "harness_started" {
                         // A running child process proves liveness but not that

--- a/crates/broker/src/runtime/worker_events.rs
+++ b/crates/broker/src/runtime/worker_events.rs
@@ -1,4 +1,6 @@
-use super::fleet::{refresh_fleet_inventory_session_ref, verified_spawn_ready_result};
+use super::fleet::{
+    refresh_fleet_inventory_session_ref, try_send_terminal, verified_spawn_ready_result,
+};
 use super::*;
 use crate::terminal_control::{TerminalControlCommand, TerminalToCloud};
 use crate::worker::AgentWorkState;
@@ -8,6 +10,8 @@ const TERMINAL_PENDING_OUTPUT_MAX_BYTES: usize = 1024 * 1024;
 fn publish_terminal_output(
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     terminal_sessions: &mut HashMap<String, TerminalSession>,
+    terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
+    terminal_input_requests: &mut HashMap<String, TerminalInputRequest>,
     name: &WorkerName,
     chunk: String,
     offset: Option<u64>,
@@ -35,19 +39,64 @@ fn publish_terminal_output(
     }
     for session_id in saturated_sessions {
         tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal snapshot wait exceeded bounded output buffer; ending session");
-        terminal_sessions.remove(&session_id);
+        end_terminal_session(
+            terminal_control_tx,
+            terminal_sessions,
+            terminal_snapshot_requests,
+            terminal_input_requests,
+            &session_id,
+            "output_backpressure",
+            "terminal snapshot wait exceeded bounded output buffer",
+        );
     }
     for session_id in session_ids {
-        if let Err(error) =
-            terminal_control_tx.try_send(TerminalControlCommand::Send(TerminalToCloud::Output {
+        if !try_send_terminal(
+            terminal_control_tx,
+            TerminalToCloud::Output {
                 session_id: session_id.clone(),
                 chunk: chunk.clone(),
                 offset,
-            }))
-        {
-            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal output queue full or closed; ending session");
-            terminal_sessions.remove(&session_id);
+            },
+        ) {
+            tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal output queue full or closed; ending session");
+            end_terminal_session(
+                terminal_control_tx,
+                terminal_sessions,
+                terminal_snapshot_requests,
+                terminal_input_requests,
+                &session_id,
+                "output_backpressure",
+                "terminal output queue is full",
+            );
         }
+    }
+}
+
+fn end_terminal_session(
+    terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
+    terminal_sessions: &mut HashMap<String, TerminalSession>,
+    terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
+    terminal_input_requests: &mut HashMap<String, TerminalInputRequest>,
+    session_id: &str,
+    code: &str,
+    message: &str,
+) {
+    terminal_sessions.remove(session_id);
+    terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
+    terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
+    if !try_send_terminal(
+        terminal_control_tx,
+        TerminalToCloud::Closed {
+            session_id: session_id.into(),
+            code: Some(code.into()),
+            message: Some(message.into()),
+        },
+    ) {
+        tracing::warn!(
+            target = "relay_broker::terminal",
+            session_id,
+            "terminal close could not be queued after session failure"
+        );
     }
 }
 
@@ -902,11 +951,17 @@ impl BrokerRuntime {
                                     message: "terminal input response was malformed".into(),
                                 }
                             };
-                            if let Err(error) =
-                                terminal_control_tx.try_send(TerminalControlCommand::Send(message))
-                            {
-                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while reporting PTY input result; ending session");
-                                terminal_sessions.remove(&session_id);
+                            if !try_send_terminal(terminal_control_tx, message) {
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while reporting PTY input result; ending session");
+                                end_terminal_session(
+                                    terminal_control_tx,
+                                    terminal_sessions,
+                                    terminal_snapshot_requests,
+                                    terminal_input_requests,
+                                    &session_id,
+                                    "output_backpressure",
+                                    "terminal output queue is full",
+                                );
                             }
                         } else if let Some(session_id) = terminal_session_id {
                             if !terminal_sessions.contains_key(&session_id) {
@@ -965,11 +1020,17 @@ impl BrokerRuntime {
                             };
                             let snapshot_ready = matches!(&message, TerminalToCloud::Ready { .. });
                             let snapshot_failed = matches!(&message, TerminalToCloud::Error { .. });
-                            if let Err(error) =
-                                terminal_control_tx.try_send(TerminalControlCommand::Send(message))
-                            {
-                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while sending snapshot; ending session");
-                                terminal_sessions.remove(&session_id);
+                            if !try_send_terminal(terminal_control_tx, message) {
+                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while sending snapshot; ending session");
+                                end_terminal_session(
+                                    terminal_control_tx,
+                                    terminal_sessions,
+                                    terminal_snapshot_requests,
+                                    terminal_input_requests,
+                                    &session_id,
+                                    "output_backpressure",
+                                    "terminal output queue is full",
+                                );
                             } else if snapshot_ready {
                                 let pending_output =
                                     if let Some(session) = terminal_sessions.get_mut(&session_id) {
@@ -980,15 +1041,24 @@ impl BrokerRuntime {
                                         Vec::new()
                                     };
                                 for (chunk, offset) in pending_output {
-                                    if let Err(error) = terminal_control_tx.try_send(
-                                        TerminalControlCommand::Send(TerminalToCloud::Output {
+                                    if !try_send_terminal(
+                                        terminal_control_tx,
+                                        TerminalToCloud::Output {
                                             session_id: session_id.clone(),
                                             chunk,
                                             offset,
-                                        }),
+                                        },
                                     ) {
-                                        tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, error = %error, "terminal queue full or closed while flushing buffered output; ending session");
-                                        terminal_sessions.remove(&session_id);
+                                        tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while flushing buffered output; ending session");
+                                        end_terminal_session(
+                                            terminal_control_tx,
+                                            terminal_sessions,
+                                            terminal_snapshot_requests,
+                                            terminal_input_requests,
+                                            &session_id,
+                                            "output_backpressure",
+                                            "terminal output queue is full",
+                                        );
                                         break;
                                     }
                                 }
@@ -1058,6 +1128,8 @@ impl BrokerRuntime {
                             publish_terminal_output(
                                 terminal_control_tx,
                                 terminal_sessions,
+                                terminal_snapshot_requests,
+                                terminal_input_requests,
                                 &name,
                                 chunk,
                                 offset,

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -1,0 +1,244 @@
+//! Dedicated Relaycast terminal transport.
+//!
+//! This deliberately does not share `node_control`: terminal output can be
+//! continuous and subject to backpressure, whereas node registration,
+//! heartbeats, and action delivery need a small independent control lane.
+
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use futures_util::{SinkExt, StreamExt};
+use relaycast::ORIGIN_ACTOR_HEADER;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, Message},
+};
+
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+const TOKEN_WAIT_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TerminalMode {
+    View,
+    Drive,
+    Passthrough,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum TerminalFromCloud {
+    #[serde(rename = "terminal.open")]
+    Open {
+        session_id: String,
+        agent: String,
+        mode: TerminalMode,
+    },
+    #[serde(rename = "terminal.input")]
+    Input {
+        session_id: String,
+        data_base64: String,
+    },
+    #[serde(rename = "terminal.resize")]
+    Resize {
+        session_id: String,
+        rows: u16,
+        cols: u16,
+    },
+    #[serde(rename = "terminal.close")]
+    Close { session_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum TerminalToCloud {
+    #[serde(rename = "terminal.ready")]
+    Ready {
+        session_id: String,
+        screen: String,
+        rows: u16,
+        cols: u16,
+        offset: u64,
+    },
+    #[serde(rename = "terminal.output")]
+    Output {
+        session_id: String,
+        chunk: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        offset: Option<u64>,
+    },
+    #[serde(rename = "terminal.input_ack")]
+    InputAck {
+        session_id: String,
+        bytes_written: usize,
+    },
+    #[serde(rename = "terminal.error")]
+    Error {
+        session_id: String,
+        code: String,
+        message: String,
+    },
+    #[serde(rename = "terminal.closed")]
+    Closed {
+        session_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum TerminalControlCommand {
+    Send(TerminalToCloud),
+    Shutdown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum TerminalControlEvent {
+    Connected,
+    Disconnected,
+    Message(TerminalFromCloud),
+}
+
+#[derive(Clone)]
+pub(crate) struct TerminalControlConfig {
+    pub(crate) ws_url: String,
+    /// Written through by node-control when it mints or rotates the node
+    /// credential. This transport never mints itself, avoiding duplicate
+    /// credential flows while still reconnecting with a fresh token.
+    pub(crate) session_token: Arc<RwLock<Option<String>>>,
+}
+
+pub(crate) async fn run_terminal_control_client(
+    config: TerminalControlConfig,
+    mut command_rx: mpsc::Receiver<TerminalControlCommand>,
+    event_tx: mpsc::Sender<TerminalControlEvent>,
+) {
+    let mut reconnect_delay = INITIAL_RECONNECT_DELAY;
+    loop {
+        let token = config
+            .session_token
+            .read()
+            .ok()
+            .and_then(|token| token.clone());
+        let Some(token) = token.filter(|token| !token.trim().is_empty()) else {
+            tokio::select! {
+                command = command_rx.recv() => {
+                    if matches!(command, Some(TerminalControlCommand::Shutdown) | None) { return; }
+                    // Preserve bounded backpressure by dropping commands only
+                    // when the caller itself chose a non-blocking try_send.
+                }
+                _ = tokio::time::sleep(TOKEN_WAIT_DELAY) => {}
+            }
+            continue;
+        };
+
+        let mut request = match config.ws_url.as_str().into_client_request() {
+            Ok(request) => request,
+            Err(error) => {
+                tracing::warn!(target = "relay_broker::terminal", error = %error, "invalid fleet terminal ws url");
+                tokio::time::sleep(reconnect_delay).await;
+                reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+                continue;
+            }
+        };
+        let header = format!("Bearer {}", token.trim());
+        let Ok(header) = header.parse() else {
+            tracing::warn!(
+                target = "relay_broker::terminal",
+                "invalid fleet terminal token header"
+            );
+            tokio::time::sleep(reconnect_delay).await;
+            continue;
+        };
+        request.headers_mut().insert("authorization", header);
+        if let Ok(value) = crate::telemetry::BROKER_ORIGIN_ACTOR.parse() {
+            request.headers_mut().insert(ORIGIN_ACTOR_HEADER, value);
+        }
+        for (name, value) in crate::telemetry::cloud_identity_headers() {
+            let Ok(header_name) = name.parse::<reqwest::header::HeaderName>() else {
+                continue;
+            };
+            if let Ok(header_value) = value.parse() {
+                request.headers_mut().insert(header_name, header_value);
+            }
+        }
+
+        let (socket, _) = match connect_async(request).await {
+            Ok(socket) => socket,
+            Err(error) => {
+                tracing::warn!(target = "relay_broker::terminal", url = %config.ws_url, error = %error, "fleet terminal ws connect failed");
+                tokio::time::sleep(reconnect_delay).await;
+                reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+                continue;
+            }
+        };
+        reconnect_delay = INITIAL_RECONNECT_DELAY;
+        let _ = event_tx.send(TerminalControlEvent::Connected).await;
+        let (mut sink, mut stream) = socket.split();
+        let mut connected = true;
+        while connected {
+            tokio::select! {
+                command = command_rx.recv() => match command {
+                    Some(TerminalControlCommand::Send(message)) => {
+                        match serde_json::to_string(&message) {
+                            Ok(encoded) => {
+                                if sink.send(Message::Text(encoded.into())).await.is_err() {
+                                    connected = false;
+                                }
+                            }
+                            Err(_) => connected = false,
+                        }
+                    }
+                    Some(TerminalControlCommand::Shutdown) | None => return,
+                },
+                inbound = stream.next() => match inbound {
+                    Some(Ok(Message::Text(text))) => match serde_json::from_str::<TerminalFromCloud>(&text) {
+                        Ok(message) => { if event_tx.send(TerminalControlEvent::Message(message)).await.is_err() { return; } }
+                        Err(error) => tracing::warn!(target = "relay_broker::terminal", error = %error, "invalid fleet terminal frame"),
+                    },
+                    Some(Ok(Message::Ping(_))) => {}
+                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => connected = false,
+                    Some(Ok(_)) => {},
+                },
+            }
+        }
+        let _ = event_tx.send(TerminalControlEvent::Disconnected).await;
+        tokio::time::sleep(reconnect_delay).await;
+        reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TerminalFromCloud, TerminalMode, TerminalToCloud};
+
+    #[test]
+    fn terminal_wire_round_trips_without_control_frames() {
+        let open: TerminalFromCloud = serde_json::from_str(
+            r#"{"type":"terminal.open","session_id":"s","agent":"Ada","mode":"view"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            open,
+            TerminalFromCloud::Open {
+                session_id: "s".into(),
+                agent: "Ada".into(),
+                mode: TerminalMode::View
+            }
+        );
+        let output = serde_json::to_value(TerminalToCloud::Output {
+            session_id: "s".into(),
+            chunk: "x".into(),
+            offset: Some(2),
+        })
+        .unwrap();
+        assert_eq!(output["type"], "terminal.output");
+    }
+}

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -154,6 +154,7 @@ pub(crate) async fn run_terminal_control_client(
                 target = "relay_broker::terminal",
                 "invalid fleet terminal token header"
             );
+            reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
             tokio::time::sleep(reconnect_delay).await;
             continue;
         };
@@ -196,7 +197,10 @@ pub(crate) async fn run_terminal_control_client(
                             Err(_) => connected = false,
                         }
                     }
-                    Some(TerminalControlCommand::Shutdown) | None => return,
+                    Some(TerminalControlCommand::Shutdown) | None => {
+                        let _ = sink.send(Message::Close(None)).await;
+                        return;
+                    }
                 },
                 inbound = stream.next() => match inbound {
                     Some(Ok(Message::Text(text))) => match serde_json::from_str::<TerminalFromCloud>(&text) {
@@ -240,5 +244,85 @@ mod tests {
         })
         .unwrap();
         assert_eq!(output["type"], "terminal.output");
+        assert_eq!(output["offset"], 2);
+
+        let output_without_offset = serde_json::to_value(TerminalToCloud::Output {
+            session_id: "s".into(),
+            chunk: "x".into(),
+            offset: None,
+        })
+        .unwrap();
+        assert!(output_without_offset.get("offset").is_none());
+
+        for (wire, expected) in [
+            (
+                r#"{"type":"terminal.input","session_id":"s","data_base64":"eA=="}"#,
+                TerminalFromCloud::Input {
+                    session_id: "s".into(),
+                    data_base64: "eA==".into(),
+                },
+            ),
+            (
+                r#"{"type":"terminal.resize","session_id":"s","rows":24,"cols":80}"#,
+                TerminalFromCloud::Resize {
+                    session_id: "s".into(),
+                    rows: 24,
+                    cols: 80,
+                },
+            ),
+            (
+                r#"{"type":"terminal.close","session_id":"s"}"#,
+                TerminalFromCloud::Close {
+                    session_id: "s".into(),
+                },
+            ),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<TerminalFromCloud>(wire).unwrap(),
+                expected
+            );
+        }
+
+        let ready = serde_json::to_value(TerminalToCloud::Ready {
+            session_id: "s".into(),
+            screen: "screen".into(),
+            rows: 24,
+            cols: 80,
+            offset: 3,
+        })
+        .unwrap();
+        assert_eq!(ready["type"], "terminal.ready");
+        assert_eq!(ready["offset"], 3);
+        let ack = serde_json::to_value(TerminalToCloud::InputAck {
+            session_id: "s".into(),
+            bytes_written: 1,
+        })
+        .unwrap();
+        assert_eq!(ack["type"], "terminal.input_ack");
+        let error = serde_json::to_value(TerminalToCloud::Error {
+            session_id: "s".into(),
+            code: "bad".into(),
+            message: "nope".into(),
+        })
+        .unwrap();
+        assert_eq!(error["type"], "terminal.error");
+        assert_eq!(error["code"], "bad");
+        let closed = serde_json::to_value(TerminalToCloud::Closed {
+            session_id: "s".into(),
+            code: None,
+            message: None,
+        })
+        .unwrap();
+        assert_eq!(closed["type"], "terminal.closed");
+        assert!(closed.get("code").is_none());
+        assert!(closed.get("message").is_none());
+        let closed_with_error = serde_json::to_value(TerminalToCloud::Closed {
+            session_id: "s".into(),
+            code: Some("closed".into()),
+            message: Some("done".into()),
+        })
+        .unwrap();
+        assert_eq!(closed_with_error["code"], "closed");
+        assert_eq!(closed_with_error["message"], "done");
     }
 }

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -189,7 +189,7 @@ pub(crate) async fn run_terminal_control_client(
                     Some(TerminalControlCommand::Send(message)) => {
                         match serde_json::to_string(&message) {
                             Ok(encoded) => {
-                                if sink.send(Message::Text(encoded.into())).await.is_err() {
+                                if sink.send(Message::Text(encoded)).await.is_err() {
                                     connected = false;
                                 }
                             }

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -100,7 +100,7 @@ describe('local agent subtree', () => {
     const { program, attach, attachRemote, attachNode } = harness();
     await program.parseAsync(
       ['local', 'agent', 'attach', 'lead', '--node', 'daytona-live', '--mode', 'passthrough', '--json'],
-      { from: 'user' },
+      { from: 'user' }
     );
     expect(attach).not.toHaveBeenCalled();
     expect(attachRemote).not.toHaveBeenCalled();
@@ -108,13 +108,15 @@ describe('local agent subtree', () => {
       'lead',
       'passthrough',
       'daytona-live',
-      expect.objectContaining({ json: true }),
+      expect.objectContaining({ json: true })
     );
   });
 
   it('attach --node rejects SSH and local broker configuration conflicts', async () => {
     const { program, attachNode, attachRemote, error, exit } = harness();
-    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn', '--ssh-host', 'finn'], { from: 'user' });
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn', '--ssh-host', 'finn'], {
+      from: 'user',
+    });
     expect(attachNode).not.toHaveBeenCalled();
     expect(attachRemote).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(expect.stringContaining('--node cannot be combined with --ssh-host'));

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -112,7 +112,7 @@ describe('local agent subtree', () => {
     );
   });
 
-  it('attach --node rejects SSH and local broker configuration conflicts', async () => {
+  it('attach --node rejects the SSH fallback conflict', async () => {
     const { program, attachNode, attachRemote, error, exit } = harness();
     await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn', '--ssh-host', 'finn'], {
       from: 'user',
@@ -120,6 +120,30 @@ describe('local agent subtree', () => {
     expect(attachNode).not.toHaveBeenCalled();
     expect(attachRemote).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(expect.stringContaining('--node cannot be combined with --ssh-host'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
+    ['--broker-url', 'http://127.0.0.1:7777'],
+    ['--api-key', 'do-not-forward'],
+    ['--state-dir', '/tmp/relay-state'],
+  ])('attach --node rejects local broker option %s', async (flag, value) => {
+    const { program, attachNode, error, exit } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn', flag, value], {
+      from: 'user',
+    });
+    expect(attachNode).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--node cannot be combined'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('attach --node prefixes a terminal setup error once', async () => {
+    const attachNode = vi.fn(async () => {
+      throw new Error('terminal unavailable');
+    });
+    const { program, error, exit } = harness({ attachNode });
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn'], { from: 'user' });
+    expect(error).toHaveBeenCalledWith('Error: terminal unavailable');
     expect(exit).toHaveBeenCalledWith(1);
   });
 

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -27,6 +27,7 @@ function harness(overrides: Partial<LocalAgentDependencies> = {}) {
   };
   const attach = vi.fn(async () => 0);
   const attachRemote = vi.fn(async () => 0);
+  const attachNode = vi.fn(async () => 0);
   const log = vi.fn();
   const error = vi.fn();
   const exit = vi.fn();
@@ -34,6 +35,7 @@ function harness(overrides: Partial<LocalAgentDependencies> = {}) {
     connect: vi.fn(async () => client as never),
     attach,
     attachRemote,
+    attachNode,
     cwd: () => '/tmp/project',
     log,
     error,
@@ -44,7 +46,7 @@ function harness(overrides: Partial<LocalAgentDependencies> = {}) {
   program.exitOverride();
   const group = program.command('local');
   registerLocalAgentCommands(group, deps);
-  return { program, client, attach, attachRemote, log, error, exit };
+  return { program, client, attach, attachRemote, attachNode, log, error, exit };
 }
 
 describe('local agent subtree', () => {
@@ -92,6 +94,31 @@ describe('local agent subtree', () => {
     await program.parseAsync(['local', 'agent', 'attach', 'lead', '--ssh-host', ''], { from: 'user' });
     expect(attach).not.toHaveBeenCalled();
     expect(attachRemote).toHaveBeenCalledWith('lead', 'view', '', expect.objectContaining({}));
+  });
+
+  it('attach --node opens the canonical authenticated terminal path without invoking SSH', async () => {
+    const { program, attach, attachRemote, attachNode } = harness();
+    await program.parseAsync(
+      ['local', 'agent', 'attach', 'lead', '--node', 'daytona-live', '--mode', 'passthrough', '--json'],
+      { from: 'user' },
+    );
+    expect(attach).not.toHaveBeenCalled();
+    expect(attachRemote).not.toHaveBeenCalled();
+    expect(attachNode).toHaveBeenCalledWith(
+      'lead',
+      'passthrough',
+      'daytona-live',
+      expect.objectContaining({ json: true }),
+    );
+  });
+
+  it('attach --node rejects SSH and local broker configuration conflicts', async () => {
+    const { program, attachNode, attachRemote, error, exit } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn', '--ssh-host', 'finn'], { from: 'user' });
+    expect(attachNode).not.toHaveBeenCalled();
+    expect(attachRemote).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--node cannot be combined with --ssh-host'));
+    expect(exit).toHaveBeenCalledWith(1);
   });
 
   it.each([

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -144,6 +144,7 @@ describe('local agent subtree', () => {
     const { program, error, exit } = harness({ attachNode });
     await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'finn'], { from: 'user' });
     expect(error).toHaveBeenCalledWith('Error: terminal unavailable');
+    expect(error).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(1);
   });
 

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -86,7 +86,7 @@ export async function attachFleetNode(
   name: string,
   mode: AttachMode,
   node: string,
-  options: NativeAttachOptions,
+  options: NativeAttachOptions
 ): Promise<number> {
   const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
   try {
@@ -118,12 +118,7 @@ export interface LocalAgentDependencies {
     node: string,
     options: RemoteNodeAttachOptions
   ) => Promise<number>;
-  attachNode: (
-    name: string,
-    mode: AttachMode,
-    node: string,
-    options: NativeAttachOptions,
-  ) => Promise<number>;
+  attachNode: (name: string, mode: AttachMode, node: string, options: NativeAttachOptions) => Promise<number>;
   cwd: () => string;
   readConnectionFile: (stateDir: string) => unknown;
   getDefaultStateDir: () => string;
@@ -549,13 +544,21 @@ export function registerLocalAgentCommands(
       const sshHost = options.sshHost as string | undefined;
       const node = options.node as string | undefined;
       if (node !== undefined && sshHost !== undefined) {
-        deps.error('Error: --node cannot be combined with --ssh-host. Use --ssh-host only as the explicit SSH fallback.');
+        deps.error(
+          'Error: --node cannot be combined with --ssh-host. Use --ssh-host only as the explicit SSH fallback.'
+        );
         deps.exit(1);
         return;
       }
       if (node !== undefined) {
-        if (options.brokerUrl !== undefined || options.apiKey !== undefined || options.stateDir !== undefined) {
-          deps.error('Error: --node cannot be combined with --broker-url, --api-key, or --state-dir. It opens an ephemeral authenticated loopback session.');
+        if (
+          options.brokerUrl !== undefined ||
+          options.apiKey !== undefined ||
+          options.stateDir !== undefined
+        ) {
+          deps.error(
+            'Error: --node cannot be combined with --broker-url, --api-key, or --state-dir. It opens an ephemeral authenticated loopback session.'
+          );
           deps.exit(1);
           return;
         }

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -12,6 +12,7 @@ import type { AttachMode } from '../lib/attach-mode.js';
 import { attachNative, isNativeHarness, type NativeAttachOptions } from '../lib/attach-native.js';
 import { attachPassthrough } from '../lib/attach-passthrough.js';
 import { attachRemoteNode, type RemoteNodeAttachOptions } from '../lib/attach-remote-node.js';
+import { startFleetNodeAttachProxy } from '../lib/attach-fleet-node.js';
 import { attachView } from '../lib/attach-view.js';
 import {
   defaultStateDir,
@@ -76,6 +77,35 @@ export function runAttach(name: string, mode: AttachMode, options: NativeAttachO
   });
 }
 
+/**
+ * Run an existing attach mode against the short-lived loopback adapter for a
+ * remote fleet node. Deliberately bypasses native-harness detection: the proxy
+ * represents a PTY byte stream, while native mode is an event protocol.
+ */
+export async function attachFleetNode(
+  name: string,
+  mode: AttachMode,
+  node: string,
+  options: NativeAttachOptions,
+): Promise<number> {
+  const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
+  try {
+    const connectionOptions = { brokerUrl: proxy.brokerUrl };
+    switch (mode) {
+      case 'view':
+        return await attachView(name, connectionOptions);
+      case 'passthrough':
+        return await attachPassthrough(name, connectionOptions);
+      case 'drive':
+      default:
+        return await attachDrive(name, connectionOptions);
+    }
+  } finally {
+    await proxy.close();
+    void options;
+  }
+}
+
 type ExitFn = (code: number) => never;
 
 export interface LocalAgentDependencies {
@@ -87,6 +117,12 @@ export interface LocalAgentDependencies {
     mode: AttachMode,
     node: string,
     options: RemoteNodeAttachOptions
+  ) => Promise<number>;
+  attachNode: (
+    name: string,
+    mode: AttachMode,
+    node: string,
+    options: NativeAttachOptions,
   ) => Promise<number>;
   cwd: () => string;
   readConnectionFile: (stateDir: string) => unknown;
@@ -109,6 +145,7 @@ function withDefaults(overrides: Partial<LocalAgentDependencies> = {}): LocalAge
     fetch: globalThis.fetch,
     attach: runAttach,
     attachRemote: attachRemoteNode,
+    attachNode: attachFleetNode,
     log: (...args: unknown[]) => console.log(...args),
     error: (...args: unknown[]) => console.error(...args),
     exit: defaultExit,
@@ -491,6 +528,7 @@ export function registerLocalAgentCommands(
     .description('Attach to a running agent interactively (drive | view | passthrough)')
     .argument('<name>', 'Agent name')
     .option('--mode <mode>', 'drive | view | passthrough', 'view')
+    .option('--node <node>', 'Canonical authenticated fleet-node terminal attach (physical or Daytona)')
     .option('--ssh-host <host>', 'SSH host fallback for a physical fleet node')
     .option('--broker-url <url>', 'Broker base URL (overrides RELAY_BROKER_URL and connection.json)')
     .option('--api-key <key>', 'Broker API key (overrides RELAY_BROKER_API_KEY and connection.json)')
@@ -509,6 +547,31 @@ export function registerLocalAgentCommands(
         return;
       }
       const sshHost = options.sshHost as string | undefined;
+      const node = options.node as string | undefined;
+      if (node !== undefined && sshHost !== undefined) {
+        deps.error('Error: --node cannot be combined with --ssh-host. Use --ssh-host only as the explicit SSH fallback.');
+        deps.exit(1);
+        return;
+      }
+      if (node !== undefined) {
+        if (options.brokerUrl !== undefined || options.apiKey !== undefined || options.stateDir !== undefined) {
+          deps.error('Error: --node cannot be combined with --broker-url, --api-key, or --state-dir. It opens an ephemeral authenticated loopback session.');
+          deps.exit(1);
+          return;
+        }
+        try {
+          const code = await deps.attachNode(name, mode, node, {
+            json: options.json as boolean | undefined,
+            reasoning: options.reasoning as boolean | undefined,
+            diagnostics: options.diagnostics as boolean | undefined,
+          });
+          if (code !== 0) deps.exit(code);
+        } catch (error) {
+          deps.error(error instanceof Error ? error.message : `Error: ${String(error)}`);
+          deps.exit(1);
+        }
+        return;
+      }
       if (sshHost !== undefined) {
         if (options.brokerUrl !== undefined || options.apiKey !== undefined) {
           deps.error('Error: --ssh-host cannot be combined with --broker-url or --api-key.');

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -91,18 +91,32 @@ export async function attachFleetNode(
   const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
   try {
     const connectionOptions = { brokerUrl: proxy.brokerUrl, apiKey: proxy.apiKey };
+    // Fleet agents expose a PTY stream rather than native-harness envelopes.
+    // In JSON mode retain the machine-readable contract by serializing every
+    // rendered stream chunk as NDJSON, including the initial snapshot.
+    const jsonOutput = (chunk: string) => {
+      process.stdout.write(`${JSON.stringify({ kind: 'worker_stream', name, stream: 'stdout', chunk })}\n`);
+    };
+    if (options.reasoning || options.diagnostics) {
+      process.stderr.write(
+        '[node attach] reasoning and diagnostics are unavailable for remote PTY terminal sessions.\n'
+      );
+    }
     switch (mode) {
       case 'view':
-        return await attachView(name, connectionOptions);
+        return await attachView(name, connectionOptions, options.json ? { writeChunk: jsonOutput } : {});
       case 'passthrough':
-        return await attachPassthrough(name, connectionOptions);
+        return await attachPassthrough(
+          name,
+          connectionOptions,
+          options.json ? { writeChunk: jsonOutput } : {}
+        );
       case 'drive':
       default:
-        return await attachDrive(name, connectionOptions);
+        return await attachDrive(name, connectionOptions, options.json ? { writeChunk: jsonOutput } : {});
     }
   } finally {
     await proxy.close();
-    void options;
   }
 }
 

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -139,6 +139,10 @@ export async function attachFleetNode(
         );
     }
   } finally {
+    // NDJSON is a data contract, unlike an interactive screen: queue every
+    // locally buffered record before teardown so the shared CLI stdio drain
+    // can carry it through a backpressured pipe.
+    jsonWriter?.flush();
     jsonWriter?.dispose();
     await proxy.close();
   }

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -90,7 +90,7 @@ export async function attachFleetNode(
 ): Promise<number> {
   const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
   try {
-    const connectionOptions = { brokerUrl: proxy.brokerUrl };
+    const connectionOptions = { brokerUrl: proxy.brokerUrl, apiKey: proxy.apiKey };
     switch (mode) {
       case 'view':
         return await attachView(name, connectionOptions);
@@ -570,7 +570,8 @@ export function registerLocalAgentCommands(
           });
           if (code !== 0) deps.exit(code);
         } catch (error) {
-          deps.error(error instanceof Error ? error.message : `Error: ${String(error)}`);
+          const message = error instanceof Error ? error.message : String(error);
+          deps.error(message.startsWith('Error:') ? message : `Error: ${message}`);
           deps.exit(1);
         }
         return;

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -14,6 +14,7 @@ import { attachPassthrough } from '../lib/attach-passthrough.js';
 import { attachRemoteNode, type RemoteNodeAttachOptions } from '../lib/attach-remote-node.js';
 import { startFleetNodeAttachProxy } from '../lib/attach-fleet-node.js';
 import { attachView } from '../lib/attach-view.js';
+import { createBackpressureAwareWriter } from '../lib/attach.js';
 import {
   defaultStateDir,
   readConnectionFileFromDisk,
@@ -89,13 +90,14 @@ export async function attachFleetNode(
   options: NativeAttachOptions
 ): Promise<number> {
   const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
+  const jsonWriter = options.json ? createBackpressureAwareWriter(process.stdout) : undefined;
   try {
     const connectionOptions = { brokerUrl: proxy.brokerUrl, apiKey: proxy.apiKey };
     // Fleet agents expose a PTY stream rather than native-harness envelopes.
     // In JSON mode retain the machine-readable contract by serializing every
     // rendered stream chunk as NDJSON, including the initial snapshot.
     const jsonOutput = (chunk: string) => {
-      process.stdout.write(`${JSON.stringify({ kind: 'worker_stream', name, stream: 'stdout', chunk })}\n`);
+      jsonWriter?.write(`${JSON.stringify({ kind: 'worker_stream', name, stream: 'stdout', chunk })}\n`);
     };
     if (options.reasoning || options.diagnostics) {
       process.stderr.write(
@@ -104,18 +106,40 @@ export async function attachFleetNode(
     }
     switch (mode) {
       case 'view':
-        return await attachView(name, connectionOptions, options.json ? { writeChunk: jsonOutput } : {});
+        return await attachView(
+          name,
+          connectionOptions,
+          options.json ? { writeChunk: jsonOutput, stdoutIsTty: false } : {}
+        );
       case 'passthrough':
         return await attachPassthrough(
           name,
           connectionOptions,
-          options.json ? { writeChunk: jsonOutput } : {}
+          options.json
+            ? {
+                writeChunk: jsonOutput,
+                // JSON mode is a non-terminal stream. Suppressing the local
+                // status line and reset controls keeps only worker bytes in
+                // the NDJSON records, matching SSH's no-TTY JSON behaviour.
+                terminal: { getSize: () => null, onResize: () => () => undefined },
+              }
+            : {}
         );
       case 'drive':
       default:
-        return await attachDrive(name, connectionOptions, options.json ? { writeChunk: jsonOutput } : {});
+        return await attachDrive(
+          name,
+          connectionOptions,
+          options.json
+            ? {
+                writeChunk: jsonOutput,
+                terminal: { getSize: () => null, onResize: () => () => undefined },
+              }
+            : {}
+        );
     }
   } finally {
+    jsonWriter?.dispose();
     await proxy.close();
   }
 }

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -1,0 +1,340 @@
+/**
+ * Ticketed fleet-node attach adapter.
+ *
+ * The established attach clients intentionally continue to speak the local
+ * broker HTTP/WebSocket contract. This short-lived loopback adapter maps that
+ * contract onto Relaycast's authenticated terminal session, so view/drive and
+ * passthrough retain their behaviour without exposing a remote broker listener
+ * or copying a broker API key off a physical or Daytona node.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { once } from 'node:events';
+import { Buffer } from 'node:buffer';
+
+import WebSocket, { WebSocketServer } from 'ws';
+
+import type { AttachMode } from './attach-mode.js';
+import { resolveBaseUrl, resolveWorkspaceKey } from './sdk-client.js';
+
+const MAX_BUFFERED_BYTES = 1024 * 1024;
+const SNAPSHOT_WAIT_MS = 10_000;
+const RECONNECT_DELAY_MS = 500;
+
+type FleetSessionResponse = {
+  ok?: boolean;
+  data?: {
+    session_id?: string;
+    terminal_url?: string;
+    resume_token?: string;
+  };
+  error?: { code?: string; message?: string };
+};
+
+type TerminalFrame = Record<string, unknown> & { type?: string; session_id?: string };
+
+export interface FleetNodeAttachOptions {
+  agent: string;
+  node: string;
+  mode: AttachMode;
+  env?: NodeJS.ProcessEnv;
+  baseUrl?: string;
+  workspaceKey?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface FleetNodeAttachProxy {
+  brokerUrl: string;
+  close(): Promise<void>;
+}
+
+export class FleetNodeAttachError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'FleetNodeAttachError';
+  }
+}
+
+function json(response: ServerResponse, status: number, payload: unknown): void {
+  response.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+  response.end(JSON.stringify(payload));
+}
+
+function readBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk: string) => { body += chunk; });
+    request.on('end', () => {
+      try {
+        const parsed = JSON.parse(body) as unknown;
+        resolve(parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function asWsUrl(value: string): string {
+  return value.replace(/^http/i, 'ws');
+}
+
+function safeNodePath(node: string): string {
+  const trimmed = node.trim().replace(/^#/, '');
+  if (!trimmed) throw new FleetNodeAttachError('Error: --node requires a node name or id.', 'invalid_node');
+  return encodeURIComponent(trimmed);
+}
+
+function parseFrame(data: WebSocket.RawData): TerminalFrame | null {
+  try {
+    const parsed = JSON.parse(rawDataToString(data)) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as TerminalFrame : null;
+  } catch {
+    return null;
+  }
+}
+
+function rawDataToString(data: WebSocket.RawData): string {
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return String(data);
+}
+
+/** Start a broker-compatible loopback proxy for one remote terminal session. */
+export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions): Promise<FleetNodeAttachProxy> {
+  const env = options.env ?? process.env;
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const workspaceKey = options.workspaceKey ?? resolveWorkspaceKey({ env });
+  const baseUrl = (options.baseUrl ?? resolveBaseUrl({ env }) ?? 'https://cast.agentrelay.com').replace(/\/+$/, '');
+  const nodePath = safeNodePath(options.node);
+  const ticketResponse = await fetchFn(`${baseUrl}/v1/nodes/${nodePath}/terminal/sessions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${workspaceKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: options.agent, mode: options.mode }),
+  });
+  const ticketPayload = await ticketResponse.json().catch(() => ({})) as FleetSessionResponse;
+  const terminalUrl = ticketPayload.data?.terminal_url;
+  const sessionId = ticketPayload.data?.session_id;
+  const resumeToken = ticketPayload.data?.resume_token;
+  if (!ticketResponse.ok || !terminalUrl || !sessionId || !resumeToken) {
+    const code = ticketPayload.error?.code;
+    const message = ticketPayload.error?.message ?? `terminal session request failed (HTTP ${ticketResponse.status})`;
+    throw new FleetNodeAttachError(`Error: ${message}`, code);
+  }
+
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  let readySettled = false;
+  const ready = new Promise<void>((resolve, reject) => { resolveReady = resolve; rejectReady = reject; });
+  // A connection failure can land before the first snapshot request attaches
+  // its waiter. Keep that rejection observable to the request while avoiding
+  // an unhandled-rejection process warning in the small intervening window.
+  void ready.catch(() => undefined);
+  const snapshot: { screen: string; rows: number; cols: number; offset: number } = { screen: '', rows: 24, cols: 80, offset: 0 };
+  const eventSockets = new Set<WebSocket>();
+  const inputSockets = new Set<WebSocket>();
+  const outputHistory: Array<{ chunk: string; offset?: number }> = [];
+  let outputHistoryBytes = 0;
+  let remote: WebSocket | undefined;
+  let stopped = false;
+  let reconnecting = false;
+
+  const server = createServer(async (request, response) => {
+    const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+    if (request.method === 'GET' && path === `/api/spawned/${encodeURIComponent(options.agent)}/snapshot`) {
+      try {
+        await Promise.race([
+          ready,
+          new Promise<void>((_, reject) => setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS)),
+        ]);
+      } catch (error) {
+        json(response, 503, { error: { code: 'snapshot_unavailable', message: error instanceof Error ? error.message : 'snapshot unavailable' } });
+        return;
+      }
+      json(response, 200, { format: 'ansi', ...snapshot });
+      return;
+    }
+    const name = encodeURIComponent(options.agent);
+    if (path === `/api/spawned/${name}/delivery-mode`) {
+      if (request.method === 'GET') {
+        json(response, 200, { mode: options.mode === 'drive' ? 'manual_flush' : 'auto_inject' });
+      } else {
+        await readBody(request);
+        json(response, 200, { mode: options.mode === 'drive' ? 'manual_flush' : 'auto_inject', flushed: 0, matched: true, revision: '1' });
+      }
+      return;
+    }
+    if (request.method === 'GET' && path === `/api/spawned/${name}/pending`) {
+      json(response, 200, { pending: [] });
+      return;
+    }
+    if (request.method === 'POST' && path === `/api/spawned/${name}/flush`) {
+      json(response, 200, { flushed: 0 });
+      return;
+    }
+    if (request.method === 'GET' && path === '/api/spawned') {
+      json(response, 200, { agents: [{ name: options.agent, workerPid: 1 }] });
+      return;
+    }
+    if (request.method === 'POST' && path === `/api/resize/${name}`) {
+      const body = await readBody(request);
+      if (body.release === true) {
+        json(response, 200, { name: options.agent, released: true });
+        return;
+      }
+      const rows = typeof body.rows === 'number' ? body.rows : 0;
+      const cols = typeof body.cols === 'number' ? body.cols : 0;
+      if (!Number.isInteger(rows) || !Number.isInteger(cols) || rows < 1 || cols < 1) {
+        json(response, 400, { error: { code: 'invalid_dimensions', message: 'rows and cols must be positive integers' } });
+        return;
+      }
+      if (!remote || remote.readyState !== WebSocket.OPEN || remote.bufferedAmount > MAX_BUFFERED_BYTES) {
+        json(response, 503, { error: { code: 'node_unreachable', message: 'terminal transport is unavailable' } });
+        return;
+      }
+      remote.send(JSON.stringify({ type: 'terminal.resize', session_id: sessionId, rows, cols }));
+      json(response, 200, { name: options.agent, rows, cols, applied: true });
+      return;
+    }
+    json(response, 404, { error: { code: 'not_found', message: 'loopback terminal endpoint not found' } });
+  });
+  const websocketServer = new WebSocketServer({ noServer: true });
+
+  const closeSocket = (socket: WebSocket, code: number, reason: string) => {
+    try { socket.close(code, reason); } catch { /* connection already gone */ }
+  };
+  const broadcast = (sockets: Set<WebSocket>, payload: unknown) => {
+    const encoded = JSON.stringify(payload);
+    for (const socket of sockets) {
+      if (socket.readyState !== WebSocket.OPEN) continue;
+      if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {
+        closeSocket(socket, 1013, 'loopback client backpressure exceeded');
+        sockets.delete(socket);
+        continue;
+      }
+      socket.send(encoded);
+    }
+  };
+  const workerStreamEvent = (chunk: string, offset?: number) => ({
+    kind: 'worker_stream',
+    name: options.agent,
+    stream: 'stdout',
+    chunk,
+    ...(offset === undefined ? {} : { offset }),
+  });
+  const retainOutput = (chunk: string, offset: number | undefined): boolean => {
+    const bytes = Buffer.byteLength(chunk, 'utf8');
+    if (outputHistoryBytes + bytes > MAX_BUFFERED_BYTES) return false;
+    outputHistory.push({ chunk, ...(offset === undefined ? {} : { offset }) });
+    outputHistoryBytes += bytes;
+    return true;
+  };
+
+  websocketServer.on('connection', (socket, request) => {
+    const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+    if (path === '/ws') {
+      eventSockets.add(socket);
+      socket.on('close', () => eventSockets.delete(socket));
+      for (const event of outputHistory) {
+        if (socket.readyState !== WebSocket.OPEN || socket.bufferedAmount > MAX_BUFFERED_BYTES) break;
+        socket.send(JSON.stringify(workerStreamEvent(event.chunk, event.offset)));
+      }
+      outputHistory.length = 0;
+      outputHistoryBytes = 0;
+      return;
+    }
+    if (path === `/api/input/${encodeURIComponent(options.agent)}/stream`) {
+      inputSockets.add(socket);
+      socket.on('close', () => inputSockets.delete(socket));
+      socket.send(JSON.stringify({ type: 'pty_input_ready', name: options.agent }));
+      socket.on('message', (data) => {
+        if (!remote || remote.readyState !== WebSocket.OPEN || remote.bufferedAmount > MAX_BUFFERED_BYTES) {
+          broadcast(inputSockets, { type: 'pty_input_error', code: 'node_unreachable', message: 'terminal transport is unavailable' });
+          return;
+        }
+        const raw = rawDataToString(data);
+        remote.send(JSON.stringify({ type: 'terminal.input', session_id: sessionId, data_base64: Buffer.from(raw, 'utf8').toString('base64') }));
+      });
+      return;
+    }
+    closeSocket(socket, 1008, 'unknown loopback endpoint');
+  });
+  server.on('upgrade', (request, socket, head) => {
+    websocketServer.handleUpgrade(request, socket, head, (client) => websocketServer.emit('connection', client, request));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new FleetNodeAttachError('Error: could not allocate loopback terminal listener.', 'loopback_unavailable');
+
+  const resumeUrl = new URL(terminalUrl);
+  resumeUrl.searchParams.delete('ticket');
+  resumeUrl.searchParams.set('session_id', sessionId);
+  resumeUrl.searchParams.set('resume', resumeToken);
+  const connect = (url: string, isResume: boolean) => {
+    if (stopped) return;
+    const socket = new WebSocket(asWsUrl(url));
+    remote = socket;
+    socket.on('message', (data) => {
+      const frame = parseFrame(data);
+      if (!frame || frame.session_id !== sessionId) return;
+      if (frame.type === 'terminal.ready') {
+        snapshot.screen = typeof frame.screen === 'string' ? frame.screen : '';
+        snapshot.rows = typeof frame.rows === 'number' ? frame.rows : 24;
+        snapshot.cols = typeof frame.cols === 'number' ? frame.cols : 80;
+        snapshot.offset = typeof frame.offset === 'number' ? frame.offset : 0;
+        if (!readySettled) { readySettled = true; resolveReady(); }
+      } else if (frame.type === 'terminal.output' && typeof frame.chunk === 'string') {
+        const offset = typeof frame.offset === 'number' ? frame.offset : undefined;
+        if (eventSockets.size === 0 && !retainOutput(frame.chunk, offset)) {
+          broadcast(inputSockets, { type: 'pty_input_error', code: 'output_backpressure', message: 'terminal output exceeded the bounded loopback buffer' });
+          if (remote?.readyState === WebSocket.OPEN) remote.close(1013, 'output backpressure');
+          return;
+        }
+        broadcast(eventSockets, workerStreamEvent(frame.chunk, offset));
+      } else if (frame.type === 'terminal.input_ack') {
+        broadcast(inputSockets, { type: 'pty_input_ack', name: options.agent, bytes_written: typeof frame.bytes_written === 'number' ? frame.bytes_written : 0 });
+      } else if (frame.type === 'terminal.error') {
+        const message = typeof frame.message === 'string' ? frame.message : 'remote terminal failed';
+        const code = typeof frame.code === 'string' ? frame.code : 'terminal_error';
+        broadcast(inputSockets, { type: 'pty_input_error', code, message });
+        if (!readySettled) { readySettled = true; rejectReady(new FleetNodeAttachError(message, code)); }
+      } else if (frame.type === 'terminal.closed') {
+        broadcast(inputSockets, { type: 'pty_input_error', code: 'terminal_closed', message: 'remote terminal session closed' });
+      }
+    });
+    socket.on('error', (error) => {
+      if (!readySettled && !isResume) { readySettled = true; rejectReady(new FleetNodeAttachError(`terminal websocket failed: ${error.message}`, 'node_unreachable')); }
+    });
+    socket.on('close', () => {
+      if (remote !== socket || stopped || reconnecting) return;
+      reconnecting = true;
+      setTimeout(() => {
+        reconnecting = false;
+        connect(resumeUrl.toString(), true);
+      }, RECONNECT_DELAY_MS);
+    });
+  };
+  connect(terminalUrl, false);
+
+  return {
+    brokerUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      if (stopped) return;
+      stopped = true;
+      if (!readySettled) { readySettled = true; rejectReady(new FleetNodeAttachError('terminal attach closed', 'closed')); }
+      if (remote && remote.readyState === WebSocket.OPEN) {
+        remote.send(JSON.stringify({ type: 'terminal.close', session_id: sessionId }));
+        remote.close();
+      }
+      for (const socket of [...eventSockets, ...inputSockets]) closeSocket(socket, 1000, 'terminal attach closed');
+      websocketServer.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -51,7 +51,7 @@ export interface FleetNodeAttachProxy {
 export class FleetNodeAttachError extends Error {
   constructor(
     message: string,
-    readonly code?: string,
+    readonly code?: string
   ) {
     super(message);
     this.name = 'FleetNodeAttachError';
@@ -67,11 +67,17 @@ function readBody(request: IncomingMessage): Promise<Record<string, unknown>> {
   return new Promise((resolve) => {
     let body = '';
     request.setEncoding('utf8');
-    request.on('data', (chunk: string) => { body += chunk; });
+    request.on('data', (chunk: string) => {
+      body += chunk;
+    });
     request.on('end', () => {
       try {
         const parsed = JSON.parse(body) as unknown;
-        resolve(parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {});
+        resolve(
+          parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {}
+        );
       } catch {
         resolve({});
       }
@@ -92,7 +98,7 @@ function safeNodePath(node: string): string {
 function parseFrame(data: WebSocket.RawData): TerminalFrame | null {
   try {
     const parsed = JSON.parse(rawDataToString(data)) as unknown;
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as TerminalFrame : null;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as TerminalFrame) : null;
   } catch {
     return null;
   }
@@ -106,36 +112,50 @@ function rawDataToString(data: WebSocket.RawData): string {
 }
 
 /** Start a broker-compatible loopback proxy for one remote terminal session. */
-export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions): Promise<FleetNodeAttachProxy> {
+export async function startFleetNodeAttachProxy(
+  options: FleetNodeAttachOptions
+): Promise<FleetNodeAttachProxy> {
   const env = options.env ?? process.env;
   const fetchFn = options.fetch ?? globalThis.fetch;
   const workspaceKey = options.workspaceKey ?? resolveWorkspaceKey({ env });
-  const baseUrl = (options.baseUrl ?? resolveBaseUrl({ env }) ?? 'https://cast.agentrelay.com').replace(/\/+$/, '');
+  const baseUrl = (options.baseUrl ?? resolveBaseUrl({ env }) ?? 'https://cast.agentrelay.com').replace(
+    /\/+$/,
+    ''
+  );
   const nodePath = safeNodePath(options.node);
   const ticketResponse = await fetchFn(`${baseUrl}/v1/nodes/${nodePath}/terminal/sessions`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${workspaceKey}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ agent: options.agent, mode: options.mode }),
   });
-  const ticketPayload = await ticketResponse.json().catch(() => ({})) as FleetSessionResponse;
+  const ticketPayload = (await ticketResponse.json().catch(() => ({}))) as FleetSessionResponse;
   const terminalUrl = ticketPayload.data?.terminal_url;
   const sessionId = ticketPayload.data?.session_id;
   const resumeToken = ticketPayload.data?.resume_token;
   if (!ticketResponse.ok || !terminalUrl || !sessionId || !resumeToken) {
     const code = ticketPayload.error?.code;
-    const message = ticketPayload.error?.message ?? `terminal session request failed (HTTP ${ticketResponse.status})`;
+    const message =
+      ticketPayload.error?.message ?? `terminal session request failed (HTTP ${ticketResponse.status})`;
     throw new FleetNodeAttachError(`Error: ${message}`, code);
   }
 
   let resolveReady!: () => void;
   let rejectReady!: (error: Error) => void;
   let readySettled = false;
-  const ready = new Promise<void>((resolve, reject) => { resolveReady = resolve; rejectReady = reject; });
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
   // A connection failure can land before the first snapshot request attaches
   // its waiter. Keep that rejection observable to the request while avoiding
   // an unhandled-rejection process warning in the small intervening window.
   void ready.catch(() => undefined);
-  const snapshot: { screen: string; rows: number; cols: number; offset: number } = { screen: '', rows: 24, cols: 80, offset: 0 };
+  const snapshot: { screen: string; rows: number; cols: number; offset: number } = {
+    screen: '',
+    rows: 24,
+    cols: 80,
+    offset: 0,
+  };
   const eventSockets = new Set<WebSocket>();
   const inputSockets = new Set<WebSocket>();
   const outputHistory: Array<{ chunk: string; offset?: number }> = [];
@@ -150,10 +170,17 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
       try {
         await Promise.race([
           ready,
-          new Promise<void>((_, reject) => setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS)),
+          new Promise<void>((_, reject) =>
+            setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS)
+          ),
         ]);
       } catch (error) {
-        json(response, 503, { error: { code: 'snapshot_unavailable', message: error instanceof Error ? error.message : 'snapshot unavailable' } });
+        json(response, 503, {
+          error: {
+            code: 'snapshot_unavailable',
+            message: error instanceof Error ? error.message : 'snapshot unavailable',
+          },
+        });
         return;
       }
       json(response, 200, { format: 'ansi', ...snapshot });
@@ -165,7 +192,12 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
         json(response, 200, { mode: options.mode === 'drive' ? 'manual_flush' : 'auto_inject' });
       } else {
         await readBody(request);
-        json(response, 200, { mode: options.mode === 'drive' ? 'manual_flush' : 'auto_inject', flushed: 0, matched: true, revision: '1' });
+        json(response, 200, {
+          mode: options.mode === 'drive' ? 'manual_flush' : 'auto_inject',
+          flushed: 0,
+          matched: true,
+          revision: '1',
+        });
       }
       return;
     }
@@ -190,11 +222,15 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
       const rows = typeof body.rows === 'number' ? body.rows : 0;
       const cols = typeof body.cols === 'number' ? body.cols : 0;
       if (!Number.isInteger(rows) || !Number.isInteger(cols) || rows < 1 || cols < 1) {
-        json(response, 400, { error: { code: 'invalid_dimensions', message: 'rows and cols must be positive integers' } });
+        json(response, 400, {
+          error: { code: 'invalid_dimensions', message: 'rows and cols must be positive integers' },
+        });
         return;
       }
       if (!remote || remote.readyState !== WebSocket.OPEN || remote.bufferedAmount > MAX_BUFFERED_BYTES) {
-        json(response, 503, { error: { code: 'node_unreachable', message: 'terminal transport is unavailable' } });
+        json(response, 503, {
+          error: { code: 'node_unreachable', message: 'terminal transport is unavailable' },
+        });
         return;
       }
       remote.send(JSON.stringify({ type: 'terminal.resize', session_id: sessionId, rows, cols }));
@@ -206,7 +242,11 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
   const websocketServer = new WebSocketServer({ noServer: true });
 
   const closeSocket = (socket: WebSocket, code: number, reason: string) => {
-    try { socket.close(code, reason); } catch { /* connection already gone */ }
+    try {
+      socket.close(code, reason);
+    } catch {
+      /* connection already gone */
+    }
   };
   const broadcast = (sockets: Set<WebSocket>, payload: unknown) => {
     const encoded = JSON.stringify(payload);
@@ -254,23 +294,39 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
       socket.send(JSON.stringify({ type: 'pty_input_ready', name: options.agent }));
       socket.on('message', (data) => {
         if (!remote || remote.readyState !== WebSocket.OPEN || remote.bufferedAmount > MAX_BUFFERED_BYTES) {
-          broadcast(inputSockets, { type: 'pty_input_error', code: 'node_unreachable', message: 'terminal transport is unavailable' });
+          broadcast(inputSockets, {
+            type: 'pty_input_error',
+            code: 'node_unreachable',
+            message: 'terminal transport is unavailable',
+          });
           return;
         }
         const raw = rawDataToString(data);
-        remote.send(JSON.stringify({ type: 'terminal.input', session_id: sessionId, data_base64: Buffer.from(raw, 'utf8').toString('base64') }));
+        remote.send(
+          JSON.stringify({
+            type: 'terminal.input',
+            session_id: sessionId,
+            data_base64: Buffer.from(raw, 'utf8').toString('base64'),
+          })
+        );
       });
       return;
     }
     closeSocket(socket, 1008, 'unknown loopback endpoint');
   });
   server.on('upgrade', (request, socket, head) => {
-    websocketServer.handleUpgrade(request, socket, head, (client) => websocketServer.emit('connection', client, request));
+    websocketServer.handleUpgrade(request, socket, head, (client) =>
+      websocketServer.emit('connection', client, request)
+    );
   });
   server.listen(0, '127.0.0.1');
   await once(server, 'listening');
   const address = server.address();
-  if (!address || typeof address === 'string') throw new FleetNodeAttachError('Error: could not allocate loopback terminal listener.', 'loopback_unavailable');
+  if (!address || typeof address === 'string')
+    throw new FleetNodeAttachError(
+      'Error: could not allocate loopback terminal listener.',
+      'loopback_unavailable'
+    );
 
   const resumeUrl = new URL(terminalUrl);
   resumeUrl.searchParams.delete('ticket');
@@ -288,28 +344,51 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
         snapshot.rows = typeof frame.rows === 'number' ? frame.rows : 24;
         snapshot.cols = typeof frame.cols === 'number' ? frame.cols : 80;
         snapshot.offset = typeof frame.offset === 'number' ? frame.offset : 0;
-        if (!readySettled) { readySettled = true; resolveReady(); }
+        if (!readySettled) {
+          readySettled = true;
+          resolveReady();
+        }
       } else if (frame.type === 'terminal.output' && typeof frame.chunk === 'string') {
         const offset = typeof frame.offset === 'number' ? frame.offset : undefined;
         if (eventSockets.size === 0 && !retainOutput(frame.chunk, offset)) {
-          broadcast(inputSockets, { type: 'pty_input_error', code: 'output_backpressure', message: 'terminal output exceeded the bounded loopback buffer' });
+          broadcast(inputSockets, {
+            type: 'pty_input_error',
+            code: 'output_backpressure',
+            message: 'terminal output exceeded the bounded loopback buffer',
+          });
           if (remote?.readyState === WebSocket.OPEN) remote.close(1013, 'output backpressure');
           return;
         }
         broadcast(eventSockets, workerStreamEvent(frame.chunk, offset));
       } else if (frame.type === 'terminal.input_ack') {
-        broadcast(inputSockets, { type: 'pty_input_ack', name: options.agent, bytes_written: typeof frame.bytes_written === 'number' ? frame.bytes_written : 0 });
+        broadcast(inputSockets, {
+          type: 'pty_input_ack',
+          name: options.agent,
+          bytes_written: typeof frame.bytes_written === 'number' ? frame.bytes_written : 0,
+        });
       } else if (frame.type === 'terminal.error') {
         const message = typeof frame.message === 'string' ? frame.message : 'remote terminal failed';
         const code = typeof frame.code === 'string' ? frame.code : 'terminal_error';
         broadcast(inputSockets, { type: 'pty_input_error', code, message });
-        if (!readySettled) { readySettled = true; rejectReady(new FleetNodeAttachError(message, code)); }
+        if (!readySettled) {
+          readySettled = true;
+          rejectReady(new FleetNodeAttachError(message, code));
+        }
       } else if (frame.type === 'terminal.closed') {
-        broadcast(inputSockets, { type: 'pty_input_error', code: 'terminal_closed', message: 'remote terminal session closed' });
+        broadcast(inputSockets, {
+          type: 'pty_input_error',
+          code: 'terminal_closed',
+          message: 'remote terminal session closed',
+        });
       }
     });
     socket.on('error', (error) => {
-      if (!readySettled && !isResume) { readySettled = true; rejectReady(new FleetNodeAttachError(`terminal websocket failed: ${error.message}`, 'node_unreachable')); }
+      if (!readySettled && !isResume) {
+        readySettled = true;
+        rejectReady(
+          new FleetNodeAttachError(`terminal websocket failed: ${error.message}`, 'node_unreachable')
+        );
+      }
     });
     socket.on('close', () => {
       if (remote !== socket || stopped || reconnecting) return;
@@ -327,12 +406,16 @@ export async function startFleetNodeAttachProxy(options: FleetNodeAttachOptions)
     async close() {
       if (stopped) return;
       stopped = true;
-      if (!readySettled) { readySettled = true; rejectReady(new FleetNodeAttachError('terminal attach closed', 'closed')); }
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(new FleetNodeAttachError('terminal attach closed', 'closed'));
+      }
       if (remote && remote.readyState === WebSocket.OPEN) {
         remote.send(JSON.stringify({ type: 'terminal.close', session_id: sessionId }));
         remote.close();
       }
-      for (const socket of [...eventSockets, ...inputSockets]) closeSocket(socket, 1000, 'terminal attach closed');
+      for (const socket of [...eventSockets, ...inputSockets])
+        closeSocket(socket, 1000, 'terminal attach closed');
       websocketServer.close();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -11,6 +11,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { once } from 'node:events';
 import { Buffer } from 'node:buffer';
+import { randomBytes } from 'node:crypto';
 
 import WebSocket, { WebSocketServer } from 'ws';
 
@@ -19,7 +20,9 @@ import { resolveBaseUrl, resolveWorkspaceKey } from './sdk-client.js';
 
 const MAX_BUFFERED_BYTES = 1024 * 1024;
 const SNAPSHOT_WAIT_MS = 10_000;
-const RECONNECT_DELAY_MS = 500;
+const INITIAL_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const MAX_RECONNECT_ATTEMPTS = 5;
 
 type FleetSessionResponse = {
   ok?: boolean;
@@ -45,6 +48,7 @@ export interface FleetNodeAttachOptions {
 
 export interface FleetNodeAttachProxy {
   brokerUrl: string;
+  apiKey: string;
   close(): Promise<void>;
 }
 
@@ -65,6 +69,12 @@ function json(response: ServerResponse, status: number, payload: unknown): void 
 
 function readBody(request: IncomingMessage): Promise<Record<string, unknown>> {
   return new Promise((resolve) => {
+    let settled = false;
+    const finish = (body: Record<string, unknown>) => {
+      if (settled) return;
+      settled = true;
+      resolve(body);
+    };
     let body = '';
     request.setEncoding('utf8');
     request.on('data', (chunk: string) => {
@@ -73,15 +83,17 @@ function readBody(request: IncomingMessage): Promise<Record<string, unknown>> {
     request.on('end', () => {
       try {
         const parsed = JSON.parse(body) as unknown;
-        resolve(
+        finish(
           parsed && typeof parsed === 'object' && !Array.isArray(parsed)
             ? (parsed as Record<string, unknown>)
             : {}
         );
       } catch {
-        resolve({});
+        finish({});
       }
     });
+    request.on('error', () => finish({}));
+    request.on('aborted', () => finish({}));
   });
 }
 
@@ -163,17 +175,34 @@ export async function startFleetNodeAttachProxy(
   let remote: WebSocket | undefined;
   let stopped = false;
   let reconnecting = false;
+  let reconnectAttempts = 0;
+  const loopbackApiKey = randomBytes(32).toString('base64url');
+  const loopbackAuthorized = (headers: IncomingMessage['headers']) =>
+    headers.authorization === `Bearer ${loopbackApiKey}` || headers['x-api-key'] === loopbackApiKey;
 
   const server = createServer(async (request, response) => {
+    if (!loopbackAuthorized(request.headers)) {
+      json(response, 401, {
+        error: { code: 'unauthorized', message: 'loopback terminal token is required' },
+      });
+      return;
+    }
     const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
     if (request.method === 'GET' && path === `/api/spawned/${encodeURIComponent(options.agent)}/snapshot`) {
       try {
-        await Promise.race([
-          ready,
-          new Promise<void>((_, reject) =>
-            setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS)
-          ),
-        ]);
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS);
+          void ready.then(
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            (error: Error) => {
+              clearTimeout(timer);
+              reject(error);
+            }
+          );
+        });
       } catch (error) {
         json(response, 503, {
           error: {
@@ -280,12 +309,19 @@ export async function startFleetNodeAttachProxy(
     if (path === '/ws') {
       eventSockets.add(socket);
       socket.on('close', () => eventSockets.delete(socket));
+      let replayed = 0;
       for (const event of outputHistory) {
         if (socket.readyState !== WebSocket.OPEN || socket.bufferedAmount > MAX_BUFFERED_BYTES) break;
         socket.send(JSON.stringify(workerStreamEvent(event.chunk, event.offset)));
+        replayed += 1;
       }
-      outputHistory.length = 0;
-      outputHistoryBytes = 0;
+      if (replayed > 0) {
+        const sentBytes = outputHistory
+          .slice(0, replayed)
+          .reduce((total, event) => total + Buffer.byteLength(event.chunk, 'utf8'), 0);
+        outputHistory.splice(0, replayed);
+        outputHistoryBytes -= sentBytes;
+      }
       return;
     }
     if (path === `/api/input/${encodeURIComponent(options.agent)}/stream`) {
@@ -315,6 +351,11 @@ export async function startFleetNodeAttachProxy(
     closeSocket(socket, 1008, 'unknown loopback endpoint');
   });
   server.on('upgrade', (request, socket, head) => {
+    if (!loopbackAuthorized(request.headers)) {
+      socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+      socket.destroy();
+      return;
+    }
     websocketServer.handleUpgrade(request, socket, head, (client) =>
       websocketServer.emit('connection', client, request)
     );
@@ -332,7 +373,17 @@ export async function startFleetNodeAttachProxy(
   resumeUrl.searchParams.delete('ticket');
   resumeUrl.searchParams.set('session_id', sessionId);
   resumeUrl.searchParams.set('resume', resumeToken);
-  const connect = (url: string, isResume: boolean) => {
+  const failRemote = (message: string) => {
+    const error = new FleetNodeAttachError(message, 'node_unreachable');
+    remote = undefined;
+    broadcast(inputSockets, { type: 'pty_input_error', code: error.code, message: error.message });
+    for (const socket of eventSockets) closeSocket(socket, 1011, error.message);
+    if (!readySettled) {
+      readySettled = true;
+      rejectReady(error);
+    }
+  };
+  const connect = (url: string) => {
     if (stopped) return;
     const socket = new WebSocket(asWsUrl(url));
     remote = socket;
@@ -344,6 +395,7 @@ export async function startFleetNodeAttachProxy(
         snapshot.rows = typeof frame.rows === 'number' ? frame.rows : 24;
         snapshot.cols = typeof frame.cols === 'number' ? frame.cols : 80;
         snapshot.offset = typeof frame.offset === 'number' ? frame.offset : 0;
+        reconnectAttempts = 0;
         if (!readySettled) {
           readySettled = true;
           resolveReady();
@@ -382,27 +434,27 @@ export async function startFleetNodeAttachProxy(
         });
       }
     });
-    socket.on('error', (error) => {
-      if (!readySettled && !isResume) {
-        readySettled = true;
-        rejectReady(
-          new FleetNodeAttachError(`terminal websocket failed: ${error.message}`, 'node_unreachable')
-        );
-      }
-    });
+    socket.on('error', () => undefined);
     socket.on('close', () => {
       if (remote !== socket || stopped || reconnecting) return;
+      if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+        failRemote('terminal transport could not reconnect to the fleet node');
+        return;
+      }
       reconnecting = true;
+      const delay = Math.min(INITIAL_RECONNECT_DELAY_MS * 2 ** reconnectAttempts, MAX_RECONNECT_DELAY_MS);
+      reconnectAttempts += 1;
       setTimeout(() => {
         reconnecting = false;
-        connect(resumeUrl.toString(), true);
-      }, RECONNECT_DELAY_MS);
+        connect(resumeUrl.toString());
+      }, delay);
     });
   };
-  connect(terminalUrl, false);
+  connect(terminalUrl);
 
   return {
     brokerUrl: `http://127.0.0.1:${address.port}`,
+    apiKey: loopbackApiKey,
     async close() {
       if (stopped) return;
       stopped = true;

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -203,6 +203,7 @@ export async function startFleetNodeAttachProxy(
   let remote: WebSocket | undefined;
   let stopped = false;
   let terminalEnded = false;
+  let terminalEverReady = false;
   let reconnecting = false;
   let reconnectAttempts = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -483,6 +484,7 @@ export async function startFleetNodeAttachProxy(
         snapshot.rows = typeof frame.rows === 'number' ? frame.rows : 24;
         snapshot.cols = typeof frame.cols === 'number' ? frame.cols : 80;
         snapshot.offset = typeof frame.offset === 'number' ? frame.offset : 0;
+        terminalEverReady = true;
         reconnectAttempts = 0;
         if (readiness === activeReadiness) {
           resolveReadiness(readiness);
@@ -524,7 +526,15 @@ export async function startFleetNodeAttachProxy(
         endTerminal(new FleetNodeAttachError('remote terminal session closed', 'terminal_closed'));
       }
     });
-    socket.on('error', () => undefined);
+    socket.on('error', () => {
+      // Initial connection failure has no terminal state worth preserving.
+      // Fail promptly with the canonical unavailable-node error instead of
+      // letting the HTTP snapshot timeout mask it. Once Ready has been seen,
+      // the close handler retains the bounded resume/backoff behaviour.
+      if (remote === socket && readiness === activeReadiness && !readiness.settled && !terminalEverReady) {
+        failRemote('terminal transport could not connect to the fleet node');
+      }
+    });
     socket.on('close', () => {
       if (remote !== socket || stopped || terminalEnded || reconnecting) return;
       // Any waiter that observed the prior connection must retry against the

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -204,10 +204,18 @@ export async function startFleetNodeAttachProxy(
           );
         });
       } catch (error) {
-        json(response, 503, {
+        const terminalError = error instanceof FleetNodeAttachError ? error : undefined;
+        const status =
+          terminalError?.code === 'agent_not_found'
+            ? 404
+            : terminalError?.code === 'unsupported_runtime'
+              ? 409
+              : 503;
+        json(response, status, {
           error: {
-            code: 'snapshot_unavailable',
-            message: error instanceof Error ? error.message : 'snapshot unavailable',
+            code: terminalError?.code ?? 'snapshot_unavailable',
+            message:
+              terminalError?.message ?? (error instanceof Error ? error.message : 'snapshot unavailable'),
           },
         });
         return;

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -36,6 +36,14 @@ type FleetSessionResponse = {
 
 type TerminalFrame = Record<string, unknown> & { type?: string; session_id?: string };
 
+type TerminalReadiness = {
+  generation: number;
+  settled: boolean;
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
 export interface FleetNodeAttachOptions {
   agent: string;
   node: string;
@@ -151,17 +159,37 @@ export async function startFleetNodeAttachProxy(
     throw new FleetNodeAttachError(`Error: ${message}`, code);
   }
 
-  let resolveReady!: () => void;
-  let rejectReady!: (error: Error) => void;
-  let readySettled = false;
-  const ready = new Promise<void>((resolve, reject) => {
-    resolveReady = resolve;
-    rejectReady = reject;
-  });
-  // A connection failure can land before the first snapshot request attaches
-  // its waiter. Keep that rejection observable to the request while avoiding
-  // an unhandled-rejection process warning in the small intervening window.
-  void ready.catch(() => undefined);
+  let connectionGeneration = 0;
+  const createReadiness = (): TerminalReadiness => {
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    // A failure can land before a snapshot request attaches its waiter. Keep
+    // the rejection observable while avoiding an unhandled-rejection warning.
+    void promise.catch(() => undefined);
+    return { generation: ++connectionGeneration, settled: false, promise, resolve, reject };
+  };
+  let activeReadiness = createReadiness();
+  const resolveReadiness = (readiness: TerminalReadiness) => {
+    if (readiness.settled) return;
+    readiness.settled = true;
+    readiness.resolve();
+  };
+  const rejectReadiness = (readiness: TerminalReadiness, error: Error) => {
+    if (readiness.settled) return;
+    readiness.settled = true;
+    readiness.reject(error);
+  };
+  const waitForCurrentReadiness = async (): Promise<void> => {
+    for (;;) {
+      const readiness = activeReadiness;
+      await readiness.promise;
+      if (readiness === activeReadiness) return;
+    }
+  };
   const snapshot: { screen: string; rows: number; cols: number; offset: number } = {
     screen: '',
     rows: 24,
@@ -174,8 +202,10 @@ export async function startFleetNodeAttachProxy(
   let outputHistoryBytes = 0;
   let remote: WebSocket | undefined;
   let stopped = false;
+  let terminalEnded = false;
   let reconnecting = false;
   let reconnectAttempts = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   const loopbackApiKey = randomBytes(32).toString('base64url');
   const loopbackAuthorized = (headers: IncomingMessage['headers']) =>
     headers.authorization === `Bearer ${loopbackApiKey}` || headers['x-api-key'] === loopbackApiKey;
@@ -192,7 +222,7 @@ export async function startFleetNodeAttachProxy(
       try {
         await new Promise<void>((resolve, reject) => {
           const timer = setTimeout(() => reject(new Error('terminal snapshot timed out')), SNAPSHOT_WAIT_MS);
-          void ready.then(
+          void waitForCurrentReadiness().then(
             () => {
               clearTimeout(timer);
               resolve();
@@ -264,6 +294,29 @@ export async function startFleetNodeAttachProxy(
         });
         return;
       }
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error('terminal resize timed out')), SNAPSHOT_WAIT_MS);
+          void waitForCurrentReadiness().then(
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            (error: Error) => {
+              clearTimeout(timer);
+              reject(error);
+            }
+          );
+        });
+      } catch (error) {
+        json(response, 503, {
+          error: {
+            code: 'session_not_ready',
+            message: error instanceof Error ? error.message : 'terminal session is not ready',
+          },
+        });
+        return;
+      }
       if (!remote || remote.readyState !== WebSocket.OPEN || remote.bufferedAmount > MAX_BUFFERED_BYTES) {
         json(response, 503, {
           error: { code: 'node_unreachable', message: 'terminal transport is unavailable' },
@@ -285,8 +338,9 @@ export async function startFleetNodeAttachProxy(
       /* connection already gone */
     }
   };
-  const broadcast = (sockets: Set<WebSocket>, payload: unknown) => {
+  const broadcast = (sockets: Set<WebSocket>, payload: unknown): boolean => {
     const encoded = JSON.stringify(payload);
+    let accepted = false;
     for (const socket of sockets) {
       if (socket.readyState !== WebSocket.OPEN) continue;
       if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {
@@ -294,8 +348,14 @@ export async function startFleetNodeAttachProxy(
         sockets.delete(socket);
         continue;
       }
-      socket.send(encoded);
+      try {
+        socket.send(encoded);
+        accepted = true;
+      } catch {
+        sockets.delete(socket);
+      }
     }
+    return accepted;
   };
   const workerStreamEvent = (chunk: string, offset?: number) => ({
     kind: 'worker_stream',
@@ -320,7 +380,11 @@ export async function startFleetNodeAttachProxy(
       let replayed = 0;
       for (const event of outputHistory) {
         if (socket.readyState !== WebSocket.OPEN || socket.bufferedAmount > MAX_BUFFERED_BYTES) break;
-        socket.send(JSON.stringify(workerStreamEvent(event.chunk, event.offset)));
+        try {
+          socket.send(JSON.stringify(workerStreamEvent(event.chunk, event.offset)));
+        } catch {
+          break;
+        }
         replayed += 1;
       }
       if (replayed > 0) {
@@ -381,21 +445,37 @@ export async function startFleetNodeAttachProxy(
   resumeUrl.searchParams.delete('ticket');
   resumeUrl.searchParams.set('session_id', sessionId);
   resumeUrl.searchParams.set('resume', resumeToken);
-  const failRemote = (message: string) => {
-    const error = new FleetNodeAttachError(message, 'node_unreachable');
+  const endTerminal = (error: FleetNodeAttachError) => {
+    if (terminalEnded) return;
+    terminalEnded = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = undefined;
+    }
+    const activeRemote = remote;
     remote = undefined;
+    rejectReadiness(activeReadiness, error);
     broadcast(inputSockets, { type: 'pty_input_error', code: error.code, message: error.message });
     for (const socket of eventSockets) closeSocket(socket, 1011, error.message);
-    if (!readySettled) {
-      readySettled = true;
-      rejectReady(error);
+    if (activeRemote && activeRemote.readyState !== WebSocket.CLOSED) {
+      try {
+        activeRemote.terminate();
+      } catch {
+        // The socket may have closed between the state check and terminate.
+      }
     }
   };
-  const connect = (url: string) => {
-    if (stopped) return;
+  const failRemote = (message: string) => {
+    endTerminal(new FleetNodeAttachError(message, 'node_unreachable'));
+  };
+  const connect = (url: string, readiness: TerminalReadiness) => {
+    if (stopped || terminalEnded) return;
     const socket = new WebSocket(asWsUrl(url));
     remote = socket;
     socket.on('message', (data) => {
+      // A late frame from a transport superseded during reconnect must never
+      // overwrite the fresh snapshot or end the replacement session.
+      if (remote !== socket || stopped || terminalEnded) return;
       const frame = parseFrame(data);
       if (!frame || frame.session_id !== sessionId) return;
       if (frame.type === 'terminal.ready') {
@@ -404,22 +484,28 @@ export async function startFleetNodeAttachProxy(
         snapshot.cols = typeof frame.cols === 'number' ? frame.cols : 80;
         snapshot.offset = typeof frame.offset === 'number' ? frame.offset : 0;
         reconnectAttempts = 0;
-        if (!readySettled) {
-          readySettled = true;
-          resolveReady();
+        if (readiness === activeReadiness) {
+          resolveReadiness(readiness);
+          // A reconnect gets a fresh ANSI grid but existing local `/ws`
+          // consumers have already performed their initial HTTP snapshot.
+          // Re-emit this screen without an offset so they repaint instead of
+          // retaining a stale pre-reconnect terminal image.
+          if (readiness.generation > 1 && snapshot.screen) {
+            broadcast(eventSockets, workerStreamEvent(snapshot.screen));
+          }
         }
       } else if (frame.type === 'terminal.output' && typeof frame.chunk === 'string') {
         const offset = typeof frame.offset === 'number' ? frame.offset : undefined;
-        if (eventSockets.size === 0 && !retainOutput(frame.chunk, offset)) {
-          broadcast(inputSockets, {
-            type: 'pty_input_error',
-            code: 'output_backpressure',
-            message: 'terminal output exceeded the bounded loopback buffer',
-          });
-          if (remote?.readyState === WebSocket.OPEN) remote.close(1013, 'output backpressure');
-          return;
+        if (!broadcast(eventSockets, workerStreamEvent(frame.chunk, offset))) {
+          if (!retainOutput(frame.chunk, offset)) {
+            endTerminal(
+              new FleetNodeAttachError(
+                'terminal output exceeded the bounded loopback buffer',
+                'output_backpressure'
+              )
+            );
+          }
         }
-        broadcast(eventSockets, workerStreamEvent(frame.chunk, offset));
       } else if (frame.type === 'terminal.input_ack') {
         broadcast(inputSockets, {
           type: 'pty_input_ack',
@@ -429,22 +515,23 @@ export async function startFleetNodeAttachProxy(
       } else if (frame.type === 'terminal.error') {
         const message = typeof frame.message === 'string' ? frame.message : 'remote terminal failed';
         const code = typeof frame.code === 'string' ? frame.code : 'terminal_error';
-        broadcast(inputSockets, { type: 'pty_input_error', code, message });
-        if (!readySettled) {
-          readySettled = true;
-          rejectReady(new FleetNodeAttachError(message, code));
+        if (readiness === activeReadiness && !readiness.settled) {
+          endTerminal(new FleetNodeAttachError(message, code));
+        } else {
+          broadcast(inputSockets, { type: 'pty_input_error', code, message });
         }
       } else if (frame.type === 'terminal.closed') {
-        broadcast(inputSockets, {
-          type: 'pty_input_error',
-          code: 'terminal_closed',
-          message: 'remote terminal session closed',
-        });
+        endTerminal(new FleetNodeAttachError('remote terminal session closed', 'terminal_closed'));
       }
     });
     socket.on('error', () => undefined);
     socket.on('close', () => {
-      if (remote !== socket || stopped || reconnecting) return;
+      if (remote !== socket || stopped || terminalEnded || reconnecting) return;
+      // Any waiter that observed the prior connection must retry against the
+      // fresh generation instead of receiving its stale resolved snapshot.
+      resolveReadiness(readiness);
+      const nextReadiness = createReadiness();
+      activeReadiness = nextReadiness;
       if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
         failRemote('terminal transport could not reconnect to the fleet node');
         return;
@@ -452,13 +539,14 @@ export async function startFleetNodeAttachProxy(
       reconnecting = true;
       const delay = Math.min(INITIAL_RECONNECT_DELAY_MS * 2 ** reconnectAttempts, MAX_RECONNECT_DELAY_MS);
       reconnectAttempts += 1;
-      setTimeout(() => {
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
         reconnecting = false;
-        connect(resumeUrl.toString());
+        connect(resumeUrl.toString(), nextReadiness);
       }, delay);
     });
   };
-  connect(terminalUrl);
+  connect(terminalUrl, activeReadiness);
 
   return {
     brokerUrl: `http://127.0.0.1:${address.port}`,
@@ -466,13 +554,27 @@ export async function startFleetNodeAttachProxy(
     async close() {
       if (stopped) return;
       stopped = true;
-      if (!readySettled) {
-        readySettled = true;
-        rejectReady(new FleetNodeAttachError('terminal attach closed', 'closed'));
+      terminalEnded = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = undefined;
       }
-      if (remote && remote.readyState === WebSocket.OPEN) {
-        remote.send(JSON.stringify({ type: 'terminal.close', session_id: sessionId }));
-        remote.close();
+      rejectReadiness(activeReadiness, new FleetNodeAttachError('terminal attach closed', 'closed'));
+      const activeRemote = remote;
+      remote = undefined;
+      if (activeRemote && activeRemote.readyState === WebSocket.OPEN) {
+        try {
+          activeRemote.send(JSON.stringify({ type: 'terminal.close', session_id: sessionId }));
+        } catch {
+          // Best effort; terminate below still prevents a late reconnect.
+        }
+      }
+      if (activeRemote && activeRemote.readyState !== WebSocket.CLOSED) {
+        try {
+          activeRemote.terminate();
+        } catch {
+          // Socket is already gone.
+        }
       }
       for (const socket of [...eventSockets, ...inputSockets])
         closeSocket(socket, 1000, 'terminal attach closed');

--- a/packages/cli/src/cli/lib/attach.test.ts
+++ b/packages/cli/src/cli/lib/attach.test.ts
@@ -962,7 +962,7 @@ describe('createBackpressureAwareWriter', () => {
 
   it('flushes buffered records in order before disposal', () => {
     const written: string[] = [];
-    let accept = false;
+    const accept = false;
     let drain: (() => void) | null = null;
     const stdout: BackpressureWritable = {
       write: (chunk) => {

--- a/packages/cli/src/cli/lib/attach.test.ts
+++ b/packages/cli/src/cli/lib/attach.test.ts
@@ -960,6 +960,33 @@ describe('createBackpressureAwareWriter', () => {
     expect(written).toEqual(['a', 'bb', 'c']);
   });
 
+  it('flushes buffered records in order before disposal', () => {
+    const written: string[] = [];
+    let accept = false;
+    let drain: (() => void) | null = null;
+    const stdout: BackpressureWritable = {
+      write: (chunk) => {
+        written.push(chunk);
+        return accept;
+      },
+      once: (_event, listener) => {
+        drain = listener;
+        return undefined;
+      },
+      off: (_event, listener) => {
+        if (listener === drain) drain = null;
+        return undefined;
+      },
+    };
+    const w = createBackpressureAwareWriter(stdout);
+    w.write('first');
+    w.write('second');
+    w.write('third');
+    w.flush();
+    w.dispose();
+    expect(written).toEqual(['first', 'second', 'third']);
+  });
+
   it('drops the pending queue and unhooks drain on dispose', () => {
     const written: string[] = [];
     let accept = true;

--- a/packages/cli/src/cli/lib/attach.ts
+++ b/packages/cli/src/cli/lib/attach.ts
@@ -1223,14 +1223,19 @@ export interface BackpressureWritable {
 }
 
 /**
- * A backpressure-aware writer plus a teardown hook. Call the writer with each
- * chunk; call {@link BackpressureAwareWriter.dispose} on detach to drop any
- * still-queued chunks and unhook the pending `'drain'` listener so nothing
- * flushes to stdout after the session tears down.
+ * A backpressure-aware writer plus teardown hooks. Call the writer with each
+ * chunk. Interactive attaches call {@link BackpressureAwareWriter.dispose} on
+ * detach to drop any still-queued terminal bytes; machine-readable callers can
+ * call {@link BackpressureAwareWriter.flush} first to preserve their records.
  */
 export interface BackpressureAwareWriter {
   /** Write a chunk, respecting backpressure. No-op after {@link dispose}. */
   write: (chunk: string) => void;
+  /**
+   * Queue every locally buffered chunk to the underlying stream in FIFO order.
+   * The stream's own buffered writes are drained by the shared CLI exit path.
+   */
+  flush: () => void;
   /** Drop the pending queue and unhook the `'drain'` listener. Idempotent. */
   dispose: () => void;
 }
@@ -1309,7 +1314,22 @@ export function createBackpressureAwareWriter(
     off?.call(stdout, 'drain', flushQueue);
   };
 
-  return { write, dispose };
+  const flush = (): void => {
+    if (disposed || queue.length === 0) return;
+    const pending = queue;
+    queue = [];
+    queuedBytes = 0;
+    paused = false;
+    const off = stdout.off ?? stdout.removeListener;
+    off?.call(stdout, 'drain', flushQueue);
+    // `stdout.write` queues asynchronously on pipes. Preserving JSON records
+    // is more important than applying another local backpressure pause here;
+    // exitAfterFlush writes a final sentinel and waits (bounded) for that
+    // stream queue after command completion.
+    for (const chunk of pending) stdout.write(chunk);
+  };
+
+  return { write, flush, dispose };
 }
 
 /** Dependencies for `captureInitialSnapshot`. `captureAndRenderSnapshot`


### PR DESCRIPTION
Closes #1449

Depends on cloud #2995.

Implements the Relay half of canonical --node terminal attach:
- a separate authenticated outbound terminal WebSocket, never multiplexed with heartbeats/actions
- bounded terminal output/input queues, server-enforced view mode defense in depth, reconnect-friendly session handling
- remote ANSI snapshots and output routing from PTY workers
- ephemeral loopback broker-compatible adapter preserving view, drive, and passthrough; no SSH process is used by --node
- keeps #1483 --ssh-host path untouched and mutually exclusive

Checks: cargo fmt --check; cargo check -p agent-relay-broker; cargo test -p agent-relay-broker terminal_wire_round_trips_without_control_frames --lib. CLI focused Vitest launched: packages/cli/src/cli/commands/local-agent.test.ts.