### PR TITLE
fix(cli): preserve Relayfile subscription path filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `agent-relay integration subscribe` now sends Relayfile path filters using Relaycast's `path_glob` wire field, preventing scoped subscriptions from silently receiving broader event sets.
 - Broker bridge now treats a blank/whitespace-only nested `sessionRef` inside `metadata.attestation` as absent; a valid top-level `session_ref` correctly fills the field instead of being silently suppressed.
 
 ## [11.5.1] - 2026-08-10

--- a/packages/cli/src/cli/commands/integration-subscribe.test.ts
+++ b/packages/cli/src/cli/commands/integration-subscribe.test.ts
@@ -295,6 +295,25 @@ describe('integration subscribe', () => {
     );
   });
 
+  it('serializes the resolved path filter with the Relaycast wire key', async () => {
+    const resolved = '/github/repos/AgentWorkforce/relay/**';
+    const relayfile = createRelayfileMock([], {
+      resolveResourcePath: vi.fn(async () => ({ pathGlob: resolved })),
+    });
+    const { program } = harness({ relayfile });
+
+    await program.parseAsync(ARGS(), { from: 'user' });
+
+    const [, request] = vi.mocked(fetch).mock.calls[0]!;
+    const body = JSON.parse(String(request?.body)) as Record<string, unknown>;
+    expect(body).toEqual({
+      channel: 'general',
+      provider: 'slack',
+      path_glob: resolved,
+    });
+    expect(body).not.toHaveProperty('pathGlob');
+  });
+
   it('fails loudly before provisioning when no workspace key is available', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-no-workspace-'));
     vi.stubEnv('AGENT_RELAY_HOME', home);

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -464,7 +464,7 @@ async function createRelayfileInboundTarget(
     body: JSON.stringify({
       channel: input.channel,
       provider: input.provider,
-      pathGlob: input.pathGlob,
+      path_glob: input.pathGlob,
     }),
   });
   let body: unknown;


### PR DESCRIPTION
## Summary

- serialize the Relayfile inbound target filter as `path_glob`, matching the Relaycast server contract
- add a request-body regression test that rejects the previous camelCase field
- document the scoped-delivery fix in the changelog

## Verification

- `npm run typecheck`
- `npm exec -- vitest run packages/cli/src/cli/commands/integration-subscribe.test.ts packages/cli/src/cli/commands/relaycast-groups.test.ts` (78 passed)
- focused ESLint (0 errors; existing warnings only)
- Prettier check and `git diff --check`

Fixes #1479

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

