### PR TITLE
fix(broker): avoid cold npx MCP startup

### DIFF
--- a/.agents/skills/choosing-swarm-patterns/SKILL.md
+++ b/.agents/skills/choosing-swarm-patterns/SKILL.md
@@ -309,18 +309,18 @@ verification:
 
 The old category-expanded names are wrong. Current Agent Relay MCP tools are
 flat names. In a client that decorates MCP tools, the prefix comes from the
-configured server key; workflow prompts commonly show `mcp__relaycast__send_dm`,
-while an `agent-relay` server key may expose `mcp__agent_relay__send_dm`.
+configured server key. Claude preserves the canonical `agent-relay` key,
+including its hyphen; `mcp__relaycast__*` belongs only to legacy configurations.
 
-| Purpose                  | Canonical tool    | Common workflow-prefixed form     |
-| ------------------------ | ----------------- | --------------------------------- |
-| Send DM to another agent | `send_dm`         | `mcp__relaycast__send_dm`         |
-| Check inbox              | `check_inbox`     | `mcp__relaycast__check_inbox`     |
-| List agents              | `list_agents`     | `mcp__relaycast__list_agents`     |
-| Post to a channel        | `post_message`    | `mcp__relaycast__post_message`    |
-| Reply in a thread        | `reply_to_thread` | `mcp__relaycast__reply_to_thread` |
-| Spawn sub-agent          | `add_agent`       | `mcp__relaycast__add_agent`       |
-| Remove sub-agent         | `remove_agent`    | `mcp__relaycast__remove_agent`    |
+| Purpose                  | Canonical tool    | Claude-prefixed form                |
+| ------------------------ | ----------------- | ----------------------------------- |
+| Send DM to another agent | `send_dm`         | `mcp__agent-relay__send_dm`         |
+| Check inbox              | `check_inbox`     | `mcp__agent-relay__check_inbox`     |
+| List agents              | `list_agents`     | `mcp__agent-relay__list_agents`     |
+| Post to a channel        | `post_message`    | `mcp__agent-relay__post_message`    |
+| Reply in a thread        | `reply_to_thread` | `mcp__agent-relay__reply_to_thread` |
+| Spawn sub-agent          | `add_agent`       | `mcp__agent-relay__add_agent`       |
+| Remove sub-agent         | `remove_agent`    | `mcp__agent-relay__remove_agent`    |
 
 > `interactive: false` agents run as non-interactive subprocesses with no relay connection. They must not call Relay MCP tools.
 
@@ -338,18 +338,18 @@ trajectories:
 
 ### Common Mistakes
 
-| Mistake                                      | Why It Fails                                                                  | Fix                                                                                           |
-| -------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                           |
-| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                            |
-| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                       |
-| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                          |
-| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match   |
-| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`         |
-| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops |
-| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                    |
-| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                    |
-| Writing `mcp__relaycast__send(...)`          | Wrong tool name                                                               | Use `post_message` / `mcp__relaycast__post_message` or `send_dm` / `mcp__relaycast__send_dm`  |
+| Mistake                                      | Why It Fails                                                                  | Fix                                                                                              |
+| -------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                              |
+| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                               |
+| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                          |
+| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                             |
+| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match      |
+| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`            |
+| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops    |
+| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                       |
+| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                       |
+| Writing `mcp__relaycast__send(...)`          | Wrong server prefix and tool name                                             | Use `post_message` / `mcp__agent-relay__post_message` or `send_dm` / `mcp__agent-relay__send_dm` |
 
 ### Resume & Re-run
 

--- a/.agents/skills/using-agent-relay/SKILL.md
+++ b/.agents/skills/using-agent-relay/SKILL.md
@@ -40,10 +40,10 @@ The current Agent Relay MCP server registers flat tool names. Use the final
 tool name exactly as listed here.
 
 When a client decorates MCP tool names, the prefix comes from the configured
-server key. Workflow prompts commonly show forms like
-`mcp__relaycast__send_dm`; a server configured as `agent-relay` may expose
-`mcp__agent_relay__send_dm`. In every case, the canonical tool name is the flat
-suffix, such as `send_dm`.
+server key. Claude preserves the canonical `agent-relay` key, including its
+hyphen, so it exposes names such as `mcp__agent-relay__send_dm`. The old
+`mcp__relaycast__*` prefix belongs only to legacy configurations. In every case,
+the canonical tool name is the flat suffix, such as `send_dm`.
 
 Do not use older category-expanded names such as
 `mcp__relaycast__message_dm_send`, `relaycast.message.dm.send`, or

--- a/.claude/agents/accessibility.md
+++ b/.claude/agents/accessibility.md
@@ -173,19 +173,19 @@ npx pa11y https://example.com
 **Acknowledge audit request:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Starting accessibility audit for [scope]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Starting accessibility audit for [scope]")
 ```
 
 **Report findings:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "A11Y AUDIT COMPLETE:\n- Critical: X issues\n- Serious: Y issues\n- Moderate: Z issues\nWCAG Level AA: [Pass/Fail]\nKey blocker: [if any]")
+mcp__agent-relay__send_dm(to: "Sender", text: "A11Y AUDIT COMPLETE:\n- Critical: X issues\n- Serious: Y issues\n- Moderate: Z issues\nWCAG Level AA: [Pass/Fail]\nKey blocker: [if any]")
 ```
 
 **Recommend priority fixes:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "A11Y PRIORITY: [component] blocks keyboard users\nRecommend: [specific fix]\nEffort: [Low/Medium/High]")
+mcp__agent-relay__send_dm(to: "Lead", text: "A11Y PRIORITY: [component] blocks keyboard users\nRecommend: [specific fix]\nEffort: [Low/Medium/High]")
 ```
 
 ## Common Issues

--- a/.claude/agents/accessibility.md
+++ b/.claude/agents/accessibility.md
@@ -172,19 +172,19 @@ npx pa11y https://example.com
 
 **Acknowledge audit request:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Starting accessibility audit for [scope]")
 ```
 
 **Report findings:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "A11Y AUDIT COMPLETE:\n- Critical: X issues\n- Serious: Y issues\n- Moderate: Z issues\nWCAG Level AA: [Pass/Fail]\nKey blocker: [if any]")
 ```
 
 **Recommend priority fixes:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "A11Y PRIORITY: [component] blocks keyboard users\nRecommend: [specific fix]\nEffort: [Low/Medium/High]")
 ```
 

--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -89,17 +89,17 @@ You are an expert API designer specializing in RESTful and GraphQL API design. Y
 ### Starting Work
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**API:** Designing [endpoint/feature]\n\n**Scope:** [What the API needs to do]\n**Consumers:** [Who will use this]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**API:** Designing [endpoint/feature]\n\n**Scope:** [What the API needs to do]\n**Consumers:** [Who will use this]")
 ```
 
 ### Design Proposal
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**API DESIGN:** [Feature name]\n\n**Endpoints:**\n- `GET /resource` - [Description]\n- `POST /resource` - [Description]\n\n**Request/Response:**\n[Brief schema outline]\n\n**Questions:**\n- [Any decisions needed]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**API DESIGN:** [Feature name]\n\n**Endpoints:**\n- `GET /resource` - [Description]\n- `POST /resource` - [Description]\n\n**Request/Response:**\n[Brief schema outline]\n\n**Questions:**\n- [Any decisions needed]")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DONE:** [API feature]\n\n**Endpoints added:**\n- [List endpoints]\n\n**Documentation:** [Location of API docs]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DONE:** [API feature]\n\n**Endpoints added:**\n- [List endpoints]\n\n**Documentation:** [Location of API docs]")
 ```

--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -88,18 +88,18 @@ You are an expert API designer specializing in RESTful and GraphQL API design. Y
 
 ### Starting Work
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "**API:** Designing [endpoint/feature]\n\n**Scope:** [What the API needs to do]\n**Consumers:** [Who will use this]")
 ```
 
 ### Design Proposal
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "**API DESIGN:** [Feature name]\n\n**Endpoints:**\n- `GET /resource` - [Description]\n- `POST /resource` - [Description]\n\n**Request/Response:**\n[Brief schema outline]\n\n**Questions:**\n- [Any decisions needed]")
 ```
 
 ### Completion
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "**DONE:** [API feature]\n\n**Endpoints added:**\n- [List endpoints]\n\n**Documentation:** [Location of API docs]")
 ```

--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -58,23 +58,23 @@ You are an expert backend developer specializing in server-side logic, business 
 ### Starting Work
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**BACKEND:** Starting [feature/task name]\n\n**Approach:** [Brief technical approach]\n**Files:** [Key files to modify]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**BACKEND:** Starting [feature/task name]\n\n**Approach:** [Brief technical approach]\n**Files:** [Key files to modify]")
 ```
 
 ### Progress Update
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**STATUS:** [Current state]\n\n**Completed:** [What's done]\n**Next:** [What's coming]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**STATUS:** [Current state]\n\n**Completed:** [What's done]\n**Next:** [What's coming]")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DONE:** [Feature/task name]\n\n**Files modified:**\n- [List of files]\n\n**Notes:** [Any important notes]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DONE:** [Feature/task name]\n\n**Files modified:**\n- [List of files]\n\n**Notes:** [Any important notes]")
 ```
 
 ### Asking Questions
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**QUESTION:** [Technical question]\n\n**Context:** [Why you're asking]\n**Options:** [Options you see, if applicable]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**QUESTION:** [Technical question]\n\n**Context:** [Why you're asking]\n**Options:** [Options you see, if applicable]")
 ```

--- a/.claude/agents/cli.md
+++ b/.claude/agents/cli.md
@@ -134,13 +134,13 @@ echo '{"status": "success", "count": 42}'
 Implementation status:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: CLI tool progress\n- Commands: init, run complete\n- Pending: config subcommand\n- Testing: 23 test cases passing\n- Docs: --help implemented")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: CLI tool progress\n- Commands: init, run complete\n- Pending: config subcommand\n- Testing: 23 test cases passing\n- Docs: --help implemented")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: CLI tool complete\n- Commands: init, run, config\n- Tests: 31 passing, 0 failing\n- Docs: README, --help, man page\n- Package: npm/brew ready")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: CLI tool complete\n- Commands: init, run, config\n- Tests: 31 passing, 0 failing\n- Docs: README, --help, man page\n- Package: npm/brew ready")
 ```
 
 ## Testing CLI Tools

--- a/.claude/agents/data.md
+++ b/.claude/agents/data.md
@@ -105,13 +105,13 @@ Speed Layer: Stream -> Process -> Serve (real-time)
 Pipeline status:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: ETL pipeline running\n- Source: 2.4M records extracted\n- Transform: 2.1M passed validation\n- Failed: 12K quarantined (malformed dates)\n- ETA: 15 min to completion")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: ETL pipeline running\n- Source: 2.4M records extracted\n- Transform: 2.1M passed validation\n- Failed: 12K quarantined (malformed dates)\n- ETA: 15 min to completion")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Daily ETL complete\n- Records processed: 2,388,421\n- Duration: 23 min\n- Failures: 0.5% (quarantined)\n- Data freshness: T-1 day")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Daily ETL complete\n- Records processed: 2,388,421\n- Duration: 23 min\n- Failures: 0.5% (quarantined)\n- Data freshness: T-1 day")
 ```
 
 ## Data Quality Checks

--- a/.claude/agents/database.md
+++ b/.claude/agents/database.md
@@ -67,17 +67,17 @@ You are an expert database specialist focusing on data modeling, schema design, 
 ### Starting Work
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DATABASE:** Starting [task name]\n\n**Impact:** [Schema/data impact assessment]\n**Risk level:** [Low/Medium/High]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DATABASE:** Starting [task name]\n\n**Impact:** [Schema/data impact assessment]\n**Risk level:** [Low/Medium/High]")
 ```
 
 ### Schema Change Proposal
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**SCHEMA CHANGE:** [Description]\n\n**Reason:** [Why this change]\n**Migration plan:**\n1. [Step 1]\n2. [Step 2]\n\n**Rollback:** [How to undo if needed]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**SCHEMA CHANGE:** [Description]\n\n**Reason:** [Why this change]\n**Migration plan:**\n1. [Step 1]\n2. [Step 2]\n\n**Rollback:** [How to undo if needed]")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DONE:** [Task name]\n\n**Changes:**\n- [Schema/query changes]\n\n**Migration file:** [Path if applicable]\n**Notes:** [Performance considerations, etc.]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DONE:** [Task name]\n\n**Changes:**\n- [Schema/query changes]\n\n**Migration file:** [Path if applicable]\n**Notes:** [Performance considerations, etc.]")
 ```

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -79,23 +79,23 @@ You are an expert debugger specializing in systematic bug investigation and root
 ### Starting Investigation
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DEBUG:** Investigating [bug description]\n\n**Symptoms:** [What's happening]\n**Initial hypothesis:** [Where I'll start looking]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DEBUG:** Investigating [bug description]\n\n**Symptoms:** [What's happening]\n**Initial hypothesis:** [Where I'll start looking]")
 ```
 
 ### Progress Update
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**DEBUG STATUS:** [Bug name]\n\n**Investigated:**\n- [What I've checked]\n- [What I've ruled out]\n\n**Current hypothesis:** [Where I'm looking now]\n**Confidence:** [Low/Medium/High]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**DEBUG STATUS:** [Bug name]\n\n**Investigated:**\n- [What I've checked]\n- [What I've ruled out]\n\n**Current hypothesis:** [Where I'm looking now]\n**Confidence:** [Low/Medium/High]")
 ```
 
 ### Root Cause Found
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**ROOT CAUSE:** [Bug name]\n\n**Location:** [File:line]\n**Cause:** [Explanation]\n**Evidence:** [How I confirmed this]\n\n**Proposed fix:** [Brief description]\n**Risk:** [Low/Medium/High]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**ROOT CAUSE:** [Bug name]\n\n**Location:** [File:line]\n**Cause:** [Explanation]\n**Evidence:** [How I confirmed this]\n\n**Proposed fix:** [Brief description]\n**Risk:** [Low/Medium/High]")
 ```
 
 ### Fix Complete
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**FIXED:** [Bug name]\n\n**Root cause:** [Brief explanation]\n**Fix:** [What was changed]\n**Files:** [Modified files]\n**Verification:** [How I confirmed the fix]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**FIXED:** [Bug name]\n\n**Root cause:** [Brief explanation]\n**Fix:** [What was changed]\n**Files:** [Modified files]\n**Verification:** [How I confirmed the fix]")
 ```

