### PR TITLE
fix(cli): let `node agent attach --node` take an explicit --workspace-key

### DIFF
--- a/.agentworkforce/trajectories/active/traj_io278d9ai5tw/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_io278d9ai5tw/trajectory.json
@@ -31,6 +31,18 @@
             "reasoning": "handle_api_request is a method on BrokerRuntime that takes &mut self. Calling it from handle_terminal_control_event (also &mut self) is valid sequential Rust. The oneshot channel is used only for data handoff — tx.send() happens synchronously inside handle_api_request, rx.await() resolves immediately after. This reuses the exact HTTP code path including side effects: interactive-hold frame, sdk_out event emission, queue flush on transition."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1786688147387,
+          "type": "decision",
+          "content": "Address every live PR #1502 review thread in one follow-up: raw option presence, path-specific guidance, regression coverage, and changelog: Address every live PR #1502 review thread in one follow-up: raw option presence, path-specific guidance, regression coverage, and changelog",
+          "raw": {
+            "question": "Address every live PR #1502 review thread in one follow-up: raw option presence, path-specific guidance, regression coverage, and changelog",
+            "chosen": "Address every live PR #1502 review thread in one follow-up: raw option presence, path-specific guidance, regression coverage, and changelog",
+            "alternatives": [],
+            "reasoning": "All five findings are valid or required by AGENTS.md; resolving the complete set avoids leaving the PR knowingly incomplete"
+          },
+          "significance": "high"
         }
       ]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Added
+
+- `agent-relay node agent attach --node` accepts `--workspace-key`, so a fleet attach command copied out of the Cloud dashboard resolves the intended workspace regardless of the directory it is pasted into. The flag is rejected on the local and `--ssh-host` paths, which authenticate with the broker instead.
 
 ## [11.6.1] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
 
 ### Added
 
