### PR TITLE
fix(cli): allow slow Relayfile provider status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Increased the Relayfile integration control-plane request budget so subscription provisioning does not fail at the previous 10-second boundary when Cloud provider status is slow.
 
 ## [11.5.2] - 2026-08-11
 

--- a/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
+++ b/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
@@ -6,7 +6,13 @@ import { join } from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { MIN_RELAYFILE_VERSION, assertRelayfileVersion, defaultRelayfileBridge } from './integration.js';
+import {
+  MIN_RELAYFILE_VERSION,
+  assertRelayfileVersion,
+  defaultRelayfileBridge,
+  relayfileIntegrationClientOptions,
+  resetSharedRelayfileControlPlaneClientForTests,
+} from './integration.js';
 import { RelayfileControlPlaneClient } from '@relayfile/client';
 
 let socketSequence = 0;
@@ -222,7 +228,16 @@ describe('assertRelayfileVersion', () => {
 });
 
 describe('default Relayfile integration bridge', () => {
+  it('constructs Relayfile clients with the exact 30-second request budget', () => {
+    expect(relayfileIntegrationClientOptions()).toEqual({ requestTimeoutMs: 30_000 });
+    expect(relayfileIntegrationClientOptions({ socketPath: '/tmp/relayfile-test.sock' })).toEqual({
+      requestTimeoutMs: 30_000,
+      socketPath: '/tmp/relayfile-test.sock',
+    });
+  });
+
   it('allows a real provider-status request to clear the former 10-second boundary', async () => {
+    resetSharedRelayfileControlPlaneClientForTests();
     await withControlPlaneServer(
       (request, response) => {
         if (request.method === 'GET' && request.url === '/v1/hello') {
@@ -240,13 +255,11 @@ describe('default Relayfile integration bridge', () => {
         writeJson(response, 404, { error: { code: 'NOT_FOUND', message: 'not found' } });
       },
       async (socketPath) => {
-        const previousSocket = process.env.RELAYFILE_SOCK;
-        process.env.RELAYFILE_SOCK = socketPath;
         try {
-          await expect(defaultRelayfileBridge().isConnected('github')).resolves.toBe(true);
+          const bridge = defaultRelayfileBridge({ socketPath, autoStart: false });
+          await expect(bridge.isConnected('github')).resolves.toBe(true);
         } finally {
-          if (previousSocket === undefined) delete process.env.RELAYFILE_SOCK;
-          else process.env.RELAYFILE_SOCK = previousSocket;
+          resetSharedRelayfileControlPlaneClientForTests();
         }
       }
     );

--- a/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
+++ b/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
@@ -221,6 +221,38 @@ describe('assertRelayfileVersion', () => {
   });
 });
 
+describe('default Relayfile integration bridge', () => {
+  it('allows a real provider-status request to clear the former 10-second boundary', async () => {
+    await withControlPlaneServer(
+      (request, response) => {
+        if (request.method === 'GET' && request.url === '/v1/hello') {
+          writeJson(response, 200, {
+            daemonVersion: '0.10.27',
+            apiVersion: 3,
+            supportedApiVersions: [1, 2, 3],
+          });
+          return;
+        }
+        if (request.method === 'GET' && request.url?.startsWith('/v1/integrations/provider-status?')) {
+          setTimeout(() => writeJson(response, 200, { provider: 'github', status: 'ready' }), 10_100);
+          return;
+        }
+        writeJson(response, 404, { error: { code: 'NOT_FOUND', message: 'not found' } });
+      },
+      async (socketPath) => {
+        const previousSocket = process.env.RELAYFILE_SOCK;
+        process.env.RELAYFILE_SOCK = socketPath;
+        try {
+          await expect(defaultRelayfileBridge().isConnected('github')).resolves.toBe(true);
+        } finally {
+          if (previousSocket === undefined) delete process.env.RELAYFILE_SOCK;
+          else process.env.RELAYFILE_SOCK = previousSocket;
+        }
+      }
+    );
+  }, 15_000);
+});
+
 describe('relayfile control-plane hello negotiation', () => {
   it('discovers supported APIs without a version header, then uses v3 for normal requests', async () => {
     const requests: Array<{ method?: string; path?: string; version?: string }> = [];

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -153,15 +153,27 @@ export type IntegrationCommandDependencies = SdkCommandDeps & {
 let sharedClient: RelayfileControlPlaneClient | undefined;
 const RELAYFILE_WEBHOOK_BINDINGS_API_VERSION = 3;
 const RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS = 30_000;
+
+export function relayfileIntegrationClientOptions(
+  options: RelayfileClientOptions = {}
+): RelayfileClientOptions {
+  return {
+    requestTimeoutMs: RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS,
+    ...options,
+  };
+}
+
+export function resetSharedRelayfileControlPlaneClientForTests(): void {
+  sharedClient = undefined;
+}
+
 function controlPlaneClient(options?: RelayfileClientOptions): RelayfileControlPlaneClient {
-  if (options) return new RelayfileControlPlaneClient(options);
+  if (options) return new RelayfileControlPlaneClient(relayfileIntegrationClientOptions(options));
   if (!sharedClient) {
-    sharedClient = new RelayfileControlPlaneClient({
-      // Provider status can include a Cloud request plus optional runtime
-      // enrichment. Keep subscription provisioning tolerant of a slow upstream
-      // while the daemon independently bounds that optional enrichment.
-      requestTimeoutMs: RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS,
-    });
+    // Provider status can include a Cloud request plus optional runtime
+    // enrichment. Keep subscription provisioning tolerant of a slow upstream
+    // while the daemon independently bounds that optional enrichment.
+    sharedClient = new RelayfileControlPlaneClient(relayfileIntegrationClientOptions());
   }
   return sharedClient;
 }

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -152,9 +152,17 @@ export type IntegrationCommandDependencies = SdkCommandDeps & {
  */
 let sharedClient: RelayfileControlPlaneClient | undefined;
 const RELAYFILE_WEBHOOK_BINDINGS_API_VERSION = 3;
+const RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS = 30_000;
 function controlPlaneClient(options?: RelayfileClientOptions): RelayfileControlPlaneClient {
   if (options) return new RelayfileControlPlaneClient(options);
-  if (!sharedClient) sharedClient = new RelayfileControlPlaneClient();
+  if (!sharedClient) {
+    sharedClient = new RelayfileControlPlaneClient({
+      // Provider status can include a Cloud request plus optional runtime
+      // enrichment. Keep subscription provisioning tolerant of a slow upstream
+      // while the daemon independently bounds that optional enrichment.
+      requestTimeoutMs: RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS,
+    });
+  }
   return sharedClient;
 }
 


### PR DESCRIPTION
## Summary
- give integration control-plane requests a 30-second budget instead of the `@relayfile/client` default of 10 seconds
- add regression coverage that inspects the default bridge request budget

## Live reproduction
The branch-built CLI repeatedly failed `integration subscribe` at exactly 10 seconds while production Relayfile provider status completed in ~9.7 seconds before client overhead. With this change and AgentWorkforce/relayfile#415, the same local CLI command successfully created both the scoped Relay inbound target and Relayfile webhook subscription.

## Verification
- `integration-relayfile-contract.test.ts`: 11 passed, 4 skipped
- `npm run typecheck`: passed
- changed-file Prettier: passed
- ESLint: 0 errors; 28 pre-existing warnings in `integration.ts`

Related end-to-end path-filter fix: #1486.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

