### PR TITLE
fix(cli): report unhandled startup crashes during `node up` instead of dying silently

### DIFF
--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -1196,11 +1196,13 @@ describe('registerCoreCommands', () => {
     });
     void runCommand(program, ['up']);
 
-    for (
-      let i = 0;
-      i < 10 && (deps.onSignal as unknown as { mock: { calls: unknown[][] } }).mock.calls.length === 0;
-      i += 1
-    ) {
+    // SIGINT/SIGTERM are now registered before the broker starts (so a
+    // signal arriving during startup is handled gracefully too), so
+    // registration alone no longer implies `relay` is set. Wait for the
+    // broker to actually be up before firing the signal.
+    for (let i = 0; i < 20 && !(deps.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.some(
+      (call) => call[0] === 'Broker started.'
+    ); i += 1) {
       await Promise.resolve();
     }
 

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -1230,6 +1230,48 @@ describe('registerCoreCommands', () => {
     expect(logCalls.filter((call) => call[0] === '\nStopping...')).toHaveLength(1);
   });
 
+  it('up shuts down the in-flight broker candidate when SIGTERM arrives before the status check resolves', async () => {
+    let resolveStatus: (() => void) | undefined;
+    const relay = createRelayMock({
+      getStatus: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = () => resolve({ agent_count: 0, pending_delivery_count: 0 });
+          })
+      ),
+    });
+    const { program, deps } = createHarness({ relay });
+    void runCommand(program, ['up']);
+
+    // Wait until the status check has actually started. By this point
+    // `startBrokerWithPortFallback`'s `onCandidateReady` callback has
+    // already assigned the outer `relay` -- well before the check itself
+    // resolves. This is exactly the window where `relay` used to still be
+    // null and a signal would leak the broker child instead of shutting it
+    // down.
+    for (
+      let i = 0;
+      i < 20 &&
+      (relay.getStatus as unknown as { mock: { calls: unknown[][] } }).mock.calls.length === 0;
+      i += 1
+    ) {
+      await Promise.resolve();
+    }
+    expect(relay.getStatus).toHaveBeenCalled();
+    expect(relay.shutdown).not.toHaveBeenCalled();
+
+    const onSignalMock = deps.onSignal as unknown as { mock: { calls: unknown[][] } };
+    const sigtermHandler = onSignalMock.mock.calls.find((call) => call[0] === 'SIGTERM')?.[1] as
+      | (() => Promise<void>)
+      | undefined;
+    expect(sigtermHandler).toBeDefined();
+
+    await expect((sigtermHandler as () => Promise<void>)()).rejects.toMatchObject({ code: 0 });
+
+    expect(relay.shutdown).toHaveBeenCalledTimes(1);
+    resolveStatus?.();
+  });
+
   it('down stops broker and cleans stale files', async () => {
     const connectionPath = '/tmp/project/.agentworkforce/relay/connection.json';
     const relaySockPath = '/tmp/project/.agentworkforce/relay/relay.sock';

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -1251,8 +1251,7 @@ describe('registerCoreCommands', () => {
     // down.
     for (
       let i = 0;
-      i < 20 &&
-      (relay.getStatus as unknown as { mock: { calls: unknown[][] } }).mock.calls.length === 0;
+      i < 20 && (relay.getStatus as unknown as { mock: { calls: unknown[][] } }).mock.calls.length === 0;
       i += 1
     ) {
       await Promise.resolve();

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -1200,9 +1200,14 @@ describe('registerCoreCommands', () => {
     // signal arriving during startup is handled gracefully too), so
     // registration alone no longer implies `relay` is set. Wait for the
     // broker to actually be up before firing the signal.
-    for (let i = 0; i < 20 && !(deps.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.some(
-      (call) => call[0] === 'Broker started.'
-    ); i += 1) {
+    for (
+      let i = 0;
+      i < 20 &&
+      !(deps.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.some(
+        (call) => call[0] === 'Broker started.'
+      );
+      i += 1
+    ) {
       await Promise.resolve();
     }
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -7,12 +7,13 @@ import {
   classifyBrokerStartError,
   classifyBrokerStartStage,
   describeErrorWithCause,
+  getBrokerStatusWithRetry,
   isBundledBunExecutableEntrypoint,
   readNodeDeliveryStatus,
   resolveNodeIdentityFromSession,
   waitForNodeDelivery,
 } from './broker-lifecycle.js';
-import type { CoreDependencies } from '../commands/core.js';
+import type { CoreDependencies, CoreRelay } from '../commands/core.js';
 
 describe('isBundledBunExecutableEntrypoint', () => {
   it.each(['/$bunfs/root/agent-relay', 'B:/~BUN/root/agent-relay.exe', 'B:\\~BUN\\root\\agent-relay.exe'])(
@@ -125,6 +126,63 @@ describe('classifyBrokerStartStage', () => {
 
   it('falls back to startup for everything else', () => {
     expect(classifyBrokerStartStage(new Error('???'), '???')).toBe('startup');
+  });
+});
+
+describe('getBrokerStatusWithRetry', () => {
+  function createDeps(sleep = vi.fn(async () => undefined)): CoreDependencies {
+    return { log: vi.fn(), sleep } as unknown as CoreDependencies;
+  }
+
+  it('returns the status on the first successful attempt without sleeping', async () => {
+    const candidate: Pick<CoreRelay, 'getStatus'> = {
+      getStatus: vi.fn(async () => ({ agent_count: 0, pending_delivery_count: 0 })),
+    };
+    const deps = createDeps();
+
+    const result = await getBrokerStatusWithRetry(candidate, deps);
+
+    expect(result).toEqual({ agent_count: 0, pending_delivery_count: 0 });
+    expect(candidate.getStatus).toHaveBeenCalledTimes(1);
+    expect(deps.sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries a transient connect failure and returns the status once the broker responds', async () => {
+    let attempt = 0;
+    const candidate: Pick<CoreRelay, 'getStatus'> = {
+      getStatus: vi.fn(async () => {
+        attempt += 1;
+        if (attempt < 3) {
+          throw new TypeError('Unable to connect. Is the computer able to access the url?');
+        }
+        return { agent_count: 0, pending_delivery_count: 0 };
+      }),
+    };
+    const deps = createDeps();
+
+    const result = await getBrokerStatusWithRetry(candidate, deps, true);
+
+    expect(result).toEqual({ agent_count: 0, pending_delivery_count: 0 });
+    expect(candidate.getStatus).toHaveBeenCalledTimes(3);
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringContaining('Broker status check failed (attempt 1/4), retrying in 300ms...')
+    );
+  });
+
+  it('exhausts its retry budget and throws the last error when the broker never responds', async () => {
+    const err = new TypeError('Unable to connect. Is the computer able to access the url?');
+    const candidate: Pick<CoreRelay, 'getStatus'> = {
+      getStatus: vi.fn(async () => {
+        throw err;
+      }),
+    };
+    const deps = createDeps();
+
+    await expect(getBrokerStatusWithRetry(candidate, deps)).rejects.toBe(err);
+    // 4 total attempts: the initial try plus 3 retries.
+    expect(candidate.getStatus).toHaveBeenCalledTimes(4);
+    expect(deps.sleep).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -184,6 +184,20 @@ describe('getBrokerStatusWithRetry', () => {
     expect(candidate.getStatus).toHaveBeenCalledTimes(4);
     expect(deps.sleep).toHaveBeenCalledTimes(3);
   });
+
+  it('does not retry a non-connect failure -- fails after a single attempt', async () => {
+    const err = new Error('unauthorized');
+    const candidate: Pick<CoreRelay, 'getStatus'> = {
+      getStatus: vi.fn(async () => {
+        throw err;
+      }),
+    };
+    const deps = createDeps();
+
+    await expect(getBrokerStatusWithRetry(candidate, deps)).rejects.toBe(err);
+    expect(candidate.getStatus).toHaveBeenCalledTimes(1);
+    expect(deps.sleep).not.toHaveBeenCalled();
+  });
 });
 
 describe('readNodeDeliveryStatus', () => {

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -332,11 +332,91 @@ export function classifyBrokerStartError(err: unknown): string {
 /** Exported for testing. */
 export function classifyBrokerStartStage(_err: unknown, message: string): string {
   if (isBrokerAlreadyRunningError(message)) return 'already_running';
-  if (/fetch failed/i.test(message)) return 'connect';
+  // Node's native fetch() throws "fetch failed"; the CLI's Bun-compiled
+  // binaries throw Bun's own connect-failure text instead ("Unable to
+  // connect. Is the computer able to access the url?"). Recognize both so
+  // the shipped binary doesn't misclassify every connect failure as generic
+  // 'startup'.
+  if (/fetch failed/i.test(message) || /unable to connect/i.test(message)) return 'connect';
   if (/Broker did not report API port/i.test(message)) return 'spawn';
   if (/Broker process exited with code/i.test(message)) return 'spawn';
   if (/ENOENT/i.test(message) && /broker/i.test(message)) return 'resolve_binary';
   return 'startup';
+}
+
+/**
+ * Render the same "Failed to start broker" diagnostic + telemetry the
+ * `runUpCommand` catch block has always used. Extracted so the process-level
+ * crash guard (below) can report an unhandled rejection/exception the exact
+ * same way as an ordinary caught startup failure.
+ */
+function reportBrokerStartFailure(
+  err: unknown,
+  deps: CoreDependencies,
+  paths: CoreProjectPaths,
+  options: UpOptions
+): void {
+  const message = toErrorMessage(err);
+  const stage = classifyBrokerStartStage(err, message);
+  track('broker_start_failed', {
+    stage,
+    error_class: classifyBrokerStartError(err),
+  });
+  const detailedMessage = describeErrorWithCause(err);
+  recordBackgroundStartError(detailedMessage, paths.dataDir, options.backgroundChild === true, deps);
+  if (isBrokerAlreadyRunningError(message)) {
+    reportAlreadyRunningError(message, paths.dataDir, deps);
+  } else {
+    deps.error(`Failed to start broker: ${detailedMessage}`);
+  }
+}
+
+/**
+ * `runUpCommand`'s startup try/catch only sees rejections it actually
+ * `await`s. Anything that rejects off to the side — a fire-and-forget
+ * background task inside a capability provider, an addon's internal promise
+ * chain, etc. — crashes the process via Node's bare default
+ * uncaughtException/unhandledRejection handler instead, which prints no
+ * "Failed to start broker" line and never records `broker_start_failed`
+ * telemetry. Observed in the wild as a `node up` that printed "Broker
+ * started." and then died with nothing further logged.
+ *
+ * This guard is armed for the lifetime of the foreground startup + hold-open
+ * phase so that class of crash gets the same diagnostic + telemetry + cleanup
+ * treatment as an ordinary caught failure, instead of vanishing into Node's
+ * default handler. `dispose()` must be called (via `finally`) so the
+ * listeners don't outlive this command invocation.
+ */
+function installStartupCrashGuard(
+  deps: CoreDependencies,
+  paths: CoreProjectPaths,
+  options: UpOptions,
+  shutdownOnce: () => Promise<void>
+): { dispose: () => void; markHandled: () => void } {
+  let handled = false;
+  const handleCrash = (err: unknown): void => {
+    if (handled) return;
+    handled = true;
+    void (async () => {
+      await shutdownOnce().catch(() => undefined);
+      reportBrokerStartFailure(err, deps, paths, options);
+      deps.exit(1);
+    })();
+  };
+  process.on('uncaughtException', handleCrash);
+  process.on('unhandledRejection', handleCrash);
+  return {
+    dispose: () => {
+      process.off('uncaughtException', handleCrash);
+      process.off('unhandledRejection', handleCrash);
+    },
+    // Called from the normal catch block so a straggler process-level event
+    // for the same failure can't fire a second, duplicate report after this
+    // function has already handled it and moved on.
+    markHandled: () => {
+      handled = true;
+    },
+  };
 }
 
 async function resolveApiPortWithFallback(
@@ -1688,6 +1768,7 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     }
     await shutdownPromise;
   };
+  const crashGuard = installStartupCrashGuard(deps, paths, options, shutdownOnce);
   try {
     if (existingPid !== null) {
       if (isProcessRunning(existingPid, deps)) {
@@ -1849,21 +1930,14 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       await holdOpen;
     }
   } catch (err: unknown) {
+    // A straggler process-level crash event for this same failure must not
+    // also fire and duplicate the report below.
+    crashGuard.markHandled();
     await shutdownOnce();
-    const message = toErrorMessage(err);
-    const stage = classifyBrokerStartStage(err, message);
-    track('broker_start_failed', {
-      stage,
-      error_class: classifyBrokerStartError(err),
-    });
-    const detailedMessage = describeErrorWithCause(err);
-    recordBackgroundStartError(detailedMessage, paths.dataDir, options.backgroundChild === true, deps);
-    if (isBrokerAlreadyRunningError(message)) {
-      reportAlreadyRunningError(message, paths.dataDir, deps);
-    } else {
-      deps.error(`Failed to start broker: ${detailedMessage}`);
-    }
+    reportBrokerStartFailure(err, deps, paths, options);
     deps.exit(1);
+  } finally {
+    crashGuard.dispose();
   }
 }
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -452,6 +452,54 @@ export function resolveBrokerBasePort(deps: Pick<CoreDependencies, 'env'>): numb
   return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_BROKER_BASE_PORT;
 }
 
+/** Bounded attempts for {@link getBrokerStatusWithRetry}'s post-handshake status check. */
+const STATUS_CHECK_MAX_ATTEMPTS = 4;
+/** Fixed delay between status-check retries, in ms. */
+const STATUS_CHECK_RETRY_DELAY_MS = 300;
+
+/**
+ * `candidate.getStatus()` is the first request made against a broker that
+ * just finished a successful handshake -- `HarnessDriverClient.spawn()`'s own
+ * `getSession()` poll already confirmed the broker was reachable moments
+ * earlier. Under load, the broker can be transiently preempted between that
+ * handshake and this immediate follow-up request, surfacing as a bare
+ * connect failure (Node's `TypeError: fetch failed` / Bun's "Unable to
+ * connect. Is the computer able to access the url?"), which previously had
+ * zero tolerance: one bad request and the whole `up` was reported failed
+ * even though the broker was (and remained) healthy.
+ *
+ * A handful of short, fixed-delay retries absorb that hiccup. This mirrors
+ * the *spirit* of the 503-retry loop `HarnessDriverClient.spawn()` runs
+ * during the handshake, not its duration -- that loop waits out a possibly
+ * slow cold start; this one is only smoothing a momentary preemption right
+ * after a broker we already know is up, so the total budget is much
+ * shorter (under 1s across all retries).
+ *
+ * Exported for testing.
+ */
+export async function getBrokerStatusWithRetry(
+  candidate: Pick<CoreRelay, 'getStatus'>,
+  deps: CoreDependencies,
+  verbose?: boolean
+): Promise<unknown> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= STATUS_CHECK_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await candidate.getStatus();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= STATUS_CHECK_MAX_ATTEMPTS) break;
+      vlog(
+        deps,
+        verbose,
+        `Broker status check failed (attempt ${attempt}/${STATUS_CHECK_MAX_ATTEMPTS}), retrying in ${STATUS_CHECK_RETRY_DELAY_MS}ms...`
+      );
+      await deps.sleep(STATUS_CHECK_RETRY_DELAY_MS);
+    }
+  }
+  throw lastError;
+}
+
 export async function startBrokerWithPortFallback(
   paths: CoreProjectPaths,
   basePort: number,
@@ -463,7 +511,7 @@ export async function startBrokerWithPortFallback(
     vlog(deps, verbose, 'Asking the OS to assign the broker API port...');
     const candidate = await deps.createRelay(paths.projectRoot, 0, brokerName, verbose);
     try {
-      await candidate.getStatus();
+      await getBrokerStatusWithRetry(candidate, deps, verbose);
       if (!candidate.apiPort) {
         throw new Error('Broker started without reporting its OS-assigned API port.');
       }
@@ -496,7 +544,7 @@ export async function startBrokerWithPortFallback(
   vlog(deps, verbose, 'Broker client created. Checking broker status...');
 
   try {
-    await candidate.getStatus();
+    await getBrokerStatusWithRetry(candidate, deps, verbose);
   } catch (startupError) {
     try {
       await candidate.shutdown();

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -1769,6 +1769,34 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     await shutdownPromise;
   };
   const crashGuard = installStartupCrashGuard(deps, paths, options, shutdownOnce);
+  // Registered before any async startup work (broker spawn, capability
+  // providers, Reflex capture, node delivery wait) so a signal arriving
+  // during that window gets the same graceful, logged shutdown as one that
+  // arrives later during hold-open. Previously these were registered just
+  // before hold-open — a SIGTERM in that earlier window hit Node's bare
+  // default disposition (silent immediate termination) instead, which is
+  // indistinguishable from a genuine crash when observed from outside.
+  deps.onSignal('SIGINT', async () => {
+    sigintCount += 1;
+    if (shuttingDown) {
+      if (sigintCount >= 2) {
+        deps.warn('Force exiting...');
+        deps.exit(130);
+      }
+      return;
+    }
+    deps.log('\nStopping...');
+    await shutdownOnce();
+    deps.exit(0);
+  });
+  deps.onSignal('SIGTERM', async () => {
+    if (shuttingDown) {
+      return;
+    }
+    deps.log('\nStopping (SIGTERM)...');
+    await shutdownOnce();
+    deps.exit(0);
+  });
   try {
     if (existingPid !== null) {
       if (isProcessRunning(existingPid, deps)) {
@@ -1901,27 +1929,6 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
     } else if (options.spawn === true && !teamsConfig) {
       deps.warn('Warning: --spawn specified but no teams.json found');
     }
-
-    deps.onSignal('SIGINT', async () => {
-      sigintCount += 1;
-      if (shuttingDown) {
-        if (sigintCount >= 2) {
-          deps.warn('Force exiting...');
-          deps.exit(130);
-        }
-        return;
-      }
-      deps.log('\nStopping...');
-      await shutdownOnce();
-      deps.exit(0);
-    });
-    deps.onSignal('SIGTERM', async () => {
-      if (shuttingDown) {
-        return;
-      }
-      await shutdownOnce();
-      deps.exit(0);
-    });
 
     const holdOpen = deps.holdOpen();
     if (nodeProviders?.done) {

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -10,6 +10,7 @@ import type { CoreDependencies, CoreProjectPaths, CoreRelay, SpawnedProcess } fr
 import { track } from '../telemetry/index.js';
 import { buildBundledAgentRelayMcpCommand } from './agent-relay-mcp-command.js';
 import { errorClassName } from './telemetry-helpers.js';
+import { runSignalHandler } from './exit.js';
 import { createTriggerSyncClient, resolveNodeCapacityHarnesses } from './fleet-sidecar.js';
 import {
   discoverNodeConfigPath,
@@ -397,11 +398,18 @@ function installStartupCrashGuard(
   const handleCrash = (err: unknown): void => {
     if (handled) return;
     handled = true;
-    void (async () => {
+    // `deps.exit(1)` throws `CliExit` (see `defaultExit`) rather than really
+    // exiting. Run this body through `runSignalHandler` -- the same wrapper
+    // `deps.onSignal` uses -- so that throw becomes a real, telemetry-flushed
+    // `process.exit`. Without it, the throw rejects this detached body with
+    // no awaiter; the `unhandledRejection` it produces hits `handleCrash`
+    // again, sees `handled` already true, and is silently dropped, leaving
+    // `runUpCommand` stuck in `holdOpen` instead of exiting.
+    runSignalHandler(async () => {
       await shutdownOnce().catch(() => undefined);
       reportBrokerStartFailure(err, deps, paths, options);
       deps.exit(1);
-    })();
+    });
   };
   process.on('uncaughtException', handleCrash);
   process.on('unhandledRejection', handleCrash);
@@ -488,7 +496,8 @@ export async function getBrokerStatusWithRetry(
       return await candidate.getStatus();
     } catch (err) {
       lastError = err;
-      if (attempt >= STATUS_CHECK_MAX_ATTEMPTS) break;
+      const isConnectFailure = classifyBrokerStartStage(err, toErrorMessage(err)) === 'connect';
+      if (!isConnectFailure || attempt >= STATUS_CHECK_MAX_ATTEMPTS) break;
       vlog(
         deps,
         verbose,
@@ -505,11 +514,21 @@ export async function startBrokerWithPortFallback(
   basePort: number,
   deps: CoreDependencies,
   brokerName?: string,
-  verbose?: boolean
+  verbose?: boolean,
+  /**
+   * Invoked as soon as the broker child process has been spawned and its
+   * client handle exists, well before the handshake/status-check retries
+   * below resolve. Lets the caller wire up cleanup (e.g. a SIGTERM handler)
+   * against the real process immediately, instead of only after this whole
+   * function returns -- a signal arriving during the status check would
+   * otherwise find no handle to shut down and leak the broker child.
+   */
+  onCandidateReady?: (candidate: CoreRelay) => void
 ): Promise<{ relay: CoreRelay; apiPort: number }> {
   if (basePort === 0) {
     vlog(deps, verbose, 'Asking the OS to assign the broker API port...');
     const candidate = await deps.createRelay(paths.projectRoot, 0, brokerName, verbose);
+    onCandidateReady?.(candidate);
     try {
       await getBrokerStatusWithRetry(candidate, deps, verbose);
       if (!candidate.apiPort) {
@@ -541,6 +560,7 @@ export async function startBrokerWithPortFallback(
 
   vlog(deps, verbose, 'Creating broker client (spawns broker process, waits for handshake)...');
   const candidate = await deps.createRelay(paths.projectRoot, apiPort, brokerName, verbose);
+  onCandidateReady?.(candidate);
   vlog(deps, verbose, 'Broker client created. Checking broker status...');
 
   try {
@@ -1886,8 +1906,23 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       basePort,
       deps,
       options.brokerName,
-      options.verbose
-    );
+      options.verbose,
+      // Assign `relay` as soon as the broker child process exists, not only
+      // once the handshake/status-check retries above also succeed. A
+      // SIGTERM/SIGINT arriving during that check window otherwise finds
+      // `relay` still null, so `shutdownOnce()` no-ops and leaks the broker
+      // child instead of shutting it down.
+      (candidate) => {
+        relay = candidate;
+      }
+    ).catch((err: unknown) => {
+      // On failure, `startBrokerWithPortFallback` has already shut down any
+      // candidate it created before rethrowing. Clear the early handle too
+      // so the outer catch's `shutdownOnce()` does not call `shutdown()` a
+      // second time on it.
+      relay = null;
+      throw err;
+    });
     relay = started.relay;
 
     try {
@@ -1985,10 +2020,20 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       await holdOpen;
     }
   } catch (err: unknown) {
+    // A rejection from cleanup must not swallow the original startup
+    // failure -- without this, `deps.exit(1)` below would never run and the
+    // startup error would go unreported.
+    try {
+      await shutdownOnce();
+    } catch (cleanupError) {
+      deps.warn(`Failed to clean up after broker startup failure: ${describeErrorWithCause(cleanupError)}`);
+    }
     // A straggler process-level crash event for this same failure must not
-    // also fire and duplicate the report below.
+    // also fire and duplicate the report below. Marked here -- after
+    // cleanup, right before reporting -- rather than at catch-entry, so an
+    // unrelated crash during the shutdownOnce() cleanup above is not
+    // silently swallowed by this guard too.
     crashGuard.markHandled();
-    await shutdownOnce();
     reportBrokerStartFailure(err, deps, paths, options);
     deps.exit(1);
   } finally {


### PR DESCRIPTION
## Summary

- `runUpCommand`'s startup try/catch only sees rejections it actually `await`s. Anything that rejects off to the side of that chain crashes the whole `node up` process via Node's bare default `uncaughtException`/`unhandledRejection` handler instead — which never prints "Failed to start broker: ..." and never records `broker_start_failed` telemetry. Adds a process-level crash guard, armed for the lifetime of the foreground startup + hold-open phase, that routes that class of crash through the exact same diagnostic + telemetry + cleanup path as an ordinary caught failure.
- Also broadens `classifyBrokerStartStage`'s connect-failure regex: it only recognized Node's native `fetch()` message ("fetch failed"), but the shipped CLI is Bun-compiled and Bun's own connect-failure text is different ("Unable to connect. Is the computer able to access the url?"). Every real connect failure on the shipped binary was being misclassified as generic `stage: 'startup'` instead of `'connect'`.
- **Update:** live-tested the crash-guard build on a real machine and found a *different* silent-death mechanism the crash guard alone can't fix: the process was dying from an external SIGTERM (exit code 143), not a JS exception, in the window before `runUpCommand` had registered its own signal handlers. Moved SIGINT/SIGTERM registration to the top of `runUpCommand`, before any async startup work, so a signal in that early window gets the same logged, graceful shutdown as one later during hold-open — regardless of what sends it.
- **Update 2:** the actual `/api/status` connect-failure race is now fixed, not just made loud. `getBrokerStatusWithRetry()` gives `candidate.getStatus()` in `startBrokerWithPortFallback` a bounded 4-attempt / 300ms-delay retry budget (~900ms total) so a broker that's momentarily unreachable right after a confirmed-successful handshake doesn't fail the whole `up`. Live-proven against a real broker process on a separate machine (not mocked) — see Test plan.

## Context

Investigating reports of `agent-relay node up` failing with no diagnosable error in some runs — sometimes dying between "Event stream connected." and "Broker started." with a bare "Failed to start broker: Unable to connect..." message, other times printing "Broker started." successfully and then dying with nothing logged at all.

Traced the second failure mode to the complete absence of a process-level `uncaughtException`/`unhandledRejection` handler anywhere in `packages/cli` or `packages/harness-driver`. `bootstrap.ts` has a `process.on('exit', ...)` hook, but it only fires telemetry — it doesn't log anything. So any rejection that isn't part of the awaited chain inside `runUpCommand`'s try block bypasses `deps.error()` and `track('broker_start_failed', ...)` entirely and crashes via Node's bare default handler.

## Changes

- `reportBrokerStartFailure()`: extracted the existing catch-block diagnostic + telemetry logic so both the normal catch and the new crash guard produce an identical report.
- `installStartupCrashGuard()`: registers `uncaughtException`/`unhandledRejection` listeners for the startup+hold-open lifetime of `runUpCommand`. On fire: best-effort `shutdownOnce()`, `reportBrokerStartFailure()`, `deps.exit(1)`. A `markHandled()` escape hatch prevents a straggler process-level event from double-reporting a failure the normal `catch` already handled; `dispose()` (called in a `finally`) removes the listeners so they don't outlive the command.
- `classifyBrokerStartStage()`: also matches `/unable to connect/i` so Bun's connect-failure text classifies as `stage: 'connect'` like Node's does.

## What this does NOT fix

This doesn't identify *which* specific promise is rejecting unhandled — it makes sure that whatever it is, the next time it happens, the CLI actually reports it (message + telemetry stage/error_class) instead of dying silently. That report is what will make the next occurrence traceable to a real throw site.

## Test plan

- [x] `packages/cli` standalone `tsc --noEmit` — clean
- [x] `packages/cli` vitest: `broker-lifecycle.test.ts` + `core.test.ts` — 126/126 passed, including 3 new unit tests for `getBrokerStatusWithRetry` (succeeds first try / recovers after N failures / exhausts budget and throws the last error)
- [x] Live-tested the crash-guard + signal-handler fix against a real broker on a separate machine repeatedly: reproduced the original silent SIGTERM death, diagnosed it to signal-registration timing, applied the fix, confirmed clean graceful exits (code 0, logged "Stopping (SIGTERM)...") across every run afterward instead of the previous silent 143
- [x] Live-tested the retry fix against a **real, unmocked broker process** on that same machine, bypassing `node up` entirely (spawned the broker binary directly) so an unrelated environmental SIGTERM issue on that box couldn't confound the result:
  - Negative control: a single un-retried `getStatus()` call against a broker that isn't listening yet fails with `TypeError: fetch failed` — the same error class as the real production bug — confirming the induced failure is a faithful reproduction, not an artifact.
  - With the fix: `getBrokerStatusWithRetry` visibly logs its retry attempts (`Broker status check failed (attempt 1/4)...`) against that same real, failing connection, and returns the correct final status without throwing once the broker comes up — both against an already-handshake-complete broker paused mid-request (recovers in ~605-608ms, run twice) and against a genuinely not-yet-listening one racing a live spawn.
  - All CI green on every commit (see checks on this PR).

Not merging — opened for review per chief; ready when they are.

## Side finding (not part of this PR)

While live-testing on that separate machine, found that a bare `agent-relay-broker` process gets sent SIGTERM almost immediately after starting, regardless of how it's spawned (confirmed via a standalone probe that never went through `node up`, `killOrphanedBrokerProcesses`, or any relay CLI code at all). Renaming the binary to a different filename made the process survive normally — strongly suggesting whatever's killing it matches on the binary's name/path, not its arguments or workspace. Root cause not yet identified (a separate, non-`up`-related investigation); flagging in case it's useful context for anyone chasing similar "broker died for no reason" reports on that box.
