### PR TITLE
fix(broker): restore live agent roster after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Fleet agent roster status recovers after a node-control reconnect instead of leaving live workers offline.
 
 ## [11.5.4] - 2026-08-12
 

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -347,6 +347,7 @@ impl BrokerRuntime {
                 // the worker MCP never re-registers over HTTP. If node binding is
                 // unavailable, fall back to HTTP pre-registration so a tokenless
                 // node (e.g. mint failure) still spawns a working agent.
+                let mut fleet_registration = None;
                 let worker_relay_key = if let Some(token) = agent_token {
                     seed_supplied_agent_token(relaycast_http, &name, &token);
                     Some(token)
@@ -362,7 +363,7 @@ impl BrokerRuntime {
                         fleet_delivery_book,
                         name.as_str(),
                         None,
-                        session_ref,
+                        session_ref.clone(),
                     )
                     .await
                     {
@@ -371,7 +372,9 @@ impl BrokerRuntime {
                                 worker = %name,
                                 "bound agent to node via agent.register for HTTP spawn"
                             );
-                            Some(token.token)
+                            let relay_key = token.token.clone();
+                            fleet_registration = Some((token, None, session_ref));
+                            Some(relay_key)
                         }
                         Err(node_error) => {
                             tracing::warn!(
@@ -578,6 +581,17 @@ impl BrokerRuntime {
                     .await
                 {
                     Ok(effective_spec) => {
+                        if let Some((token, invocation_id, session_ref)) = fleet_registration.take()
+                        {
+                            super::fleet::record_fleet_inventory_agent(
+                                fleet_control_tx,
+                                fleet_inventory,
+                                &token,
+                                invocation_id,
+                                session_ref,
+                            )
+                            .await;
+                        }
                         // Prepend relay skill text for small-tier models and CLI harnesses that
                         // need explicit tool guidance to reliably call add_agent / remove_agent.
                         // Skip when relay prompt injection is opted out — relay tools are absent.

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -348,8 +348,28 @@ impl BrokerRuntime {
                 // unavailable, fall back to HTTP pre-registration so a tokenless
                 // node (e.g. mint failure) still spawns a working agent.
                 let mut fleet_registration = None;
+                let session_ref = super::fleet::fleet_initial_session_ref(&spec);
                 let worker_relay_key = if let Some(token) = agent_token {
                     seed_supplied_agent_token(relaycast_http, &name, &token);
+                    match super::fleet::resolve_fleet_agent_token_identity(
+                        relaycast_http,
+                        fleet_delivery_book,
+                        &name,
+                        &token,
+                    )
+                    .await
+                    {
+                        Ok(registration) => {
+                            fleet_registration = Some((registration, None, session_ref.clone()));
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                worker = %name,
+                                error = %error,
+                                "could not resolve supplied agent token for reconnect inventory"
+                            );
+                        }
+                    }
                     Some(token)
                 } else {
                     // Derive the session ref from the resolved spec the same way
@@ -357,7 +377,6 @@ impl BrokerRuntime {
                     // `harnessConfig.session_id` registers as a resumable session
                     // rather than a fresh spawn. No invocation id exists on the
                     // HTTP path.
-                    let session_ref = super::fleet::fleet_initial_session_ref(&spec);
                     match super::fleet::register_node_agent_token(
                         fleet_control_tx,
                         fleet_delivery_book,
@@ -391,15 +410,35 @@ impl BrokerRuntime {
                                     // delivery. Bind it to this node so it is
                                     // deliverable, surfacing a loud warning if the
                                     // bind fails.
-                                    if let Some(warning) =
-                                        super::relaycast_events::bind_http_registered_agent_to_node(
+                                    let bind_warning = super::relaycast_events::bind_http_registered_agent_to_node(
+                                        relaycast_http,
+                                        fleet_node_name,
+                                        &name,
+                                    )
+                                    .await;
+                                    if let Some(warning) = bind_warning {
+                                        preregistration_warning = Some(warning);
+                                    } else {
+                                        match super::fleet::resolve_fleet_agent_token_identity(
                                             relaycast_http,
-                                            fleet_node_name,
+                                            fleet_delivery_book,
                                             &name,
+                                            &token,
                                         )
                                         .await
-                                    {
-                                        preregistration_warning = Some(warning);
+                                        {
+                                            Ok(registration) => {
+                                                fleet_registration =
+                                                    Some((registration, None, session_ref.clone()));
+                                            }
+                                            Err(error) => {
+                                                tracing::warn!(
+                                                    worker = %name,
+                                                    error = %error,
+                                                    "could not resolve HTTP-registered agent for reconnect inventory"
+                                                );
+                                            }
+                                        }
                                     }
                                     Some(token)
                                 }

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -1355,10 +1355,13 @@ pub(super) async fn publish_fleet_inventory_snapshot(
     fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
     fleet_inventory: &HashMap<WorkerName, InventoryAgent>,
 ) {
-    if let Err(error) = fleet_control_tx.try_send(FleetControlCommand::UpdateInventory(
-        fleet_inventory.values().cloned().collect(),
-    )) {
-        tracing::warn!(error = %error, "fleet inventory queue is unavailable; periodic heartbeat will retry");
+    if let Err(error) = fleet_control_tx
+        .send(FleetControlCommand::UpdateInventory(
+            fleet_inventory.values().cloned().collect(),
+        ))
+        .await
+    {
+        tracing::warn!(error = %error, "fleet inventory channel closed; reconnect inventory update was not delivered");
     }
 }
 
@@ -2634,6 +2637,45 @@ mod tests {
                 }));
             }
             other => panic!("expected inventory update, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fleet_inventory_snapshot_waits_for_backpressure_instead_of_dropping() {
+        let (tx, mut rx) = mpsc::channel::<FleetControlCommand>(1);
+        tx.send(FleetControlCommand::HeartbeatNow)
+            .await
+            .expect("prefill fleet control queue");
+        let inventory = HashMap::from([(
+            WorkerName::from("worker-a"),
+            InventoryAgent {
+                agent_id: "agent-a-id".to_string(),
+                name: "worker-a".to_string(),
+                invocation_id: None,
+                session_ref: None,
+            },
+        )]);
+        let publish = tokio::spawn({
+            let tx = tx.clone();
+            async move { publish_fleet_inventory_snapshot(&tx, &inventory).await }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !publish.is_finished(),
+            "inventory publication must wait while the queue is full"
+        );
+        assert!(matches!(
+            rx.recv().await,
+            Some(FleetControlCommand::HeartbeatNow)
+        ));
+        publish.await.expect("inventory publisher should complete");
+        match rx.recv().await {
+            Some(FleetControlCommand::UpdateInventory(agents)) => {
+                assert_eq!(agents.len(), 1);
+                assert_eq!(agents[0].name, "worker-a");
+            }
+            other => panic!("expected reliable inventory update, got {other:?}"),
         }
     }
 

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -947,6 +947,7 @@ impl BrokerRuntime {
             &mut self.agent_spawn_count,
             &self.fleet_control_tx,
             &mut self.fleet_delivery_book,
+            &mut self.fleet_inventory,
             &self.fleet_node_name,
             Some(invoke.invocation_id.clone()),
             session_ref,
@@ -1359,6 +1360,33 @@ pub(super) async fn publish_fleet_inventory_snapshot(
     )) {
         tracing::warn!(error = %error, "fleet inventory queue is unavailable; periodic heartbeat will retry");
     }
+}
+
+/// Add a successfully launched, node-registered worker to the authoritative
+/// reconnect inventory and publish the new snapshot immediately.
+///
+/// Relaycast marks every agent hosted by a provider offline when that
+/// provider's node-control socket disconnects. The reconnect path can restore
+/// those still-running workers only from `inventory.sync`; keeping the
+/// registration solely in [`FleetDeliveryBook`] is not enough because that
+/// book is delivery-local and is never sent to the engine.
+pub(super) async fn record_fleet_inventory_agent(
+    fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
+    fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
+    token: &crate::node_control::AgentRegistrationToken,
+    invocation_id: Option<String>,
+    session_ref: Option<String>,
+) {
+    fleet_inventory.insert(
+        WorkerName::from(token.name.as_str()),
+        InventoryAgent {
+            agent_id: token.agent_id.clone(),
+            name: token.name.clone(),
+            invocation_id,
+            session_ref,
+        },
+    );
+    publish_fleet_inventory_snapshot(fleet_control_tx, fleet_inventory).await;
 }
 
 pub(super) async fn refresh_fleet_inventory_session_ref(
@@ -2506,6 +2534,59 @@ mod tests {
             Some(FleetControlCommand::UpdateInventory(agents)) => {
                 assert_eq!(agents.len(), 1);
                 assert_eq!(agents[0].name, "agent-b");
+            }
+            other => panic!("expected inventory update, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_node_registration_is_added_to_reconnect_inventory() {
+        let (tx, mut rx) = mpsc::channel::<FleetControlCommand>(2);
+        let mut inventory = HashMap::from([(
+            WorkerName::from("already-running"),
+            InventoryAgent {
+                agent_id: "agent-existing-id".to_string(),
+                name: "already-running".to_string(),
+                invocation_id: Some("inv-existing".to_string()),
+                session_ref: None,
+            },
+        )]);
+        let token = crate::node_control::AgentRegistrationToken {
+            name: "new-worker".to_string(),
+            agent_id: "agent-new-id".to_string(),
+            token: "at_test".to_string(),
+            delivery_ack_seq: None,
+        };
+
+        record_fleet_inventory_agent(
+            &tx,
+            &mut inventory,
+            &token,
+            Some("inv-new".to_string()),
+            Some("session-new".to_string()),
+        )
+        .await;
+
+        assert_eq!(inventory.len(), 2);
+        assert_eq!(
+            inventory.get(&WorkerName::from("new-worker")),
+            Some(&InventoryAgent {
+                agent_id: "agent-new-id".to_string(),
+                name: "new-worker".to_string(),
+                invocation_id: Some("inv-new".to_string()),
+                session_ref: Some("session-new".to_string()),
+            })
+        );
+        match rx.recv().await {
+            Some(FleetControlCommand::UpdateInventory(agents)) => {
+                assert_eq!(agents.len(), 2);
+                assert!(agents.iter().any(|agent| agent.name == "already-running"));
+                assert!(agents.iter().any(|agent| {
+                    agent.name == "new-worker"
+                        && agent.agent_id == "agent-new-id"
+                        && agent.invocation_id.as_deref() == Some("inv-new")
+                        && agent.session_ref.as_deref() == Some("session-new")
+                }));
             }
             other => panic!("expected inventory update, got {other:?}"),
         }

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -1389,6 +1389,51 @@ pub(super) async fn record_fleet_inventory_agent(
     publish_fleet_inventory_snapshot(fleet_control_tx, fleet_inventory).await;
 }
 
+/// Resolve an opaque agent token to the authoritative identity required by
+/// `inventory.sync` and delivery bookkeeping.
+///
+/// Some supported spawn callers pre-mint the worker token and pass only that
+/// credential to the broker. The token itself does not encode an agent id, so
+/// resolve it through Relaycast before launch rather than silently omitting the
+/// worker from reconnect inventory.
+pub(super) async fn resolve_fleet_agent_token_identity(
+    relaycast_http: &RelaycastHttpClient,
+    fleet_delivery_book: &mut FleetDeliveryBook,
+    expected_name: &WorkerName,
+    token: &str,
+) -> Result<crate::node_control::AgentRegistrationToken, String> {
+    let relay = relaycast_http
+        .relay_client()
+        .ok_or_else(|| "relaycast_client_unavailable".to_string())?;
+    let agent = relay
+        .get_current_agent(token.to_string())
+        .await
+        .map_err(|error| format!("agent_token_identity_lookup_failed: {error}"))?;
+    registration_token_for_resolved_agent(fleet_delivery_book, expected_name, token, agent)
+}
+
+fn registration_token_for_resolved_agent(
+    fleet_delivery_book: &mut FleetDeliveryBook,
+    expected_name: &WorkerName,
+    token: &str,
+    agent: relaycast::Agent,
+) -> Result<crate::node_control::AgentRegistrationToken, String> {
+    if agent.name != expected_name.as_str() {
+        return Err(format!(
+            "agent_token_identity_mismatch: expected '{}', resolved '{}'",
+            expected_name, agent.name
+        ));
+    }
+
+    fleet_delivery_book.bind_authoritative_identity(agent.name.clone(), agent.id.clone());
+    Ok(crate::node_control::AgentRegistrationToken {
+        name: agent.name,
+        agent_id: agent.id,
+        token: token.to_string(),
+        delivery_ack_seq: None,
+    })
+}
+
 pub(super) async fn refresh_fleet_inventory_session_ref(
     fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
     fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
@@ -2590,6 +2635,63 @@ mod tests {
             }
             other => panic!("expected inventory update, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn supplied_agent_token_resolves_to_authoritative_fleet_identity() {
+        let mut delivery_book = FleetDeliveryBook::default();
+        let token = registration_token_for_resolved_agent(
+            &mut delivery_book,
+            &WorkerName::from("worker-a"),
+            "at_test",
+            relaycast::Agent {
+                id: "agent-a-id".to_string(),
+                workspace_id: Some("workspace-a".to_string()),
+                name: "worker-a".to_string(),
+                agent_type: "agent".to_string(),
+                status: "active".to_string(),
+                persona: None,
+                metadata: serde_json::Map::new(),
+                created_at: None,
+                last_seen: None,
+                channels: Vec::new(),
+            },
+        )
+        .expect("matching supplied token identity should resolve");
+
+        assert_eq!(token.name, "worker-a");
+        assert_eq!(token.agent_id, "agent-a-id");
+        assert_eq!(token.token, "at_test");
+        assert_eq!(
+            delivery_book.active_agent_id("worker-a"),
+            Some("agent-a-id")
+        );
+    }
+
+    #[test]
+    fn supplied_agent_token_rejects_a_different_agent_identity() {
+        let mut delivery_book = FleetDeliveryBook::default();
+        let error = registration_token_for_resolved_agent(
+            &mut delivery_book,
+            &WorkerName::from("worker-a"),
+            "at_test",
+            relaycast::Agent {
+                id: "agent-b-id".to_string(),
+                workspace_id: Some("workspace-a".to_string()),
+                name: "worker-b".to_string(),
+                agent_type: "agent".to_string(),
+                status: "active".to_string(),
+                persona: None,
+                metadata: serde_json::Map::new(),
+                created_at: None,
+                last_seen: None,
+                channels: Vec::new(),
+            },
+        )
+        .expect_err("a supplied token for another agent must not enter inventory");
+
+        assert!(error.contains("agent_token_identity_mismatch"));
+        assert_eq!(delivery_book.active_agent_id("worker-a"), None);
     }
 
     #[tokio::test]

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -354,6 +354,7 @@ pub(super) async fn spawn_worker_from_request(
     agent_spawn_count: &mut u32,
     fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
     fleet_delivery_book: &mut FleetDeliveryBook,
+    fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
     node_name: &str,
     invocation_id: Option<String>,
     session_ref: Option<String>,
@@ -488,6 +489,7 @@ pub(super) async fn spawn_worker_from_request(
     // injected as RELAY_AGENT_TOKEN (which also sets RELAY_SKIP_BOOTSTRAP), so
     // the worker MCP never re-registers over HTTP. Falls back to HTTP
     // pre-registration when node binding is unavailable.
+    let mut fleet_registration = None;
     let worker_relay_key = {
         if let Some(token) = relaycast_ws_spawn_token(ws_value)
             .filter(|_| !require_node_registration && !relaycast_spawn_verifies_ready(ws_value))
@@ -509,7 +511,9 @@ pub(super) async fn spawn_worker_from_request(
                         worker = %name,
                         "bound agent to node via agent.register for action.invoke spawn"
                     );
-                    Some(token.token)
+                    let relay_key = token.token.clone();
+                    fleet_registration = Some((token, invocation_id.clone(), session_ref.clone()));
+                    Some(relay_key)
                 }
                 Err(node_error) => {
                     if require_node_registration || relaycast_spawn_verifies_ready(ws_value) {
@@ -600,6 +604,16 @@ pub(super) async fn spawn_worker_from_request(
         .await
     {
         Ok(effective_spec) => {
+            if let Some((token, invocation_id, session_ref)) = fleet_registration.take() {
+                super::fleet::record_fleet_inventory_agent(
+                    fleet_control_tx,
+                    fleet_inventory,
+                    &token,
+                    invocation_id,
+                    session_ref,
+                )
+                .await;
+            }
             if let Some(prefix) = super::api::relay_skill_prefix(
                 effective_spec.cli.as_deref().unwrap_or(&cli),
                 effective_spec.model.as_deref(),

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -495,6 +495,26 @@ pub(super) async fn spawn_worker_from_request(
             .filter(|_| !require_node_registration && !relaycast_spawn_verifies_ready(ws_value))
         {
             seed_supplied_agent_token(workspace_http, &name, &token);
+            match super::fleet::resolve_fleet_agent_token_identity(
+                workspace_http,
+                fleet_delivery_book,
+                &name,
+                &token,
+            )
+            .await
+            {
+                Ok(registration) => {
+                    fleet_registration =
+                        Some((registration, invocation_id.clone(), session_ref.clone()));
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        worker = %name,
+                        error = %error,
+                        "could not resolve supplied agent token for reconnect inventory"
+                    );
+                }
+            }
             Some(token)
         } else {
             match super::fleet::register_node_agent_token(
@@ -545,8 +565,37 @@ pub(super) async fn spawn_worker_from_request(
                             // node binding; in node-only delivery the engine only
                             // delivers to `via_node` agents. Bind it to this node
                             // so it becomes deliverable.
-                            bind_http_registered_agent_to_node(workspace_http, node_name, &name)
-                                .await;
+                            let bind_warning = bind_http_registered_agent_to_node(
+                                workspace_http,
+                                node_name,
+                                &name,
+                            )
+                            .await;
+                            if bind_warning.is_none() {
+                                match super::fleet::resolve_fleet_agent_token_identity(
+                                    workspace_http,
+                                    fleet_delivery_book,
+                                    &name,
+                                    &token,
+                                )
+                                .await
+                                {
+                                    Ok(registration) => {
+                                        fleet_registration = Some((
+                                            registration,
+                                            invocation_id.clone(),
+                                            session_ref.clone(),
+                                        ));
+                                    }
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            worker = %name,
+                                            error = %error,
+                                            "could not resolve HTTP-registered agent for reconnect inventory"
+                                        );
+                                    }
+                                }
+                            }
                             Some(token)
                         }
                         Ok(Err(error)) => {


### PR DESCRIPTION
## Summary

- retain each successfully launched, node-registered worker in the broker reconnect inventory
- resolve opaque caller-supplied and HTTP-fallback tokens to their authoritative agent IDs, validating the requested name before inventorying them
- deliver inventory updates reliably and in order under fleet-control backpressure
- replay that inventory through the existing inventory.sync reconnect path so Relaycast reactivates live workers
- preserve invocation and resumable-session metadata in the snapshot

### Root cause

Relaycast deliberately marks all agents attached to a node provider offline when its node-control socket disconnects. The broker reconnect path can restore those agents through inventory.sync, but production fleet_inventory started empty and successful agent.register calls only populated FleetDeliveryBook. The node therefore reconnected with an empty inventory while its local worker processes remained alive. Node heartbeat and activeAgents could be healthy at the same time that individual roster rows remained offline.

This records inventory only after process launch succeeds, so a failed spawn is not advertised as live. Existing release and failed-spawn cleanup paths already prune the same inventory. Opaque pre-minted tokens are resolved through the authenticated current-agent endpoint; a token for a different name is rejected from reconnect inventory. Inventory publication now awaits bounded-channel capacity instead of dropping the only updated snapshot.

Refs #1458. This is complementary to #1462: that PR detects blackholed node-control sockets; this PR makes any eventual reconnect restore individual agent state.

## Test Plan

- [x] Added regression coverage for retaining a successful registration and publishing the complete reconnect inventory
- [x] Added supplied-token identity resolution and name-mismatch regression coverage
- [x] Added bounded-channel backpressure coverage proving inventory publication waits instead of dropping
- [x] cargo test -p agent-relay-broker --lib (916 passed, 0 failed, 4 ignored)
- [x] cargo test -p agent-relay-broker successful_node_registration_is_added_to_reconnect_inventory
- [x] cargo test -p agent-relay-broker supplied_agent_token_
- [x] cargo test -p agent-relay-broker fleet_inventory_snapshot_waits_for_backpressure_instead_of_dropping
- [x] cargo test -p agent-relay-broker node_control_reconnect_sends_inventory_sync
- [x] cargo test -p agent-relay-broker refresh_fleet_inventory_session_ref_publishes_immediate_sync
- [x] cargo fmt -p agent-relay-broker -- --check
- [x] cargo clippy -p agent-relay-broker --lib -- -D warnings
- [ ] Forced production node disconnect (not performed because it would mark every worker on the shared node offline)

Note: clippy with --tests reaches two pre-existing unrelated warnings in crates/broker/src/snippets.rs and crates/broker/src/runtime/worker_events.rs. The non-test library target is clean.

## Screenshots

Not applicable.