-- `agent-relay node agent attach --node` accepts `--workspace-key`, so a fleet attach command copied out of the Cloud dashboard resolves the intended workspace regardless of the directory it is pasted into. The flag is rejected on the local and `--ssh-host` paths, which authenticate with the broker instead.
+- `agent-relay node agent attach --node` now accepts `--workspace-key`, so commands copied from the Cloud dashboard resolve the intended workspace regardless of the working directory.
+- Passing `--workspace-key` to the local or `--ssh-host` attach path is rejected because those paths authenticate with the broker instead.
 
 ## [11.6.1] - 2026-08-13
 

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -216,7 +216,7 @@ describe('local agent subtree', () => {
   // The two rejected paths do not take the same credentials: --ssh-host itself
   // rejects --broker-url / --api-key, so naming them there sends the caller
   // into a second, contradictory error.
-  it('attach points a rejected local-broker caller at --broker-url / --api-key', async () => {
+  it('attach points a rejected local-broker caller at its supported connection options', async () => {
     const { program, error } = harness();
     await program.parseAsync(['local', 'agent', 'attach', 'lead', '--workspace-key', 'rk_live_explicit'], {
       from: 'user',
@@ -224,7 +224,7 @@ describe('local agent subtree', () => {
     const message = error.mock.calls.at(0)?.[0] as string;
     expect(message).toContain('--broker-url');
     expect(message).toContain('--api-key');
-    expect(message).not.toContain('--state-dir');
+    expect(message).toContain('--state-dir');
     // Guidance for a path the caller is not on is guidance they cannot follow.
     expect(message).not.toContain('--ssh-host');
   });

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -137,6 +137,56 @@ describe('local agent subtree', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  it('attach --node forwards --workspace-key so a copy-pasted command is cwd-independent', async () => {
+    const { program, attachNode } = harness();
+    await program.parseAsync(
+      ['local', 'agent', 'attach', 'lead', '--node', 'sf-mini', '--workspace-key', 'rk_live_explicit'],
+      { from: 'user' }
+    );
+    expect(attachNode).toHaveBeenCalledWith(
+      'lead',
+      'view',
+      'sf-mini',
+      expect.objectContaining({ workspaceKey: 'rk_live_explicit' })
+    );
+  });
+
+  it('attach --node without --workspace-key leaves the precedence ladder to resolve it', async () => {
+    const { program, attachNode } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--node', 'sf-mini'], { from: 'user' });
+    expect(attachNode).toHaveBeenCalledWith(
+      'lead',
+      'view',
+      'sf-mini',
+      expect.objectContaining({ workspaceKey: undefined })
+    );
+  });
+
+  it('attach --node treats a blank --workspace-key as unset rather than a literal credential', async () => {
+    const { program, attachNode } = harness();
+    await program.parseAsync(
+      ['local', 'agent', 'attach', 'lead', '--node', 'sf-mini', '--workspace-key', '   '],
+      { from: 'user' }
+    );
+    expect(attachNode).toHaveBeenCalledWith(
+      'lead',
+      'view',
+      'sf-mini',
+      expect.objectContaining({ workspaceKey: undefined })
+    );
+  });
+
+  it('attach rejects --workspace-key without --node instead of silently ignoring it', async () => {
+    const { program, attach, attachNode, error, exit } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--workspace-key', 'rk_live_explicit'], {
+      from: 'user',
+    });
+    expect(attach).not.toHaveBeenCalled();
+    expect(attachNode).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--workspace-key requires --node'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
   it('attach --node prefixes a terminal setup error once', async () => {
     const attachNode = vi.fn(async () => {
       throw new Error('terminal unavailable');

--- a/packages/cli/src/cli/commands/local-agent.test.ts
+++ b/packages/cli/src/cli/commands/local-agent.test.ts
@@ -187,6 +187,60 @@ describe('local agent subtree', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  // `--workspace-key "$KEY"` with an unset variable reaches the parser as a
+  // blank string. Normalizing it away before the path check would hand the
+  // caller a silent local attach against whatever broker happened to be there.
+  it('attach rejects a blank --workspace-key without --node rather than falling through to the local broker', async () => {
+    const { program, attach, attachNode, error, exit } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--workspace-key', '   '], {
+      from: 'user',
+    });
+    expect(attach).not.toHaveBeenCalled();
+    expect(attachNode).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--workspace-key requires --node'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('attach rejects a blank --workspace-key on the --ssh-host path rather than silently attaching', async () => {
+    const { program, attachRemote, attachNode, error, exit } = harness();
+    await program.parseAsync(
+      ['local', 'agent', 'attach', 'lead', '--ssh-host', 'barry', '--workspace-key', ''],
+      { from: 'user' }
+    );
+    expect(attachRemote).not.toHaveBeenCalled();
+    expect(attachNode).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--workspace-key requires --node'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  // The two rejected paths do not take the same credentials: --ssh-host itself
+  // rejects --broker-url / --api-key, so naming them there sends the caller
+  // into a second, contradictory error.
+  it('attach points a rejected local-broker caller at --broker-url / --api-key', async () => {
+    const { program, error } = harness();
+    await program.parseAsync(['local', 'agent', 'attach', 'lead', '--workspace-key', 'rk_live_explicit'], {
+      from: 'user',
+    });
+    const message = error.mock.calls.at(0)?.[0] as string;
+    expect(message).toContain('--broker-url');
+    expect(message).toContain('--api-key');
+    expect(message).not.toContain('--state-dir');
+    // Guidance for a path the caller is not on is guidance they cannot follow.
+    expect(message).not.toContain('--ssh-host');
+  });
+
+  it('attach points a rejected --ssh-host caller at --state-dir, not the flags that path forbids', async () => {
+    const { program, error } = harness();
+    await program.parseAsync(
+      ['local', 'agent', 'attach', 'lead', '--ssh-host', 'barry', '--workspace-key', 'rk_live_explicit'],
+      { from: 'user' }
+    );
+    const message = error.mock.calls.at(0)?.[0] as string;
+    expect(message).toContain('--state-dir');
+    expect(message).not.toContain('--broker-url');
+    expect(message).not.toContain('--api-key');
+  });
+
   it('attach --node prefixes a terminal setup error once', async () => {
     const attachNode = vi.fn(async () => {
       throw new Error('terminal unavailable');

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -79,6 +79,19 @@ export function runAttach(name: string, mode: AttachMode, options: NativeAttachO
 }
 
 /**
+ * Options for the `--node` fleet path. Deliberately not `NativeAttachOptions`:
+ * a fleet attach authenticates with the Relaycast workspace key and has no
+ * local broker, so `--broker-url` / `--api-key` / `--state-dir` are rejected
+ * rather than accepted and ignored.
+ */
+export type FleetNodeAttachCliOptions = Pick<
+  NativeAttachOptions,
+  'json' | 'reasoning' | 'diagnostics'
+> & {
+  workspaceKey?: string;
+};
+
+/**
  * Run an existing attach mode against the short-lived loopback adapter for a
  * remote fleet node. Deliberately bypasses native-harness detection: the proxy
  * represents a PTY byte stream, while native mode is an event protocol.
@@ -87,9 +100,14 @@ export async function attachFleetNode(
   name: string,
   mode: AttachMode,
   node: string,
-  options: NativeAttachOptions
+  options: FleetNodeAttachCliOptions
 ): Promise<number> {
-  const proxy = await startFleetNodeAttachProxy({ agent: name, node, mode });
+  const proxy = await startFleetNodeAttachProxy({
+    agent: name,
+    node,
+    mode,
+    ...(options.workspaceKey === undefined ? {} : { workspaceKey: options.workspaceKey }),
+  });
   const jsonWriter = options.json ? createBackpressureAwareWriter(process.stdout) : undefined;
   try {
     const connectionOptions = { brokerUrl: proxy.brokerUrl, apiKey: proxy.apiKey };
@@ -160,7 +178,12 @@ export interface LocalAgentDependencies {
     node: string,
     options: RemoteNodeAttachOptions
   ) => Promise<number>;
-  attachNode: (name: string, mode: AttachMode, node: string, options: NativeAttachOptions) => Promise<number>;
+  attachNode: (
+    name: string,
+    mode: AttachMode,
+    node: string,
+    options: FleetNodeAttachCliOptions
+  ) => Promise<number>;
   cwd: () => string;
   readConnectionFile: (stateDir: string) => unknown;
   getDefaultStateDir: () => string;
@@ -573,6 +596,10 @@ export function registerLocalAgentCommands(
       '--state-dir <dir>',
       'Directory containing connection.json (with --ssh-host: path on target; auto-discovered when omitted)'
     )
+    .option(
+      '--workspace-key <key>',
+      'Relaycast workspace key for --node (overrides RELAY_WORKSPACE_KEY, the project pin, and the machine-global active workspace)'
+    )
     .option('--json', 'Emit normalized agent events as NDJSON')
     .option('--reasoning', 'Include agent reasoning events')
     .option('--diagnostics', 'Include native harness diagnostics')
@@ -585,6 +612,20 @@ export function registerLocalAgentCommands(
       }
       const sshHost = options.sshHost as string | undefined;
       const node = options.node as string | undefined;
+      // An all-whitespace flag must fall through to the normal precedence
+      // ladder rather than being sent as a literal credential.
+      const rawWorkspaceKey = options.workspaceKey as string | undefined;
+      const workspaceKey = rawWorkspaceKey?.trim() ? rawWorkspaceKey.trim() : undefined;
+      // Only the fleet path authenticates with a workspace key. The local and
+      // SSH paths speak the broker contract, so accepting the flag there would
+      // silently ignore it and send the caller to the wrong workspace.
+      if (workspaceKey !== undefined && node === undefined) {
+        deps.error(
+          'Error: --workspace-key requires --node. The local and --ssh-host attach paths authenticate with --broker-url / --api-key instead.'
+        );
+        deps.exit(1);
+        return;
+      }
       if (node !== undefined && sshHost !== undefined) {
         deps.error(
           'Error: --node cannot be combined with --ssh-host. Use --ssh-host only as the explicit SSH fallback.'
@@ -606,6 +647,7 @@ export function registerLocalAgentCommands(
         }
         try {
           const code = await deps.attachNode(name, mode, node, {
+            workspaceKey,
             json: options.json as boolean | undefined,
             reasoning: options.reasoning as boolean | undefined,
             diagnostics: options.diagnostics as boolean | undefined,

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -626,7 +626,7 @@ export function registerLocalAgentCommands(
         deps.error(
           sshHost !== undefined
             ? 'Error: --workspace-key requires --node. The --ssh-host attach path reads the target broker connection.json — locate it with --state-dir instead.'
-            : 'Error: --workspace-key requires --node. The local attach path authenticates with --broker-url / --api-key instead.'
+            : 'Error: --workspace-key requires --node. The local attach path uses --broker-url / --api-key or reads connection.json from --state-dir instead.'
         );
         deps.exit(1);
         return;

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -615,10 +615,18 @@ export function registerLocalAgentCommands(
       const workspaceKey = rawWorkspaceKey?.trim() ? rawWorkspaceKey.trim() : undefined;
       // Only the fleet path authenticates with a workspace key. The local and
       // SSH paths speak the broker contract, so accepting the flag there would
-      // silently ignore it and send the caller to the wrong workspace.
-      if (workspaceKey !== undefined && node === undefined) {
+      // silently ignore it and send the caller to the wrong workspace. Gate on
+      // the raw option rather than the normalized one: `--workspace-key "$KEY"`
+      // with an unset variable is still a caller asking for a workspace, and
+      // must be told so instead of being routed to a broker.
+      if (rawWorkspaceKey !== undefined && node === undefined) {
+        // The two rejected paths take different credentials, so name the ones
+        // the caller's path actually accepts — --ssh-host rejects
+        // --broker-url / --api-key and reads connection.json on the target.
         deps.error(
-          'Error: --workspace-key requires --node. The local and --ssh-host attach paths authenticate with --broker-url / --api-key instead.'
+          sshHost !== undefined
+            ? 'Error: --workspace-key requires --node. The --ssh-host attach path reads the target broker connection.json — locate it with --state-dir instead.'
+            : 'Error: --workspace-key requires --node. The local attach path authenticates with --broker-url / --api-key instead.'
         );
         deps.exit(1);
         return;

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -84,10 +84,7 @@ export function runAttach(name: string, mode: AttachMode, options: NativeAttachO
  * local broker, so `--broker-url` / `--api-key` / `--state-dir` are rejected
  * rather than accepted and ignored.
  */
-export type FleetNodeAttachCliOptions = Pick<
-  NativeAttachOptions,
-  'json' | 'reasoning' | 'diagnostics'
-> & {
+export type FleetNodeAttachCliOptions = Pick<NativeAttachOptions, 'json' | 'reasoning' | 'diagnostics'> & {
   workspaceKey?: string;
 };
 

--- a/packages/cli/src/cli/lib/attach-fleet-node.test.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.test.ts
@@ -262,3 +262,74 @@ describe('startFleetNodeAttachProxy delivery-mode PUT lifecycle', () => {
     expect(elapsedMs).toBeLessThan(5_000);
   }, 10_000);
 });
+
+describe('startFleetNodeAttachProxy workspace-key precedence', () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      const fn = cleanup.pop()!;
+      await fn().catch(() => undefined);
+    }
+  });
+
+  /** Ticket fetch that records the Authorization header it was called with. */
+  function capturingTicketFetch(remoteUrl: string): {
+    fetch: typeof globalThis.fetch;
+    authorization: () => string | undefined;
+  } {
+    let seen: string | undefined;
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      seen = headers.Authorization;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            session_id: SESSION_ID,
+            terminal_url: `${remoteUrl}?ticket=abc`,
+            resume_token: RESUME_TOKEN,
+          },
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    return { fetch: fetchFn, authorization: () => seen };
+  }
+
+  it('presents an explicit workspace key ahead of the ambient environment', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const ticket = capturingTicketFetch(remote.url);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-e',
+      node: 'node-e',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'rk_live_explicit',
+      env: { RELAY_WORKSPACE_KEY: 'rk_live_ambient' },
+      fetch: ticket.fetch,
+    });
+    cleanup.push(proxy.close);
+
+    expect(ticket.authorization()).toBe('Bearer rk_live_explicit');
+  });
+
+  it('falls back to the environment when no explicit key is supplied', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const ticket = capturingTicketFetch(remote.url);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-f',
+      node: 'node-f',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      env: { RELAY_WORKSPACE_KEY: 'rk_live_ambient' },
+      fetch: ticket.fetch,
+    });
+    cleanup.push(proxy.close);
+
+    expect(ticket.authorization()).toBe('Bearer rk_live_ambient');
+  });
+});


### PR DESCRIPTION
## Problem

A fleet attach command copied out of the Cloud dashboard —

```
agent-relay node agent attach '<agent>' --node '<node>' --mode <mode>
```

— is only useful if it works wherever it is pasted. Today it does not, and the reason is not the local broker `connection.json` (the `--node` path never reads it). `--node` authenticates with the **Relaycast workspace key**, resolved through the ladder in `resolveWorkspaceSelection`:

```
flag > env > <project>/.agentworkforce/relay/workspace-key.json > machine-global store
```

`agent attach` exposed no flag, so the top rung was unreachable. Reproduced against the installed CLI (v11.5.5):

| where it runs | result |
|---|---|
| dir whose repo pins a *different* workspace | `Error: Invalid API key` — the project pin outranks the global active entry |
| machine with no pin and no global active entry | `Error: No workspace key found. Pass --workspace-key, ...` |
| `agent attach ... --workspace-key <key>` | `error: unknown option '--workspace-key'` |

The error message names a flag the command rejects. And the obvious-looking workaround does not exist either — `--node` is mutually exclusive with `--broker-url` / `--api-key` / `--state-dir`, because those configure a local broker that this path has no use for.

## Fix

Add `--workspace-key <key>` to `node agent attach` and thread it into `startFleetNodeAttachProxy`. `FleetNodeAttachOptions.workspaceKey` already existed and already took precedence over the environment — only the CLI surface was missing.

- Accepted **only** with `--node`. The local and `--ssh-host` paths speak the broker contract, so accepting it there would resolve nothing and quietly point the caller at the wrong workspace. Rejected with a message that says which flags those paths use instead.
- A blank/whitespace value falls through to the ladder rather than being presented as a literal credential.
- `attachNode` now takes `FleetNodeAttachCliOptions` rather than `NativeAttachOptions`, so the type stops advertising the three broker fields this path rejects at parse time.

## Verification

- Red-check: the four new CLI tests fail against unmodified source (`CommanderError: unknown option '--workspace-key'`) and pass after. The 38 pre-existing tests in those files stay green throughout.
- The two `attach-fleet-node` tests are precedence **regression guards**, not novelty proofs — they pass before and after, because that plumbing already worked. They pin explicit-key-beats-env so a later refactor cannot quietly invert it.
- `npm run typecheck` exits 0.
- `npx eslint` — 0 errors. One pre-existing `complexity` warning on the attach action rises 20 → 24; lint runs without `--max-warnings`, so this does not fail CI. Splitting that action is left out to keep this diff to the defect.

## Note on scope

This is the enabling half. The dashboard side (whether the generated command should embed a key, or carry a one-time `agent-relay workspace join` hint instead) is a separate call in `AgentWorkforce/cloud` — embedding `rk_live_…` in a copy-pastable UI string is a credential-handling decision, not a mechanical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

