### PR TITLE
fix(broker): keep idle fleet agents active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Fleet brokers now periodically renew live worker inventory so quiet agents remain active in Relaycast instead of aging offline while their node is healthy.
 
 ## [11.6.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fleet brokers now periodically renew live worker inventory so quiet agents remain active in Relaycast instead of aging offline while their node is healthy.
+- Fleet brokers now periodically renew authoritative worker inventory, including empty snapshots that clear stale server entries, so quiet agents remain active in Relaycast instead of aging offline while their node is healthy.
 
 ## [11.6.0] - 2026-08-13
 

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -27,6 +27,11 @@ use crate::{
 };
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(12);
+// Relaycast's agent-presence lease expires after five minutes of authenticated
+// silence. A node heartbeat renews only the node/provider row, so replay the
+// authoritative live-worker inventory well inside that window even when every
+// worker is otherwise idle.
+const INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
 const REGISTER_AGENT_PENDING_TTL: Duration = Duration::from_secs(300);
@@ -1426,6 +1431,7 @@ pub(crate) async fn run_node_control_client(
             &mut registration,
             &mut inventory,
             &mut load,
+            INVENTORY_REFRESH_INTERVAL,
         )
         .await;
         if matches!(result, ControlRunResult::Shutdown) {
@@ -1516,6 +1522,7 @@ async fn run_connected_once(
     registration: &mut Option<NodeRegister>,
     inventory: &mut Vec<InventoryAgent>,
     load: &mut FleetLoadSnapshot,
+    inventory_refresh_interval: Duration,
 ) -> ControlRunResult {
     let Some(mut node_register) = registration.clone() else {
         return ControlRunResult::Disconnected;
@@ -1617,6 +1624,12 @@ async fn run_connected_once(
 
     let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut inventory_refresh = tokio::time::interval(inventory_refresh_interval);
+    inventory_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Tokio intervals tick immediately. The initial inventory.sync above has
+    // already renewed the lease, so schedule the first refresh one full period
+    // from now instead of duplicating it on connection setup.
+    inventory_refresh.tick().await;
 
     loop {
         tokio::select! {
@@ -1694,6 +1707,26 @@ async fn run_connected_once(
                 expire_agent_registrations(&mut pending_agent_registrations, Instant::now());
                 if send_wire(&mut sink, &BrokerToRelaycast::NodeHeartbeat(load.heartbeat(&node_register))).await.is_err() {
                     drain_agent_registrations(&mut pending_agent_registrations, "node_control_disconnected");
+                    return ControlRunResult::Disconnected;
+                }
+            }
+            _ = inventory_refresh.tick() => {
+                if !inventory.is_empty()
+                    && send_wire(
+                        &mut sink,
+                        &BrokerToRelaycast::InventorySync(InventorySync {
+                            v: FLEET_WIRE_VERSION,
+                            id: None,
+                            agents: inventory.clone(),
+                        }),
+                    )
+                    .await
+                    .is_err()
+                {
+                    drain_agent_registrations(
+                        &mut pending_agent_registrations,
+                        "node_control_disconnected",
+                    );
                     return ControlRunResult::Disconnected;
                 }
             }
@@ -3433,6 +3466,91 @@ mod tests {
             .unwrap();
         let _ = command_tx.send(FleetControlCommand::Shutdown).await;
     }
+
+    #[tokio::test]
+    async fn connected_node_refreshes_idle_agent_inventory_before_presence_expires() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ws_url = format!("ws://{}/v1/node/ws", listener.local_addr().unwrap());
+        let (_command_tx, mut command_rx) = mpsc::channel(4);
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let mut registration = Some(build_node_register(
+            &test_manifest(),
+            "node-test",
+            "host-test",
+            "broker/test",
+            None,
+        ));
+        let mut inventory = vec![InventoryAgent {
+            agent_id: "agt-1".to_string(),
+            name: "agent-a".to_string(),
+            invocation_id: Some("inv-1".to_string()),
+            session_ref: Some("session-1".to_string()),
+        }];
+        let mut load = FleetLoadSnapshot {
+            active_agents: 1,
+            max_agents: 4,
+            handlers_live: true,
+        };
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            assert!(matches!(
+                next_node_to_server(&mut ws).await,
+                BrokerToRelaycast::NodeRegister(_)
+            ));
+            assert!(matches!(
+                next_node_to_server(&mut ws).await,
+                BrokerToRelaycast::InventorySync(_)
+            ));
+            assert!(matches!(
+                next_node_to_server(&mut ws).await,
+                BrokerToRelaycast::NodeHeartbeat(_)
+            ));
+
+            let refreshed = tokio::time::timeout(
+                Duration::from_millis(500),
+                next_non_heartbeat_node_to_server(&mut ws),
+            )
+            .await
+            .expect("a live but idle agent must renew its Relaycast presence lease");
+            match refreshed {
+                BrokerToRelaycast::InventorySync(sync) => {
+                    assert_eq!(sync.agents.len(), 1);
+                    assert_eq!(sync.agents[0].name, "agent-a");
+                }
+                other => panic!("expected periodic inventory.sync, got {other:?}"),
+            }
+            ws.close(None).await.unwrap();
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            run_connected_once(
+                &FleetControlConfig {
+                    ws_url,
+                    node_token: Some("nt_test".to_string()),
+                    node_id: "node-test".to_string(),
+                    node_name: "host-test".to_string(),
+                    broker_version: "broker/test".to_string(),
+                    token_minter: None,
+                    session_token: None,
+                },
+                &mut command_rx,
+                &event_tx,
+                &mut registration,
+                &mut inventory,
+                &mut load,
+                Duration::from_millis(25),
+            ),
+        )
+        .await
+        .expect("mock node-control session should finish");
+
+        assert_eq!(result, ControlRunResult::Disconnected);
+        server.await.unwrap();
+    }
+
     #[tokio::test]
     async fn node_control_reconnect_sends_inventory_sync() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -3473,7 +3591,7 @@ mod tests {
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeRegister(_)
             ));
-            match next_node_to_server(&mut ws).await {
+            match next_non_heartbeat_node_to_server(&mut ws).await {
                 BrokerToRelaycast::InventorySync(sync) => {
                     assert_eq!(sync.agents.len(), 1);
                     assert_eq!(sync.agents[0].name, "agent-a");

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -1598,18 +1598,7 @@ async fn run_connected_once(
     {
         return ControlRunResult::Disconnected;
     }
-    if !inventory.is_empty()
-        && send_wire(
-            &mut sink,
-            &BrokerToRelaycast::InventorySync(InventorySync {
-                v: FLEET_WIRE_VERSION,
-                id: None,
-                agents: inventory.clone(),
-            }),
-        )
-        .await
-        .is_err()
-    {
+    if !send_inventory_sync(&mut sink, inventory, &mut pending_agent_registrations).await {
         return ControlRunResult::Disconnected;
     }
     if send_wire(
@@ -1648,21 +1637,13 @@ async fn run_connected_once(
                     }
                     Some(FleetControlCommand::UpdateInventory(next)) => {
                         *inventory = next;
-                        if send_wire(
+                        if !send_inventory_sync(
                             &mut sink,
-                            &BrokerToRelaycast::InventorySync(InventorySync {
-                                v: FLEET_WIRE_VERSION,
-                                id: None,
-                                agents: inventory.clone(),
-                            }),
+                            inventory,
+                            &mut pending_agent_registrations,
                         )
                         .await
-                        .is_err()
                         {
-                            drain_agent_registrations(
-                                &mut pending_agent_registrations,
-                                "node_control_disconnected",
-                            );
                             return ControlRunResult::Disconnected;
                         }
                     }
@@ -1711,22 +1692,13 @@ async fn run_connected_once(
                 }
             }
             _ = inventory_refresh.tick() => {
-                if !inventory.is_empty()
-                    && send_wire(
-                        &mut sink,
-                        &BrokerToRelaycast::InventorySync(InventorySync {
-                            v: FLEET_WIRE_VERSION,
-                            id: None,
-                            agents: inventory.clone(),
-                        }),
-                    )
-                    .await
-                    .is_err()
+                if !send_inventory_sync(
+                    &mut sink,
+                    inventory,
+                    &mut pending_agent_registrations,
+                )
+                .await
                 {
-                    drain_agent_registrations(
-                        &mut pending_agent_registrations,
-                        "node_control_disconnected",
-                    );
                     return ControlRunResult::Disconnected;
                 }
             }
@@ -1750,6 +1722,33 @@ async fn run_connected_once(
             }
         }
     }
+}
+
+async fn send_inventory_sync<S>(
+    sink: &mut S,
+    inventory: &[InventoryAgent],
+    pending_agent_registrations: &mut HashMap<String, PendingAgentRegistration>,
+) -> bool
+where
+    S: Sink<Message> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    if send_wire(
+        sink,
+        &BrokerToRelaycast::InventorySync(InventorySync {
+            v: FLEET_WIRE_VERSION,
+            id: None,
+            agents: inventory.to_vec(),
+        }),
+    )
+    .await
+    .is_err()
+    {
+        drain_agent_registrations(pending_agent_registrations, "node_control_disconnected");
+        return false;
+    }
+
+    true
 }
 
 async fn handle_server_message<S>(
@@ -3042,6 +3041,10 @@ mod tests {
 
             let register = next_node_to_server(&mut ws).await;
             assert!(matches!(register, BrokerToRelaycast::NodeRegister(_)));
+            match next_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected initial empty inventory.sync, got {other:?}"),
+            }
             let heartbeat = next_node_to_server(&mut ws).await;
             match heartbeat {
                 BrokerToRelaycast::NodeHeartbeat(heartbeat) => {
@@ -3164,6 +3167,10 @@ mod tests {
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeRegister(_)
             ));
+            match next_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected initial empty inventory.sync, got {other:?}"),
+            }
             assert!(matches!(
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeHeartbeat(_)
@@ -3388,6 +3395,10 @@ mod tests {
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeRegister(_)
             ));
+            match next_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected initial empty inventory.sync, got {other:?}"),
+            }
             assert!(matches!(
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeHeartbeat(_)
@@ -3552,6 +3563,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connected_node_replays_empty_inventory_to_clear_stale_presence() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ws_url = format!("ws://{}/v1/node/ws", listener.local_addr().unwrap());
+        let (_command_tx, mut command_rx) = mpsc::channel(4);
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let mut registration = Some(build_node_register(
+            &test_manifest(),
+            "node-test",
+            "host-test",
+            "broker/test",
+            None,
+        ));
+        let mut inventory = Vec::new();
+        let mut load = FleetLoadSnapshot {
+            active_agents: 0,
+            max_agents: 4,
+            handlers_live: true,
+        };
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            assert!(matches!(
+                next_node_to_server(&mut ws).await,
+                BrokerToRelaycast::NodeRegister(_)
+            ));
+            match next_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected initial empty inventory.sync, got {other:?}"),
+            }
+            assert!(matches!(
+                next_node_to_server(&mut ws).await,
+                BrokerToRelaycast::NodeHeartbeat(_)
+            ));
+
+            let refreshed = tokio::time::timeout(
+                Duration::from_millis(500),
+                next_non_heartbeat_node_to_server(&mut ws),
+            )
+            .await
+            .expect("an empty authoritative inventory must be periodically replayed");
+            match refreshed {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected periodic empty inventory.sync, got {other:?}"),
+            }
+            ws.close(None).await.unwrap();
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            run_connected_once(
+                &FleetControlConfig {
+                    ws_url,
+                    node_token: Some("nt_test".to_string()),
+                    node_id: "node-test".to_string(),
+                    node_name: "host-test".to_string(),
+                    broker_version: "broker/test".to_string(),
+                    token_minter: None,
+                    session_token: None,
+                },
+                &mut command_rx,
+                &event_tx,
+                &mut registration,
+                &mut inventory,
+                &mut load,
+                Duration::from_millis(25),
+            ),
+        )
+        .await
+        .expect("mock node-control session should finish");
+
+        assert_eq!(result, ControlRunResult::Disconnected);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn node_control_reconnect_sends_inventory_sync() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let ws_url = format!("ws://{}/v1/node/ws", listener.local_addr().unwrap());
@@ -3579,10 +3666,21 @@ mod tests {
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeRegister(_)
             ));
+            match next_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => assert!(sync.agents.is_empty()),
+                other => panic!("expected initial empty inventory.sync, got {other:?}"),
+            }
             assert!(matches!(
                 next_node_to_server(&mut ws).await,
                 BrokerToRelaycast::NodeHeartbeat(_)
             ));
+            match next_non_heartbeat_node_to_server(&mut ws).await {
+                BrokerToRelaycast::InventorySync(sync) => {
+                    assert_eq!(sync.agents.len(), 1);
+                    assert_eq!(sync.agents[0].name, "agent-a");
+                }
+                other => panic!("expected inventory update before reconnect, got {other:?}"),
+            }
             ws.close(None).await.unwrap();
 
             let (stream, _) = listener.accept().await.unwrap();


### PR DESCRIPTION
## Summary

- renew the authoritative live-worker inventory once per minute while node control remains connected
- send authoritative snapshots even when empty, clearing stale server-side workers immediately on connect and on periodic refresh
- centralize inventory snapshot construction and disconnect cleanup in one helper shared by connect, mutation, and refresh paths
- preserve the immediate mutation and reconnect inventory behavior added by #1494
- add regression coverage for quiet live workers and stale presence cleanup from empty inventories

## What #1494 fixed vs. this residual gap

#1494 made successful launches enter fleet_inventory, published snapshots reliably on changes, and replayed the inventory after reconnect. That fixes agents stranded offline by a provider disconnect. The remaining gap was time based: after the reconnect or launch snapshot, a healthy but idle worker produced no more agent-authenticated activity and no further inventory snapshot.

## Root cause

Relaycast expires active agent presence after five minutes without authenticated agent activity. Broker node heartbeats run every 12 seconds, but they renew only the node/provider rows. inventory.sync refreshes each authoritative agent row, yet before this change the broker sent it only on inventory changes and reconnect. A live worker that stayed quiet for five minutes therefore aged offline while its node remained healthy and online.

The broker now replays authoritative inventory every 60 seconds, well inside that lease. Empty snapshots are sent too, both immediately after connecting and periodically, so Relaycast clears workers that no longer exist locally. Worker exit and release paths still remove workers and immediately publish the pruned inventory.

## Verification

- [x] Added a red-before regression: without the renewal, the mock Relaycast server times out waiting for the idle workers next inventory.sync
- [x] Added regression coverage proving empty authoritative snapshots are sent on connect and periodic refresh
- [x] Ran an isolated local Relaycast engine on 127.0.0.1:18787 and the patched broker on 127.0.0.1:18788
- [x] Bound a locally minted node token to the exact isolated node ID, then confirmed the node stayed online with accepted 12-second heartbeats
- [x] Spawned an idle /bin/sh worker, sent it no input, and observed its PID remain alive while the agent stayed active beyond the five-minute TTL; last_seen advanced once per minute (11:34:49Z to 11:40:22Z)
- [x] Did not restart, reconfigure, deploy to, or otherwise touch finn-mini, sf-mini, barry, or the Daytona broker

## Test plan

- [x] cargo test -p agent-relay-broker (925 library tests passed, 4 ignored; 16 integration tests passed)
- [x] cargo test -p agent-relay-broker node_control::tests:: (51 passed)
- [x] cargo fmt -p agent-relay-broker -- --check
- [x] cargo clippy -p agent-relay-broker --lib -- -D warnings
- [x] git diff --check

Refs #1458. Follow-up to #1494.