### PR TITLE
chore(deps): bump @relaycast/* from ^6 to ^8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-relay/monorepo",
-  "version": "11.2.0",
+  "version": "11.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-relay/monorepo",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -16,7 +16,7 @@
         "@agentworkforce/delivery": "^4.1.23",
         "@agentworkforce/runtime": "^4.1.23",
         "@eslint/js": "^10.0.1",
-        "@relaycast/sdk": "^6.0.0",
+        "@relaycast/sdk": "^8.0.0",
         "@relayfile/relay-helpers": "^0.4.6",
         "@testing-library/jest-dom": "^6.9.1",
         "@types/better-sqlite3": "^7.6.13",
@@ -2259,7 +2259,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4249,7 +4248,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4267,7 +4265,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4285,7 +4282,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4303,7 +4299,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4321,7 +4316,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4339,7 +4333,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4357,7 +4350,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4375,7 +4367,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4393,7 +4384,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4411,7 +4401,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4429,7 +4418,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4447,7 +4435,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4465,7 +4452,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4483,7 +4469,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4501,7 +4486,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4519,7 +4503,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4537,7 +4520,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4555,7 +4537,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4573,7 +4554,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4591,7 +4571,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4609,7 +4588,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4627,7 +4605,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4645,7 +4622,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4663,7 +4639,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4681,7 +4656,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4699,7 +4673,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6161,18 +6134,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@relaycast/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-NW+tKscZp5LDs3Zl9iBoRchV8qTQ1AWNtm9/uBWvc6u4ZFXzIlW1YO5FbaqjLy4IPFlFNdvPRwUwQQbHrhgYgA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-8.0.0.tgz",
+      "integrity": "sha512-+j4DmRt9yYvsftRPkpPSayNx+LplO3YHJDQFlOOy6G7tahosmC7qp13sxOcs6qUOFjed8oyAC4M1icdwI2jX4A==",
       "dependencies": {
-        "@relaycast/types": "6.0.2",
+        "@relaycast/types": "8.0.0",
         "zod": "^4.3.6"
       }
     },
     "node_modules/@relaycast/types": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-6.0.2.tgz",
-      "integrity": "sha512-VOMOPEzHWxq+HR25YfWWL1XyB+22C6OQ7ryau9rU/Gi7SDPSQ2rLKHOdBQDEah1FnoYfEGyywyCswn7M9vNFGg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-GMBA8doHg6nyhtNJP6s8iX1H/KMN+EcQhWeiiIUoVPNULejB/NrFNre4AyaXsA0JqY2C+2U5AG2K6azUZyvt3Q==",
       "dependencies": {
         "zod": "^4.3.6"
       }
@@ -8554,7 +8527,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
       "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -8909,7 +8881,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
       "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -11343,7 +11314,6 @@
       "version": "2.27.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
       "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -13532,14 +13502,14 @@
     },
     "packages/brand": {
       "name": "@agent-relay/brand",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "packages/broker-darwin-arm64": {
       "name": "@agent-relay/broker-darwin-arm64",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -13547,7 +13517,7 @@
     },
     "packages/broker-darwin-x64": {
       "name": "@agent-relay/broker-darwin-x64",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -13555,7 +13525,7 @@
     },
     "packages/broker-linux-arm64": {
       "name": "@agent-relay/broker-linux-arm64",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -13563,7 +13533,7 @@
     },
     "packages/broker-linux-x64": {
       "name": "@agent-relay/broker-linux-x64",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -13571,7 +13541,7 @@
     },
     "packages/broker-win32-x64": {
       "name": "@agent-relay/broker-win32-x64",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -13579,16 +13549,16 @@
     },
     "packages/cli": {
       "name": "agent-relay",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/cloud": "11.2.0",
-        "@agent-relay/config": "11.2.0",
-        "@agent-relay/fleet": "11.2.0",
-        "@agent-relay/harness-driver": "11.2.0",
-        "@agent-relay/harnesses": "11.2.0",
-        "@agent-relay/sdk": "11.2.0",
-        "@agent-relay/utils": "11.2.0",
+        "@agent-relay/cloud": "11.5.2",
+        "@agent-relay/config": "11.5.2",
+        "@agent-relay/fleet": "11.5.2",
+        "@agent-relay/harness-driver": "11.5.2",
+        "@agent-relay/harnesses": "11.5.2",
+        "@agent-relay/sdk": "11.5.2",
+        "@agent-relay/utils": "11.5.2",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@relayfile/client": "^0.10.27",
         "@relayflows/cli": "1.0.1",
@@ -13616,9 +13586,9 @@
     },
     "packages/cloud": {
       "name": "@agent-relay/cloud",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "dependencies": {
-        "@agent-relay/config": "11.2.0",
+        "@agent-relay/config": "11.5.2",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.21"
@@ -13637,7 +13607,7 @@
     },
     "packages/config": {
       "name": "@agent-relay/config",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -13652,11 +13622,11 @@
     },
     "packages/evals": {
       "name": "@agent-relay/evals",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "11.2.0",
-        "@agent-relay/integration-prompts": "11.2.0"
+        "@agent-relay/harness-driver": "11.5.2",
+        "@agent-relay/integration-prompts": "11.5.2"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -13664,12 +13634,12 @@
     },
     "packages/fleet": {
       "name": "@agent-relay/fleet",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "11.2.0",
-        "@agent-relay/harnesses": "11.2.0",
-        "@relaycast/sdk": "^6.0.0",
+        "@agent-relay/harness-driver": "11.5.2",
+        "@agent-relay/harnesses": "11.5.2",
+        "@relaycast/sdk": "^8.0.0",
         "ws": "^8.18.3",
         "zod": "^4.4.3"
       },
@@ -13682,10 +13652,10 @@
     },
     "packages/harness-driver": {
       "name": "@agent-relay/harness-driver",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/sdk": "11.2.0",
+        "@agent-relay/sdk": "11.5.2",
         "ws": "^8.18.3",
         "zod": "^4.4.3"
       },
@@ -13693,20 +13663,20 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "11.2.0",
-        "@agent-relay/broker-darwin-x64": "11.2.0",
-        "@agent-relay/broker-linux-arm64": "11.2.0",
-        "@agent-relay/broker-linux-x64": "11.2.0",
-        "@agent-relay/broker-win32-x64": "11.2.0"
+        "@agent-relay/broker-darwin-arm64": "11.5.2",
+        "@agent-relay/broker-darwin-x64": "11.5.2",
+        "@agent-relay/broker-linux-arm64": "11.5.2",
+        "@agent-relay/broker-linux-x64": "11.5.2",
+        "@agent-relay/broker-win32-x64": "11.5.2"
       }
     },
     "packages/harnesses": {
       "name": "@agent-relay/harnesses",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-relay/harness-driver": "11.2.0",
-        "@agent-relay/sdk": "11.2.0",
+        "@agent-relay/harness-driver": "11.5.2",
+        "@agent-relay/sdk": "11.5.2",
         "@ai-sdk/harness": "1.0.34",
         "@ai-sdk/harness-claude-code": "1.0.35",
         "@ai-sdk/harness-codex": "1.0.40",
@@ -13720,7 +13690,7 @@
     },
     "packages/integration-prompts": {
       "name": "@agent-relay/integration-prompts",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -13728,9 +13698,9 @@
     },
     "packages/policy": {
       "name": "@agent-relay/policy",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "dependencies": {
-        "@agent-relay/config": "11.2.0"
+        "@agent-relay/config": "11.5.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -13742,10 +13712,10 @@
     },
     "packages/sdk": {
       "name": "@agent-relay/sdk",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "dependencies": {
-        "@relaycast/sdk": "^6.0.0",
-        "@relaycast/types": "^6.0.0",
+        "@relaycast/sdk": "^8.0.0",
+        "@relaycast/types": "^8.0.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -13757,9 +13727,9 @@
     },
     "packages/utils": {
       "name": "@agent-relay/utils",
-      "version": "11.2.0",
+      "version": "11.5.2",
       "dependencies": {
-        "@agent-relay/config": "11.2.0",
+        "@agent-relay/config": "11.5.2",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@agentworkforce/delivery": "^4.1.23",
     "@agentworkforce/runtime": "^4.1.23",
     "@eslint/js": "^10.0.1",
-    "@relaycast/sdk": "^6.0.0",
+    "@relaycast/sdk": "^8.0.0",
     "@relayfile/relay-helpers": "^0.4.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@agent-relay/harness-driver": "11.5.2",
     "@agent-relay/harnesses": "11.5.2",
-    "@relaycast/sdk": "^6.0.0",
+    "@relaycast/sdk": "^8.0.0",
     "ws": "^8.18.3",
     "zod": "^4.4.3"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,8 +62,8 @@
     "@types/node": "^22.13.10"
   },
   "dependencies": {
-    "@relaycast/sdk": "^6.0.0",
-    "@relaycast/types": "^6.0.0",
+    "@relaycast/sdk": "^8.0.0",
+    "@relaycast/types": "^8.0.0",
     "zod": "^4.4.3"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `@relaycast/sdk` and `@relaycast/types` from `^6.0.0` to `^8.0.0` (resolves to `8.0.0`) in `packages/fleet/package.json`, `packages/sdk/package.json`, and the root `package.json` devDependencies
- Updates `package-lock.json` accordingly (lockfile was also catching up workspace version bookkeeping from 11.2.0 → 11.5.2, no external third-party version changes beyond `@relaycast/*`)
- Follows relay#1473 which stabilised fleet E2E tests against relaycast v7+

## Test plan

- [x] `tsc --noEmit` passes for `packages/sdk` and `packages/fleet`
- [x] Fleet unit tests: 18/18 pass
- [x] SDK unit tests: 12 pre-existing failures on main baseline (verified by running against ^6 before the bump); no new failures introduced
- [x] `cargo build -p agent-relay-broker` passes — Rust side unaffected
- [ ] CI queued on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