--- a/.claude/agents/deployer.md
+++ b/.claude/agents/deployer.md
@@ -116,19 +116,19 @@ You are a deployment specialist focused on safe, reliable releases. You manage r
 Deployment start:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DEPLOY: Starting v2.4.1 rollout\n- Strategy: Canary (1% -> 10% -> 100%)\n- Services: api, worker, scheduler\n- Duration: ~30 min\n- Rollback: Automated on error rate >1%")
+mcp__agent-relay__send_dm(to: "Lead", text: "DEPLOY: Starting v2.4.1 rollout\n- Strategy: Canary (1% -> 10% -> 100%)\n- Services: api, worker, scheduler\n- Duration: ~30 min\n- Rollback: Automated on error rate >1%")
 ```
 
 Progress update:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DEPLOY: Progress update\n- Phase: 10% traffic\n- Error rate: 0.02% (baseline: 0.03%)\n- Latency p99: 142ms (baseline: 145ms)\n- Proceeding to full rollout")
+mcp__agent-relay__send_dm(to: "Lead", text: "DEPLOY: Progress update\n- Phase: 10% traffic\n- Error rate: 0.02% (baseline: 0.03%)\n- Latency p99: 142ms (baseline: 145ms)\n- Proceeding to full rollout")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: v2.4.1 deployed successfully\n- Duration: 28 min\n- Error rate: 0.02%\n- All health checks passing\n- Rollback window: 2h")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: v2.4.1 deployed successfully\n- Duration: 28 min\n- Error rate: 0.02%\n- All health checks passing\n- Rollback window: 2h")
 ```
 
 ## Deployment Checklist

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -80,13 +80,13 @@ You are a DevOps CI specialist focused on continuous integration, continuous dep
 When reporting pipeline status:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "CI: Build #42 passed\n- Tests: 156 passed, 0 failed\n- Coverage: 84%\n- Security: 0 critical, 2 low\n- Deploy: Ready for staging")
+mcp__agent-relay__send_dm(to: "Lead", text: "CI: Build #42 passed\n- Tests: 156 passed, 0 failed\n- Coverage: 84%\n- Security: 0 critical, 2 low\n- Deploy: Ready for staging")
 ```
 
 When blocked:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "BLOCKED: CI pipeline failing\n- Issue: Docker build timeout\n- Root cause: [investigation]\n- Options: [proposed solutions]")
+mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: CI pipeline failing\n- Issue: Docker build timeout\n- Root cause: [investigation]\n- Options: [proposed solutions]")
 ```
 
 ## Key Metrics to Track

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -79,13 +79,13 @@ You are a DevOps CI specialist focused on continuous integration, continuous dep
 
 When reporting pipeline status:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "CI: Build #42 passed\n- Tests: 156 passed, 0 failed\n- Coverage: 84%\n- Security: 0 critical, 2 low\n- Deploy: Ready for staging")
 ```
 
 When blocked:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: CI pipeline failing\n- Issue: Docker build timeout\n- Root cause: [investigation]\n- Options: [proposed solutions]")
 ```
 

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -117,25 +117,25 @@ You are a rapid response specialist focused on quick fixes, hotfixes, and urgent
 Acknowledging issue:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "ACK: On the login failure issue\n- Reproducing now\n- ETA for diagnosis: 10 min")
+mcp__agent-relay__send_dm(to: "Lead", text: "ACK: On the login failure issue\n- Reproducing now\n- ETA for diagnosis: 10 min")
 ```
 
 Diagnosis update:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Found root cause\n- Issue: Null pointer in session validation\n- Cause: Missing null check after DB timeout\n- Fix: Add defensive check\n- ETA: 15 min to deploy")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Found root cause\n- Issue: Null pointer in session validation\n- Cause: Missing null check after DB timeout\n- Fix: Add defensive check\n- ETA: 15 min to deploy")
 ```
 
 Fix deployed:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Hotfix deployed\n- Change: Added null check in session.validate()\n- Commit: abc123\n- Deployed: Production\n- Monitoring: Error rate dropping\n- Follow-up: Proper timeout handling ticket created")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Hotfix deployed\n- Change: Added null check in session.validate()\n- Commit: abc123\n- Deployed: Production\n- Monitoring: Error rate dropping\n- Follow-up: Proper timeout handling ticket created")
 ```
 
 Escalation:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "ESCALATE: Need help with database issue\n- Problem: Can't reproduce locally\n- Tried: [list of attempts]\n- Need: DBA access / More context\n- Impact: Users still affected")
+mcp__agent-relay__send_dm(to: "Lead", text: "ESCALATE: Need help with database issue\n- Problem: Can't reproduce locally\n- Tried: [list of attempts]\n- Need: DBA access / More context\n- Impact: Users still affected")
 ```
 
 ## Hotfix Checklist

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -29,11 +29,11 @@ You are an expert frontend designer and developer. You create production-grade c
 ### Starting Work
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**FRONTEND:** Starting [component/page name]\n\n**Direction:** [Chosen aesthetic]\n**Key feature:** [The memorable thing]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**FRONTEND:** Starting [component/page name]\n\n**Direction:** [Chosen aesthetic]\n**Key feature:** [The memorable thing]")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**COMPLETE:** [Component name]\n\n**Files:** [List of files]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**COMPLETE:** [Component name]\n\n**Files:** [List of files]")
 ```

--- a/.claude/agents/infrastructure.md
+++ b/.claude/agents/infrastructure.md
@@ -76,19 +76,19 @@ You are an infrastructure specialist focused on cloud platforms, container orche
 ### Task Acknowledgment
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Setting up CI/CD pipeline for [project]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Setting up CI/CD pipeline for [project]")
 ```
 
 ### Status Updates
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Pipeline configuration 70% complete, testing deployment stage")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Pipeline configuration 70% complete, testing deployment stage")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: CI/CD pipeline deployed\n- Build: 2-3 min average\n- Tests: Automated gate\n- Deploy: Blue-green to staging")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: CI/CD pipeline deployed\n- Build: 2-3 min average\n- Tests: Automated gate\n- Deploy: Blue-green to staging")
 ```
 
 ## Anti-Patterns to Avoid

--- a/.claude/agents/integrator.md
+++ b/.claude/agents/integrator.md
@@ -136,19 +136,19 @@ Then: Dead letter queue
 Integration status:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Stripe integration progress\n- Auth: OAuth flow complete\n- Endpoints: 3/5 implemented\n- Webhooks: payment_intent events handled\n- Testing: Sandbox verified")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Stripe integration progress\n- Auth: OAuth flow complete\n- Endpoints: 3/5 implemented\n- Webhooks: payment_intent events handled\n- Testing: Sandbox verified")
 ```
 
 When blocked:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "BLOCKED: GitHub integration issue\n- Problem: Rate limited (5000/hour exceeded)\n- Impact: Sync delayed\n- Mitigation: Implementing request queuing\n- ETA: 30 min for fix")
+mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: GitHub integration issue\n- Problem: Rate limited (5000/hour exceeded)\n- Impact: Sync delayed\n- Mitigation: Implementing request queuing\n- ETA: 30 min for fix")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Slack integration complete\n- OAuth: Workspace install flow\n- Events: message, reaction handlers\n- Commands: /status slash command\n- Tests: 15 cases passing")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Slack integration complete\n- OAuth: Workspace install flow\n- Events: message, reaction handlers\n- Commands: /status slash command\n- Tests: 15 cases passing")
 ```
 
 ## Error Handling

--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -64,9 +64,9 @@ Always emit [[SUMMARY]] blocks to communicate state to dashboard and other agent
 
 ## Communication Patterns
 
-**CRITICAL: ALL relay communication MUST use MCP tools (`mcp__relaycast__message_dm_send`, `mcp__relaycast__agent_add`, `mcp__relaycast__agent_remove`). This includes ACKs, status updates, and all other messages.**
+**CRITICAL: ALL relay communication MUST use MCP tools (`mcp__agent-relay__send_dm`, `mcp__agent-relay__add_agent`, `mcp__agent-relay__remove_agent`). This includes ACKs, status updates, and all other messages.**
 
-Use MCP tools for all agent communication. Call `mcp__relaycast__message_dm_send()` to send messages, `mcp__relaycast__agent_add()` to create new agents, and `mcp__relaycast__agent_remove()` to release agents.
+Use MCP tools for all agent communication. Call `mcp__agent-relay__send_dm()` to send messages, `mcp__agent-relay__add_agent()` to create new agents, and `mcp__agent-relay__remove_agent()` to release agents.
 
 ## Relay-First Communication
 
@@ -74,7 +74,7 @@ Use MCP tools for all agent communication. Call `mcp__relaycast__message_dm_send
 
 ### The Rule
 
-- When receiving a relay message -> Use `mcp__relaycast__message_dm_send()` ALWAYS
+- When receiving a relay message -> Use `mcp__agent-relay__send_dm()` ALWAYS
 - Responding to non-relay questions -> Text is OK
 - Agent-to-agent communication -> ALWAYS use MCP relay tools
 
@@ -102,23 +102,23 @@ Relay message from alice [xyz789] [#general]: Question for the team
 **ACK (Acknowledgment):**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Brief description of task received")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Brief description of task received")
 ```
 
 **Delegate Task:**
 
 ```
-mcp__relaycast__agent_add(name: "WorkerName", cli: "claude", task: "Task description here with clear requirements and acceptance criteria.")
+mcp__agent-relay__add_agent(name: "WorkerName", cli: "claude", task: "Task description here with clear requirements and acceptance criteria.")
 ```
 
 **Status Check:**
 
 ```
-mcp__relaycast__message_dm_send(to: "WorkerName", text: "Status check - how is [task] progressing?")
+mcp__agent-relay__send_dm(to: "WorkerName", text: "Status check - how is [task] progressing?")
 ```
 
 **Release Agent:**
 
 ```
-mcp__relaycast__agent_remove(name: "WorkerName")
+mcp__agent-relay__remove_agent(name: "WorkerName")
 ```

--- a/.claude/agents/migrator.md
+++ b/.claude/agents/migrator.md
@@ -106,13 +106,13 @@ You are a data migration specialist focused on safe, reversible database changes
 When starting migration:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "MIGRATION: Starting user_profiles schema update\n- Records affected: ~2.4M\n- Estimated duration: 15 min\n- Rollback: Ready\n- Backup: Completed")
+mcp__agent-relay__send_dm(to: "Lead", text: "MIGRATION: Starting user_profiles schema update\n- Records affected: ~2.4M\n- Estimated duration: 15 min\n- Rollback: Ready\n- Backup: Completed")
 ```
 
 When complete:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Migration completed\n- Duration: 12 min\n- Records migrated: 2,401,234\n- Validation: PASSED\n- Rollback window: 24h")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Migration completed\n- Duration: 12 min\n- Records migrated: 2,401,234\n- Validation: PASSED\n- Rollback window: 24h")
 ```
 
 ## Safety Checklist

--- a/.claude/agents/mobile.md
+++ b/.claude/agents/mobile.md
@@ -107,13 +107,13 @@ View <- ViewModel <- Repository <- DataSource
 Development update:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Mobile feature progress\n- Screen: ProfileEdit 80% complete\n- Blocking: API endpoint not ready\n- Testing: iPhone 12, Pixel 6 verified\n- Next: Form validation, error states")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Mobile feature progress\n- Screen: ProfileEdit 80% complete\n- Blocking: API endpoint not ready\n- Testing: iPhone 12, Pixel 6 verified\n- Next: Form validation, error states")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: ProfileEdit screen complete\n- iOS: SwiftUI implementation\n- Android: Compose implementation\n- Tests: UI tests passing\n- Accessibility: VoiceOver/TalkBack verified")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: ProfileEdit screen complete\n- iOS: SwiftUI implementation\n- Android: Compose implementation\n- Tests: UI tests passing\n- Accessibility: VoiceOver/TalkBack verified")
 ```
 
 ## Testing Checklist

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -115,13 +115,13 @@ You are an observability specialist focused on monitoring, alerting, and perform
 When setting up monitoring:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Setting up observability for payment-service\n- Metrics: Prometheus scrapers configured\n- Dashboards: 3 created (overview, latency, errors)\n- Alerts: 5 rules with runbooks\n- Next: Distributed tracing")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Setting up observability for payment-service\n- Metrics: Prometheus scrapers configured\n- Dashboards: 3 created (overview, latency, errors)\n- Alerts: 5 rules with runbooks\n- Next: Distributed tracing")
 ```
 
 When reporting issues found:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "ALERT-REVIEW: Found monitoring gaps\n- Missing: Database connection pool metrics\n- Missing: External API latency tracking\n- Noisy: 3 alerts firing >10x/day with no action\n- Recommendation: Add missing metrics, tune or remove noisy alerts")
+mcp__agent-relay__send_dm(to: "Lead", text: "ALERT-REVIEW: Found monitoring gaps\n- Missing: Database connection pool metrics\n- Missing: External API latency tracking\n- Noisy: 3 alerts firing >10x/day with no action\n- Recommendation: Add missing metrics, tune or remove noisy alerts")
 ```
 
 ## Key Metrics by Service Type

