### PR TITLE
fix(cli): preserve Relayfile timeout fallback for undefined options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Increased the Relayfile integration control-plane request budget so subscription provisioning does not fail at the previous 10-second boundary when Cloud provider status is slow.
+- Increased the Relayfile integration control-plane request budget so subscription provisioning does not fail at the previous 10-second boundary when Cloud provider status is slow, including when callers forward an undefined optional timeout.
 
 ## [11.5.2] - 2026-08-11
 

--- a/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
+++ b/packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
@@ -234,6 +234,12 @@ describe('default Relayfile integration bridge', () => {
       requestTimeoutMs: 30_000,
       socketPath: '/tmp/relayfile-test.sock',
     });
+    expect(relayfileIntegrationClientOptions({ requestTimeoutMs: undefined })).toEqual({
+      requestTimeoutMs: 30_000,
+    });
+    expect(relayfileIntegrationClientOptions({ requestTimeoutMs: 45_000 })).toEqual({
+      requestTimeoutMs: 45_000,
+    });
   });
 
   it('allows a real provider-status request to clear the former 10-second boundary', async () => {

--- a/packages/cli/src/cli/commands/integration.ts
+++ b/packages/cli/src/cli/commands/integration.ts
@@ -158,8 +158,8 @@ export function relayfileIntegrationClientOptions(
   options: RelayfileClientOptions = {}
 ): RelayfileClientOptions {
   return {
-    requestTimeoutMs: RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS,
     ...options,
+    requestTimeoutMs: options.requestTimeoutMs ?? RELAYFILE_INTEGRATION_REQUEST_TIMEOUT_MS,
   };
 }
 


### PR DESCRIPTION
Summary

- normalize an explicitly forwarded undefined requestTimeoutMs to the 30-second Relayfile integration default
- preserve defined caller timeout overrides
- add regression assertions for both cases

Follow-up to #1487 and the late Cubic finding in discussion_r3764394639.

Verification

- npx vitest run packages/cli/src/cli/commands/integration-relayfile-contract.test.ts (12 passed, 4 skipped)
- npm run typecheck
- npx prettier --check CHANGELOG.md packages/cli/src/cli/commands/integration.ts packages/cli/src/cli/commands/integration-relayfile-contract.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