--- a/.claude/agents/performance.md
+++ b/.claude/agents/performance.md
@@ -102,23 +102,23 @@ You are an expert performance engineer specializing in identifying bottlenecks, 
 ### Starting Investigation
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**PERF:** Investigating [area/endpoint]\n\n**Symptom:** [What's slow/resource-heavy]\n**Target:** [Performance goal]\n**Approach:** [How I'll profile]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**PERF:** Investigating [area/endpoint]\n\n**Symptom:** [What's slow/resource-heavy]\n**Target:** [Performance goal]\n**Approach:** [How I'll profile]")
 ```
 
 ### Profiling Results
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**PERF ANALYSIS:** [Area]\n\n**Baseline:** [Current metrics]\n**Bottleneck:** [Where time/resources go]\n**Breakdown:**\n- [Component 1]: X ms (Y%)\n- [Component 2]: X ms (Y%)\n\n**Recommended fix:** [What to optimize]\n**Expected improvement:** [Target metrics]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**PERF ANALYSIS:** [Area]\n\n**Baseline:** [Current metrics]\n**Bottleneck:** [Where time/resources go]\n**Breakdown:**\n- [Component 1]: X ms (Y%)\n- [Component 2]: X ms (Y%)\n\n**Recommended fix:** [What to optimize]\n**Expected improvement:** [Target metrics]")
 ```
 
 ### Optimization Complete
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**PERF DONE:** [Area]\n\n**Before:** [Baseline metrics]\n**After:** [New metrics]\n**Improvement:** [X% faster / Y% less memory]\n\n**Changes:**\n- [What was optimized]\n\n**Tradeoffs:** [Any downsides]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**PERF DONE:** [Area]\n\n**Before:** [Baseline metrics]\n**After:** [New metrics]\n**Improvement:** [X% faster / Y% less memory]\n\n**Changes:**\n- [What was optimized]\n\n**Tradeoffs:** [Any downsides]")
 ```
 
 ### Performance Concern
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**PERF WARNING:** [Concern]\n\n**Found:** [What I discovered]\n**Impact:** [How bad is it]\n**Recommendation:** [What should be done]\n**Priority:** [Now/Soon/Later]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**PERF WARNING:** [Concern]\n\n**Found:** [What I discovered]\n**Impact:** [How bad is it]\n**Recommendation:** [What should be done]\n**Priority:** [Now/Soon/Later]")
 ```

--- a/.claude/agents/prototyper.md
+++ b/.claude/agents/prototyper.md
@@ -127,19 +127,19 @@ STILL avoid even in prototypes:
 Starting prototype:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "ACK: Starting prototype for [feature]\n- Hypothesis: [what we're testing]\n- Scope: [core flow only]\n- Timeline: [hours, not days]\n- Shortcuts: [what I'll fake/skip]")
+mcp__agent-relay__send_dm(to: "Lead", text: "ACK: Starting prototype for [feature]\n- Hypothesis: [what we're testing]\n- Scope: [core flow only]\n- Timeline: [hours, not days]\n- Shortcuts: [what I'll fake/skip]")
 ```
 
 Progress update:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Prototype progress\n- Core flow: Working\n- Hardcoded: User data, config\n- Faked: Payment processing\n- Ready for: Internal demo")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Prototype progress\n- Core flow: Working\n- Hardcoded: User data, config\n- Faked: Payment processing\n- Ready for: Internal demo")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Prototype ready for feedback\n- Demo: [link/instructions]\n- Works: [core scenarios]\n- Faked: [list of shortcuts]\n- Next: [recommend keep/kill/iterate]")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Prototype ready for feedback\n- Demo: [link/instructions]\n- Works: [core scenarios]\n- Faked: [list of shortcuts]\n- Next: [recommend keep/kill/iterate]")
 ```
 
 ## Prototype Documentation

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -155,19 +155,19 @@ You are a quality assurance specialist focused on ensuring software meets requir
 **Acknowledge test request:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Creating test plan for [feature]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Creating test plan for [feature]")
 ```
 
 **Report test results:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "TEST RESULTS: [Feature]\n- Total: X tests\n- Passed: Y\n- Failed: Z\n- Blocked: N\nCritical defects: [list or none]")
+mcp__agent-relay__send_dm(to: "Sender", text: "TEST RESULTS: [Feature]\n- Total: X tests\n- Passed: Y\n- Failed: Z\n- Blocked: N\nCritical defects: [list or none]")
 ```
 
 **Escalate blockers:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "BLOCKED: Cannot proceed with [test]\nReason: [blocker description]\nNeed: [what's required to unblock]")
+mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: Cannot proceed with [test]\nReason: [blocker description]\nNeed: [what's required to unblock]")
 ```
 
 ## Test Execution Tracking

--- a/.claude/agents/refactorer.md
+++ b/.claude/agents/refactorer.md
@@ -97,23 +97,23 @@ Bad Reasons:
 ### Starting Work
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**REFACTOR:** Starting [area/component]\n\n**Goal:** [What improvement]\n**Reason:** [Why this matters]\n**Scope:** [What will be touched]\n**Risk:** [Low/Medium/High]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**REFACTOR:** Starting [area/component]\n\n**Goal:** [What improvement]\n**Reason:** [Why this matters]\n**Scope:** [What will be touched]\n**Risk:** [Low/Medium/High]")
 ```
 
 ### Progress Update
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**REFACTOR STATUS:** [Area]\n\n**Completed:**\n- [Changes made]\n\n**Tests:** [Passing/Updated]\n**Next:** [Remaining steps]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**REFACTOR STATUS:** [Area]\n\n**Completed:**\n- [Changes made]\n\n**Tests:** [Passing/Updated]\n**Next:** [Remaining steps]")
 ```
 
 ### Completion
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**REFACTOR DONE:** [Area/component]\n\n**Improvement:** [What's better now]\n**Changes:**\n- [List of changes]\n\n**Files:** [Modified files]\n**Tests:** [Test status]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**REFACTOR DONE:** [Area/component]\n\n**Improvement:** [What's better now]\n**Changes:**\n- [List of changes]\n\n**Files:** [Modified files]\n**Tests:** [Test status]")
 ```
 
 ### Scope Question
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "**REFACTOR SCOPE:** [Question]\n\n**Found:** [Additional tech debt discovered]\n**Options:**\n1. [Fix now - impact]\n2. [Defer - risk]\n\n**Recommendation:** [What you suggest]")
+mcp__agent-relay__send_dm(to: "Lead", text: "**REFACTOR SCOPE:** [Question]\n\n**Found:** [Additional tech debt discovered]\n**Options:**\n1. [Fix now - impact]\n2. [Defer - risk]\n\n**Recommendation:** [What you suggest]")
 ```

--- a/.claude/agents/roles/planner-strategy.md
+++ b/.claude/agents/roles/planner-strategy.md
@@ -66,7 +66,7 @@ When given a task, produce this structure:
 Use precise task descriptions:
 
 ```
-mcp__relaycast__agent_add(name: "BackendAuth", cli: "claude --agent backend", task: "Implement JWT authentication middleware.
+mcp__agent-relay__add_agent(name: "BackendAuth", cli: "claude --agent backend", task: "Implement JWT authentication middleware.
 
 Requirements:
 - Verify token from Authorization header
@@ -97,10 +97,10 @@ Keep workers informed but don't micromanage:
 
 ```
 # Good: Context sharing
-mcp__relaycast__message_dm_send(to: "BackendAuth", text: "Database worker completed user schema. Your dependency is ready.\nColumn names: id, email, password_hash, created_at")
+mcp__agent-relay__send_dm(to: "BackendAuth", text: "Database worker completed user schema. Your dependency is ready.\nColumn names: id, email, password_hash, created_at")
 
 # Bad: Micromanaging
-mcp__relaycast__message_dm_send(to: "BackendAuth", text: "Now write the middleware. First import jwt. Then create a function...")
+mcp__agent-relay__send_dm(to: "BackendAuth", text: "Now write the middleware. First import jwt. Then create a function...")
 ```
 
 ## When Workers Get Stuck

--- a/.claude/agents/roles/worker-focus.md
+++ b/.claude/agents/roles/worker-focus.md
@@ -82,7 +82,7 @@ OUT OF SCOPE:
 
 Use clear, structured completion messages:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Password validation for registration\n\nImplemented:\n- src/auth/validation.ts - passwordSchema with Zod\n- Checks: min 8 chars, 1+ number, 1+ special char\n- Tests: tests/auth/validation.test.ts (12 tests, all pass)\n\nIntegration:\n- Import { validatePassword } from 'src/auth/validation'\n- Call before hashing in registration handler\n\nNotes:\n- Saw email validation is missing too (separate task?)")
 ```
 
@@ -90,7 +90,7 @@ mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Password validation for regis
 
 When stuck, communicate clearly:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: Cannot proceed with JWT middleware\n\nMissing:\n- JWT_SECRET not in .env.example\n- Unclear: should I use RS256 or HS256?\n\nWhat I've done so far:\n- Middleware structure ready\n- Token parsing logic complete\n- Waiting on secret configuration\n\nCan continue once:\n1. Secret is configured\n2. Algorithm is decided")
 ```
 

--- a/.claude/agents/roles/worker-focus.md
+++ b/.claude/agents/roles/worker-focus.md
@@ -83,7 +83,7 @@ OUT OF SCOPE:
 Use clear, structured completion messages:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Password validation for registration\n\nImplemented:\n- src/auth/validation.ts - passwordSchema with Zod\n- Checks: min 8 chars, 1+ number, 1+ special char\n- Tests: tests/auth/validation.test.ts (12 tests, all pass)\n\nIntegration:\n- Import { validatePassword } from 'src/auth/validation'\n- Call before hashing in registration handler\n\nNotes:\n- Saw email validation is missing too (separate task?)")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Password validation for registration\n\nImplemented:\n- src/auth/validation.ts - passwordSchema with Zod\n- Checks: min 8 chars, 1+ number, 1+ special char\n- Tests: tests/auth/validation.test.ts (12 tests, all pass)\n\nIntegration:\n- Import { validatePassword } from 'src/auth/validation'\n- Call before hashing in registration handler\n\nNotes:\n- Saw email validation is missing too (separate task?)")
 ```
 
 ## Handling Blockers
@@ -91,7 +91,7 @@ mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Password validation for
 When stuck, communicate clearly:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "BLOCKED: Cannot proceed with JWT middleware\n\nMissing:\n- JWT_SECRET not in .env.example\n- Unclear: should I use RS256 or HS256?\n\nWhat I've done so far:\n- Middleware structure ready\n- Token parsing logic complete\n- Waiting on secret configuration\n\nCan continue once:\n1. Secret is configured\n2. Algorithm is decided")
+mcp__agent-relay__send_dm(to: "Lead", text: "BLOCKED: Cannot proceed with JWT middleware\n\nMissing:\n- JWT_SECRET not in .env.example\n- Unclear: should I use RS256 or HS256?\n\nWhat I've done so far:\n- Middleware structure ready\n- Token parsing logic complete\n- Waiting on secret configuration\n\nCan continue once:\n1. Secret is configured\n2. Algorithm is decided")
 ```
 
 ## Anti-Patterns to Avoid

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -148,19 +148,19 @@ You are a security specialist focused on identifying vulnerabilities, assessing 
 
 **Acknowledge audit request:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Beginning security audit of [scope]")
 ```
 
 **Report findings:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "SECURITY AUDIT COMPLETE:\n- Critical: X findings\n- High: Y findings\n- Medium: Z findings\nFull report in [location]")
 ```
 
 **Escalate critical issues:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "CRITICAL SECURITY ISSUE: [brief description]\nRequires immediate attention")
 ```
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -149,19 +149,19 @@ You are a security specialist focused on identifying vulnerabilities, assessing 
 **Acknowledge audit request:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Beginning security audit of [scope]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Beginning security audit of [scope]")
 ```
 
 **Report findings:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "SECURITY AUDIT COMPLETE:\n- Critical: X findings\n- High: Y findings\n- Medium: Z findings\nFull report in [location]")
+mcp__agent-relay__send_dm(to: "Sender", text: "SECURITY AUDIT COMPLETE:\n- Critical: X findings\n- High: Y findings\n- Medium: Z findings\nFull report in [location]")
 ```
 
 **Escalate critical issues:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "CRITICAL SECURITY ISSUE: [brief description]\nRequires immediate attention")
+mcp__agent-relay__send_dm(to: "Lead", text: "CRITICAL SECURITY ISSUE: [brief description]\nRequires immediate attention")
 ```
 
 ## Dependency Analysis

--- a/.claude/agents/sysadmin.md
+++ b/.claude/agents/sysadmin.md
@@ -127,19 +127,19 @@ apt-get install --only-upgrade $(apt-get --just-print upgrade 2>&1 | grep -i sec
 When reporting system status:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "STATUS: Server audit complete\n- Servers: 12 assessed\n- Security: 2 need patching (CVE-2024-xxxx)\n- Disk: 1 server at 85% capacity\n- Backups: All verified within 24h\n- Action needed: Patch 2 servers, expand disk on web-03")
+mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Server audit complete\n- Servers: 12 assessed\n- Security: 2 need patching (CVE-2024-xxxx)\n- Disk: 1 server at 85% capacity\n- Backups: All verified within 24h\n- Action needed: Patch 2 servers, expand disk on web-03")
 ```
 
 When implementing changes:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "CHANGE: Applying security hardening to prod-db-01\n- SSH: Disabling password auth\n- Firewall: Restricting to app servers only\n- Users: Removing unused accounts\n- Rollback: SSH keys verified, console access available\n- ETA: 15 min")
+mcp__agent-relay__send_dm(to: "Lead", text: "CHANGE: Applying security hardening to prod-db-01\n- SSH: Disabling password auth\n- Firewall: Restricting to app servers only\n- Users: Removing unused accounts\n- Rollback: SSH keys verified, console access available\n- ETA: 15 min")
 ```
 
 Completion:
 
 ```
-mcp__relaycast__message_dm_send(to: "Lead", text: "DONE: Security hardening applied\n- SSH hardened: password auth disabled\n- Firewall configured: 3 rules active\n- Users cleaned: 4 unused accounts removed\n- Verification: All services healthy, SSH working")
+mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Security hardening applied\n- SSH hardened: password auth disabled\n- Firewall configured: 3 rules active\n- Users cleaned: 4 unused accounts removed\n- Verification: All services healthy, SSH working")
 ```
 
 ## Maintenance Windows

--- a/.claude/agents/sysadmin.md
+++ b/.claude/agents/sysadmin.md
@@ -126,19 +126,19 @@ apt-get install --only-upgrade $(apt-get --just-print upgrade 2>&1 | grep -i sec
 
 When reporting system status:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "STATUS: Server audit complete\n- Servers: 12 assessed\n- Security: 2 need patching (CVE-2024-xxxx)\n- Disk: 1 server at 85% capacity\n- Backups: All verified within 24h\n- Action needed: Patch 2 servers, expand disk on web-03")
 ```
 
 When implementing changes:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "CHANGE: Applying security hardening to prod-db-01\n- SSH: Disabling password auth\n- Firewall: Restricting to app servers only\n- Users: Removing unused accounts\n- Rollback: SSH keys verified, console access available\n- ETA: 15 min")
 ```
 
 Completion:
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Lead", text: "DONE: Security hardening applied\n- SSH hardened: password auth disabled\n- Firewall configured: 3 rules active\n- Users cleaned: 4 unused accounts removed\n- Verification: All services healthy, SSH working")
 ```
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -118,19 +118,19 @@ it('works correctly');
 
 **Acknowledge tasks:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Writing tests for [component/feature]")
 ```
 
 **Report completion:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "DONE: Created X unit tests, Y integration tests\nCoverage: [summary]\nFiles: [list]")
 ```
 
 **Ask for clarification:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "QUESTION: Should I prioritize coverage for [A] or [B]?")
 ```
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -119,19 +119,19 @@ it('works correctly');
 **Acknowledge tasks:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Writing tests for [component/feature]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Writing tests for [component/feature]")
 ```
 
 **Report completion:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "DONE: Created X unit tests, Y integration tests\nCoverage: [summary]\nFiles: [list]")
+mcp__agent-relay__send_dm(to: "Sender", text: "DONE: Created X unit tests, Y integration tests\nCoverage: [summary]\nFiles: [list]")
 ```
 
 **Ask for clarification:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "QUESTION: Should I prioritize coverage for [A] or [B]?")
+mcp__agent-relay__send_dm(to: "Sender", text: "QUESTION: Should I prioritize coverage for [A] or [B]?")
 ```
 
 ## Anti-Patterns to Avoid

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -189,19 +189,19 @@ if (!result.success) {
 
 **Acknowledge validation task:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Reviewing validation for [component]")
 ```
 
 **Report findings:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Sender", text: "VALIDATION REVIEW COMPLETE:\n- Fields checked: X\n- Issues found: Y\n- Critical gaps: [list]\nSchema proposal ready")
 ```
 
 **Recommend implementation:**
 
-```
+```text
 mcp__agent-relay__send_dm(to: "Developer", text: "TASK: Implement validation schema\nSee proposed schema in [file]\nKey requirements:\n- All user input validated\n- Clear error messages\n- Type-safe with inference")
 ```
 

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -190,19 +190,19 @@ if (!result.success) {
 **Acknowledge validation task:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "ACK: Reviewing validation for [component]")
+mcp__agent-relay__send_dm(to: "Sender", text: "ACK: Reviewing validation for [component]")
 ```
 
 **Report findings:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Sender", text: "VALIDATION REVIEW COMPLETE:\n- Fields checked: X\n- Issues found: Y\n- Critical gaps: [list]\nSchema proposal ready")
+mcp__agent-relay__send_dm(to: "Sender", text: "VALIDATION REVIEW COMPLETE:\n- Fields checked: X\n- Issues found: Y\n- Critical gaps: [list]\nSchema proposal ready")
 ```
 
 **Recommend implementation:**
 
 ```
-mcp__relaycast__message_dm_send(to: "Developer", text: "TASK: Implement validation schema\nSee proposed schema in [file]\nKey requirements:\n- All user input validated\n- Clear error messages\n- Type-safe with inference")
+mcp__agent-relay__send_dm(to: "Developer", text: "TASK: Implement validation schema\nSee proposed schema in [file]\nKey requirements:\n- All user input validated\n- Clear error messages\n- Type-safe with inference")
 ```
 
 ## Common Validation Patterns

--- a/.claude/rules/mcp-injection.md
+++ b/.claude/rules/mcp-injection.md
@@ -32,6 +32,26 @@ spawn_wrap_with_token() (spawner.rs)
 5. `<cwd>/.claude/settings.local.json` — project local
 6. `agent-relay` server entry — always added last (highest precedence)
 
+## MCP Executable Resolution
+
+Spawned MCP servers must use an already-installed Relay executable. Never add
+`npx -y agent-relay mcp` back as a default: a cold package resolution can exceed
+the client connection timeout and leave a live worker with no Relay tools.
+
+The broker resolves the command in this order:
+
+1. An explicit `AGENT_RELAY_MCP_COMMAND` whose executable is usable
+2. `$AGENT_RELAY_INSTALL_DIR/bin/agent-relay`
+3. `~/.agentworkforce/relay/bin/agent-relay`
+4. `agent-relay` resolved on `PATH`
+5. `$AGENT_RELAY_BIN_DIR/agent-relay`, or `~/.local/bin/agent-relay`
+
+The standalone Bun CLI re-enters its own installed executable as
+`agent-relay mcp`; npm/Node installs continue to use their adjacent bundled MCP
+script. If no usable command can be resolved, MCP configuration returns an
+actionable error before the worker is spawned, so the dispatcher cannot mistake
+process liveness for Relay readiness.
+
 ## Important: CLI Name in Spawner
 
 In `spawner.rs`, always pass the **original CLI name** (e.g. `"claude"`, `"cursor"`) to `configure_agent_relay_mcp_with_token()`, not `resolved_cli`. `parse_cli_command()` resolves aliases (e.g. `"cursor"` → `"agent"`), which would bypass CLI-specific config logic.
@@ -105,6 +125,12 @@ After an agent is running, incoming relay messages are injected into the PTY wit
 - Channel messages → hint to use `mcp__agent-relay__post_message`
 - Includes channel context `[#channel-name]` when applicable
 - Prevents double-wrapping of system-reminder tags
+
+Claude decorates the canonical `agent-relay` server key literally, including
+the hyphen: `mcp__agent-relay__send_dm`, `mcp__agent-relay__post_message`, and
+`mcp__agent-relay__check_inbox`. The `relaycast` server key is a legacy alias
+used only to detect and migrate older configuration; do not use
+`mcp__relaycast__*` in new allowlists or guidance.
 
 ## CLIs Without MCP Support
 

--- a/.claude/rules/sdk.md
+++ b/.claude/rules/sdk.md
@@ -54,8 +54,9 @@ The SDK uses subpath exports:
 ## Communication Protocol
 
 - **Primary**: MCP tools (`mcp__agent-relay__send_dm`,
-  `mcp__agent-relay__check_inbox`, `mcp__agent-relay__list_agents`,
-  `mcp__agent-relay__add_agent`, `mcp__agent-relay__remove_agent`)
+  `mcp__agent-relay__post_message`, `mcp__agent-relay__check_inbox`,
+  `mcp__agent-relay__list_agents`, `mcp__agent-relay__add_agent`,
+  `mcp__agent-relay__remove_agent`)
 
 ## No Storage Layer
 

--- a/.claude/rules/sdk.md
+++ b/.claude/rules/sdk.md
@@ -53,9 +53,9 @@ The SDK uses subpath exports:
 
 ## Communication Protocol
 
-- **Primary**: MCP tools (`mcp__relaycast__message_dm_send`,
-  `mcp__relaycast__message_inbox_check`, `mcp__relaycast__agent_list`,
-  `mcp__relaycast__agent_add`, `mcp__relaycast__agent_remove`)
+- **Primary**: MCP tools (`mcp__agent-relay__send_dm`,
+  `mcp__agent-relay__check_inbox`, `mcp__agent-relay__list_agents`,
+  `mcp__agent-relay__add_agent`, `mcp__agent-relay__remove_agent`)
 
 ## No Storage Layer
 

--- a/.claude/skills/choosing-swarm-patterns/SKILL.md
+++ b/.claude/skills/choosing-swarm-patterns/SKILL.md
@@ -199,7 +199,7 @@ await workflow('api-build')
   .run();
 ```
 
-Hub (picked via `role: lead` or first agent) stays on the channel and direct-messages interactive workers via the flat `send_dm` MCP tool, often exposed by workflow prompts as `mcp__relaycast__send_dm`.
+Hub (picked via `role: lead` or first agent) stays on the channel and direct-messages interactive workers via the flat `send_dm` MCP tool, exposed by Claude for the canonical server key as `mcp__agent-relay__send_dm`.
 
 > **Don't set `interactive: false` on a hub-spoke worker** if you want it to receive coordination DMs — `resolveTopology` strips non-interactive agents from the message graph (`coordinator.ts:218-237`). Use `interactive: false` only when the worker is a one-shot subprocess whose stdout you collect via `{{steps.X.output}}` without any mid-run coordination.
 
@@ -364,18 +364,18 @@ The runner captures PTY chunks as step output and also records channel posts + f
 
 The old category-expanded names are wrong. Current Agent Relay MCP tools are
 flat names. In a client that decorates MCP tools, the prefix comes from the
-configured server key; workflow prompts commonly show `mcp__relaycast__send_dm`,
-while an `agent-relay` server key may expose `mcp__agent_relay__send_dm`.
+configured server key. Claude preserves the canonical `agent-relay` key,
+including its hyphen; `mcp__relaycast__*` belongs only to legacy configurations.
 
-| Purpose                  | Canonical tool    | Common workflow-prefixed form     |
-| ------------------------ | ----------------- | --------------------------------- |
-| Send DM to another agent | `send_dm`         | `mcp__relaycast__send_dm`         |
-| Check inbox              | `check_inbox`     | `mcp__relaycast__check_inbox`     |
-| List agents              | `list_agents`     | `mcp__relaycast__list_agents`     |
-| Post to a channel        | `post_message`    | `mcp__relaycast__post_message`    |
-| Reply in a thread        | `reply_to_thread` | `mcp__relaycast__reply_to_thread` |
-| Spawn sub-agent          | `add_agent`       | `mcp__relaycast__add_agent`       |
-| Remove sub-agent         | `remove_agent`    | `mcp__relaycast__remove_agent`    |
+| Purpose                  | Canonical tool    | Claude-prefixed form                |
+| ------------------------ | ----------------- | ----------------------------------- |
+| Send DM to another agent | `send_dm`         | `mcp__agent-relay__send_dm`         |
+| Check inbox              | `check_inbox`     | `mcp__agent-relay__check_inbox`     |
+| List agents              | `list_agents`     | `mcp__agent-relay__list_agents`     |
+| Post to a channel        | `post_message`    | `mcp__agent-relay__post_message`    |
+| Reply in a thread        | `reply_to_thread` | `mcp__agent-relay__reply_to_thread` |
+| Spawn sub-agent          | `add_agent`       | `mcp__agent-relay__add_agent`       |
+| Remove sub-agent         | `remove_agent`    | `mcp__agent-relay__remove_agent`    |
 
 > `interactive: false` agents run as non-interactive subprocesses with no relay connection. They must not call Relay MCP tools.
 
@@ -403,18 +403,18 @@ For a first-class critic loop, use the `reflection` **pattern** (agents with `ro
 
 ## Common Mistakes
 
-| Mistake                                      | Why It Fails                                                                  | Fix                                                                                           |
-| -------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                           |
-| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                            |
-| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                       |
-| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                          |
-| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match   |
-| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`         |
-| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops |
-| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                    |
-| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                    |
-| Writing `mcp__relaycast__send(...)`          | Wrong tool name                                                               | Use `post_message` / `mcp__relaycast__post_message` or `send_dm` / `mcp__relaycast__send_dm`  |
+| Mistake                                      | Why It Fails                                                                  | Fix                                                                                              |
+| -------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Using mesh/debate for everything             | Full-mesh blows up message volume past ~5 agents                              | Use hub-spoke or dag for most tasks                                                              |
+| Pipeline for independent work                | Sequential bottleneck                                                         | Use fan-out or dag                                                                               |
+| Hub-spoke for 2 agents                       | Hub is unnecessary overhead                                                   | Use pipeline or fan-out                                                                          |
+| Expecting `consensusStrategy` to tally votes | Runner has no vote-tally logic; field only affects coordinator auto-selection | Aggregate votes in a judge/lead step that reads `{{steps.*.output}}`                             |
+| Handoff with "routing = skip other branches" | Skipping only fires on upstream **failure**, not routing decisions            | Emit a routing token in triage output; downstream prompts self-no-op if token doesn't match      |
+| Cascade expecting skip-on-success            | Runner has no cascade skip logic; failed upstream skips downstream            | Chain downstream prompts to pass-through or redo based on `{{steps.previous.output}}`            |
+| Relying on `reflectOnBarriers`               | Config flag exists but runner never calls it                                  | Use `reflectOnConverge` for convergence reflection; use `reflection` pattern for critic loops    |
+| `interactive: false` agent calling MCP       | Non-interactive subprocess has no relay                                       | Use `interactive: true` (default) or emit output on stdout                                       |
+| Relying on multi-level `hierarchical`        | Topology is single-level hub in current impl                                  | Use pattern for naming; model levels via `dependsOn` graph                                       |
+| Writing `mcp__relaycast__send(...)`          | Wrong server prefix and tool name                                             | Use `post_message` / `mcp__agent-relay__post_message` or `send_dm` / `mcp__agent-relay__send_dm` |
 
 ## Resume & Re-run
 

--- a/.claude/skills/using-agent-relay/SKILL.md
+++ b/.claude/skills/using-agent-relay/SKILL.md
@@ -40,10 +40,10 @@ The current Agent Relay MCP server registers flat tool names. Use the final
 tool name exactly as listed here.
 
 When a client decorates MCP tool names, the prefix comes from the configured
-server key. Workflow prompts commonly show forms like
-`mcp__relaycast__send_dm`; a server configured as `agent-relay` may expose
-`mcp__agent_relay__send_dm`. In every case, the canonical tool name is the flat
-suffix, such as `send_dm`.
+server key. Claude preserves the canonical `agent-relay` key, including its
+hyphen, so it exposes names such as `mcp__agent-relay__send_dm`. The old
+`mcp__relaycast__*` prefix belongs only to legacy configurations. In every case,
+the canonical tool name is the flat suffix, such as `send_dm`.
 
 Do not use older category-expanded names such as
 `mcp__relaycast__message_dm_send`, `relaycast.message.dm.send`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay-broker reclaim-legacy-identity`: restore restart reclaim for one
   offline agent registered before identity proofs were stamped.
 
+### Fixed
+
+- Spawned agents now launch Agent Relay MCP through an installed local `agent-relay` executable instead of cold `npx` resolution.
+- Spawn now fails before start with an actionable error when no usable Agent Relay MCP executable is available.
+
 ## [11.6.1] - 2026-08-13
 
 ### Fixed

--- a/crates/broker/src/cli_mcp_args.rs
+++ b/crates/broker/src/cli_mcp_args.rs
@@ -274,6 +274,9 @@ mod tests {
         "RELAY_AGENT_TOKEN",
         "RELAY_WORKSPACES_JSON",
         "RELAY_DEFAULT_WORKSPACE",
+        "AGENT_RELAY_MCP_COMMAND",
+        "AGENT_RELAY_INSTALL_DIR",
+        "AGENT_RELAY_BIN_DIR",
     ];
 
     /// RAII guard that (1) holds the env mutex so parallel tests don't race,
@@ -360,6 +363,14 @@ mod tests {
 
     #[tokio::test]
     async fn codex_output_contains_agent_relay_config_args() {
+        // Clear the MCP resolution env vars so the expected command/args
+        // below match the default resolution path regardless of what the
+        // ambient test environment (e.g. a harness-provided override) sets.
+        let _env = EnvGuard::all();
+        std::env::remove_var("AGENT_RELAY_MCP_COMMAND");
+        std::env::remove_var("AGENT_RELAY_INSTALL_DIR");
+        std::env::remove_var("AGENT_RELAY_BIN_DIR");
+
         let temp = tempdir().expect("tempdir");
         let output = compute_mcp_args_output(command("codex", temp.path()))
             .await

--- a/crates/broker/src/cli_mcp_args.rs
+++ b/crates/broker/src/cli_mcp_args.rs
@@ -366,12 +366,15 @@ mod tests {
             .expect("compute mcp args");
 
         assert!(output.args.contains(&"--config".to_string()));
+        let command = output
+            .args
+            .iter()
+            .find(|arg| arg.starts_with("mcp_servers.agent-relay.command="))
+            .expect("agent-relay MCP command config");
+        assert_ne!(command, "mcp_servers.agent-relay.command=\"npx\"");
         assert!(output
             .args
-            .contains(&"mcp_servers.agent-relay.command=\"npx\"".to_string()));
-        assert!(output.args.contains(
-            &"mcp_servers.agent-relay.args=[\"-y\", \"agent-relay\", \"mcp\"]".to_string()
-        ));
+            .contains(&"mcp_servers.agent-relay.args=[\"mcp\"]".to_string()));
         assert!(output.side_effect_files.is_empty());
     }
 

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -1,4 +1,6 @@
 use std::{
+    env,
+    ffi::OsStr,
     fs, io,
     path::{Path, PathBuf},
     process::Stdio,
@@ -7,12 +9,16 @@ use std::{
 
 use anyhow::{Context, Result};
 use serde_json::{json, Map, Value};
-use tokio::process::Command;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+};
 
 use crate::types::AgentResultMcpConfig;
 
 const AGENT_RELAY_MCP_PACKAGE: &str = "agent-relay";
 const AGENT_RELAY_MCP_SUBCOMMAND: &str = "mcp";
+const REQUIRED_AGENT_RELAY_MCP_TOOLS: [&str; 3] = ["send_dm", "post_message", "check_inbox"];
 
 const MCP_FILE: &str = ".mcp.json";
 const AGENT_RELAY_MCP_SERVER: &str = "agent-relay";
@@ -28,35 +34,287 @@ struct AgentRelayMcpCommand {
     args: Vec<String>,
 }
 
-fn parse_agent_relay_mcp_command(custom_cmd: Option<&str>) -> AgentRelayMcpCommand {
+fn parse_agent_relay_mcp_command(custom_cmd: Option<&str>) -> Option<AgentRelayMcpCommand> {
     if let Some(custom_cmd) = custom_cmd {
-        let parts: Vec<String> = custom_cmd
-            .split_whitespace()
-            .map(ToString::to_string)
-            .collect();
+        let parts = shlex::split(custom_cmd)?;
         if let Some((command, args)) = parts.split_first() {
-            return AgentRelayMcpCommand {
+            return Some(AgentRelayMcpCommand {
                 command: command.clone(),
                 args: args.to_vec(),
-            };
+            });
         }
+        return None;
     }
 
-    AgentRelayMcpCommand {
-        command: "npx".to_string(),
-        args: vec![
-            "-y".to_string(),
-            AGENT_RELAY_MCP_PACKAGE.to_string(),
-            AGENT_RELAY_MCP_SUBCOMMAND.to_string(),
-        ],
+    Some(AgentRelayMcpCommand {
+        command: AGENT_RELAY_MCP_PACKAGE.to_string(),
+        args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+    })
+}
+
+fn executable_file(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
     }
 }
 
+fn executable_on_path(command: &str, path: Option<&OsStr>) -> Option<PathBuf> {
+    let command_path = Path::new(command);
+    if command_path.components().count() > 1 {
+        return executable_file(command_path).then(|| command_path.to_path_buf());
+    }
+
+    let path = path?;
+    for directory in env::split_paths(path) {
+        let candidate = directory.join(command);
+        if executable_file(&candidate) {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        if candidate.extension().is_none() {
+            for extension in ["exe", "cmd", "bat", "com"] {
+                let candidate = candidate.with_extension(extension);
+                if executable_file(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn resolve_agent_relay_mcp_command(
+    custom_cmd: Option<&str>,
+    path: Option<&OsStr>,
+    home: Option<&Path>,
+    install_dir: Option<&Path>,
+    bin_dir: Option<&Path>,
+) -> Option<AgentRelayMcpCommand> {
+    if custom_cmd.is_some_and(|command| !command.trim().is_empty()) {
+        let command = parse_agent_relay_mcp_command(custom_cmd)?;
+        return executable_on_path(&command.command, path).map(|_| command);
+    }
+
+    let executable_name = if cfg!(windows) {
+        "agent-relay.exe"
+    } else {
+        AGENT_RELAY_MCP_PACKAGE
+    };
+    let mut candidates = Vec::new();
+    if let Some(install_dir) = install_dir {
+        candidates.push(install_dir.join("bin").join(executable_name));
+    }
+    if let Some(home) = home {
+        candidates.push(
+            home.join(".agentworkforce")
+                .join("relay")
+                .join("bin")
+                .join(executable_name),
+        );
+    }
+    if let Some(candidate) = candidates.into_iter().find(|path| executable_file(path)) {
+        return Some(AgentRelayMcpCommand {
+            command: candidate.to_string_lossy().into_owned(),
+            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        });
+    }
+
+    if let Some(candidate) = executable_on_path(AGENT_RELAY_MCP_PACKAGE, path) {
+        return Some(AgentRelayMcpCommand {
+            command: candidate.to_string_lossy().into_owned(),
+            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        });
+    }
+
+    let fallback_bin_dir = bin_dir
+        .map(Path::to_path_buf)
+        .or_else(|| home.map(|home| home.join(".local").join("bin")));
+    fallback_bin_dir
+        .map(|directory| directory.join(executable_name))
+        .filter(|path| executable_file(path))
+        .map(|candidate| AgentRelayMcpCommand {
+            command: candidate.to_string_lossy().into_owned(),
+            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        })
+}
+
 fn agent_relay_mcp_command() -> AgentRelayMcpCommand {
-    // Allow overriding the Agent Relay MCP command for local development/testing.
-    // e.g. AGENT_RELAY_MCP_COMMAND="node /path/to/agent-relay/dist/cli/agent-relay-mcp.js"
     let custom_cmd = std::env::var("AGENT_RELAY_MCP_COMMAND").ok();
-    parse_agent_relay_mcp_command(custom_cmd.as_deref())
+    let install_dir = std::env::var_os("AGENT_RELAY_INSTALL_DIR").map(PathBuf::from);
+    let bin_dir = std::env::var_os("AGENT_RELAY_BIN_DIR").map(PathBuf::from);
+    resolve_agent_relay_mcp_command(
+        custom_cmd.as_deref(),
+        std::env::var_os("PATH").as_deref(),
+        dirs::home_dir().as_deref(),
+        install_dir.as_deref(),
+        bin_dir.as_deref(),
+    )
+    .unwrap_or_else(|| parse_agent_relay_mcp_command(None).expect("default MCP command"))
+}
+
+#[cfg(not(test))]
+fn required_agent_relay_mcp_command() -> io::Result<AgentRelayMcpCommand> {
+    let custom_cmd = std::env::var("AGENT_RELAY_MCP_COMMAND").ok();
+    let install_dir = std::env::var_os("AGENT_RELAY_INSTALL_DIR").map(PathBuf::from);
+    let bin_dir = std::env::var_os("AGENT_RELAY_BIN_DIR").map(PathBuf::from);
+    resolve_agent_relay_mcp_command(
+        custom_cmd.as_deref(),
+        std::env::var_os("PATH").as_deref(),
+        dirs::home_dir().as_deref(),
+        install_dir.as_deref(),
+        bin_dir.as_deref(),
+    )
+    .ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "Agent Relay MCP executable not found; refusing to spawn an agent without coordination tools. Install agent-relay, or set AGENT_RELAY_MCP_COMMAND to an executable local command",
+        )
+    })
+}
+
+async fn probe_agent_relay_mcp_command_with_timeout(
+    command: &AgentRelayMcpCommand,
+    timeout: Duration,
+) -> io::Result<()> {
+    let mut child = Command::new(&command.command)
+        .args(&command.args)
+        // Tool discovery is local and must not rotate an agent identity or
+        // print credentials while diagnosing a broken MCP executable.
+        .env("RELAY_SKIP_BOOTSTRAP", "1")
+        .env_remove("RELAY_API_KEY")
+        .env_remove("RELAY_WORKSPACE_KEY")
+        .env_remove("AGENT_RELAY_WORKSPACE_KEY")
+        .env_remove("RELAY_AGENT_TOKEN")
+        .env_remove("RELAY_WORKSPACES_JSON")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("could not start the Agent Relay MCP executable: {error}"),
+            )
+        })?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("Agent Relay MCP preflight stdin was unavailable"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("Agent Relay MCP preflight stdout was unavailable"))?;
+    let request = concat!(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"agent-relay-broker-preflight\",\"version\":\"1.0\"}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n"
+    );
+    if let Err(error) = stdin.write_all(request.as_bytes()).await {
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        return Err(io::Error::new(
+            error.kind(),
+            format!("could not initialize the Agent Relay MCP executable: {error}"),
+        ));
+    }
+
+    let result = tokio::time::timeout(timeout, async {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Some(line) = lines.next_line().await? {
+            let response: Value = serde_json::from_str(&line).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Agent Relay MCP returned invalid protocol output: {error}"),
+                )
+            })?;
+            if response.get("id").and_then(Value::as_u64) != Some(2) {
+                continue;
+            }
+            if let Some(error) = response.get("error") {
+                return Err(io::Error::other(format!(
+                    "Agent Relay MCP rejected tool discovery: {error}"
+                )));
+            }
+            let tools = response
+                .pointer("/result/tools")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Agent Relay MCP tool discovery returned no tool list",
+                    )
+                })?;
+            let names = tools
+                .iter()
+                .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+                .collect::<std::collections::HashSet<_>>();
+            let missing = REQUIRED_AGENT_RELAY_MCP_TOOLS
+                .iter()
+                .copied()
+                .filter(|name| !names.contains(name))
+                .collect::<Vec<_>>();
+            if missing.is_empty() {
+                return Ok(());
+            }
+            return Err(io::Error::other(format!(
+                "Agent Relay MCP is missing required coordination tools: {}",
+                missing.join(", ")
+            )));
+        }
+        Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "Agent Relay MCP exited before returning its tool list",
+        ))
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "Agent Relay MCP did not expose required coordination tools within {} seconds",
+                timeout.as_secs()
+            ),
+        ))
+    });
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+    result
+}
+
+#[cfg(not(test))]
+async fn validate_agent_relay_mcp_command() -> io::Result<()> {
+    static PREFLIGHT_COMPLETE: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    let command = required_agent_relay_mcp_command()?;
+    PREFLIGHT_COMPLETE
+        .get_or_try_init(|| async {
+            probe_agent_relay_mcp_command_with_timeout(&command, Duration::from_secs(10))
+                .await
+                .map_err(|error| {
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "Agent Relay MCP preflight failed; refusing to spawn an agent without coordination tools: {error}. Reinstall agent-relay or set AGENT_RELAY_MCP_COMMAND to a working local MCP command"
+                        ),
+                    )
+                })
+        })
+        .await
+        .map(|_| ())
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -473,16 +731,17 @@ pub fn ensure_opencode_config_with_result(
     let path = root.join(OPENCODE_CONFIG);
 
     // Build the Agent Relay MCP entry in opencode format.
+    let mcp_command = agent_relay_mcp_command();
     let mut mcp_server = Map::new();
     mcp_server.insert("type".into(), Value::String("local".into()));
     mcp_server.insert(
         "command".into(),
-        Value::Array(vec![
-            Value::String("npx".into()),
-            Value::String("-y".into()),
-            Value::String(AGENT_RELAY_MCP_PACKAGE.into()),
-            Value::String(AGENT_RELAY_MCP_SUBCOMMAND.into()),
-        ]),
+        Value::Array(
+            std::iter::once(mcp_command.command)
+                .chain(mcp_command.args)
+                .map(Value::String)
+                .collect(),
+        ),
     );
     let mut env = Map::new();
     if let Some(v) = relay_api_key.map(str::trim).filter(|s| !s.is_empty()) {
@@ -819,6 +1078,26 @@ pub async fn configure_agent_relay_mcp_with_result(
     let is_grok = cli_lower == "grok";
     let is_cursor = cli_lower == "cursor" || cli_lower == "cursor-agent" || cli_lower == "agent"; // "agent" is cursor-agent's binary name
 
+    let injects_agent_relay_mcp = (is_claude
+        && !existing_args
+            .iter()
+            .any(|a| a == "--mcp-config" || a.starts_with("--mcp-config=")))
+        || (is_codex
+            && !existing_args.iter().any(|a| {
+                a.contains("mcp_servers.agent-relay") || a.contains("mcp_servers.relaycast")
+            }))
+        || is_gemini
+        || is_droid
+        || is_grok
+        || (is_opencode && !existing_args.iter().any(|a| a == "--agent"))
+        || is_cursor;
+    #[cfg(not(test))]
+    if injects_agent_relay_mcp {
+        validate_agent_relay_mcp_command().await?;
+    }
+    #[cfg(test)]
+    let _ = injects_agent_relay_mcp;
+
     let api_key = api_key.map(str::trim).filter(|s| !s.is_empty());
     let base_url = base_url.map(str::trim).filter(|s| !s.is_empty());
 
@@ -871,7 +1150,7 @@ pub async fn configure_agent_relay_mcp_with_result(
     {
         let mcp_command = agent_relay_mcp_command();
         // NOTE: All values passed via codex `--config` are parsed as TOML.
-        // String values MUST be quoted (e.g. `"npx"` not `npx`) to avoid parse
+        // String values MUST be quoted (e.g. `"agent-relay"` not `agent-relay`) to avoid parse
         // errors or type mismatches.  Bare `1` is an integer; bare `at_live_xxx`
         // is a TOML parse error; only quoted values are reliably treated as strings.
         push_codex_mcp_command_config_args(&mut args, &mcp_command);
@@ -1163,7 +1442,7 @@ fn gemini_droid_mcp_add_args_with_result(
     }
     args.push(AGENT_RELAY_MCP_SERVER.to_string());
     // Droid's CLI parser continues parsing options after positional args.
-    // Insert `--` so `-y` is treated as an argument to `npx`.
+    // Insert `--` so any flag-shaped MCP command arguments stay positional.
     if !is_gemini {
         args.push("--".to_string());
     }
@@ -1226,8 +1505,8 @@ fn grok_mcp_add_args(
     // by embedding flag-shaped args directly into the `--command` string so
     // that only plain positional args are passed via `--args`.
     //
-    // e.g. `["npx", ["-y", "agent-relay", "mcp"]]`
-    //   → `--command "npx -y"  --args agent-relay  --args mcp`
+    // e.g. `["custom-runner", ["--fast", "mcp"]]`
+    //   → `--command "custom-runner --fast"  --args mcp`
     let (flag_args, positional_args): (Vec<_>, Vec<_>) = mcp_command
         .args
         .into_iter()
@@ -1488,18 +1767,26 @@ fn write_pretty_json(path: &Path, value: &Value) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{env, ffi::OsString, fs};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     use serde_json::{json, Map, Value};
     use tempfile::tempdir;
 
     use super::ensure_agent_relay_mcp_config;
 
-    fn assert_is_agent_relay_mcp_args(args: Option<&Vec<Value>>) {
-        let args = args.expect("expected agent-relay mcp args");
-        assert_eq!(args.first().and_then(Value::as_str), Some("-y"));
-        assert_eq!(args.get(1).and_then(Value::as_str), Some("agent-relay"));
-        assert_eq!(args.get(2).and_then(Value::as_str), Some("mcp"));
+    fn assert_is_agent_relay_mcp_config(server: &Value) {
+        let expected = super::agent_relay_mcp_command();
+        assert_eq!(server["command"].as_str(), Some(expected.command.as_str()));
+        let args = server["args"]
+            .as_array()
+            .expect("expected agent-relay mcp args");
+        assert_eq!(
+            args.iter().filter_map(Value::as_str).collect::<Vec<_>>(),
+            expected.args.iter().map(String::as_str).collect::<Vec<_>>()
+        );
     }
 
     fn test_agent_result_config() -> crate::types::AgentResultMcpConfig {
@@ -1511,24 +1798,139 @@ mod tests {
     }
 
     #[test]
-    fn agent_relay_mcp_command_defaults_to_npx_agent_relay() {
-        let command = super::parse_agent_relay_mcp_command(None);
+    fn agent_relay_mcp_command_defaults_to_installed_agent_relay() {
+        let command = super::parse_agent_relay_mcp_command(None).expect("default command");
 
-        assert_eq!(command.command, "npx");
-        assert_eq!(command.args, vec!["-y", "agent-relay", "mcp"]);
+        assert_eq!(command.command, "agent-relay");
+        assert_eq!(command.args, vec!["mcp"]);
     }
 
     #[test]
     fn agent_relay_mcp_command_parses_custom_override() {
-        let command = super::parse_agent_relay_mcp_command(Some("node /tmp/agent-relay-mcp.js"));
+        let command = super::parse_agent_relay_mcp_command(Some("node /tmp/agent-relay-mcp.js"))
+            .expect("custom command");
 
         assert_eq!(command.command, "node");
         assert_eq!(command.args, vec!["/tmp/agent-relay-mcp.js"]);
     }
 
     #[test]
+    fn agent_relay_mcp_command_preserves_quoted_override_paths() {
+        let command = super::parse_agent_relay_mcp_command(Some(
+            r#"node "/tmp/Agent Relay/agent-relay-mcp.js""#,
+        ))
+        .expect("quoted command");
+
+        assert_eq!(command.command, "node");
+        assert_eq!(command.args, vec!["/tmp/Agent Relay/agent-relay-mcp.js"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installed_agent_relay_wins_even_when_npx_on_path_is_slow() {
+        let temp = tempdir().expect("tempdir");
+        let bin = temp.path().join("bin");
+        fs::create_dir(&bin).expect("create bin");
+        let relay = bin.join("agent-relay");
+        fs::write(&relay, "#!/bin/sh\nexit 0\n").expect("write relay executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make relay executable");
+        let npx = bin.join("npx");
+        fs::write(&npx, "#!/bin/sh\nsleep 31\n").expect("write slow npx");
+        fs::set_permissions(&npx, fs::Permissions::from_mode(0o755)).expect("make npx executable");
+        let path = env::join_paths([&bin]).expect("join PATH");
+
+        let command =
+            super::resolve_agent_relay_mcp_command(None, Some(path.as_os_str()), None, None, None)
+                .expect("resolve installed relay");
+
+        assert_eq!(command.command, relay.to_string_lossy());
+        assert_eq!(command.args, vec!["mcp"]);
+        assert_ne!(command.command, npx.to_string_lossy());
+    }
+
+    #[test]
+    fn missing_explicit_mcp_command_is_rejected() {
+        let empty_path = OsString::new();
+        assert!(super::resolve_agent_relay_mcp_command(
+            Some("missing-agent-relay-mcp mcp"),
+            Some(empty_path.as_os_str()),
+            None,
+            None,
+            None,
+        )
+        .is_none());
+        assert!(super::resolve_agent_relay_mcp_command(
+            Some("node \"unterminated"),
+            Some(empty_path.as_os_str()),
+            None,
+            None,
+            None,
+        )
+        .is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mcp_preflight_requires_core_coordination_tools() {
+        let temp = tempdir().expect("tempdir");
+        let relay = temp.path().join("agent-relay");
+        fs::write(
+            &relay,
+            r#"#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"agent-relay","version":"test"}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"send_dm"},{"name":"post_message"},{"name":"check_inbox"}]}}'
+"#,
+        )
+        .expect("write fake MCP executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make MCP executable");
+        let command = super::AgentRelayMcpCommand {
+            command: relay.to_string_lossy().into_owned(),
+            args: Vec::new(),
+        };
+
+        super::probe_agent_relay_mcp_command_with_timeout(
+            &command,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("MCP preflight");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mcp_preflight_rejects_incomplete_tool_registration() {
+        let temp = tempdir().expect("tempdir");
+        let relay = temp.path().join("agent-relay");
+        fs::write(
+            &relay,
+            r#"#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"check_inbox"}]}}'
+"#,
+        )
+        .expect("write fake MCP executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make MCP executable");
+        let command = super::AgentRelayMcpCommand {
+            command: relay.to_string_lossy().into_owned(),
+            args: Vec::new(),
+        };
+
+        let error = super::probe_agent_relay_mcp_command_with_timeout(
+            &command,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect_err("incomplete MCP tool list must fail");
+
+        assert!(error.to_string().contains("send_dm, post_message"));
+    }
+
+    #[test]
     fn codex_mcp_command_config_args_use_custom_command() {
-        let command = super::parse_agent_relay_mcp_command(Some("node /tmp/agent-relay-mcp.js"));
+        let command = super::parse_agent_relay_mcp_command(Some("node /tmp/agent-relay-mcp.js"))
+            .expect("custom command");
         let mut args = Vec::new();
 
         super::push_codex_mcp_command_config_args(&mut args, &command);
@@ -1563,11 +1965,7 @@ mod tests {
 
         let contents = fs::read_to_string(root.join(".mcp.json")).expect("read mcp file");
         let json: Value = serde_json::from_str(&contents).expect("parse mcp file");
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
-        assert_is_agent_relay_mcp_args(json["mcpServers"]["agent-relay"]["args"].as_array());
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
     }
 
     #[test]
@@ -1590,10 +1988,7 @@ mod tests {
         let contents = fs::read_to_string(root.join(".mcp.json")).expect("read mcp file");
         let json: Value = serde_json::from_str(&contents).expect("parse mcp file");
         assert!(json["mcpServers"]["other"].is_object());
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
     }
 
     #[test]
@@ -1616,10 +2011,7 @@ mod tests {
         let contents = fs::read_to_string(root.join(".mcp.json")).expect("read mcp file");
         let json: Value = serde_json::from_str(&contents).expect("parse mcp file");
         assert!(json["mcpServers"][legacy].is_null());
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
         // RELAY_API_KEY is intentionally omitted from .mcp.json — injected via process env by the broker
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_API_KEY"].as_str(),
@@ -1696,16 +2088,7 @@ mod tests {
         );
 
         let json: Value = serde_json::from_str(&args[1]).expect("parse mcp-config JSON");
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
-        let mcp_args = json["mcpServers"]["agent-relay"]["args"]
-            .as_array()
-            .expect("args array");
-        assert_eq!(mcp_args[0].as_str(), Some("-y"));
-        assert_eq!(mcp_args[1].as_str(), Some("agent-relay"));
-        assert_eq!(mcp_args[2].as_str(), Some("mcp"));
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
     }
 
     #[tokio::test]
@@ -1891,17 +2274,14 @@ mod tests {
         assert!(args.contains(&"RELAY_API_KEY=rk_live_xyz".to_string()));
         assert!(args.contains(&"RELAY_AGENT_NAME=GrokWorker".to_string()));
         assert!(args.contains(&"RELAY_AGENT_TOKEN=tok_grok_123".to_string()));
-        // Flag-shaped args (-y) are embedded into the --command value to avoid
-        // grok's CLI parser treating them as unknown options.
         let command_idx = args
             .iter()
             .position(|arg| arg == "--command")
             .expect("--command arg");
-        assert_eq!(args[command_idx + 1], "npx -y");
+        let expected = super::agent_relay_mcp_command();
+        assert_eq!(args[command_idx + 1], expected.command);
         assert_eq!(args[command_idx + 2], "--args");
-        assert_eq!(args[command_idx + 3], "agent-relay");
-        assert_eq!(args[command_idx + 4], "--args");
-        assert_eq!(args[command_idx + 5], "mcp");
+        assert_eq!(args[command_idx + 3], "mcp");
     }
 
     #[test]
@@ -1920,11 +2300,10 @@ mod tests {
             .iter()
             .position(|arg| arg == "agent-relay")
             .expect("agent-relay arg");
+        let expected = super::agent_relay_mcp_command();
         assert_eq!(args[agent_relay_idx + 1], "--");
-        assert_eq!(args[agent_relay_idx + 2], "npx");
-        assert_eq!(args[agent_relay_idx + 3], "-y");
-        assert_eq!(args[agent_relay_idx + 4], "agent-relay");
-        assert_eq!(args[agent_relay_idx + 5], "mcp");
+        assert_eq!(args[agent_relay_idx + 2], expected.command);
+        assert_eq!(args[agent_relay_idx + 3], "mcp");
     }
 
     #[test]
@@ -1951,7 +2330,9 @@ mod tests {
             .iter()
             .position(|arg| arg == "agent-relay")
             .expect("agent-relay arg");
-        assert_eq!(args[agent_relay_idx + 1], "npx");
+        let expected = super::agent_relay_mcp_command();
+        assert_eq!(args[agent_relay_idx + 1], expected.command);
+        assert_eq!(args[agent_relay_idx + 2], "mcp");
         assert!(
             !args.iter().any(|arg| arg == "--"),
             "Gemini command should not include `--` argument separator"
@@ -1961,11 +2342,12 @@ mod tests {
     #[test]
     fn droid_manual_mcp_add_command_uses_option_separator() {
         let droid_cmd = super::gemini_droid_manual_mcp_add_cmd("droid", false);
-        assert!(droid_cmd.contains("agent-relay -- npx -y agent-relay mcp"));
+        assert!(droid_cmd.contains("agent-relay -- "));
+        assert!(droid_cmd.ends_with(" mcp"));
 
         let gemini_cmd = super::gemini_droid_manual_mcp_add_cmd("gemini", true);
-        assert!(!gemini_cmd.contains("agent-relay -- npx -y agent-relay mcp"));
-        assert!(gemini_cmd.contains("agent-relay npx -y agent-relay mcp"));
+        assert!(!gemini_cmd.contains("agent-relay -- "));
+        assert!(gemini_cmd.ends_with(" mcp"));
     }
 
     #[test]
@@ -2032,7 +2414,11 @@ mod tests {
         assert!(args.iter().step_by(2).all(|a| a == "--config"));
 
         // Verify key config values
-        assert!(args.contains(&"mcp_servers.agent-relay.command=\"npx\"".to_string()));
+        let expected = super::agent_relay_mcp_command();
+        assert!(args.contains(&format!(
+            "mcp_servers.agent-relay.command=\"{}\"",
+            super::escape_toml_basic_string(&expected.command)
+        )));
         assert!(args
             .iter()
             .any(|a| a.contains("mcp_servers.agent-relay.args=")));
@@ -2228,10 +2614,14 @@ mod tests {
         let mcp = &json["mcp"]["agent-relay"];
         assert_eq!(mcp["type"].as_str(), Some("local"));
         let cmd = mcp["command"].as_array().expect("command array");
-        assert_eq!(cmd[0].as_str(), Some("npx"));
-        assert_eq!(cmd[1].as_str(), Some("-y"));
-        assert_eq!(cmd[2].as_str(), Some("agent-relay"));
-        assert_eq!(cmd[3].as_str(), Some("mcp"));
+        let expected = super::agent_relay_mcp_command();
+        let expected_command = std::iter::once(expected.command.as_str())
+            .chain(expected.args.iter().map(String::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            cmd.iter().filter_map(Value::as_str).collect::<Vec<_>>(),
+            expected_command
+        );
 
         // Environment (note: opencode uses "environment" not "env")
         let oc_env = &mcp["environment"];
@@ -2372,10 +2762,7 @@ mod tests {
         let contents = fs::read_to_string(path).expect("read cursor mcp config");
         let json: Value = serde_json::from_str(&contents).expect("parse cursor mcp config");
 
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_API_KEY"].as_str(),
             Some("rk_live_cursor")
@@ -2511,10 +2898,7 @@ mod tests {
         assert!(json["mcpServers"]["agent-relay"].is_object());
 
         // Command
-        assert_eq!(
-            json["mcpServers"]["agent-relay"]["command"].as_str(),
-            Some("npx")
-        );
+        assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
 
         // API key intentionally omitted
         assert!(

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -2090,6 +2090,47 @@ printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"check_inbox"}
         assert!(!error.to_string().contains("could not initialize"));
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mcp_preflight_fails_when_server_dies_after_initialize_but_before_tools_list() {
+        let temp = tempdir().expect("tempdir");
+        let relay = temp.path().join("agent-relay");
+        // Answers `initialize` (a genuine, valid id=1 response) and then exits
+        // without reading stdin again and without ever producing an id=2
+        // response. This is the discriminating case for BrokenPipe tolerance:
+        // the server truly answered something, then died mid-handshake. Our
+        // second write (notifications/initialized + tools/list) may race a
+        // closed pipe on this exited process, so BrokenPipe tolerance alone
+        // must not be mistaken for a completed tool-discovery response.
+        fs::write(
+            &relay,
+            r#"#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"agent-relay","version":"test"}}}'
+exit 0
+"#,
+        )
+        .expect("write fake MCP executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make MCP executable");
+        let command = super::AgentRelayMcpCommand {
+            command: relay.to_string_lossy().into_owned(),
+            args: Vec::new(),
+        };
+
+        let error = super::probe_agent_relay_mcp_command_with_timeout(
+            &command,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect_err(
+            "a server that dies after initialize but before tools/list must not pass preflight",
+        );
+
+        // Whether or not the second write actually hit BrokenPipe, the probe
+        // must fail on the missing tools/list response, not report success.
+        assert!(error.to_string().contains("tool list"));
+    }
+
     #[test]
     fn codex_mcp_command_config_args_use_custom_command() {
         let command = super::parse_agent_relay_mcp_command(Some("node /tmp/agent-relay-mcp.js"))

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -95,6 +95,36 @@ fn executable_on_path(command: &str, path: Option<&OsStr>) -> Option<PathBuf> {
     None
 }
 
+/// Builds the MCP command for a resolved executable path. Downstream MCP
+/// clients (e.g. Cursor, Codex) may spawn the generated command without a
+/// shell, so a resolved `.cmd`/`.bat` shim is wrapped through `cmd.exe /C`;
+/// other resolved executables (including `.exe`) launch directly.
+fn command_for_resolved_executable(executable: &Path, args: Vec<String>) -> AgentRelayMcpCommand {
+    #[cfg(windows)]
+    {
+        let is_batch_shim =
+            executable
+                .extension()
+                .and_then(OsStr::to_str)
+                .is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+                });
+        if is_batch_shim {
+            let mut wrapped_args =
+                vec!["/C".to_string(), executable.to_string_lossy().into_owned()];
+            wrapped_args.extend(args);
+            return AgentRelayMcpCommand {
+                command: "cmd.exe".to_string(),
+                args: wrapped_args,
+            };
+        }
+    }
+    AgentRelayMcpCommand {
+        command: executable.to_string_lossy().into_owned(),
+        args,
+    }
+}
+
 fn resolve_agent_relay_mcp_command(
     custom_cmd: Option<&str>,
     path: Option<&OsStr>,
@@ -123,19 +153,22 @@ fn resolve_agent_relay_mcp_command(
                 .join("bin")
                 .join(executable_name),
         );
+        // Legacy install directory from before the `.agentworkforce/relay`
+        // migration (see broker-path.ts's getInstalledBinaryPaths).
+        candidates.push(home.join(".agent-relay").join("bin").join(executable_name));
     }
     if let Some(candidate) = candidates.into_iter().find(|path| executable_file(path)) {
-        return Some(AgentRelayMcpCommand {
-            command: candidate.to_string_lossy().into_owned(),
-            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
-        });
+        return Some(command_for_resolved_executable(
+            &candidate,
+            vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        ));
     }
 
     if let Some(candidate) = executable_on_path(AGENT_RELAY_MCP_PACKAGE, path) {
-        return Some(AgentRelayMcpCommand {
-            command: candidate.to_string_lossy().into_owned(),
-            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
-        });
+        return Some(command_for_resolved_executable(
+            &candidate,
+            vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        ));
     }
 
     let fallback_bin_dir = bin_dir
@@ -144,9 +177,11 @@ fn resolve_agent_relay_mcp_command(
     fallback_bin_dir
         .map(|directory| directory.join(executable_name))
         .filter(|path| executable_file(path))
-        .map(|candidate| AgentRelayMcpCommand {
-            command: candidate.to_string_lossy().into_owned(),
-            args: vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+        .map(|candidate| {
+            command_for_resolved_executable(
+                &candidate,
+                vec![AGENT_RELAY_MCP_SUBCOMMAND.to_string()],
+            )
         })
 }
 
@@ -161,7 +196,13 @@ fn agent_relay_mcp_command() -> AgentRelayMcpCommand {
         install_dir.as_deref(),
         bin_dir.as_deref(),
     )
-    .unwrap_or_else(|| parse_agent_relay_mcp_command(None).expect("default MCP command"))
+    .unwrap_or_else(|| {
+        tracing::warn!(
+            custom_cmd = custom_cmd.as_deref().unwrap_or(""),
+            "Agent Relay MCP command could not be resolved to an executable; falling back to the unresolved default command, which will fail to spawn"
+        );
+        parse_agent_relay_mcp_command(None).expect("default MCP command")
+    })
 }
 
 #[cfg(not(test))]
@@ -182,6 +223,24 @@ fn required_agent_relay_mcp_command() -> io::Result<AgentRelayMcpCommand> {
             "Agent Relay MCP executable not found; refusing to spawn an agent without coordination tools. Install agent-relay, or set AGENT_RELAY_MCP_COMMAND to an executable local command",
         )
     })
+}
+
+/// Writes a preflight JSON-RPC request to the child's stdin. A `BrokenPipe`
+/// is not fatal here: the server may have already answered and exited,
+/// closing its end of stdin before we finished writing. The read phase
+/// decides whether that response is usable.
+async fn write_preflight_request(
+    stdin: &mut tokio::process::ChildStdin,
+    request: &str,
+) -> io::Result<()> {
+    match stdin.write_all(request.as_bytes()).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(io::Error::new(
+            error.kind(),
+            format!("could not initialize the Agent Relay MCP executable: {error}"),
+        )),
+    }
 }
 
 async fn probe_agent_relay_mcp_command_with_timeout(
@@ -217,29 +276,49 @@ async fn probe_agent_relay_mcp_command_with_timeout(
         .stdout
         .take()
         .ok_or_else(|| io::Error::other("Agent Relay MCP preflight stdout was unavailable"))?;
-    let request = concat!(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"agent-relay-broker-preflight\",\"version\":\"1.0\"}}}\n",
-        "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
-        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n"
-    );
-    if let Err(error) = stdin.write_all(request.as_bytes()).await {
-        let _ = child.kill().await;
-        let _ = child.wait().await;
-        return Err(io::Error::new(
-            error.kind(),
-            format!("could not initialize the Agent Relay MCP executable: {error}"),
-        ));
-    }
 
     let result = tokio::time::timeout(timeout, async {
         let mut lines = BufReader::new(stdout).lines();
+
+        // Send `initialize` and wait for its response before sending
+        // `notifications/initialized` and `tools/list`: strict MCP servers
+        // can reject requests that arrive ahead of the initialize response.
+        let initialize_request = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"agent-relay-broker-preflight\",\"version\":\"1.0\"}}}\n";
+        write_preflight_request(&mut stdin, initialize_request).await?;
+
+        loop {
+            let Some(line) = lines.next_line().await? else {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Agent Relay MCP exited before completing the MCP initialize handshake",
+                ));
+            };
+            // Wrappers and servers sometimes log to stdout. Only JSON-RPC
+            // lines are protocol data; ignore everything else.
+            let Ok(response) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if response.get("id").and_then(Value::as_u64) != Some(1) {
+                continue;
+            }
+            if let Some(error) = response.get("error") {
+                return Err(io::Error::other(format!(
+                    "Agent Relay MCP rejected initialize: {error}"
+                )));
+            }
+            break;
+        }
+
+        let followup_request = concat!(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n"
+        );
+        write_preflight_request(&mut stdin, followup_request).await?;
+
         while let Some(line) = lines.next_line().await? {
-            let response: Value = serde_json::from_str(&line).map_err(|error| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Agent Relay MCP returned invalid protocol output: {error}"),
-                )
-            })?;
+            let Ok(response) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
             if response.get("id").and_then(Value::as_u64) != Some(2) {
                 continue;
             }
@@ -1849,6 +1928,59 @@ mod tests {
         assert_ne!(command.command, npx.to_string_lossy());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn resolves_legacy_agent_relay_install_dir() {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path();
+        let bin = home.join(".agent-relay").join("bin");
+        fs::create_dir_all(&bin).expect("create legacy bin dir");
+        let relay = bin.join("agent-relay");
+        fs::write(&relay, "#!/bin/sh\nexit 0\n").expect("write relay executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make relay executable");
+        let empty_path = OsString::new();
+
+        let command = super::resolve_agent_relay_mcp_command(
+            None,
+            Some(empty_path.as_os_str()),
+            Some(home),
+            None,
+            None,
+        )
+        .expect("resolve legacy install");
+
+        assert_eq!(command.command, relay.to_string_lossy());
+        assert_eq!(command.args, vec!["mcp"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn wraps_batch_shim_through_cmd_exe() {
+        let shim = Path::new(r"C:\Users\test\AppData\Roaming\npm\agent-relay.cmd");
+        let command = super::command_for_resolved_executable(shim, vec!["mcp".to_string()]);
+
+        assert_eq!(command.command, "cmd.exe");
+        assert_eq!(
+            command.args,
+            vec![
+                "/C".to_string(),
+                shim.to_string_lossy().into_owned(),
+                "mcp".to_string()
+            ]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn does_not_wrap_exe_candidates() {
+        let exe = Path::new(r"C:\Users\test\.agentworkforce\relay\bin\agent-relay.exe");
+        let command = super::command_for_resolved_executable(exe, vec!["mcp".to_string()]);
+
+        assert_eq!(command.command, exe.to_string_lossy());
+        assert_eq!(command.args, vec!["mcp".to_string()]);
+    }
+
     #[test]
     fn missing_explicit_mcp_command_is_rejected() {
         let empty_path = OsString::new();
@@ -1878,6 +2010,7 @@ mod tests {
         fs::write(
             &relay,
             r#"#!/bin/sh
+cat >/dev/null &
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"agent-relay","version":"test"}}}'
 printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"send_dm"},{"name":"post_message"},{"name":"check_inbox"}]}}'
 "#,
@@ -1906,6 +2039,8 @@ printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"send_dm"},{"n
         fs::write(
             &relay,
             r#"#!/bin/sh
+cat >/dev/null &
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"agent-relay","version":"test"}}}'
 printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"check_inbox"}]}}'
 "#,
         )
@@ -1925,6 +2060,34 @@ printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"check_inbox"}
         .expect_err("incomplete MCP tool list must fail");
 
         assert!(error.to_string().contains("send_dm, post_message"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mcp_preflight_tolerates_broken_pipe_on_write() {
+        let temp = tempdir().expect("tempdir");
+        let relay = temp.path().join("agent-relay");
+        // Exits immediately without reading stdin, so our write to its stdin
+        // can race a closed pipe (BrokenPipe) instead of a clean read.
+        fs::write(&relay, "#!/bin/sh\nexit 0\n").expect("write fake MCP executable");
+        fs::set_permissions(&relay, fs::Permissions::from_mode(0o755))
+            .expect("make MCP executable");
+        let command = super::AgentRelayMcpCommand {
+            command: relay.to_string_lossy().into_owned(),
+            args: Vec::new(),
+        };
+
+        let error = super::probe_agent_relay_mcp_command_with_timeout(
+            &command,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect_err("preflight against a silent exiting process must fail");
+
+        // A BrokenPipe on write must not surface as the fatal error; the
+        // read-phase EOF is the real, actionable failure.
+        assert!(error.to_string().contains("handshake") || error.to_string().contains("tool list"));
+        assert!(!error.to_string().contains("could not initialize"));
     }
 
     #[test]

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -12,6 +12,19 @@ type RelayBehavior = {
   registerImpl: (input: { name: string; type?: string }) => Promise<{ name?: string; token: string }>;
 };
 
+function assertToolsListDiscoversAndStripsMetadata(
+  toolsList: { tools?: Array<Record<string, unknown>> } | undefined
+) {
+  expect(toolsList?.tools?.map((tool) => tool.name)).toEqual(
+    expect.arrayContaining(['post_message', 'send_dm', 'check_inbox'])
+  );
+  for (const tool of toolsList?.tools ?? []) {
+    expect(tool).not.toHaveProperty('execution');
+    expect(tool).not.toHaveProperty('outputSchema');
+    expect(tool).not.toHaveProperty('_meta');
+  }
+}
+
 async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
   vi.resetModules();
 
@@ -88,17 +101,27 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
         _requestHandlers: new Map([
           [
             'tools/list',
+            // Derived from `this.tools` (populated by registerTool calls
+            // made after this constructor runs, but before this handler is
+            // invoked) so the response reflects every registered tool, not
+            // just one hardcoded name. Each entry carries the same
+            // execution/outputSchema/_meta fields the real MCP SDK exposes,
+            // so tests can assert the production wrapper strips them.
             vi.fn(async () => ({
-              tools: [
-                {
-                  name: 'post_message',
-                  title: 'Post Message',
+              tools: [...this.tools.entries()].map(([name, { config }]) => {
+                const { title, description } = (config ?? {}) as {
+                  title?: string;
+                  description?: string;
+                };
+                return {
+                  name,
+                  title: title ?? name,
+                  description: description ?? `Tool ${name}`,
                   execution: { hidden: true },
                   outputSchema: { type: 'object' },
                   _meta: { hidden: true },
-                  description: 'Send a channel message',
-                },
-              ],
+                };
+              }),
             })),
           ],
         ]),
@@ -516,7 +539,14 @@ describe('createAgentRelayMcpServer', () => {
       to: 'Broker',
       text: 'MCP startup check',
     });
-    expect(dmResult.structuredContent).toMatchObject({ id: 'dm_1', to: 'Broker' });
+    // Don't assert `to` here: the mock's `dm` echoes back whatever recipient
+    // it's given, but a correct handler resolves the recipient independently
+    // (and reports `recipient_unresolved` when it can't). Asserting `to`
+    // would encode that passthrough as expected behavior.
+    expect(dmResult.structuredContent).toMatchObject({
+      id: 'dm_1',
+      text: 'MCP startup check',
+    });
     const inboxResult = await server.tools.get('check_inbox')?.handler({});
     expect(inboxResult.structuredContent).toEqual({
       unreadChannels: [],
@@ -575,13 +605,10 @@ describe('createAgentRelayMcpServer', () => {
       target_node: 'node-a',
     });
     const toolsList = await server.listToolsHandler?.({}, {});
-    expect(toolsList?.tools).toEqual([
-      {
-        name: 'post_message',
-        title: 'Post Message',
-        description: 'Send a channel message',
-      },
-    ]);
+    // Assert protocol-level tool discovery: the wrapped tools/list response
+    // must surface every registered tool (not just post_message) with
+    // execution/outputSchema/_meta stripped.
+    assertToolsListDiscoversAndStripsMetadata(toolsList);
 
     const promptResult = await server.prompts.get('system')?.handler();
     expect(promptResult.messages[0].content.text).toContain('create_workspace');

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -446,6 +446,8 @@ describe('createAgentRelayMcpServer', () => {
     expect(server.tools.get('list_agents')).toBeDefined();
     expect(server.tools.get('query_nodes')).toBeDefined();
     expect(server.tools.get('post_message')).toBeDefined();
+    expect(server.tools.get('send_dm')).toBeDefined();
+    expect(server.tools.get('check_inbox')).toBeDefined();
     expect(server.tools.get('add_agent')).toBeDefined();
     expect(server.tools.get('spawn')).toBeDefined();
     expect([...server.tools.keys()].filter((name) => name.includes('.'))).toEqual([]);
@@ -503,6 +505,24 @@ describe('createAgentRelayMcpServer', () => {
     expect(registerResult.structuredContent).toMatchObject({
       token: 'at_live_WorkerA',
       registered_name: 'WorkerA',
+    });
+
+    const postResult = await server.tools.get('post_message')?.handler({
+      channel: 'general',
+      text: 'MCP startup check',
+    });
+    expect(postResult.structuredContent).toMatchObject({ id: 'msg_1', channel: 'general' });
+    const dmResult = await server.tools.get('send_dm')?.handler({
+      to: 'Broker',
+      text: 'MCP startup check',
+    });
+    expect(dmResult.structuredContent).toMatchObject({ id: 'dm_1', to: 'Broker' });
+    const inboxResult = await server.tools.get('check_inbox')?.handler({});
+    expect(inboxResult.structuredContent).toEqual({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
     });
 
     const queryNodesResult = await server.tools.get('query_nodes')?.handler({ capability: 'spawn:codex' });

--- a/packages/cli/src/cli/commands/core.test.ts
+++ b/packages/cli/src/cli/commands/core.test.ts
@@ -1830,6 +1830,40 @@ describe('registerCoreCommands', () => {
     expect(env.AGENT_RELAY_MCP_COMMAND).toBe('/usr/bin/node /tmp/agent-relay-mcp.js');
   });
 
+  it('up re-enters the installed Bun executable for Agent Relay MCP', async () => {
+    const env: NodeJS.ProcessEnv = {};
+    const relay = createRelayMock();
+    const { program } = createHarness({
+      relay,
+      env,
+      argv: ['bun', '/$bunfs/root/agent-relay', 'up'],
+      execPath: '/opt/agent-relay/bin/agent-relay',
+      cliScript: '/$bunfs/root/agent-relay',
+    });
+
+    const exitCode = await runCommand(program, ['up']);
+
+    expect(exitCode).toBeUndefined();
+    expect(env.AGENT_RELAY_MCP_COMMAND).toBe('/opt/agent-relay/bin/agent-relay mcp');
+  });
+
+  it('up quotes an installed Bun executable path containing spaces', async () => {
+    const env: NodeJS.ProcessEnv = {};
+    const relay = createRelayMock();
+    const { program } = createHarness({
+      relay,
+      env,
+      argv: ['bun', '/$bunfs/root/agent-relay', 'up'],
+      execPath: '/Applications/Agent Relay/agent-relay',
+      cliScript: '/$bunfs/root/agent-relay',
+    });
+
+    const exitCode = await runCommand(program, ['up']);
+
+    expect(exitCode).toBeUndefined();
+    expect(env.AGENT_RELAY_MCP_COMMAND).toBe('"/Applications/Agent Relay/agent-relay" mcp');
+  });
+
   it('up preserves an explicit AGENT_RELAY_MCP_COMMAND override', async () => {
     const env: NodeJS.ProcessEnv = { AGENT_RELAY_MCP_COMMAND: 'node /custom/agent-relay-mcp.js' };
     const fs = createFsMock({ '/tmp/agent-relay-mcp.js': '' });

--- a/packages/cli/src/cli/lib/agent-relay-mcp-command.ts
+++ b/packages/cli/src/cli/lib/agent-relay-mcp-command.ts
@@ -2,6 +2,15 @@ import path from 'node:path';
 
 type ExistsSyncLike = (filePath: string) => boolean;
 
+function isBundledBunEntrypoint(cliScript: string): boolean {
+  const normalized = cliScript.replace(/\\/g, '/');
+  return normalized.startsWith('/$bunfs/root/') || /^[A-Z]:\/~BUN\/root\//i.test(normalized);
+}
+
+function quoteCommandPart(value: string): string {
+  return /[\s"'\\]/.test(value) ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : value;
+}
+
 export function resolveBundledAgentRelayMcpScript(
   cliScript: string,
   existsSync: ExistsSyncLike
@@ -15,10 +24,19 @@ export function buildBundledAgentRelayMcpCommand(
   cliScript: string,
   existsSync: ExistsSyncLike
 ): string | null {
+  // Bun's compiled executable exposes argv[1] as a virtual /$bunfs path, so
+  // there is no adjacent agent-relay-mcp.js for the Node-style path below to
+  // find. Re-enter the already-installed standalone executable instead. This
+  // keeps MCP startup local and deterministic instead of falling through to a
+  // cold `npx -y agent-relay mcp` resolution.
+  if (isBundledBunEntrypoint(cliScript)) {
+    return `${quoteCommandPart(execPath)} mcp`;
+  }
+
   const scriptPath = resolveBundledAgentRelayMcpScript(cliScript, existsSync);
   if (!scriptPath) {
     return null;
   }
 
-  return `${execPath} ${scriptPath}`;
+  return `${quoteCommandPart(execPath)} ${quoteCommandPart(scriptPath)}`;
 }

--- a/packages/cli/src/cli/lib/agent-relay-mcp-command.ts
+++ b/packages/cli/src/cli/lib/agent-relay-mcp-command.ts
@@ -2,7 +2,15 @@ import path from 'node:path';
 
 type ExistsSyncLike = (filePath: string) => boolean;
 
-function isBundledBunEntrypoint(cliScript: string): boolean {
+/**
+ * Bun's `--compile` executable exposes argv[1] as a virtual `/$bunfs/root/...`
+ * (or `X:/~BUN/root/...` on Windows) path rather than a real file on disk.
+ * Shared with `isBundledBunExecutableEntrypoint` in broker-lifecycle.ts so a
+ * future Bun path change only needs to update this one place; that caller
+ * additionally checks `argv[0] === 'bun'`, which this module doesn't have
+ * access to.
+ */
+export function isBundledBunEntrypointPath(cliScript: string): boolean {
   const normalized = cliScript.replace(/\\/g, '/');
   return normalized.startsWith('/$bunfs/root/') || /^[A-Z]:\/~BUN\/root\//i.test(normalized);
 }
@@ -29,7 +37,7 @@ export function buildBundledAgentRelayMcpCommand(
   // find. Re-enter the already-installed standalone executable instead. This
   // keeps MCP startup local and deterministic instead of falling through to a
   // cold `npx -y agent-relay mcp` resolution.
-  if (isBundledBunEntrypoint(cliScript)) {
+  if (isBundledBunEntrypointPath(cliScript)) {
     return `${quoteCommandPart(execPath)} mcp`;
   }
 

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -8,7 +8,7 @@ import { redactCredentialValues } from '@agent-relay/cloud/redact';
 
 import type { CoreDependencies, CoreProjectPaths, CoreRelay, SpawnedProcess } from '../commands/core.js';
 import { track } from '../telemetry/index.js';
-import { buildBundledAgentRelayMcpCommand } from './agent-relay-mcp-command.js';
+import { buildBundledAgentRelayMcpCommand, isBundledBunEntrypointPath } from './agent-relay-mcp-command.js';
 import { errorClassName } from './telemetry-helpers.js';
 import { createTriggerSyncClient, resolveNodeCapacityHarnesses } from './fleet-sidecar.js';
 import {
@@ -1166,12 +1166,7 @@ function isCliScriptEntrypoint(deps: CoreDependencies): boolean {
 }
 
 export function isBundledBunExecutableEntrypoint(deps: CoreDependencies): boolean {
-  // Bun --compile exposes argv[1] as a virtual path for the embedded executable.
-  const entrypoint = deps.cliScript.replace(/\\/g, '/');
-  return (
-    deps.argv[0] === 'bun' &&
-    (entrypoint.startsWith('/$bunfs/root/') || /^[A-Z]:\/~BUN\/root\//i.test(entrypoint))
-  );
+  return deps.argv[0] === 'bun' && isBundledBunEntrypointPath(deps.cliScript);
 }
 
 function sameCliPath(left: string, right: string): boolean {

--- a/tests/e2e/tic-tac-toe/README.md
+++ b/tests/e2e/tic-tac-toe/README.md
@@ -100,8 +100,8 @@ next person doesn't rediscover them.
   growth.
 
 - **`AGENT_RELAY_MCP_COMMAND` must point at the local build.** The broker
-  otherwise configures spawned agents with `npx -y agent-relay mcp`, which
-  fetches the published package instead of the code under test.
+  otherwise configures spawned agents with the installed Relay executable,
+  which runs packaged code instead of the code under test.
 
 - **PTYs come from `pty-run.py`.** `stdout.isTTY` gates the status line, the
   terminal reset on detach, and the input-report filter; driving the clients

--- a/tests/e2e/tic-tac-toe/harness.ts
+++ b/tests/e2e/tic-tac-toe/harness.ts
@@ -227,8 +227,8 @@ export async function startBroker(
     HOME: home,
     RELAYCAST_BASE_URL: engineBaseUrl,
     BROKER_BINARY_PATH: resolveBrokerBinary() ?? '',
-    // Point spawned agents at the freshly built MCP server rather than
-    // `npx -y agent-relay mcp`, which would fetch the published package.
+    // Point spawned agents at the freshly built MCP server rather than the
+    // installed Relay binary, which would execute code outside this checkout.
     AGENT_RELAY_MCP_COMMAND: `node ${path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'agent-relay-mcp.js')}`,
   });
 

--- a/tests/integration/broker/evals/scoring/toolcheck.unit.test.ts
+++ b/tests/integration/broker/evals/scoring/toolcheck.unit.test.ts
@@ -26,7 +26,11 @@ describe('checkToolNames', () => {
   const registered = ['send_dm', 'post_message', 'check_inbox'];
 
   it('passes when every reference maps to a registered tool', () => {
-    const r = checkToolNames(registered, ['mcp__agent-relay__send_dm', 'mcp__agent-relay__post_message']);
+    const r = checkToolNames(registered, [
+      'mcp__agent-relay__send_dm',
+      'mcp__agent-relay__post_message',
+      'mcp__agent-relay__check_inbox',
+    ]);
     expect(r.ok).toBe(true);
     expect(r.mismatches).toHaveLength(0);
   });


### PR DESCRIPTION
Closes #1410.

## Root cause

The npm/Node CLI configures the broker with its adjacent bundled MCP script, but a compiled Bun installation reports a virtual `/$bunfs/root/...` entrypoint. The adjacent-script lookup therefore returned no command, and the Rust broker fell back to `npx -y agent-relay mcp`. A cold package resolution could exceed Claude Code's roughly 30-second MCP connection timeout while the worker process itself stayed alive.

## Changes

- Re-enter the installed Bun executable as `agent-relay mcp`; keep the adjacent script for Node/npm installs.
- Resolve MCP commands explicitly from the configured override, canonical Relay install, PATH, and local bin, with no network/package-manager fallback.
- Before the first MCP-enabled spawn, perform a credential-free stdio handshake and require `send_dm`, `post_message`, and `check_inbox`; fail the spawn with an actionable error on missing, slow, crashing, or incomplete MCP servers.
- Cover a 31-second fake `npx`, standalone Bun paths, quoted paths, tool discovery, and incomplete tool registration.
- Standardize Claude's decorated tool spelling on `mcp__agent-relay__*` and migrate legacy guidance.

## Validation

- `cargo test -p agent-relay-broker --lib` — 930 passed, 4 ignored
- `cargo clippy -p agent-relay-broker --all-targets -- -D warnings`
- `npx vitest run --maxWorkers=1` — 1,903 passed, 25 skipped
- `npm run typecheck`
- `npm run lint` — no errors (existing warnings only)
- `npm run build:cli` plus a real stdio MCP initialize/tools-list smoke — all three required tools present
- `trufflehog` scan of this branch — zero verified or unverified secrets


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

