### PR TITLE
security: close sponsor-registration authority bypass

### DIFF
--- a/.github/actions/setup-relaycast-ci/action.yml
+++ b/.github/actions/setup-relaycast-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   engine-ref:
     description: Immutable Relaycast commit containing server-side credential authority
     required: false
-    default: d1fd18a817466debdf4b3a8460ee071e4b321ac4
+    default: 717ca65a1cb7d4726babef4d8a6de45a1fe3d34b
 
 runs:
   using: composite

--- a/.github/actions/setup-relaycast-ci/action.yml
+++ b/.github/actions/setup-relaycast-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   engine-ref:
     description: Immutable Relaycast commit containing server-side credential authority
     required: false
-    default: 717ca65a1cb7d4726babef4d8a6de45a1fe3d34b
+    default: a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2
 
 runs:
   using: composite

--- a/.github/actions/setup-relaycast-ci/action.yml
+++ b/.github/actions/setup-relaycast-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   engine-ref:
     description: Immutable Relaycast commit containing server-side credential authority
     required: false
-    default: da7670d7034d3c5797739dfb526a075c94ce3c82
+    default: d1fd18a817466debdf4b3a8460ee071e4b321ac4
 
 runs:
   using: composite

--- a/.github/actions/setup-relaycast-ci/action.yml
+++ b/.github/actions/setup-relaycast-ci/action.yml
@@ -1,0 +1,57 @@
+name: Setup sponsor-enforced Relaycast
+description: Build a pinned local Relaycast and mint an ephemeral CI sponsor grant it trusts
+
+inputs:
+  engine-ref:
+    description: Immutable Relaycast commit containing server-side credential authority
+    required: false
+    default: 0b29cc36a3df6ef2c715d6f5e097155da35cedd5
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout sponsor-enforced Relaycast
+      uses: actions/checkout@v4
+      with:
+        repository: AgentWorkforce/relaycast
+        ref: ${{ inputs.engine-ref }}
+        path: .ci/relaycast-engine
+
+    - name: Build local Relaycast engine
+      shell: bash
+      working-directory: .ci/relaycast-engine
+      run: |
+        npm ci
+        npm run build --workspace @relaycast/types
+        npm run build --workspace @relaycast/a2a
+        npm run build --workspace @relaycast/engine
+
+    - name: Mint ephemeral sponsor grant
+      shell: bash
+      run: node scripts/mint-ci-sponsor-grant.mjs
+
+    - name: Start sponsor-enforced local engine
+      shell: bash
+      run: |
+        ENGINE_PORT="$((42000 + RANDOM % 10000))"
+        ENGINE_LOG="$RUNNER_TEMP/relaycast-ci-engine.log"
+        node .ci/relaycast-engine/packages/engine/dist/bin/serve.js \
+          --port "$ENGINE_PORT" \
+          --db "$RUNNER_TEMP/relaycast-ci-engine.db" \
+          --env test >"$ENGINE_LOG" 2>&1 &
+        ENGINE_PID=$!
+        for attempt in $(seq 1 60); do
+          if curl --silent --fail "http://127.0.0.1:${ENGINE_PORT}/health" >/dev/null; then
+            echo "RELAY_BASE_URL=http://127.0.0.1:${ENGINE_PORT}" >> "$GITHUB_ENV"
+            echo "RELAYCAST_BASE_URL=http://127.0.0.1:${ENGINE_PORT}" >> "$GITHUB_ENV"
+            echo "RELAYCAST_CI_ENGINE_PID=${ENGINE_PID}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if ! kill -0 "$ENGINE_PID" 2>/dev/null; then
+            cat "$ENGINE_LOG" >&2
+            exit 1
+          fi
+          sleep 0.25
+        done
+        cat "$ENGINE_LOG" >&2
+        exit 1

--- a/.github/actions/setup-relaycast-ci/action.yml
+++ b/.github/actions/setup-relaycast-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   engine-ref:
     description: Immutable Relaycast commit containing server-side credential authority
     required: false
-    default: 0b29cc36a3df6ef2c715d6f5e097155da35cedd5
+    default: da7670d7034d3c5797739dfb526a075c94ce3c82
 
 runs:
   using: composite

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,9 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/e2e-test.sh'
+      - 'scripts/mint-ci-sponsor-grant.mjs'
       - 'package.json'
+      - '.github/actions/setup-relaycast-ci/**'
       - '.github/workflows/e2e-tests.yml'
   pull_request:
     branches: [main]
@@ -21,7 +23,9 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/e2e-test.sh'
+      - 'scripts/mint-ci-sponsor-grant.mjs'
       - 'package.json'
+      - '.github/actions/setup-relaycast-ci/**'
       - '.github/workflows/e2e-tests.yml'
   # Allow manual trigger for on-demand testing
   workflow_dispatch:
@@ -55,6 +59,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+
+      - name: Setup sponsor-enforced local Relaycast
+        uses: ./.github/actions/setup-relaycast-ci
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: eb7563ffcf0e54698c23363c5753060f99d37dd3 # relaycast v7.0.0 (node providers + unreported-load heartbeat compatibility)
+          ref: 0b29cc36a3df6ef2c715d6f5e097155da35cedd5 # sponsor-enforced credential authority + node providers
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: 0b29cc36a3df6ef2c715d6f5e097155da35cedd5 # sponsor-enforced credential authority + node providers
+          ref: da7670d7034d3c5797739dfb526a075c94ce3c82 # sponsor-enforced credential authority + claim race guards
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: d1fd18a817466debdf4b3a8460ee071e4b321ac4 # sponsor authority + claim race/lifetime guards
+          ref: 717ca65a1cb7d4726babef4d8a6de45a1fe3d34b # complete sponsor authority + destructive SDK surface
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: da7670d7034d3c5797739dfb526a075c94ce3c82 # sponsor-enforced credential authority + claim race guards
+          ref: d1fd18a817466debdf4b3a8460ee071e4b321ac4 # sponsor authority + claim race/lifetime guards
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AgentWorkforce/relaycast
-          ref: 717ca65a1cb7d4726babef4d8a6de45a1fe3d34b # complete sponsor authority + destructive SDK surface
+          ref: a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2 # complete sponsor authority + D1 legacy-claim guard
           path: relaycast-engine
 
       - name: Setup Node.js

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup sponsor-enforced local Relaycast
+        uses: ./.github/actions/setup-relaycast-ci
+
       # Restore node_modules — skip npm ci entirely if unchanged. Split
       # restore/save (instead of actions/cache@v4) so the cache is saved
       # right after `npm ci` produces a clean tree; otherwise the implicit
@@ -254,6 +257,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Setup sponsor-enforced local Relaycast
+        uses: ./.github/actions/setup-relaycast-ci
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay node agent attach --node` now accepts `--workspace-key`, so commands copied from the Cloud dashboard resolve the intended workspace regardless of the working directory.
 - Passing `--workspace-key` to the local or `--ssh-host` attach path is rejected because those paths authenticate with the broker instead.
 
+### Security
+
+- Workspace-key agent registration and token rotation now require Chief's SSO-authenticated RelayAuth sponsor ID and signed sponsor proof, bind the agent metadata to that human, and reject workspace-key-only identity claims.
+
 ## [11.6.1] - 2026-08-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349#8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=717ca65a1cb7d4726babef4d8a6de45a1fe3d34b#717ca65a1cb7d4726babef4d8a6de45a1fe3d34b"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,8 +2064,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78f728d34cfb36d07d78b1d28d70784810bf4d1dcffc896906d92eac27b1669"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=0b29cc36a3df6ef2c715d6f5e097155da35cedd5#0b29cc36a3df6ef2c715d6f5e097155da35cedd5"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "httpmock",
+ "jsonwebtoken",
  "libc",
  "nix 0.30.1",
  "rand 0.8.5",
@@ -1405,6 +1406,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,10 +1629,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1678,6 +1713,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2454,6 +2499,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -798,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1626,7 +1626,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1867,7 +1867,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1904,9 +1904,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=0b29cc36a3df6ef2c715d6f5e097155da35cedd5#0b29cc36a3df6ef2c715d6f5e097155da35cedd5"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=da7670d7034d3c5797739dfb526a075c94ce3c82#da7670d7034d3c5797739dfb526a075c94ce3c82"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -2162,7 +2162,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2638,7 +2638,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3259,7 +3259,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=d1fd18a817466debdf4b3a8460ee071e4b321ac4#d1fd18a817466debdf4b3a8460ee071e4b321ac4"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=3be0995680e1baa3d2509bd64504aba18b254ce5#3be0995680e1baa3d2509bd64504aba18b254ce5"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=3be0995680e1baa3d2509bd64504aba18b254ce5#3be0995680e1baa3d2509bd64504aba18b254ce5"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349#8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -798,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1626,7 +1626,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1867,7 +1867,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1904,9 +1904,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=da7670d7034d3c5797739dfb526a075c94ce3c82#da7670d7034d3c5797739dfb526a075c94ce3c82"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=d1fd18a817466debdf4b3a8460ee071e4b321ac4#d1fd18a817466debdf4b3a8460ee071e4b321ac4"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -2162,7 +2162,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2638,7 +2638,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3259,7 +3259,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "relaycast"
 version = "6.0.0"
-source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=717ca65a1cb7d4726babef4d8a6de45a1fe3d34b#717ca65a1cb7d4726babef4d8a6de45a1fe3d34b"
+source = "git+https://github.com/AgentWorkforce/relaycast.git?rev=a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2#a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,10 +29,11 @@ workspace key is deliberately insufficient.
 Existing persistent brokers need a staged rollout because older versions did
 not retain their incumbent agent token. Deploy the client update first and
 restart every persistent broker while the old registration authority is still
-active. A successful startup writes an owner-only, atomically replaced
+active. A successful startup writes an atomically replaced
 `state-<broker>.json.agent-credentials.json` cache beside broker state. The file
-contains the scoped agent token and only a SHA-256 fingerprint of the workspace
-key.
+and the adjacent work-unit ownership key are owner-only on Unix and encrypted
+to the current Windows user with DPAPI. The credential cache contains the
+scoped agent token and only a SHA-256 fingerprint of the workspace key.
 
 After that pre-stage is verified across the fleet, migrate the Relaycast
 database and enable its sponsor-verification configuration. On the next broker

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,11 @@ incumbent `RELAY_AGENT_TOKEN` supplied explicitly; they fail closed rather than
 falling back to a workspace-key-only reclaim. Do not enable hosted enforcement
 before the client pre-stage is complete.
 
+Every accepted Relaycast base URL is an authority boundary. Operators must
+upgrade, cut over, or decommission legacy gateways separately; protecting the
+canonical hosted worker does not make an older gateway safe. Keep direct
+credential-issuance tests against every public hostname in the deployment gate.
+
 Agent Relay moves messages, credentials, and tool invocations between
 autonomous agents. A defect here can expose a workspace to agents — or people —
 that should never have reached it, so we treat security reports as a priority

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,16 +8,39 @@ proof from RelayAuth for the currently SSO-authenticated human and passes the
 returned values to the broker as `RELAYAUTH_SPONSOR_ID` and
 `RELAYAUTH_SPONSOR_PROOF`, together with the pinned
 `RELAYAUTH_SIGNING_KEY_PEM_PUBLIC`, `RELAYAUTH_ISSUER`, and
-`RELAYAUTH_SPONSOR_ORG_ID`. The broker verifies the RS256 signature, issuer,
-organization, audience, expiry, `identity.create` intent, and OIDC subject. It
-refuses registration and rotation when any input is absent or invalid.
+`RELAYAUTH_SPONSOR_ORG_ID`. The broker validates those claims before startup,
+then sends the signed proof and a secret work-unit key to Relaycast's
+registration authority. Relaycast independently verifies the RS256 signature,
+pinned key ID, issuer, organization, audience, expiry, `identity.create` intent,
+token type, and OIDC subject before it creates a workspace, registers an agent,
+or rotates an agent credential. This server-side check is the security
+boundary: a workspace key holder calling the REST API, node-control socket, or
+A2A endpoint directly cannot bypass it.
 
-Relay sends the verified `user_...` sponsor ID, `oidc` binding mode, and a
-SHA-256 digest of the proof in agent metadata. It never stores or publishes the
-replayable proof. Crash recovery additionally requires the original work-unit
-identity key, and reclaim/rotation checks that the existing agent is bound to
-the same human sponsor. RelayAuth remains the authority that verifies and binds
-the signed sponsor proof; a workspace key never establishes sponsor identity.
+Relaycast stores the sponsor and work-unit binding in immutable database
+columns and a durable name claim, never in caller-editable agent metadata. It
+stores only a digest of the replayable proof. Crash recovery must present the
+same sponsor and secret work-unit key. A legacy agent with no immutable binding
+can be bound once only by presenting its incumbent agent bearer token; a
+workspace key is deliberately insufficient.
+
+### Sponsor-enforcement rollout order
+
+Existing persistent brokers need a staged rollout because older versions did
+not retain their incumbent agent token. Deploy the client update first and
+restart every persistent broker while the old registration authority is still
+active. A successful startup writes an owner-only, atomically replaced
+`state-<broker>.json.agent-credentials.json` cache beside broker state. The file
+contains the scoped agent token and only a SHA-256 fingerprint of the workspace
+key.
+
+After that pre-stage is verified across the fleet, migrate the Relaycast
+database and enable its sponsor-verification configuration. On the next broker
+restart, the cached token authenticates the exact incumbent agent and performs
+the one-time immutable binding. Hosts that skipped the pre-stage need their
+incumbent `RELAY_AGENT_TOKEN` supplied explicitly; they fail closed rather than
+falling back to a workspace-key-only reclaim. Do not enable hosted enforcement
+before the client pre-stage is complete.
 
 Agent Relay moves messages, credentials, and tool invocations between
 autonomous agents. A defect here can expose a workspace to agents — or people —

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,24 @@
 # Security Policy
 
+## Human sponsor binding
+
+Agent registration is a delegated identity issuance action, not a capability of
+the shared workspace key by itself. Chief obtains an `identity.create` sponsor
+proof from RelayAuth for the currently SSO-authenticated human and passes the
+returned values to the broker as `RELAYAUTH_SPONSOR_ID` and
+`RELAYAUTH_SPONSOR_PROOF`, together with the pinned
+`RELAYAUTH_SIGNING_KEY_PEM_PUBLIC`, `RELAYAUTH_ISSUER`, and
+`RELAYAUTH_SPONSOR_ORG_ID`. The broker verifies the RS256 signature, issuer,
+organization, audience, expiry, `identity.create` intent, and OIDC subject. It
+refuses registration and rotation when any input is absent or invalid.
+
+Relay sends the verified `user_...` sponsor ID, `oidc` binding mode, and a
+SHA-256 digest of the proof in agent metadata. It never stores or publishes the
+replayable proof. Crash recovery additionally requires the original work-unit
+identity key, and reclaim/rotation checks that the existing agent is bound to
+the same human sponsor. RelayAuth remains the authority that verifies and binds
+the signed sponsor proof; a workspace key never establishes sponsor identity.
+
 Agent Relay moves messages, credentials, and tool invocations between
 autonomous agents. A defect here can expose a workspace to agents — or people —
 that should never have reached it, so we treat security reports as a priority

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", features = ["serde", "clock"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6.0"
 hostname = "0.4"
+jsonwebtoken = "9.3"
 rand = "0.8"
 relay-pty = { path = "../relay-pty" }
 regex = "1.11"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "0b29cc36a3df6ef2c715d6f5e097155da35cedd5" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "da7670d7034d3c5797739dfb526a075c94ce3c82" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "da7670d7034d3c5797739dfb526a075c94ce3c82" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "d1fd18a817466debdf4b3a8460ee071e4b321ac4" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "3be0995680e1baa3d2509bd64504aba18b254ce5" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "8ef4dfac0d7d0a952a00a48d7884a9ff1cfaa349" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "717ca65a1cb7d4726babef4d8a6de45a1fe3d34b" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "d1fd18a817466debdf4b3a8460ee071e4b321ac4" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "3be0995680e1baa3d2509bd64504aba18b254ce5" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "717ca65a1cb7d4726babef4d8a6de45a1fe3d34b" }
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shlex = "1.3"
 thiserror = "2.0"
-relaycast = "=6.0.0"
+relaycast = { git = "https://github.com/AgentWorkforce/relaycast.git", rev = "0b29cc36a3df6ef2c715d6f5e097155da35cedd5" }
 tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -47,6 +47,9 @@ tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 nix = { version = "0.30", features = ["signal", "process", "term", "fs"] }
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
+
 [dev-dependencies]
 httpmock = "0.7"
 tempfile = "3.19"

--- a/crates/broker/src/cli_mcp_args.rs
+++ b/crates/broker/src/cli_mcp_args.rs
@@ -148,7 +148,10 @@ async fn register_agent_token_for_mcp_args(
         api_key.clone(),
         agent_name.to_string(),
         cli_lower.clone(),
-    );
+    )
+    .with_registration_work_unit_root(crate::relaycast::agent_identity_key().ok_or_else(|| {
+        anyhow!("--register requires RELAY_AGENT_IDENTITY_KEY for sponsor-bound ownership")
+    })?);
 
     let agent_token = match tokio::time::timeout(
         Duration::from_secs(10),
@@ -272,6 +275,8 @@ mod tests {
         "RELAY_API_KEY",
         "RELAY_BASE_URL",
         "RELAY_AGENT_TOKEN",
+        "RELAY_AGENT_IDENTITY_KEY",
+        "RELAYAUTH_TEST_SPONSOR_FIXTURE",
         "RELAY_WORKSPACES_JSON",
         "RELAY_DEFAULT_WORKSPACE",
     ];
@@ -521,6 +526,14 @@ mod tests {
         std::env::remove_var("RELAY_API_KEY");
         std::env::remove_var("RELAY_BASE_URL");
         std::env::remove_var("RELAY_AGENT_TOKEN");
+        std::env::set_var(
+            "RELAY_AGENT_IDENTITY_KEY",
+            "mcp-args-test-work-unit-key-00000000000000000001",
+        );
+        // Compiled only under cfg(test): production still requires a validly
+        // signed RelayAuth proof. This mock-server test is about mcp-args token
+        // propagation; signature verification is covered in auth and live CI.
+        std::env::set_var("RELAYAUTH_TEST_SPONSOR_FIXTURE", "1");
 
         let server = MockServer::start();
         let register_mock = server.mock(|when, then| {

--- a/crates/broker/src/fleet_wire.rs
+++ b/crates/broker/src/fleet_wire.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use relaycast::AgentRegistrationAuthority;
 use serde::{
     de::{self, Deserializer},
     ser, Deserialize, Serialize, Serializer,
@@ -233,6 +234,12 @@ pub struct AgentRegister {
         skip_serializing_if = "Option::is_none"
     )]
     pub resumable: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_presence",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub registration_authority: Option<AgentRegistrationAuthority>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -678,6 +685,7 @@ mod tests {
             invocation_id: None,
             session_ref: None,
             resumable: None,
+            registration_authority: None,
         });
 
         let value = serde_json::to_value(msg).unwrap();

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -3233,6 +3233,7 @@ mod tests {
                     invocation_id: Some("inv-1".to_string()),
                     session_ref: Some("session-1".to_string()),
                     resumable: Some(true),
+                    registration_authority: None,
                 },
                 reply: reply_tx,
             })
@@ -3459,6 +3460,7 @@ mod tests {
                     invocation_id: Some("inv-1".to_string()),
                     session_ref: None,
                     resumable: None,
+                    registration_authority: None,
                 },
                 reply: reply_tx,
             })

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -37,6 +37,7 @@ use crate::readiness::{cli_prompt_ready, detect_cli_ready, GridReadinessSnapshot
 use crate::runtime::{get_terminal_size, send_frame};
 use crate::snapshot::Snapshot;
 use crate::util::ansi::{floor_char_boundary, strip_ansi, AnsiStripper};
+use crate::util::child_env::REGISTRATION_AUTHORITY_ENV_KEYS;
 use crate::util::terminal::detect_codex_trust_prompt;
 use crate::util::utf8_stream::Utf8StreamDecoder;
 use crate::worker::detection::ActivityDetector;
@@ -497,8 +498,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
     effective_args.extend(cmd.args.clone());
 
     let (init_rows, init_cols) = get_terminal_size().unwrap_or((24, 80));
-    let (pty, mut pty_rx) =
-        PtySession::spawn(&resolved_cli, &effective_args, init_rows, init_cols)?;
+    let (pty, mut pty_rx) = PtySession::spawn_with_env_removals(
+        &resolved_cli,
+        &effective_args,
+        init_rows,
+        init_cols,
+        REGISTRATION_AUTHORITY_ENV_KEYS,
+    )?;
     // Query responses (DSR/DA1/DA2/CPR) are answered by alacritty's
     // `RelayEventListener` inside `PtySession` — no parser needed here.
 

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -1431,6 +1431,7 @@ const RELAYAUTH_PUBLIC_KEY_ENV: &str = "RELAYAUTH_SIGNING_KEY_PEM_PUBLIC";
 const SPONSOR_GRANT_AUDIENCE: &str = "relayauth:sponsor-binding";
 const SPONSOR_GRANT_INTENT: &str = "identity.create";
 const SPONSOR_GRANT_TOKEN_TYPE: &str = "sponsor_grant";
+const SPONSOR_GRANT_MAX_TTL_SECONDS: i64 = 15 * 60;
 
 #[derive(Debug, Deserialize)]
 struct SponsorGrantClaims {
@@ -1523,6 +1524,8 @@ fn verify_sponsor_proof(
         && claims.intent == SPONSOR_GRANT_INTENT
         && claims.token_type == SPONSOR_GRANT_TOKEN_TYPE
         && claims.iat <= now + 60
+        && claims.exp > claims.iat
+        && claims.exp - claims.iat <= SPONSOR_GRANT_MAX_TTL_SECONDS
         && !claims.oidc.issuer.trim().is_empty()
         && !claims.oidc.subject.trim().is_empty()
         && claims.oidc.iat > 0)

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -11,6 +11,8 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+const INCUMBENT_CREDENTIAL_CACHE_VERSION: u8 = 1;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceCredential {
     pub workspace_id: String,
@@ -41,6 +43,29 @@ pub struct CredentialSet {
         skip_serializing_if = "Option::is_none"
     )]
     pub default_workspace_id: Option<String>,
+}
+
+/// Owner-only local proof that this broker possessed an agent credential
+/// before sponsor enforcement was enabled on the registration authority.
+///
+/// The workspace key itself is intentionally not duplicated here. A digest is
+/// sufficient to select the incumbent token for the exact configured
+/// workspace, while the agent name prevents a token cached for one identity
+/// from being offered while reclaiming another.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IncumbentCredentialCache {
+    version: u8,
+    #[serde(default)]
+    memberships: Vec<IncumbentCredential>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IncumbentCredential {
+    workspace_key_sha256: String,
+    workspace_id: String,
+    agent_id: String,
+    agent_name: String,
+    agent_token: String,
 }
 
 #[derive(Debug, Clone)]
@@ -170,6 +195,107 @@ impl CredentialSet {
         }
         set
     }
+}
+
+impl IncumbentCredentialCache {
+    fn empty() -> Self {
+        Self {
+            version: INCUMBENT_CREDENTIAL_CACHE_VERSION,
+            memberships: Vec::new(),
+        }
+    }
+
+    fn from_credential_set(credentials: &CredentialSet) -> Result<Self> {
+        let memberships = credentials
+            .memberships
+            .iter()
+            .map(|credential| {
+                let workspace_key = normalize_workspace_key(&credential.api_key)
+                    .context("cannot cache an invalid workspace key fingerprint")?;
+                let agent_name = credential
+                    .agent_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .context("cannot cache an incumbent credential without an agent name")?;
+                let agent_token = credential
+                    .agent_token
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .context("cannot cache an incumbent credential without an agent token")?;
+                Ok(IncumbentCredential {
+                    workspace_key_sha256: workspace_key_fingerprint(&workspace_key),
+                    workspace_id: credential.workspace_id.clone(),
+                    agent_id: credential.agent_id.clone(),
+                    agent_name: agent_name.to_string(),
+                    agent_token: agent_token.to_string(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            version: INCUMBENT_CREDENTIAL_CACHE_VERSION,
+            memberships,
+        })
+    }
+
+    fn merge_credential_set(&mut self, credentials: &CredentialSet) -> Result<()> {
+        let updates = Self::from_credential_set(credentials)?;
+        for update in updates.memberships {
+            if let Some(existing) = self.memberships.iter_mut().find(|existing| {
+                existing.workspace_key_sha256 == update.workspace_key_sha256
+                    && existing.agent_name.eq_ignore_ascii_case(&update.agent_name)
+            }) {
+                *existing = update;
+            } else {
+                self.memberships.push(update);
+            }
+        }
+        Ok(())
+    }
+
+    fn incumbent_token_for(&self, workspace_key: &str, agent_name: Option<&str>) -> Option<&str> {
+        let agent_name = agent_name?.trim();
+        if agent_name.is_empty() {
+            return None;
+        }
+        let fingerprint = workspace_key_fingerprint(workspace_key);
+        self.memberships
+            .iter()
+            .find(|credential| {
+                credential.workspace_key_sha256 == fingerprint
+                    && credential.agent_name.eq_ignore_ascii_case(agent_name)
+            })
+            .map(|credential| credential.agent_token.as_str())
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.version != INCUMBENT_CREDENTIAL_CACHE_VERSION {
+            anyhow::bail!(
+                "unsupported incumbent credential cache version {}",
+                self.version
+            );
+        }
+        for credential in &self.memberships {
+            if credential.workspace_key_sha256.len() != 64
+                || !credential
+                    .workspace_key_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit())
+                || credential.workspace_id.trim().is_empty()
+                || credential.agent_id.trim().is_empty()
+                || credential.agent_name.trim().is_empty()
+                || credential.agent_token.trim().is_empty()
+            {
+                anyhow::bail!("incumbent credential cache contains an invalid membership");
+            }
+        }
+        Ok(())
+    }
+}
+
+fn workspace_key_fingerprint(workspace_key: &str) -> String {
+    format!("{:x}", Sha256::digest(workspace_key.as_bytes()))
 }
 
 impl AuthSessionSet {
@@ -372,6 +498,28 @@ impl AuthClient {
         agent_type: Option<&str>,
         identity_key: Option<&str>,
     ) -> Result<AuthSessionSet> {
+        self.startup_session_set_with_identity_and_incumbents(
+            requested_name,
+            strict_name,
+            agent_type,
+            identity_key,
+            &IncumbentCredentialCache::empty(),
+        )
+        .await
+    }
+
+    /// Broker-only startup variant that can prove possession of a credential
+    /// cached before server-side sponsor enforcement was enabled. Cached
+    /// tokens are considered solely for the exact workspace-key fingerprint
+    /// and requested agent name; they never activate token-only bootstrap.
+    pub(crate) async fn startup_session_set_with_identity_and_incumbents(
+        &self,
+        requested_name: Option<&str>,
+        strict_name: bool,
+        agent_type: Option<&str>,
+        identity_key: Option<&str>,
+        incumbent_cache: &IncumbentCredentialCache,
+    ) -> Result<AuthSessionSet> {
         let incumbent_agent_token = env_agent_token();
         if self.sponsor.is_none() {
             if let Some(agent_token) = incumbent_agent_token.as_deref() {
@@ -389,6 +537,25 @@ impl AuthClient {
                 let Some(api_key) = normalize_workspace_key(&source.api_key) else {
                     anyhow::bail!("RELAY_WORKSPACES_JSON contained an invalid workspace key");
                 };
+                let cached_incumbent_token =
+                    incumbent_cache.incumbent_token_for(&api_key, preferred_name);
+                if let Some(incumbent_token) = cached_incumbent_token {
+                    if let Some(mut session) = self
+                        .try_startup_session_from_incumbent(
+                            &api_key,
+                            source.workspace_id.as_deref(),
+                            preferred_name,
+                            incumbent_token,
+                            identity_key,
+                        )
+                        .await?
+                    {
+                        session.credentials.workspace_alias = source.workspace_alias.clone();
+                        memberships.push(session);
+                        continue;
+                    }
+                }
+                let incumbent_token = source.agent_token.as_deref().or(cached_incumbent_token);
                 match self
                     .register_agent_with_workspace_key(
                         &api_key,
@@ -396,7 +563,7 @@ impl AuthClient {
                         strict_name,
                         agent_type,
                         identity_key,
-                        source.agent_token.as_deref(),
+                        incumbent_token,
                     )
                     .await
                 {
@@ -449,6 +616,7 @@ impl AuthClient {
             agent_type,
             identity_key,
             incumbent_agent_token.as_deref(),
+            incumbent_cache,
         )
         .await
     }
@@ -500,6 +668,83 @@ impl AuthClient {
             memberships: vec![session],
             default_workspace_id: Some(workspace_id),
         })
+    }
+
+    /// Pre-stage or perform a legacy authority binding without rotating the
+    /// only known incumbent token. Old servers return 404 for the binding
+    /// endpoint; in that case a successful `/me` proves the cached token is
+    /// still current and lets the client retain it until enforcement ships.
+    /// New servers bind it idempotently before the session starts.
+    async fn try_startup_session_from_incumbent(
+        &self,
+        workspace_key: &str,
+        workspace_id_hint: Option<&str>,
+        requested_name: Option<&str>,
+        incumbent_token: &str,
+        identity_key: Option<&str>,
+    ) -> Result<Option<AuthSession>> {
+        // Validate the sponsor before even making the token-authenticated
+        // identity lookup. In particular, an absent or expired proof must
+        // stop startup before any Relaycast request is sent.
+        let sponsor = self.require_authenticated_sponsor()?;
+        let authority = registration_authority(sponsor, identity_key)?;
+        let agent = match relaycast::AgentClient::new(incumbent_token, self.base_url.clone())
+            .context("invalid cached incumbent agent token client")?
+            .me()
+            .await
+        {
+            Ok(agent) => agent,
+            Err(error) if is_agent_token_invalid(&error) => return Ok(None),
+            Err(error) => {
+                return Err(relay_error_to_anyhow(error))
+                    .context("cached incumbent agent token was rejected");
+            }
+        };
+        if let Some(requested_name) = requested_name {
+            if !requested_name.trim().eq_ignore_ascii_case(&agent.name) {
+                anyhow::bail!(
+                    "cached incumbent agent token belongs to '{}' rather than requested agent '{}'",
+                    agent.name,
+                    requested_name
+                );
+            }
+        }
+        let workspace_id = agent
+            .workspace_id
+            .context("cached incumbent agent response omitted workspace_id")?;
+        if let Some(expected_workspace_id) = workspace_id_hint {
+            if expected_workspace_id != workspace_id {
+                anyhow::bail!(
+                    "cached incumbent agent token belongs to workspace '{}' rather than configured workspace '{}'",
+                    workspace_id,
+                    expected_workspace_id
+                );
+            }
+        }
+        let relay = build_relay_client(workspace_key, self.base_url.as_deref())?;
+        match relay
+            .bind_agent_credential_authority(incumbent_token, authority)
+            .await
+        {
+            Ok(_) | Err(RelayError::Api { status: 404, .. }) => {}
+            Err(error) if is_agent_token_invalid(&error) => return Ok(None),
+            Err(error) => {
+                return Err(relay_error_to_anyhow(error))
+                    .context("incumbent agent credential authority was rejected");
+            }
+        }
+        Ok(Some(AuthSession {
+            credentials: WorkspaceCredential {
+                workspace_id,
+                workspace_alias: None,
+                agent_id: agent.id,
+                api_key: workspace_key.to_string(),
+                agent_name: Some(agent.name),
+                agent_token: Some(incumbent_token.to_string()),
+                updated_at: Utc::now(),
+            },
+            token: incumbent_token.to_string(),
+        }))
     }
 
     /// Rotate the token for an existing agent without re-registering.
@@ -597,6 +842,7 @@ impl AuthClient {
         agent_type: Option<&str>,
         identity_key: Option<&str>,
         incumbent_agent_token: Option<&str>,
+        incumbent_cache: &IncumbentCredentialCache,
     ) -> Result<AuthSessionSet> {
         let env_workspace_key = env_workspace_key()?;
 
@@ -624,6 +870,26 @@ impl AuthClient {
         let mut auth_rejections = Vec::new();
 
         for candidate in &candidates {
+            let cached_incumbent_token =
+                incumbent_cache.incumbent_token_for(&candidate.key, preferred_name);
+            if let Some(incumbent_token) = cached_incumbent_token {
+                if let Some(session) = self
+                    .try_startup_session_from_incumbent(
+                        &candidate.key,
+                        workspace_id_hint.as_deref(),
+                        preferred_name,
+                        incumbent_token,
+                        identity_key,
+                    )
+                    .await?
+                {
+                    return Ok(AuthSessionSet {
+                        default_workspace_id: Some(session.credentials.workspace_id.clone()),
+                        memberships: vec![session],
+                    });
+                }
+            }
+            let incumbent_token = incumbent_agent_token.or(cached_incumbent_token);
             tracing::info!(
                 target = "relay_broker::auth",
                 source = %candidate.source,
@@ -639,7 +905,7 @@ impl AuthClient {
                     strict_name,
                     agent_type,
                     identity_key,
-                    incumbent_agent_token,
+                    incumbent_token,
                 )
                 .await
             {
@@ -1324,6 +1590,159 @@ pub(crate) fn stable_node_identity_key(state_path: &std::path::Path) -> Result<S
     }
 }
 
+fn incumbent_credential_cache_path(state_path: &std::path::Path) -> Result<std::path::PathBuf> {
+    let parent = state_path
+        .parent()
+        .context("broker state path has no parent directory")?;
+    let state_name = state_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state");
+    Ok(parent.join(format!("{state_name}.agent-credentials.json")))
+}
+
+/// Load incumbent agent credentials without following a caller-controlled
+/// symlink or accepting a file readable by another local user. Missing is a
+/// valid pre-staging state; malformed or insecure existing state fails closed.
+pub(crate) fn load_incumbent_credential_cache(
+    state_path: &std::path::Path,
+) -> Result<IncumbentCredentialCache> {
+    use std::fs::OpenOptions;
+    use std::io::Read;
+
+    let path = incumbent_credential_cache_path(state_path)?;
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(nix::libc::O_NOFOLLOW);
+    }
+    let mut file = match options.open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(IncumbentCredentialCache::empty());
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to open incumbent credential cache {}",
+                    path.display()
+                )
+            });
+        }
+    };
+    let metadata = file.metadata().with_context(|| {
+        format!(
+            "failed to inspect incumbent credential cache {}",
+            path.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "incumbent credential cache is not a regular file: {}",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o077 != 0 {
+            anyhow::bail!(
+                "incumbent credential cache must not be accessible by group or other users: {}",
+                path.display()
+            );
+        }
+    }
+    let mut body = Vec::new();
+    file.read_to_end(&mut body).with_context(|| {
+        format!(
+            "failed to read incumbent credential cache {}",
+            path.display()
+        )
+    })?;
+    let cache: IncumbentCredentialCache = serde_json::from_slice(&body).with_context(|| {
+        format!(
+            "failed to parse incumbent credential cache {}",
+            path.display()
+        )
+    })?;
+    cache.validate()?;
+    Ok(cache)
+}
+
+/// Atomically replace the incumbent credential cache after a successful
+/// registration. Startup fails if this durability step fails: proceeding
+/// without retaining the only migration proof could strand the identity once
+/// hosted sponsor enforcement is enabled.
+pub(crate) fn persist_incumbent_credential_cache(
+    state_path: &std::path::Path,
+    credentials: &CredentialSet,
+) -> Result<()> {
+    use std::io::Write;
+
+    let path = incumbent_credential_cache_path(state_path)?;
+    let parent = path
+        .parent()
+        .context("incumbent credential cache path has no parent directory")?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create incumbent credential cache directory {}",
+            parent.display()
+        )
+    })?;
+    // Multi-workspace startup intentionally tolerates an unavailable
+    // membership when at least one other membership succeeds. Preserve its
+    // last known incumbent token instead of replacing the entire cache and
+    // accidentally destroying the proof needed on its next healthy restart.
+    let mut cache = load_incumbent_credential_cache(state_path)?;
+    cache.merge_credential_set(credentials)?;
+    let body = serde_json::to_vec_pretty(&cache)
+        .context("failed to serialize incumbent credential cache")?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "failed to create temporary incumbent credential cache in {}",
+            parent.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temporary
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .with_context(|| {
+                format!(
+                    "failed to restrict temporary incumbent credential cache in {}",
+                    parent.display()
+                )
+            })?;
+    }
+    temporary
+        .write_all(&body)
+        .context("failed to write incumbent credential cache")?;
+    temporary
+        .as_file()
+        .sync_all()
+        .context("failed to sync incumbent credential cache")?;
+    temporary.persist(&path).with_context(|| {
+        format!(
+            "failed to atomically persist incumbent credential cache {}",
+            path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| {
+            format!(
+                "failed to durably sync incumbent credential cache directory {}",
+                parent.display()
+            )
+        })?;
+    Ok(())
+}
+
 fn registration_authority(
     sponsor: &AuthenticatedSponsor,
     identity_key: Option<&str>,
@@ -1467,8 +1886,9 @@ mod tests {
 
     use super::{
         is_agent_token_invalid, is_agent_token_invalid_anyhow, is_agent_token_invalid_code,
-        relay_error_to_anyhow, stable_node_identity_key, AuthClient, CredentialCache,
-        AGENT_TOKEN_INVALID_CODE,
+        load_incumbent_credential_cache, persist_incumbent_credential_cache, relay_error_to_anyhow,
+        stable_node_identity_key, AuthClient, CredentialCache, CredentialSet,
+        AGENT_TOKEN_INVALID_CODE, INCUMBENT_CREDENTIAL_CACHE_VERSION,
     };
     use relaycast::RelayError;
 
@@ -2156,6 +2576,228 @@ mod tests {
         get_existing.assert_hits(1);
         rotate.assert_hits(1);
         bind.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn staged_restart_migrates_legacy_agent_with_persisted_incumbent_token() {
+        let _env_guard = clear_relay_env();
+        let state_dir = tempfile::tempdir().unwrap();
+        let state_path = state_dir.path().join("state.json");
+        unsafe {
+            std::env::set_var("RELAY_API_KEY", "rk_live_shared");
+        }
+
+        // Stage 1: deploy this client while the old authority still allows the
+        // legacy rotation. The resulting scoped token is persisted before the
+        // server-side enforcement rollout.
+        let old_server = MockServer::start();
+        let old_conflict = old_server.mock(|when, then| {
+            when.method(POST).path("/v1/agents");
+            then.status(409)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
+        });
+        let old_get = old_server.mock(|when, then| {
+            when.method(GET).path("/v1/agents/lead");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_legacy","workspace_id":"ws_legacy","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
+        });
+        let old_rotate = old_server.mock(|when, then| {
+            when.method(POST).path("/v1/agents/lead/rotate-token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"name":"lead","token":"at_live_incumbent"}}"#);
+        });
+        let staged = AuthClient::new_for_test(Some(old_server.base_url()))
+            .startup_session_set_with_identity(Some("lead"), true, None, Some(TEST_WORK_UNIT_KEY))
+            .await
+            .expect("the client-first stage should capture the incumbent token");
+        persist_incumbent_credential_cache(&state_path, &staged.credential_set()).unwrap();
+        old_conflict.assert_hits(1);
+        old_get.assert_hits(1);
+        old_rotate.assert_hits(1);
+
+        // Stage 2: after enforcement, the next restart proves possession with
+        // that exact agent token and binds the immutable sponsor/work-unit
+        // authority. It never asks the workspace-key endpoint to rotate.
+        let enforced_server = MockServer::start();
+        let me = enforced_server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agent")
+                .header("authorization", "Bearer at_live_incumbent");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_legacy","workspace_id":"ws_legacy","name":"lead","type":"agent","status":"online","persona":null,"metadata":{}}}"#);
+        });
+        let bind = enforced_server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agent/credential-authority")
+                .header("authorization", "Bearer at_live_incumbent")
+                .json_body(json!({
+                    "registration_authority": {
+                        "sponsor_proof": "header.payload.signature",
+                        "work_unit_key": TEST_WORK_UNIT_KEY,
+                    }
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"bound":true}}"#);
+        });
+        let workspace_key_registration = enforced_server.mock(|when, then| {
+            when.method(POST).path("/v1/agents");
+            then.status(500);
+        });
+        let cache = load_incumbent_credential_cache(&state_path).unwrap();
+        let migrated = AuthClient::new_for_test(Some(enforced_server.base_url()))
+            .startup_session_set_with_identity_and_incumbents(
+                Some("lead"),
+                true,
+                None,
+                Some(TEST_WORK_UNIT_KEY),
+                &cache,
+            )
+            .await
+            .expect("the staged token should authorize the one-time migration");
+
+        assert_eq!(
+            migrated.default_session().unwrap().token,
+            "at_live_incumbent"
+        );
+        me.assert_hits(1);
+        bind.assert_hits(1);
+        workspace_key_registration.assert_hits(0);
+
+        unsafe {
+            std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    #[test]
+    fn incumbent_cache_is_name_and_workspace_bound_without_storing_workspace_key() {
+        let cache =
+            super::IncumbentCredentialCache::from_credential_set(&CredentialSet::from_memberships(
+                vec![CredentialCache {
+                    workspace_id: "ws_1".into(),
+                    workspace_alias: None,
+                    agent_id: "a_1".into(),
+                    api_key: "rk_live_secret_workspace_key".into(),
+                    agent_name: Some("lead".into()),
+                    agent_token: Some("at_live_incumbent".into()),
+                    updated_at: chrono::Utc::now(),
+                }],
+                None,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            cache.incumbent_token_for("rk_live_secret_workspace_key", Some("LEAD")),
+            Some("at_live_incumbent")
+        );
+        assert_eq!(
+            cache.incumbent_token_for("rk_live_other_workspace_key", Some("lead")),
+            None
+        );
+        assert_eq!(
+            cache.incumbent_token_for("rk_live_secret_workspace_key", Some("victim")),
+            None
+        );
+        let serialized = serde_json::to_string(&cache).unwrap();
+        assert!(!serialized.contains("rk_live_secret_workspace_key"));
+        assert_eq!(cache.version, INCUMBENT_CREDENTIAL_CACHE_VERSION);
+    }
+
+    #[test]
+    fn incumbent_cache_persistence_preserves_an_unavailable_workspace_membership() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let membership = |workspace_id: &str,
+                          agent_id: &str,
+                          workspace_key: &str,
+                          agent_name: &str,
+                          agent_token: &str| CredentialCache {
+            workspace_id: workspace_id.into(),
+            workspace_alias: None,
+            agent_id: agent_id.into(),
+            api_key: workspace_key.into(),
+            agent_name: Some(agent_name.into()),
+            agent_token: Some(agent_token.into()),
+            updated_at: chrono::Utc::now(),
+        };
+        persist_incumbent_credential_cache(
+            &state_path,
+            &CredentialSet::from_memberships(
+                vec![
+                    membership("ws_1", "a_1", "rk_live_one", "lead", "at_live_old_one"),
+                    membership("ws_2", "a_2", "rk_live_two", "lead", "at_live_old_two"),
+                ],
+                None,
+            ),
+        )
+        .unwrap();
+        persist_incumbent_credential_cache(
+            &state_path,
+            &CredentialSet::from_memberships(
+                vec![membership(
+                    "ws_1",
+                    "a_1",
+                    "rk_live_one",
+                    "lead",
+                    "at_live_new_one",
+                )],
+                None,
+            ),
+        )
+        .unwrap();
+
+        let cache = load_incumbent_credential_cache(&state_path).unwrap();
+        assert_eq!(
+            cache.incumbent_token_for("rk_live_one", Some("lead")),
+            Some("at_live_new_one")
+        );
+        assert_eq!(
+            cache.incumbent_token_for("rk_live_two", Some("lead")),
+            Some("at_live_old_two")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn incumbent_cache_is_owner_only_and_rejects_insecure_existing_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let credentials = CredentialSet::from_memberships(
+            vec![CredentialCache {
+                workspace_id: "ws_1".into(),
+                workspace_alias: None,
+                agent_id: "a_1".into(),
+                api_key: "rk_live_workspace".into(),
+                agent_name: Some("lead".into()),
+                agent_token: Some("at_live_incumbent".into()),
+                updated_at: chrono::Utc::now(),
+            }],
+            None,
+        );
+        persist_incumbent_credential_cache(&state_path, &credentials).unwrap();
+        let path = super::incumbent_credential_cache_path(&state_path).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o077,
+            0
+        );
+        assert_eq!(
+            load_incumbent_credential_cache(&state_path)
+                .unwrap()
+                .memberships
+                .len(),
+            1
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let error = load_incumbent_credential_cache(&state_path)
+            .expect_err("a group/world-readable token cache must fail closed");
+        assert!(error.to_string().contains("group or other users"));
     }
 
     #[test]

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use relaycast::{CreateAgentRequest, RelayCast, RelayCastOptions, RelayError};
+use relaycast::{
+    AgentRegistrationAuthority, CreateAgentRequest, RelayCast, RelayCastOptions, RelayError,
+    WorkspaceRegistrationAuthority,
+};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -59,6 +62,10 @@ struct WorkspaceSource {
     #[serde(default, alias = "workspaceAlias")]
     workspace_alias: Option<String>,
     api_key: String,
+    #[serde(default)]
+    agent_name: Option<String>,
+    #[serde(default)]
+    agent_token: Option<String>,
 }
 
 struct EnvWorkspaceKey {
@@ -97,8 +104,8 @@ impl CredentialSet {
                     workspace_alias: source.workspace_alias,
                     agent_id: String::new(),
                     api_key: source.api_key,
-                    agent_name: None,
-                    agent_token: None,
+                    agent_name: source.agent_name,
+                    agent_token: source.agent_token,
                     updated_at: Utc::now(),
                 }],
                 None,
@@ -365,6 +372,14 @@ impl AuthClient {
         agent_type: Option<&str>,
         identity_key: Option<&str>,
     ) -> Result<AuthSessionSet> {
+        let incumbent_agent_token = env_agent_token();
+        if self.sponsor.is_none() {
+            if let Some(agent_token) = incumbent_agent_token.as_deref() {
+                return self
+                    .startup_session_set_from_agent_token(requested_name, agent_token)
+                    .await;
+            }
+        }
         if let Some((sources, default_hint)) = self.load_workspace_sources_from_env()? {
             let preferred_name = requested_name;
             let mut memberships = Vec::with_capacity(sources.len());
@@ -381,6 +396,7 @@ impl AuthClient {
                         strict_name,
                         agent_type,
                         identity_key,
+                        source.agent_token.as_deref(),
                     )
                     .await
                 {
@@ -432,8 +448,58 @@ impl AuthClient {
             strict_name,
             agent_type,
             identity_key,
+            incumbent_agent_token.as_deref(),
         )
         .await
+    }
+
+    /// Bootstrap an already pre-registered worker without exercising the
+    /// workspace-key registration authority at all. Parent brokers use this
+    /// path for transport wrappers: the scoped agent token proves exactly one
+    /// identity and therefore does not require exposing a sponsor grant or the
+    /// broker's root work-unit secret to the child process.
+    async fn startup_session_set_from_agent_token(
+        &self,
+        requested_name: Option<&str>,
+        agent_token: &str,
+    ) -> Result<AuthSessionSet> {
+        let agent = relaycast::AgentClient::new(agent_token, self.base_url.clone())
+            .context("invalid pre-registered RELAY_AGENT_TOKEN client")?
+            .me()
+            .await
+            .map_err(relay_error_to_anyhow)
+            .context("pre-registered RELAY_AGENT_TOKEN was rejected")?;
+        if let Some(requested_name) = requested_name {
+            if !requested_name.trim().eq_ignore_ascii_case(&agent.name) {
+                anyhow::bail!(
+                    "pre-registered RELAY_AGENT_TOKEN belongs to '{}' rather than requested agent '{}'",
+                    agent.name,
+                    requested_name
+                );
+            }
+        }
+        let workspace_id = agent
+            .workspace_id
+            .context("pre-registered agent response omitted workspace_id")?;
+        let workspace_key = workspace_key_for_id_from_env(&workspace_id)?.context(
+            "pre-registered agent workspace is missing from the configured workspace keys",
+        )?;
+        let session = AuthSession {
+            credentials: WorkspaceCredential {
+                workspace_id: workspace_id.clone(),
+                workspace_alias: None,
+                agent_id: agent.id,
+                api_key: workspace_key,
+                agent_name: Some(agent.name),
+                agent_token: Some(agent_token.to_string()),
+                updated_at: Utc::now(),
+            },
+            token: agent_token.to_string(),
+        };
+        Ok(AuthSessionSet {
+            memberships: vec![session],
+            default_workspace_id: Some(workspace_id),
+        })
     }
 
     /// Rotate the token for an existing agent without re-registering.
@@ -463,6 +529,7 @@ impl AuthClient {
                         false,
                         None,
                         agent_identity_key().as_deref(),
+                        cached.agent_token.as_deref(),
                     )
                     .await
                     .context("failed to re-register after rotate-token 404")?;
@@ -485,30 +552,28 @@ impl AuthClient {
         let sponsor = self.require_authenticated_sponsor()?;
 
         let relay = build_relay_client(&api_key, self.base_url.as_deref())?;
-        let existing = relay
-            .get_agent(agent_name)
+        let identity_key =
+            agent_identity_key().context("cannot rotate token without RELAY_AGENT_IDENTITY_KEY")?;
+        let authority = registration_authority(sponsor, Some(&identity_key))?;
+        let token = match relay
+            .rotate_agent_token_with_authority(agent_name, authority.clone())
             .await
-            .map_err(relay_error_to_anyhow)?;
-        let existing_sponsor = existing
-            .metadata
-            .get(SPONSOR_ID_METADATA_KEY)
-            .and_then(Value::as_str);
-        let existing_binding = existing
-            .metadata
-            .get(SPONSOR_BINDING_METADATA_KEY)
-            .and_then(Value::as_str);
-        if existing_sponsor != Some(sponsor.sponsor_id.as_str()) || existing_binding != Some("oidc")
         {
-            anyhow::bail!(
-                "refusing to rotate agent token because the existing identity is not bound to the authenticated SSO sponsor"
-            );
-        }
-        let result = relay
-            .rotate_agent_token(agent_name)
-            .await
-            .map_err(relay_error_to_anyhow)?;
-        let token = result.token;
-
+            Ok(result) => result.token,
+            Err(RelayError::Api {
+                code, status: 409, ..
+            }) if code == "agent_sponsor_migration_required" => {
+                let incumbent_token = cached.agent_token.as_deref().context(
+                    "legacy agent sponsor migration requires its cached incumbent agent token; refusing workspace-key-only reclaim",
+                )?;
+                relay
+                    .bind_agent_credential_authority(incumbent_token, authority.clone())
+                    .await
+                    .map_err(relay_error_to_anyhow)?;
+                incumbent_token.to_string()
+            }
+            Err(error) => return Err(relay_error_to_anyhow(error)),
+        };
         let creds = CredentialCache {
             workspace_id: cached.workspace_id.clone(),
             workspace_alias: cached.workspace_alias.clone(),
@@ -531,6 +596,7 @@ impl AuthClient {
         strict_name: bool,
         agent_type: Option<&str>,
         identity_key: Option<&str>,
+        incumbent_agent_token: Option<&str>,
     ) -> Result<AuthSessionSet> {
         let env_workspace_key = env_workspace_key()?;
 
@@ -573,6 +639,7 @@ impl AuthClient {
                     strict_name,
                     agent_type,
                     identity_key,
+                    incumbent_agent_token,
                 )
                 .await
             {
@@ -631,6 +698,7 @@ impl AuthClient {
                     strict_name,
                     agent_type,
                     identity_key,
+                    None,
                 )
                 .await
             {
@@ -699,6 +767,8 @@ impl AuthClient {
                     workspace_id: Some(credential.workspace_id),
                     workspace_alias: credential.workspace_alias,
                     api_key: credential.api_key,
+                    agent_name: credential.agent_name,
+                    agent_token: credential.agent_token,
                 });
                 continue;
             }
@@ -740,7 +810,17 @@ impl AuthClient {
     }
 
     async fn create_workspace(&self, name: &str) -> Result<(String, String)> {
-        match RelayCast::create_workspace(name, self.base_url.as_deref()).await {
+        let sponsor = self.require_authenticated_sponsor()?;
+        let authority = Some(WorkspaceRegistrationAuthority {
+            sponsor_proof: sponsor.sponsor_proof.clone(),
+        });
+        match RelayCast::create_workspace_with_authority(
+            name,
+            self.base_url.as_deref(),
+            authority.clone(),
+        )
+        .await
+        {
             Ok(result) => Ok((result.workspace_id, result.api_key)),
             Err(error) if is_workspace_name_conflict(&error) => {
                 let suffix = Uuid::new_v4().simple().to_string();
@@ -750,9 +830,13 @@ impl AuthClient {
                     fallback_name = %fallback_name,
                     "workspace already exists; retrying with a fresh fallback name"
                 );
-                let result = RelayCast::create_workspace(&fallback_name, self.base_url.as_deref())
-                    .await
-                    .map_err(relay_error_to_anyhow)?;
+                let result = RelayCast::create_workspace_with_authority(
+                    &fallback_name,
+                    self.base_url.as_deref(),
+                    authority,
+                )
+                .await
+                .map_err(relay_error_to_anyhow)?;
                 Ok((result.workspace_id, result.api_key))
             }
             Err(error) => Err(relay_error_to_anyhow(error)),
@@ -773,6 +857,7 @@ impl AuthClient {
         _strict_name: bool,
         agent_type: Option<&str>,
         identity_key: Option<&str>,
+        incumbent_agent_token: Option<&str>,
     ) -> Result<(String, String, String, Option<String>)> {
         let sponsor = self.require_authenticated_sponsor()?;
         let relay = build_relay_client(workspace_key, self.base_url.as_deref())?;
@@ -780,7 +865,15 @@ impl AuthClient {
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| format!("agent-{}", Uuid::new_v4().simple()));
 
-        admit_agent_registration(&relay, &name, agent_type, identity_key, sponsor).await
+        admit_agent_registration(
+            &relay,
+            &name,
+            agent_type,
+            identity_key,
+            incumbent_agent_token,
+            sponsor,
+        )
+        .await
     }
 
     pub async fn workspace_key_is_live(&self, workspace_key: &str) -> Result<bool> {
@@ -864,6 +957,45 @@ fn env_workspace_key() -> Result<Option<EnvWorkspaceKey>> {
         }))
 }
 
+fn env_agent_token() -> Option<String> {
+    std::env::var("RELAY_AGENT_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn workspace_key_for_id_from_env(workspace_id: &str) -> Result<Option<String>> {
+    if let Ok(raw) = std::env::var("RELAY_WORKSPACES_JSON") {
+        let value: Value =
+            serde_json::from_str(raw.trim()).context("RELAY_WORKSPACES_JSON must be valid JSON")?;
+        let memberships = if let Some(values) = value.as_array() {
+            values.clone()
+        } else if let Some(values) = value.get("memberships").and_then(Value::as_array) {
+            values.clone()
+        } else {
+            vec![value]
+        };
+        for membership in memberships {
+            let id = membership
+                .get("workspace_id")
+                .or_else(|| membership.get("workspaceId"))
+                .and_then(Value::as_str);
+            let key = membership.get("api_key").and_then(Value::as_str);
+            if id == Some(workspace_id) {
+                return Ok(key.and_then(normalize_workspace_key));
+            }
+        }
+
+        // A token proves membership in exactly one server-reported workspace.
+        // If an explicit membership set was supplied but does not contain that
+        // workspace, do not silently pair the token with an unrelated fallback
+        // key from RELAY_WORKSPACE_KEY.
+        return Ok(None);
+    }
+
+    env_workspace_key().map(|source| source.map(|source| source.key))
+}
+
 fn is_auth_rejection(err: &anyhow::Error) -> bool {
     auth_http_status(err)
         .is_some_and(|status| status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN)
@@ -932,12 +1064,6 @@ fn is_conflict_code(code: &str) -> bool {
     )
 }
 
-/// Metadata key an agent's identity proof is stamped under at registration,
-/// so a later collision can check it back. See `admit_agent_registration`.
-const IDENTITY_METADATA_KEY: &str = "identity_key";
-const SPONSOR_ID_METADATA_KEY: &str = "relayauth_sponsor_id";
-const SPONSOR_BINDING_METADATA_KEY: &str = "relayauth_sponsor_binding";
-const SPONSOR_PROOF_HASH_METADATA_KEY: &str = "relayauth_sponsor_proof_sha256";
 const RELAYAUTH_SPONSOR_ID_ENV: &str = "RELAYAUTH_SPONSOR_ID";
 const RELAYAUTH_SPONSOR_PROOF_ENV: &str = "RELAYAUTH_SPONSOR_PROOF";
 const RELAYAUTH_SPONSOR_ORG_ENV: &str = "RELAYAUTH_SPONSOR_ORG_ID";
@@ -969,7 +1095,7 @@ struct SponsorOidcClaims {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct AuthenticatedSponsor {
     sponsor_id: String,
-    proof_hash: String,
+    sponsor_proof: String,
     expires_at: i64,
 }
 
@@ -990,7 +1116,7 @@ impl AuthenticatedSponsor {
             verify_sponsor_proof(&sponsor_proof, &public_key, &issuer, &org_id, &sponsor_id)?;
         Some(Self {
             sponsor_id,
-            proof_hash: hash_identity_key(&sponsor_proof),
+            sponsor_proof,
             expires_at,
         })
     }
@@ -999,7 +1125,7 @@ impl AuthenticatedSponsor {
     fn fixture() -> Self {
         Self {
             sponsor_id: "user_test_owner".to_string(),
-            proof_hash: hash_identity_key("header.payload.signature"),
+            sponsor_proof: "header.payload.signature".to_string(),
             expires_at: i64::MAX,
         }
     }
@@ -1069,10 +1195,11 @@ fn is_compact_jws(value: &str) -> bool {
 ///
 /// A crashed (or resumed) work unit that needs to re-register under its
 /// prior name sets this to a value stable across that work unit's restarts.
-/// It gets stamped onto the agent's metadata at creation; a later collision
-/// under the same name is only treated as a reclaim of that SAME work unit
-/// if the value presented then matches what's stored — never by the name
-/// string alone. Absent, registration cannot reclaim on collision.
+/// Relaycast hashes this into its immutable, server-controlled credential
+/// binding at creation. A later collision under the same name is only treated
+/// as a reclaim of that SAME work unit if the presented value matches the
+/// server binding — never by the name string or caller-editable metadata.
+/// Absent, registration cannot reclaim on collision.
 pub(crate) fn agent_identity_key() -> Option<String> {
     std::env::var("RELAY_AGENT_IDENTITY_KEY")
         .ok()
@@ -1080,33 +1207,152 @@ pub(crate) fn agent_identity_key() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-/// Stable per-node identity proof derived from the broker's own persisted
-/// state directory, for the ONE caller (the broker's own startup
-/// registration) that needs restart-reclaim without an operator having to
-/// set `RELAY_AGENT_IDENTITY_KEY` by hand. The same project/state directory
-/// always hashes to the same value across a kill + restart, while a
-/// different project (or a different, unrelated agent) hashes to something
-/// else — so it participates in the same fail-closed identity check as any
-/// other identity key, never bypassing it.
-pub(crate) fn stable_node_identity_key(state_path: &std::path::Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(state_path.to_string_lossy().as_bytes());
-    format!("node-{:x}", hasher.finalize())
+/// Read or atomically create the broker's local work-unit secret.
+///
+/// The previous implementation hashed the state path, which any workspace-key
+/// holder could predict and replay. Credential ownership requires possession
+/// of an actual secret, so the broker persists 32 random bytes beside its state
+/// file with owner-only permissions and reuses them across restarts.
+pub(crate) fn stable_node_identity_key(state_path: &std::path::Path) -> Result<String> {
+    use rand::RngCore;
+    use std::fs::OpenOptions;
+    use std::io::{Read, Write};
+
+    let parent = state_path
+        .parent()
+        .context("broker state path has no parent directory")?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create broker state directory {}",
+            parent.display()
+        )
+    })?;
+    let key_path = parent.join(format!(
+        "{}.work-unit-key",
+        state_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("state")
+    ));
+
+    loop {
+        let mut read_options = OpenOptions::new();
+        read_options.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            read_options.custom_flags(nix::libc::O_NOFOLLOW);
+        }
+        match read_options.open(&key_path) {
+            Ok(mut file) => {
+                let metadata = file.metadata().with_context(|| {
+                    format!("failed to inspect work-unit key {}", key_path.display())
+                })?;
+                if !metadata.is_file() {
+                    anyhow::bail!(
+                        "persisted work-unit key is not a regular file: {}",
+                        key_path.display()
+                    );
+                }
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if metadata.permissions().mode() & 0o077 != 0 {
+                        anyhow::bail!(
+                            "persisted work-unit key must not be accessible by group or other users: {}",
+                            key_path.display()
+                        );
+                    }
+                }
+                let mut key = String::new();
+                file.read_to_string(&mut key).with_context(|| {
+                    format!("failed to read work-unit key {}", key_path.display())
+                })?;
+                let key = key.trim();
+                if key.len() < 64 || !key.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                    anyhow::bail!("invalid persisted work-unit key at {}", key_path.display());
+                }
+                return Ok(key.to_string());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to open work-unit key {}", key_path.display())
+                });
+            }
+        }
+
+        let mut bytes = [0_u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut bytes);
+        let key = bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(nix::libc::O_NOFOLLOW);
+        }
+        match options.open(&key_path) {
+            Ok(mut file) => {
+                file.write_all(key.as_bytes()).with_context(|| {
+                    format!("failed to persist work-unit key {}", key_path.display())
+                })?;
+                file.sync_all().with_context(|| {
+                    format!("failed to sync work-unit key {}", key_path.display())
+                })?;
+                #[cfg(unix)]
+                std::fs::File::open(parent)
+                    .and_then(|directory| directory.sync_all())
+                    .with_context(|| {
+                        format!(
+                            "failed to durably sync work-unit key directory {}",
+                            parent.display()
+                        )
+                    })?;
+                return Ok(key);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to create work-unit key {}", key_path.display())
+                });
+            }
+        }
+    }
 }
 
-/// One-way verifier stored in place of a caller's raw identity key.
-///
-/// `admit_agent_registration` stamps this (never the raw key) onto the
-/// agent's metadata. Metadata is readable by any caller holding the same
-/// workspace key (`get_agent` returns it), so storing the raw key there
-/// would let any workspace member replay it verbatim to reclaim another
-/// work unit's credentials — the identity check would authenticate nothing.
-/// Hashing keeps the credential-bearing capability confined to whoever
-/// starts with the original key.
-fn hash_identity_key(raw: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(raw.as_bytes());
-    format!("{:x}", hasher.finalize())
+fn registration_authority(
+    sponsor: &AuthenticatedSponsor,
+    identity_key: Option<&str>,
+) -> Result<AgentRegistrationAuthority> {
+    let work_unit_key = identity_key
+        .map(str::trim)
+        .filter(|value| value.len() >= 32)
+        .context(
+            "agent registration requires a stable secret work-unit key of at least 32 bytes; set RELAY_AGENT_IDENTITY_KEY or use the broker's persisted node identity",
+        )?;
+    Ok(AgentRegistrationAuthority {
+        sponsor_proof: sponsor.sponsor_proof.clone(),
+        work_unit_key: work_unit_key.to_string(),
+    })
+}
+
+pub(crate) fn registration_authority_from_env(
+    work_unit_key: &str,
+) -> Result<AgentRegistrationAuthority> {
+    #[cfg(test)]
+    if std::env::var_os("RELAYAUTH_TEST_SPONSOR_FIXTURE").is_some() {
+        return registration_authority(&AuthenticatedSponsor::fixture(), Some(work_unit_key));
+    }
+    let sponsor = AuthenticatedSponsor::from_env()
+        .context("agent registration requires Chief's valid RelayAuth sponsor proof environment")?;
+    if sponsor.expires_at <= Utc::now().timestamp() {
+        anyhow::bail!("agent registration requires a current RELAYAUTH_SPONSOR_PROOF");
+    }
+    registration_authority(&sponsor, Some(work_unit_key))
 }
 
 /// Single spawn-admission decision shared by every registration path
@@ -1122,99 +1368,54 @@ fn hash_identity_key(raw: &str) -> String {
 /// an acceptable alternative to rejection either.
 ///
 /// Reclaim (return the existing agent's identity with a freshly rotated
-/// token, so a crashed broker's resume path keeps working) is permitted
-/// ONLY when the registration request proves it is the same work unit: the
-/// caller-supplied `identity_key` (see `agent_identity_key` and
-/// `stable_node_identity_key`) must match the identity key stamped on the
-/// existing agent's metadata at its own creation — compared by hash
-/// (`hash_identity_key`), never by raw value, since metadata is readable by
-/// any caller with the workspace key. Absent or mismatched identity on a
-/// collision is rejected.
+/// token, so a crashed broker's resume path keeps working) is decided by
+/// Relaycast's immutable sponsor/work-unit binding. Legacy agents without a
+/// binding may be migrated only by presenting their incumbent agent token;
+/// a workspace key plus sponsor grant is deliberately insufficient.
 async fn admit_agent_registration(
     relay: &RelayCast,
     name: &str,
     agent_type: Option<&str>,
     identity_key: Option<&str>,
+    incumbent_agent_token: Option<&str>,
     sponsor: &AuthenticatedSponsor,
 ) -> Result<(String, String, String, Option<String>)> {
-    let metadata = {
-        let mut map = serde_json::Map::new();
-        if let Some(key) = identity_key {
-            map.insert(
-                IDENTITY_METADATA_KEY.to_string(),
-                Value::String(hash_identity_key(key)),
-            );
-        }
-        map.insert(
-            SPONSOR_ID_METADATA_KEY.to_string(),
-            Value::String(sponsor.sponsor_id.clone()),
-        );
-        map.insert(
-            SPONSOR_BINDING_METADATA_KEY.to_string(),
-            Value::String("oidc".to_string()),
-        );
-        map.insert(
-            SPONSOR_PROOF_HASH_METADATA_KEY.to_string(),
-            Value::String(sponsor.proof_hash.clone()),
-        );
-        Some(map)
-    };
+    let authority = registration_authority(sponsor, identity_key)?;
 
     let request = CreateAgentRequest {
         name: name.to_string(),
         agent_type: Some(agent_type.unwrap_or("agent").to_string()),
         persona: None,
-        metadata,
+        metadata: None,
     };
 
-    match relay.register_agent(request).await {
+    match relay
+        .register_agent_with_authority(request, authority.clone())
+        .await
+    {
         Ok(result) => Ok((result.id, result.name, result.token, result.workspace_id)),
         Err(RelayError::Api { code, status, .. }) if is_conflict_code(&code) || status == 409 => {
             let existing = relay.get_agent(name).await.map_err(relay_error_to_anyhow)?;
-            let existing_identity = existing
-                .metadata
-                .get(IDENTITY_METADATA_KEY)
-                .and_then(Value::as_str);
-
-            let reclaims_same_work_unit = matches!(
-                (identity_key, existing_identity),
-                (Some(ours), Some(theirs)) if hash_identity_key(ours) == theirs
-            );
-            let existing_sponsor = existing
-                .metadata
-                .get(SPONSOR_ID_METADATA_KEY)
-                .and_then(Value::as_str);
-            let existing_binding = existing
-                .metadata
-                .get(SPONSOR_BINDING_METADATA_KEY)
-                .and_then(Value::as_str);
-            let reclaims_same_sponsor = existing_sponsor == Some(sponsor.sponsor_id.as_str())
-                && existing_binding == Some("oidc");
-
-            if !reclaims_same_work_unit || !reclaims_same_sponsor {
-                return Err(relay_error_to_anyhow(RelayError::Api {
-                    code: "agent_identity_mismatch".to_string(),
-                    status: 409,
-                    message: format!(
-                        "agent name '{name}' is already registered and this registration did \
-                         not prove ownership of that identity and its SSO-bound human sponsor; \
-                         refusing to hand over its \
-                         credentials (set RELAY_AGENT_IDENTITY_KEY to the original work unit's \
-                         identity to reclaim it after a crash)"
-                    ),
-                }));
-            }
-
-            let token_response = relay
-                .rotate_agent_token(&existing.name)
+            let token = match relay
+                .rotate_agent_token_with_authority(&existing.name, authority.clone())
                 .await
-                .map_err(relay_error_to_anyhow)?;
-            Ok((
-                existing.id,
-                existing.name,
-                token_response.token,
-                existing.workspace_id,
-            ))
+            {
+                Ok(response) => response.token,
+                Err(RelayError::Api {
+                    code, status: 409, ..
+                }) if code == "agent_sponsor_migration_required" => {
+                    let incumbent_token = incumbent_agent_token.context(
+                        "legacy agent sponsor migration requires its incumbent RELAY_AGENT_TOKEN (or agent_token in RELAY_WORKSPACES_JSON); refusing workspace-key-only reclaim",
+                    )?;
+                    relay
+                        .bind_agent_credential_authority(incumbent_token, authority.clone())
+                        .await
+                        .map_err(relay_error_to_anyhow)?;
+                    incumbent_token.to_string()
+                }
+                Err(error) => return Err(relay_error_to_anyhow(error)),
+            };
+            Ok((existing.id, existing.name, token, existing.workspace_id))
         }
         Err(RelayError::Api {
             code,
@@ -1265,30 +1466,30 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        hash_identity_key, is_agent_token_invalid, is_agent_token_invalid_anyhow,
-        is_agent_token_invalid_code, relay_error_to_anyhow, stable_node_identity_key, AuthClient,
-        CredentialCache, AGENT_TOKEN_INVALID_CODE,
+        is_agent_token_invalid, is_agent_token_invalid_anyhow, is_agent_token_invalid_code,
+        relay_error_to_anyhow, stable_node_identity_key, AuthClient, CredentialCache,
+        AGENT_TOKEN_INVALID_CODE,
     };
     use relaycast::RelayError;
 
     static RELAY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+    const TEST_WORK_UNIT_KEY: &str =
+        "test-work-unit-key-000000000000000000000000000000000000000000000001";
 
-    fn test_sponsor_metadata(identity_hash: Option<&str>) -> serde_json::Value {
+    fn test_registration_body(
+        name: &str,
+        agent_type: &str,
+        work_unit_key: &str,
+    ) -> serde_json::Value {
         let sponsor = super::AuthenticatedSponsor::fixture();
-        let mut metadata = serde_json::Map::new();
-        if let Some(identity_hash) = identity_hash {
-            metadata.insert("identity_key".to_string(), json!(identity_hash));
-        }
-        metadata.insert(
-            "relayauth_sponsor_id".to_string(),
-            json!(sponsor.sponsor_id),
-        );
-        metadata.insert("relayauth_sponsor_binding".to_string(), json!("oidc"));
-        metadata.insert(
-            "relayauth_sponsor_proof_sha256".to_string(),
-            json!(sponsor.proof_hash),
-        );
-        serde_json::Value::Object(metadata)
+        json!({
+            "name": name,
+            "type": agent_type,
+            "registration_authority": {
+                "sponsor_proof": sponsor.sponsor_proof,
+                "work_unit_key": work_unit_key,
+            }
+        })
     }
 
     #[test]
@@ -1375,6 +1576,7 @@ mod tests {
                 true,
                 Some("agent"),
                 Some("forged-work-unit"),
+                None,
             )
             .await
             .expect_err("a workspace key without Chief's SSO sponsor proof must fail closed");
@@ -1399,6 +1601,7 @@ mod tests {
                 true,
                 Some("agent"),
                 Some("expired-sponsor-work-unit"),
+                None,
             )
             .await
             .expect_err("an expired SSO sponsor proof must fail before registration");
@@ -1407,11 +1610,69 @@ mod tests {
             .contains("expired RELAYAUTH_SPONSOR_PROOF"));
     }
 
+    #[tokio::test]
+    async fn missing_sponsor_proof_fails_before_workspace_creation() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        let workspace = server.mock(|when, then| {
+            when.method(POST).path("/v1/workspaces");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"ok":true,"data":{"workspace_id":"ws_orphan","api_key":"rk_live_orphan"}}"#,
+                );
+        });
+
+        let client = AuthClient::new(Some(server.base_url()));
+        let error = client
+            .startup_session(Some("lead"))
+            .await
+            .expect_err("missing sponsor authority must fail before any startup write");
+
+        assert!(error
+            .to_string()
+            .contains("SSO-authenticated human sponsor"));
+        workspace.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn expired_sponsor_proof_fails_before_workspace_creation() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        let workspace = server.mock(|when, then| {
+            when.method(POST).path("/v1/workspaces");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"ok":true,"data":{"workspace_id":"ws_orphan","api_key":"rk_live_orphan"}}"#,
+                );
+        });
+        let client = AuthClient {
+            base_url: Some(server.base_url()),
+            sponsor: Some(super::AuthenticatedSponsor {
+                expires_at: chrono::Utc::now().timestamp() - 1,
+                ..super::AuthenticatedSponsor::fixture()
+            }),
+        };
+
+        let error = client
+            .startup_session(Some("lead"))
+            .await
+            .expect_err("expired sponsor authority must fail before any startup write");
+
+        assert!(error
+            .to_string()
+            .contains("expired RELAYAUTH_SPONSOR_PROOF"));
+        workspace.assert_hits(0);
+    }
+
     /// Remove RELAY_API_KEY from the environment so it doesn't interfere with
     /// mock-server tests. Tests use httpmock and only set up specific auth
     /// headers — the real env key causes 404s against the mock.
     fn clear_relay_env() -> MutexGuard<'static, ()> {
-        let guard = RELAY_ENV_MUTEX.lock().unwrap();
+        let guard = RELAY_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // SAFETY: test-only; Rust warns about remove_var in multi-threaded
         // contexts but we accept the risk in test code.
         unsafe {
@@ -1420,9 +1681,31 @@ mod tests {
             std::env::remove_var("RELAY_API_KEY");
             std::env::remove_var("RELAY_WORKSPACES_JSON");
             std::env::remove_var("RELAY_DEFAULT_WORKSPACE");
-            std::env::remove_var("RELAY_AGENT_IDENTITY_KEY");
+            std::env::remove_var("RELAY_AGENT_TOKEN");
+            std::env::set_var("RELAY_AGENT_IDENTITY_KEY", TEST_WORK_UNIT_KEY);
         }
         guard
+    }
+
+    #[test]
+    fn pre_registered_token_does_not_pair_with_an_unrelated_fallback_workspace_key() {
+        let _env_guard = clear_relay_env();
+        unsafe {
+            std::env::set_var(
+                "RELAY_WORKSPACES_JSON",
+                r#"[{"workspace_id":"ws_other","api_key":"rk_live_other"}]"#,
+            );
+            std::env::set_var("AGENT_RELAY_WORKSPACE_KEY", "rk_live_fallback");
+        }
+
+        let key = super::workspace_key_for_id_from_env("ws_token")
+            .expect("membership configuration should parse");
+        assert_eq!(key, None);
+
+        unsafe {
+            std::env::remove_var("RELAY_WORKSPACES_JSON");
+            std::env::remove_var("AGENT_RELAY_WORKSPACE_KEY");
+        }
     }
 
     #[tokio::test]
@@ -1487,6 +1770,63 @@ mod tests {
         unsafe {
             std::env::remove_var("AGENT_RELAY_WORKSPACE_KEY");
         }
+    }
+
+    #[tokio::test]
+    async fn pre_registered_agent_token_bootstraps_without_sponsor_or_registration() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("AGENT_RELAY_WORKSPACE_KEY", "rk_live_env");
+            std::env::set_var("RELAY_AGENT_TOKEN", "at_live_existing");
+        }
+        let me = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agent")
+                .header("authorization", "Bearer at_live_existing");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_existing","workspace_id":"ws_env","name":"lead","type":"agent","status":"online","persona":null,"metadata":{}}}"#);
+        });
+        let register = server.mock(|when, then| {
+            when.method(POST).path("/v1/agents");
+            then.status(500);
+        });
+
+        // Deliberately no sponsor fixture: the incumbent token is the only
+        // authority this bootstrap path may exercise.
+        let client = AuthClient::new(Some(server.base_url()));
+        let session = client.startup_session(Some("lead")).await.unwrap();
+
+        assert_eq!(session.token, "at_live_existing");
+        assert_eq!(session.credentials.workspace_id, "ws_env");
+        assert_eq!(session.credentials.api_key, "rk_live_env");
+        assert_eq!(session.credentials.agent_id, "a_existing");
+        me.assert_hits(1);
+        register.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn pre_registered_agent_token_cannot_claim_a_different_name() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("AGENT_RELAY_WORKSPACE_KEY", "rk_live_env");
+            std::env::set_var("RELAY_AGENT_TOKEN", "at_live_existing");
+        }
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/agent");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_existing","workspace_id":"ws_env","name":"incumbent","type":"agent","status":"online","persona":null,"metadata":{}}}"#);
+        });
+
+        let client = AuthClient::new(Some(server.base_url()));
+        let error = client
+            .startup_session(Some("attacker-selected-name"))
+            .await
+            .expect_err("an agent token must remain bound to its server identity");
+        assert!(error.to_string().contains("belongs to 'incumbent'"));
     }
 
     #[tokio::test]
@@ -1651,11 +1991,7 @@ mod tests {
             when.method(POST)
                 .path("/v1/agents")
                 .header("authorization", "Bearer rk_live_shared")
-                .json_body(json!({
-                    "name": "lead",
-                    "type": "agent",
-                    "metadata": test_sponsor_metadata(None)
-                }));
+                .json_body(test_registration_body("lead", "agent", TEST_WORK_UNIT_KEY));
             then.status(409)
                 .header("content-type", "application/json")
                 .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
@@ -1672,9 +2008,9 @@ mod tests {
             when.method(POST)
                 .path("/v1/agents/lead/rotate-token")
                 .header("authorization", "Bearer rk_live_shared");
-            then.status(200)
+            then.status(409)
                 .header("content-type", "application/json")
-                .body(r#"{"ok":true,"data":{"name":"lead","token":"at_live_rotated"}}"#);
+                .body(r#"{"ok":false,"error":{"code":"agent_sponsor_migration_required","message":"legacy agent requires incumbent-token migration"}}"#);
         });
 
         let client = AuthClient::new_for_test(Some(server.base_url()));
@@ -1693,7 +2029,7 @@ mod tests {
         );
         conflict.assert_hits(1);
         get_existing.assert_hits(1);
-        rotate.assert_hits(0);
+        rotate.assert_hits(1);
 
         unsafe {
             std::env::remove_var("RELAY_API_KEY");
@@ -1710,21 +2046,16 @@ mod tests {
         let server = MockServer::start();
         unsafe {
             std::env::set_var("RELAY_API_KEY", "rk_live_shared");
-            std::env::set_var("RELAY_AGENT_IDENTITY_KEY", "work-unit-42");
         }
-        // The identity proof is stored (and matched) as a one-way hash, never
-        // the raw value: metadata is readable by any caller with the same
-        // workspace key, so a raw value there would let a co-tenant replay it.
-        let identity_hash = hash_identity_key("work-unit-42");
+        let work_unit_key = "work-unit-42-000000000000000000000000000000000000";
+        unsafe {
+            std::env::set_var("RELAY_AGENT_IDENTITY_KEY", work_unit_key);
+        }
         let conflict = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/agents")
                 .header("authorization", "Bearer rk_live_shared")
-                .json_body(json!({
-                    "name": "lead",
-                    "type": "agent",
-                    "metadata": test_sponsor_metadata(Some(&identity_hash))
-                }));
+                .json_body(test_registration_body("lead", "agent", work_unit_key));
             then.status(409)
                 .header("content-type", "application/json")
                 .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
@@ -1735,9 +2066,7 @@ mod tests {
                 .header("authorization", "Bearer rk_live_shared");
             then.status(200)
                 .header("content-type", "application/json")
-                .body(format!(
-                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}","relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
-                ));
+                .body(r#"{"ok":true,"data":{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
         });
         let rotate = server.mock(|when, then| {
             when.method(POST)
@@ -1766,22 +2095,115 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn legacy_agent_migration_requires_and_uses_incumbent_agent_token() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("RELAY_API_KEY", "rk_live_shared");
+            std::env::set_var("RELAY_AGENT_TOKEN", "at_live_incumbent");
+        }
+
+        let conflict = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_shared")
+                .json_body(test_registration_body("lead", "agent", TEST_WORK_UNIT_KEY));
+            then.status(409)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
+        });
+        let get_existing = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/lead")
+                .header("authorization", "Bearer rk_live_shared");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_legacy","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
+        });
+        let rotate = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents/lead/rotate-token")
+                .header("authorization", "Bearer rk_live_shared");
+            then.status(409)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"agent_sponsor_migration_required","message":"legacy agent requires incumbent-token migration"}}"#);
+        });
+        let bind = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agent/credential-authority")
+                .header("authorization", "Bearer at_live_incumbent")
+                .json_body(json!({
+                    "registration_authority": {
+                        "sponsor_proof": "header.payload.signature",
+                        "work_unit_key": TEST_WORK_UNIT_KEY,
+                    }
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"bound":true}}"#);
+        });
+
+        let client = AuthClient::new_for_test(Some(server.base_url()));
+        let session = client
+            .startup_session(Some("lead"))
+            .await
+            .expect("the incumbent token should authorize the one-time legacy binding");
+
+        assert_eq!(session.credentials.agent_id, "a_legacy");
+        assert_eq!(session.token, "at_live_incumbent");
+        conflict.assert_hits(1);
+        get_existing.assert_hits(1);
+        rotate.assert_hits(1);
+        bind.assert_hits(1);
+    }
+
     #[test]
     fn stable_node_identity_key_is_stable_per_state_path() {
-        use std::path::Path;
+        let node_a = tempfile::tempdir().unwrap();
+        let node_b = tempfile::tempdir().unwrap();
         // Same project/state directory (the "same work unit" across a kill +
         // restart, per the fleet node harness) must hash identically every
         // time, or the broker could never reclaim its own name after a crash.
-        let a = stable_node_identity_key(Path::new("/tmp/node-a/.agentworkforce/relay/state.json"));
-        let a_again =
-            stable_node_identity_key(Path::new("/tmp/node-a/.agentworkforce/relay/state.json"));
+        let a_path = node_a.path().join("state.json");
+        let a = stable_node_identity_key(&a_path).unwrap();
+        let a_again = stable_node_identity_key(&a_path).unwrap();
         assert_eq!(a, a_again);
 
         // A different project/state directory (a genuinely different node)
         // must hash to something else, or two unrelated nodes could reclaim
         // each other's registrations.
-        let b = stable_node_identity_key(Path::new("/tmp/node-b/.agentworkforce/relay/state.json"));
+        let b = stable_node_identity_key(&node_b.path().join("state.json")).unwrap();
         assert_ne!(a, b);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_node_identity_key_rejects_insecure_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let node = tempfile::tempdir().unwrap();
+        let state_path = node.path().join("state.json");
+        stable_node_identity_key(&state_path).unwrap();
+        let key_path = node.path().join("state.json.work-unit-key");
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = stable_node_identity_key(&state_path)
+            .expect_err("a group/world-readable ownership root must fail closed");
+        assert!(error.to_string().contains("group or other users"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_node_identity_key_refuses_symlinks() {
+        let node = tempfile::tempdir().unwrap();
+        let target = node.path().join("attacker-controlled");
+        std::fs::write(&target, "0".repeat(64)).unwrap();
+        let key_path = node.path().join("state.json.work-unit-key");
+        std::os::unix::fs::symlink(&target, &key_path).unwrap();
+
+        stable_node_identity_key(&node.path().join("state.json"))
+            .expect_err("the ownership root path must never follow a symlink");
     }
 
     #[tokio::test]
@@ -1803,17 +2225,13 @@ mod tests {
         }
         let stable_identity = stable_node_identity_key(std::path::Path::new(
             "/tmp/node-a/.agentworkforce/relay/state.json",
-        ));
-        let identity_hash = hash_identity_key(&stable_identity);
+        ))
+        .unwrap();
         let conflict = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/agents")
                 .header("authorization", "Bearer rk_live_shared")
-                .json_body(json!({
-                    "name": "node-a",
-                    "type": "agent",
-                    "metadata": test_sponsor_metadata(Some(&identity_hash))
-                }));
+                .json_body(test_registration_body("node-a", "agent", &stable_identity));
             then.status(409)
                 .header("content-type", "application/json")
                 .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
@@ -1824,9 +2242,7 @@ mod tests {
                 .header("authorization", "Bearer rk_live_shared");
             then.status(200)
                 .header("content-type", "application/json")
-                .body(format!(
-                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}","relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
-                ));
+                .body(r#"{"ok":true,"data":{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
         });
         let rotate = server.mock(|when, then| {
             when.method(POST)
@@ -1871,10 +2287,8 @@ mod tests {
         }
         let our_identity = stable_node_identity_key(std::path::Path::new(
             "/tmp/node-a/.agentworkforce/relay/state.json",
-        ));
-        let their_identity_hash = hash_identity_key(&stable_node_identity_key(
-            std::path::Path::new("/tmp/node-a-impostor/.agentworkforce/relay/state.json"),
-        ));
+        ))
+        .unwrap();
         let conflict = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/agents")
@@ -1889,9 +2303,15 @@ mod tests {
                 .header("authorization", "Bearer rk_live_shared");
             then.status(200)
                 .header("content-type", "application/json")
-                .body(format!(
-                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{their_identity_hash}"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
-                ));
+                .body(r#"{"ok":true,"data":{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
+        });
+        let rotate = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents/node-a/rotate-token")
+                .header("authorization", "Bearer rk_live_shared");
+            then.status(409)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"agent_credential_binding_mismatch","message":"work unit does not own credential"}}"#);
         });
 
         let client = AuthClient::new_for_test(Some(server.base_url()));
@@ -1905,11 +2325,12 @@ mod tests {
         assert!(
             error
                 .chain()
-                .any(|layer| layer.to_string().contains("did not prove ownership")),
+                .any(|layer| layer.to_string().contains("does not own credential")),
             "expected an ownership-mismatch rejection, got: {error:#}"
         );
         conflict.assert_hits(1);
         get_existing.assert_hits(1);
+        rotate.assert_hits(1);
 
         unsafe {
             std::env::remove_var("RELAY_API_KEY");
@@ -1936,11 +2357,7 @@ mod tests {
             when.method(POST)
                 .path("/v1/agents")
                 .header("authorization", "Bearer rk_live_cached")
-                .json_body(json!({
-                    "name": "lead",
-                    "type": "agent",
-                    "metadata": test_sponsor_metadata(None)
-                }));
+                .json_body(test_registration_body("lead", "agent", TEST_WORK_UNIT_KEY));
             then.status(409)
                 .header("content-type", "application/json")
                 .body(r#"{"ok":false,"error":{"code":"agent_already_exists","message":"name_taken"}}"#);
@@ -1953,6 +2370,14 @@ mod tests {
                 .header("content-type", "application/json")
                 .body(r#"{"ok":true,"data":{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
         });
+        let rotate = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents/lead/rotate-token")
+                .header("authorization", "Bearer rk_live_cached");
+            then.status(409)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"agent_sponsor_migration_required","message":"legacy agent requires incumbent-token migration"}}"#);
+        });
 
         let client = AuthClient::new_for_test(Some(server.base_url()));
         let result = client.startup_session(Some("lead")).await;
@@ -1964,6 +2389,7 @@ mod tests {
         workspace.assert_hits(1);
         conflict.assert_hits(1);
         get_existing.assert_hits(1);
+        rotate.assert_hits(1);
     }
 
     // `strict_name_conflict_reclaims_via_sdk_register_or_get_agent` (issue
@@ -1984,7 +2410,12 @@ mod tests {
         let first_conflict = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/workspaces")
-                .json_body(json!({ "name": workspace_name }));
+                .json_body(json!({
+                    "name": workspace_name,
+                    "registration_authority": {
+                        "sponsor_proof": "header.payload.signature"
+                    }
+                }));
             then.status(409)
                 .header("content-type", "application/json")
                 .body(
@@ -2057,7 +2488,7 @@ mod tests {
         assert_eq!(session.credentials.agent_name.as_deref(), Some("lead"));
         assert_eq!(session.credentials.agent_id, "a_old");
         assert_eq!(session.credentials.workspace_id, "ws_cached");
-        existing.assert_hits(1);
+        existing.assert_hits(0);
         rotate.assert_hits(1);
     }
 
@@ -2105,7 +2536,7 @@ mod tests {
         let session = client.rotate_token(&cached).await.unwrap();
         assert_eq!(session.token, "at_live_reregistered");
         assert_eq!(session.credentials.agent_name.as_deref(), Some("lead"));
-        existing.assert_hits(1);
+        existing.assert_hits(0);
         rotate_404.assert_hits(1);
         register.assert_hits(1);
     }

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -298,6 +298,98 @@ fn workspace_key_fingerprint(workspace_key: &str) -> String {
     format!("{:x}", Sha256::digest(workspace_key.as_bytes()))
 }
 
+#[cfg(not(windows))]
+fn protect_local_secret(body: Vec<u8>) -> Result<Vec<u8>> {
+    Ok(body)
+}
+
+#[cfg(not(windows))]
+fn unprotect_local_secret(body: Vec<u8>) -> Result<Vec<u8>> {
+    Ok(body)
+}
+
+/// Windows has no POSIX owner-only mode bit. Protect broker-local secrets with
+/// DPAPI's current-user scope so copying a file to another local account does
+/// not disclose an incumbent agent token or work-unit ownership key.
+#[cfg(windows)]
+fn protect_local_secret(mut body: Vec<u8>) -> Result<Vec<u8>> {
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::Cryptography::{CryptProtectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB},
+    };
+
+    let body_len = u32::try_from(body.len()).context("incumbent credential cache is too large")?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: body_len,
+        pbData: body.as_mut_ptr(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    // SAFETY: `input` borrows `body` for the duration of the call; Windows
+    // allocates `output.pbData`, which we copy before releasing via LocalFree.
+    if unsafe {
+        CryptProtectData(
+            &input,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to protect incumbent credential cache with Windows DPAPI");
+    }
+    // SAFETY: CryptProtectData returned a valid allocation of `cbData` bytes.
+    let protected =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    // SAFETY: DPAPI documents that callers release this allocation with
+    // LocalFree. The copied `protected` bytes no longer borrow it.
+    unsafe { LocalFree(output.pbData.cast()) };
+    Ok(protected)
+}
+
+#[cfg(windows)]
+fn unprotect_local_secret(mut body: Vec<u8>) -> Result<Vec<u8>> {
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::Cryptography::{
+            CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
+        },
+    };
+
+    let body_len = u32::try_from(body.len()).context("incumbent credential cache is too large")?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: body_len,
+        pbData: body.as_mut_ptr(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    // SAFETY: same lifetime/allocation contract as `protect_incumbent_cache`.
+    if unsafe {
+        CryptUnprotectData(
+            &input,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to unprotect incumbent credential cache with Windows DPAPI");
+    }
+    // SAFETY: CryptUnprotectData returned a valid allocation of `cbData`
+    // bytes, copied before LocalFree.
+    let plaintext =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    // SAFETY: release the Windows-owned output after copying it.
+    unsafe { LocalFree(output.pbData.cast()) };
+    Ok(plaintext)
+}
+
 impl AuthSessionSet {
     pub fn credential_set(&self) -> CredentialSet {
         CredentialSet::from_memberships(
@@ -1530,10 +1622,12 @@ pub(crate) fn stable_node_identity_key(state_path: &std::path::Path) -> Result<S
                         );
                     }
                 }
-                let mut key = String::new();
-                file.read_to_string(&mut key).with_context(|| {
+                let mut stored = Vec::new();
+                file.read_to_end(&mut stored).with_context(|| {
                     format!("failed to read work-unit key {}", key_path.display())
                 })?;
+                let key = String::from_utf8(unprotect_local_secret(stored)?)
+                    .context("persisted work-unit key is not UTF-8")?;
                 let key = key.trim();
                 if key.len() < 64 || !key.bytes().all(|byte| byte.is_ascii_hexdigit()) {
                     anyhow::bail!("invalid persisted work-unit key at {}", key_path.display());
@@ -1563,7 +1657,8 @@ pub(crate) fn stable_node_identity_key(state_path: &std::path::Path) -> Result<S
         }
         match options.open(&key_path) {
             Ok(mut file) => {
-                file.write_all(key.as_bytes()).with_context(|| {
+                let stored = protect_local_secret(key.as_bytes().to_vec())?;
+                file.write_all(&stored).with_context(|| {
                     format!("failed to persist work-unit key {}", key_path.display())
                 })?;
                 file.sync_all().with_context(|| {
@@ -1661,6 +1756,7 @@ pub(crate) fn load_incumbent_credential_cache(
             path.display()
         )
     })?;
+    let body = unprotect_local_secret(body)?;
     let cache: IncumbentCredentialCache = serde_json::from_slice(&body).with_context(|| {
         format!(
             "failed to parse incumbent credential cache {}",
@@ -1697,8 +1793,10 @@ pub(crate) fn persist_incumbent_credential_cache(
     // accidentally destroying the proof needed on its next healthy restart.
     let mut cache = load_incumbent_credential_cache(state_path)?;
     cache.merge_credential_set(credentials)?;
-    let body = serde_json::to_vec_pretty(&cache)
-        .context("failed to serialize incumbent credential cache")?;
+    let body = protect_local_secret(
+        serde_json::to_vec_pretty(&cache)
+            .context("failed to serialize incumbent credential cache")?,
+    )?;
     let mut temporary = tempfile::NamedTempFile::new_in(parent).with_context(|| {
         format!(
             "failed to create temporary incumbent credential cache in {}",

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use relaycast::{CreateAgentRequest, RelayCast, RelayCastOptions, RelayError};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -272,11 +273,35 @@ fn deterministic_workspace_name() -> String {
 #[derive(Clone)]
 pub struct AuthClient {
     base_url: Option<String>,
+    sponsor: Option<AuthenticatedSponsor>,
 }
 
 impl AuthClient {
     pub fn new(base_url: Option<String>) -> Self {
-        Self { base_url }
+        Self {
+            base_url,
+            sponsor: AuthenticatedSponsor::from_env(),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test(base_url: Option<String>) -> Self {
+        Self {
+            base_url,
+            sponsor: Some(AuthenticatedSponsor::fixture()),
+        }
+    }
+
+    fn require_authenticated_sponsor(&self) -> Result<&AuthenticatedSponsor> {
+        let sponsor = self.sponsor.as_ref().context(
+            "agent registration requires an SSO-authenticated human sponsor; Chief must provide RELAYAUTH_SPONSOR_ID and RELAYAUTH_SPONSOR_PROOF, and a workspace key alone is insufficient",
+        )?;
+        if sponsor.expires_at <= Utc::now().timestamp() {
+            anyhow::bail!(
+                "agent registration requires a current SSO sponsor proof; Chief must refresh the expired RELAYAUTH_SPONSOR_PROOF"
+            );
+        }
+        Ok(sponsor)
     }
 
     pub async fn startup_session(&self, requested_name: Option<&str>) -> Result<AuthSession> {
@@ -457,8 +482,27 @@ impl AuthClient {
             .context("cannot rotate token without agent name")?;
         let api_key = normalize_workspace_key(&cached.api_key)
             .context("cached api_key is not a valid workspace key")?;
+        let sponsor = self.require_authenticated_sponsor()?;
 
         let relay = build_relay_client(&api_key, self.base_url.as_deref())?;
+        let existing = relay
+            .get_agent(agent_name)
+            .await
+            .map_err(relay_error_to_anyhow)?;
+        let existing_sponsor = existing
+            .metadata
+            .get(SPONSOR_ID_METADATA_KEY)
+            .and_then(Value::as_str);
+        let existing_binding = existing
+            .metadata
+            .get(SPONSOR_BINDING_METADATA_KEY)
+            .and_then(Value::as_str);
+        if existing_sponsor != Some(sponsor.sponsor_id.as_str()) || existing_binding != Some("oidc")
+        {
+            anyhow::bail!(
+                "refusing to rotate agent token because the existing identity is not bound to the authenticated SSO sponsor"
+            );
+        }
         let result = relay
             .rotate_agent_token(agent_name)
             .await
@@ -730,12 +774,13 @@ impl AuthClient {
         agent_type: Option<&str>,
         identity_key: Option<&str>,
     ) -> Result<(String, String, String, Option<String>)> {
+        let sponsor = self.require_authenticated_sponsor()?;
         let relay = build_relay_client(workspace_key, self.base_url.as_deref())?;
         let name = requested_name
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| format!("agent-{}", Uuid::new_v4().simple()));
 
-        admit_agent_registration(&relay, &name, agent_type, identity_key).await
+        admit_agent_registration(&relay, &name, agent_type, identity_key, sponsor).await
     }
 
     pub async fn workspace_key_is_live(&self, workspace_key: &str) -> Result<bool> {
@@ -890,6 +935,135 @@ fn is_conflict_code(code: &str) -> bool {
 /// Metadata key an agent's identity proof is stamped under at registration,
 /// so a later collision can check it back. See `admit_agent_registration`.
 const IDENTITY_METADATA_KEY: &str = "identity_key";
+const SPONSOR_ID_METADATA_KEY: &str = "relayauth_sponsor_id";
+const SPONSOR_BINDING_METADATA_KEY: &str = "relayauth_sponsor_binding";
+const SPONSOR_PROOF_HASH_METADATA_KEY: &str = "relayauth_sponsor_proof_sha256";
+const RELAYAUTH_SPONSOR_ID_ENV: &str = "RELAYAUTH_SPONSOR_ID";
+const RELAYAUTH_SPONSOR_PROOF_ENV: &str = "RELAYAUTH_SPONSOR_PROOF";
+const RELAYAUTH_SPONSOR_ORG_ENV: &str = "RELAYAUTH_SPONSOR_ORG_ID";
+const RELAYAUTH_ISSUER_ENV: &str = "RELAYAUTH_ISSUER";
+const RELAYAUTH_PUBLIC_KEY_ENV: &str = "RELAYAUTH_SIGNING_KEY_PEM_PUBLIC";
+const SPONSOR_GRANT_AUDIENCE: &str = "relayauth:sponsor-binding";
+const SPONSOR_GRANT_INTENT: &str = "identity.create";
+const SPONSOR_GRANT_TOKEN_TYPE: &str = "sponsor_grant";
+
+#[derive(Debug, Deserialize)]
+struct SponsorGrantClaims {
+    iss: String,
+    sub: String,
+    org: String,
+    iat: i64,
+    exp: i64,
+    intent: String,
+    token_type: String,
+    oidc: SponsorOidcClaims,
+}
+
+#[derive(Debug, Deserialize)]
+struct SponsorOidcClaims {
+    issuer: String,
+    subject: String,
+    iat: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AuthenticatedSponsor {
+    sponsor_id: String,
+    proof_hash: String,
+    expires_at: i64,
+}
+
+impl AuthenticatedSponsor {
+    fn from_env() -> Option<Self> {
+        let sponsor_id = std::env::var(RELAYAUTH_SPONSOR_ID_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| is_human_sponsor_id(value))?;
+        let sponsor_proof = std::env::var(RELAYAUTH_SPONSOR_PROOF_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| is_compact_jws(value))?;
+        let org_id = required_env(RELAYAUTH_SPONSOR_ORG_ENV)?;
+        let issuer = required_env(RELAYAUTH_ISSUER_ENV)?;
+        let public_key = required_env(RELAYAUTH_PUBLIC_KEY_ENV)?;
+        let expires_at =
+            verify_sponsor_proof(&sponsor_proof, &public_key, &issuer, &org_id, &sponsor_id)?;
+        Some(Self {
+            sponsor_id,
+            proof_hash: hash_identity_key(&sponsor_proof),
+            expires_at,
+        })
+    }
+
+    #[cfg(test)]
+    fn fixture() -> Self {
+        Self {
+            sponsor_id: "user_test_owner".to_string(),
+            proof_hash: hash_identity_key("header.payload.signature"),
+            expires_at: i64::MAX,
+        }
+    }
+}
+
+fn required_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn verify_sponsor_proof(
+    proof: &str,
+    public_key_pem: &str,
+    expected_issuer: &str,
+    expected_org: &str,
+    expected_sponsor_id: &str,
+) -> Option<i64> {
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&[SPONSOR_GRANT_AUDIENCE]);
+    validation.set_issuer(&[expected_issuer]);
+    validation.set_required_spec_claims(&["exp", "iat", "iss", "aud", "sub"]);
+    validation.leeway = 60;
+    let token = decode::<SponsorGrantClaims>(
+        proof,
+        &DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).ok()?,
+        &validation,
+    )
+    .ok()?;
+    let claims = token.claims;
+    let now = Utc::now().timestamp();
+    (claims.iss == expected_issuer
+        && claims.sub == expected_sponsor_id
+        && claims.org == expected_org
+        && claims.intent == SPONSOR_GRANT_INTENT
+        && claims.token_type == SPONSOR_GRANT_TOKEN_TYPE
+        && claims.iat <= now + 60
+        && !claims.oidc.issuer.trim().is_empty()
+        && !claims.oidc.subject.trim().is_empty()
+        && claims.oidc.iat > 0)
+        .then_some(claims.exp)
+}
+
+fn is_human_sponsor_id(value: &str) -> bool {
+    value.strip_prefix("user_").is_some_and(|suffix| {
+        !suffix.is_empty()
+            && value.len() <= 256
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    })
+}
+
+fn is_compact_jws(value: &str) -> bool {
+    value.len() <= 16 * 1024
+        && value.split('.').count() == 3
+        && value.split('.').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+        })
+}
 
 /// Caller-supplied proof of work-unit identity for spawn-admission reclaim.
 ///
@@ -961,15 +1135,30 @@ async fn admit_agent_registration(
     name: &str,
     agent_type: Option<&str>,
     identity_key: Option<&str>,
+    sponsor: &AuthenticatedSponsor,
 ) -> Result<(String, String, String, Option<String>)> {
-    let metadata = identity_key.map(|key| {
+    let metadata = {
         let mut map = serde_json::Map::new();
+        if let Some(key) = identity_key {
+            map.insert(
+                IDENTITY_METADATA_KEY.to_string(),
+                Value::String(hash_identity_key(key)),
+            );
+        }
         map.insert(
-            IDENTITY_METADATA_KEY.to_string(),
-            Value::String(hash_identity_key(key)),
+            SPONSOR_ID_METADATA_KEY.to_string(),
+            Value::String(sponsor.sponsor_id.clone()),
         );
-        map
-    });
+        map.insert(
+            SPONSOR_BINDING_METADATA_KEY.to_string(),
+            Value::String("oidc".to_string()),
+        );
+        map.insert(
+            SPONSOR_PROOF_HASH_METADATA_KEY.to_string(),
+            Value::String(sponsor.proof_hash.clone()),
+        );
+        Some(map)
+    };
 
     let request = CreateAgentRequest {
         name: name.to_string(),
@@ -991,14 +1180,25 @@ async fn admit_agent_registration(
                 (identity_key, existing_identity),
                 (Some(ours), Some(theirs)) if hash_identity_key(ours) == theirs
             );
+            let existing_sponsor = existing
+                .metadata
+                .get(SPONSOR_ID_METADATA_KEY)
+                .and_then(Value::as_str);
+            let existing_binding = existing
+                .metadata
+                .get(SPONSOR_BINDING_METADATA_KEY)
+                .and_then(Value::as_str);
+            let reclaims_same_sponsor = existing_sponsor == Some(sponsor.sponsor_id.as_str())
+                && existing_binding == Some("oidc");
 
-            if !reclaims_same_work_unit {
+            if !reclaims_same_work_unit || !reclaims_same_sponsor {
                 return Err(relay_error_to_anyhow(RelayError::Api {
                     code: "agent_identity_mismatch".to_string(),
                     status: 409,
                     message: format!(
                         "agent name '{name}' is already registered and this registration did \
-                         not prove ownership of that identity; refusing to hand over its \
+                         not prove ownership of that identity and its SSO-bound human sponsor; \
+                         refusing to hand over its \
                          credentials (set RELAY_AGENT_IDENTITY_KEY to the original work unit's \
                          identity to reclaim it after a crash)"
                     ),
@@ -1073,6 +1273,24 @@ mod tests {
 
     static RELAY_ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    fn test_sponsor_metadata(identity_hash: Option<&str>) -> serde_json::Value {
+        let sponsor = super::AuthenticatedSponsor::fixture();
+        let mut metadata = serde_json::Map::new();
+        if let Some(identity_hash) = identity_hash {
+            metadata.insert("identity_key".to_string(), json!(identity_hash));
+        }
+        metadata.insert(
+            "relayauth_sponsor_id".to_string(),
+            json!(sponsor.sponsor_id),
+        );
+        metadata.insert("relayauth_sponsor_binding".to_string(), json!("oidc"));
+        metadata.insert(
+            "relayauth_sponsor_proof_sha256".to_string(),
+            json!(sponsor.proof_hash),
+        );
+        serde_json::Value::Object(metadata)
+    }
+
     #[test]
     fn agent_token_invalid_code_matches_canonical_string_case_insensitively() {
         assert!(is_agent_token_invalid_code(AGENT_TOKEN_INVALID_CODE));
@@ -1144,6 +1362,51 @@ mod tests {
         assert!(!is_agent_token_invalid_anyhow(&unrelated));
     }
 
+    #[tokio::test]
+    async fn workspace_key_alone_cannot_register_an_agent() {
+        let client = AuthClient {
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            sponsor: None,
+        };
+        let error = client
+            .register_agent_with_workspace_key(
+                "rk_live_shared",
+                Some("forged-agent"),
+                true,
+                Some("agent"),
+                Some("forged-work-unit"),
+            )
+            .await
+            .expect_err("a workspace key without Chief's SSO sponsor proof must fail closed");
+        assert!(error
+            .to_string()
+            .contains("SSO-authenticated human sponsor"));
+    }
+
+    #[tokio::test]
+    async fn expired_sponsor_proof_cannot_register_an_agent() {
+        let client = AuthClient {
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            sponsor: Some(super::AuthenticatedSponsor {
+                expires_at: chrono::Utc::now().timestamp() - 1,
+                ..super::AuthenticatedSponsor::fixture()
+            }),
+        };
+        let error = client
+            .register_agent_with_workspace_key(
+                "rk_live_shared",
+                Some("expired-sponsor-agent"),
+                true,
+                Some("agent"),
+                Some("expired-sponsor-work-unit"),
+            )
+            .await
+            .expect_err("an expired SSO sponsor proof must fail before registration");
+        assert!(error
+            .to_string()
+            .contains("expired RELAYAUTH_SPONSOR_PROOF"));
+    }
+
     /// Remove RELAY_API_KEY from the environment so it doesn't interfere with
     /// mock-server tests. Tests use httpmock and only set up specific auth
     /// headers — the real env key causes 404s against the mock.
@@ -1181,7 +1444,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a1","name":"lead","token":"at_live_1","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let session = client.startup_session(Some("lead")).await.unwrap();
         assert_eq!(session.token, "at_live_1");
@@ -1213,7 +1476,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a2","workspace_id":"ws_env","name":"lead","token":"at_live_2","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let session = client.startup_session(Some("lead")).await.unwrap();
         assert_eq!(session.token, "at_live_2");
@@ -1248,7 +1511,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"workspace_id":"ws_new","api_key":"rk_live_new","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let error = client.startup_session(Some("lead")).await.unwrap_err();
         assert!(
             error
@@ -1289,7 +1552,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a3","name":"lead","token":"at_live_3","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client.startup_session(Some("lead")).await.unwrap();
         assert_eq!(session.credentials.api_key, "rk_live_canonical");
         canonical_register.assert_hits(1);
@@ -1317,7 +1580,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a2","name":"lead","token":"at_live_2","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let session = client.startup_session(Some("lead")).await.unwrap();
         assert_eq!(session.credentials.api_key, "rk_live_legacy");
@@ -1359,7 +1622,7 @@ mod tests {
             std::env::set_var("RELAY_API_KEY", "rk_live_stale");
         }
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client.startup_session(Some("lead")).await.unwrap();
         assert_eq!(session.token, "at_live_9");
         assert_eq!(session.credentials.api_key, "rk_live_new");
@@ -1390,7 +1653,8 @@ mod tests {
                 .header("authorization", "Bearer rk_live_shared")
                 .json_body(json!({
                     "name": "lead",
-                    "type": "agent"
+                    "type": "agent",
+                    "metadata": test_sponsor_metadata(None)
                 }));
             then.status(409)
                 .header("content-type", "application/json")
@@ -1413,7 +1677,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"name":"lead","token":"at_live_rotated"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let result = client
             .startup_session_with_options(Some("lead"), true, None)
             .await;
@@ -1459,7 +1723,7 @@ mod tests {
                 .json_body(json!({
                     "name": "lead",
                     "type": "agent",
-                    "metadata": { "identity_key": identity_hash }
+                    "metadata": test_sponsor_metadata(Some(&identity_hash))
                 }));
             then.status(409)
                 .header("content-type", "application/json")
@@ -1472,7 +1736,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .body(format!(
-                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
+                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}","relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
                 ));
         });
         let rotate = server.mock(|when, then| {
@@ -1484,7 +1748,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"name":"lead","token":"at_live_rotated"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client
             .startup_session_with_options(Some("lead"), true, None)
             .await
@@ -1548,7 +1812,7 @@ mod tests {
                 .json_body(json!({
                     "name": "node-a",
                     "type": "agent",
-                    "metadata": { "identity_key": identity_hash }
+                    "metadata": test_sponsor_metadata(Some(&identity_hash))
                 }));
             then.status(409)
                 .header("content-type", "application/json")
@@ -1561,7 +1825,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .body(format!(
-                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
+                    r#"{{"ok":true,"data":{{"id":"a_existing","name":"node-a","type":"agent","status":"offline","persona":null,"metadata":{{"identity_key":"{identity_hash}","relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"}},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}}}"#
                 ));
         });
         let rotate = server.mock(|when, then| {
@@ -1573,7 +1837,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"name":"node-a","token":"at_live_rotated"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client
             .startup_session_set_with_identity(Some("node-a"), true, None, Some(&stable_identity))
             .await
@@ -1630,7 +1894,7 @@ mod tests {
                 ));
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let error = client
             .startup_session_set_with_identity(Some("node-a"), true, None, Some(&our_identity))
             .await
@@ -1674,7 +1938,8 @@ mod tests {
                 .header("authorization", "Bearer rk_live_cached")
                 .json_body(json!({
                     "name": "lead",
-                    "type": "agent"
+                    "type": "agent",
+                    "metadata": test_sponsor_metadata(None)
                 }));
             then.status(409)
                 .header("content-type", "application/json")
@@ -1689,7 +1954,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a_existing","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let result = client.startup_session(Some("lead")).await;
 
         assert!(
@@ -1743,7 +2008,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a_fallback","name":"lead","token":"at_live_fallback","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client.startup_session(Some("lead")).await.unwrap();
 
         assert_eq!(session.token, "at_live_fallback");
@@ -1758,6 +2023,14 @@ mod tests {
     async fn rotate_token_calls_rotate_endpoint_and_preserves_name() {
         let _env_guard = clear_relay_env();
         let server = MockServer::start();
+        let existing = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/lead")
+                .header("authorization", "Bearer rk_live_cached");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_old","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{"relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
+        });
         let rotate = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/agents/lead/rotate-token")
@@ -1767,7 +2040,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"token":"at_live_rotated","name":"lead"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let cached = CredentialCache {
             workspace_id: "ws_cached".into(),
@@ -1784,6 +2057,7 @@ mod tests {
         assert_eq!(session.credentials.agent_name.as_deref(), Some("lead"));
         assert_eq!(session.credentials.agent_id, "a_old");
         assert_eq!(session.credentials.workspace_id, "ws_cached");
+        existing.assert_hits(1);
         rotate.assert_hits(1);
     }
 
@@ -1791,6 +2065,14 @@ mod tests {
     async fn rotate_token_falls_back_to_reregister_on_404() {
         let _env_guard = clear_relay_env();
         let server = MockServer::start();
+        let existing = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/lead")
+                .header("authorization", "Bearer rk_live_cached");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true,"data":{"id":"a_old","name":"lead","type":"agent","status":"offline","persona":null,"metadata":{"relayauth_sponsor_id":"user_test_owner","relayauth_sponsor_binding":"oidc"},"last_seen":"2025-01-01T00:00:00Z","channels":[]}}"#);
+        });
         let rotate_404 = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/agents/lead/rotate-token")
@@ -1808,7 +2090,7 @@ mod tests {
                 .body(r#"{"ok":true,"data":{"id":"a_new","name":"lead","token":"at_live_reregistered","status":"online","created_at":"2025-01-01T00:00:00Z"}}"#);
         });
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let cached = CredentialCache {
             workspace_id: "ws_cached".into(),
@@ -1823,6 +2105,7 @@ mod tests {
         let session = client.rotate_token(&cached).await.unwrap();
         assert_eq!(session.token, "at_live_reregistered");
         assert_eq!(session.credentials.agent_name.as_deref(), Some("lead"));
+        existing.assert_hits(1);
         rotate_404.assert_hits(1);
         register.assert_hits(1);
     }
@@ -1839,7 +2122,7 @@ mod tests {
                 .header("content-type", "application/json")
                 .body(r#"{"ok":true,"data":[]}"#);
         });
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let live = client
             .workspace_key_is_live("rk_live_cached")
@@ -1861,7 +2144,7 @@ mod tests {
                 .header("content-type", "application/json")
                 .body(r#"{"ok":false,"error":{"code":"unauthorized","message":"unauthorized"}}"#);
         });
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
 
         let live = client
             .workspace_key_is_live("rk_live_cached")
@@ -1922,7 +2205,7 @@ mod tests {
             std::env::set_var("RELAY_API_KEY", "rk_live_forbidden");
         }
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client.startup_session(Some("broker")).await.unwrap();
 
         // Must return the FRESH workspace key, not the forbidden env key.
@@ -1973,7 +2256,7 @@ mod tests {
             std::env::set_var("RELAY_API_KEY", stale_key);
         }
 
-        let client = AuthClient::new(Some(server.base_url()));
+        let client = AuthClient::new_for_test(Some(server.base_url()));
         let session = client.startup_session(Some("broker")).await.unwrap();
 
         // The stale env key must NEVER appear in the returned session.

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -603,7 +603,8 @@ impl AuthClient {
     /// Broker-only startup variant that can prove possession of a credential
     /// cached before server-side sponsor enforcement was enabled. Cached
     /// tokens are considered solely for the exact workspace-key fingerprint
-    /// and requested agent name; they never activate token-only bootstrap.
+    /// and requested agent name; they never activate token-only bootstrap or
+    /// authorize a different identity merely because both share a workspace.
     pub(crate) async fn startup_session_set_with_identity_and_incumbents(
         &self,
         requested_name: Option<&str>,

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -8,7 +8,9 @@ pub(crate) mod ws;
 pub(crate) use crate::snippets::{
     configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token,
 };
-pub(crate) use auth::{agent_identity_key, stable_node_identity_key, AuthClient};
+pub(crate) use auth::{
+    agent_identity_key, registration_authority_from_env, stable_node_identity_key, AuthClient,
+};
 // `is_agent_token_invalid`, `is_agent_token_invalid_anyhow`,
 // `is_agent_token_invalid_code`, and `AGENT_TOKEN_INVALID_CODE` are declared
 // `pub` on `auth` so future callers (bridge, ws, listen_api) can reach them

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -9,7 +9,8 @@ pub(crate) use crate::snippets::{
     configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token,
 };
 pub(crate) use auth::{
-    agent_identity_key, registration_authority_from_env, stable_node_identity_key, AuthClient,
+    agent_identity_key, load_incumbent_credential_cache, persist_incumbent_credential_cache,
+    registration_authority_from_env, stable_node_identity_key, AuthClient,
 };
 // `is_agent_token_invalid`, `is_agent_token_invalid_anyhow`,
 // `is_agent_token_invalid_code`, and `AGENT_TOKEN_INVALID_CODE` are declared

--- a/crates/broker/src/relaycast/workspace.rs
+++ b/crates/broker/src/relaycast/workspace.rs
@@ -48,6 +48,7 @@ impl MultiWorkspaceSession {
         read_mcp_identity: bool,
         runtime_cwd: &std::path::Path,
         _events: EventEmitter,
+        registration_work_unit_root: String,
     ) -> Self {
         let (merged_tx, inbound_rx) = mpsc::channel(1024);
         let mut handles = Vec::with_capacity(sessions.memberships.len());
@@ -95,7 +96,8 @@ impl MultiWorkspaceSession {
                 relay_workspace_key.clone(),
                 self_name.clone(),
                 "claude",
-            );
+            )
+            .with_registration_work_unit_root(registration_work_unit_root.clone());
             http_client.seed_agent_token(&self_name, &self_token);
 
             // Node-only delivery (v5.0.1): messages flow over /v1/node/ws and are

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -3,11 +3,11 @@ use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use anyhow::{Context, Result};
 use relaycast::{
     agent::DmOptions, format_registration_error,
-    retry_agent_registration as sdk_retry_agent_registration, ActionDefinition, ActionInvocation,
-    AgentClient, AgentRegistrationClient, AgentRegistrationError, AgentRegistrationRetryOutcome,
-    CompleteInvocationRequest, CreateObserverTokenRequest, EmitSessionEventRequest,
-    MessageListQuery, ObserverToken, RegisterActionRequest, RelayCast, RelayCastOptions,
-    RelayError, ReleaseAgentRequest,
+    retry_agent_registration_with_authority as sdk_retry_agent_registration_with_authority,
+    ActionDefinition, ActionInvocation, AgentClient, AgentRegistrationClient,
+    AgentRegistrationError, AgentRegistrationRetryOutcome, CompleteInvocationRequest,
+    CreateObserverTokenRequest, EmitSessionEventRequest, MessageListQuery, ObserverToken,
+    RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
 };
 use serde_json::Value;
 
@@ -36,6 +36,7 @@ pub struct RelaycastHttpClient {
     registration: Arc<Option<AgentRegistrationClient>>,
     pub agent_name: String,
     pub default_cli: String,
+    registration_work_unit_root: Option<String>,
 }
 
 pub type RelaycastRegistrationError = AgentRegistrationError;
@@ -67,7 +68,39 @@ impl RelaycastHttpClient {
             registration,
             agent_name: agent_name.into(),
             default_cli,
+            registration_work_unit_root: None,
         }
+    }
+
+    pub fn with_registration_work_unit_root(mut self, root: impl Into<String>) -> Self {
+        self.registration_work_unit_root = Some(root.into());
+        self
+    }
+
+    fn registration_authority(
+        &self,
+        agent_name: &str,
+    ) -> anyhow::Result<relaycast::AgentRegistrationAuthority> {
+        let work_unit_key = self.registration_work_unit_key(agent_name)?;
+        super::auth::registration_authority_from_env(&work_unit_key)
+    }
+
+    fn registration_work_unit_key(&self, agent_name: &str) -> anyhow::Result<String> {
+        use sha2::{Digest, Sha256};
+
+        let root = self.registration_work_unit_root.as_deref().context(
+            "registration authority is unavailable because this client has no work-unit secret",
+        )?;
+        let work_unit_key = if agent_name == self.agent_name {
+            root.to_string()
+        } else {
+            let mut hasher = Sha256::new();
+            hasher.update(root.as_bytes());
+            hasher.update([0]);
+            hasher.update(agent_name.as_bytes());
+            format!("{:x}", hasher.finalize())
+        };
+        Ok(work_unit_key)
     }
 
     /// Pre-populate the SDK token cache so registered-agent client creation
@@ -138,8 +171,14 @@ impl RelaycastHttpClient {
                 detail: "SDK relay client not initialized".to_string(),
             }
         })?;
+        let authority = self.registration_authority(trimmed_name).map_err(|error| {
+            RelaycastRegistrationError::Transport {
+                agent_name: trimmed_name.to_string(),
+                detail: error.to_string(),
+            }
+        })?;
         registration
-            .register_agent_token(trimmed_name, cli_hint)
+            .register_agent_token_with_authority(trimmed_name, cli_hint, authority)
             .await
     }
 
@@ -150,7 +189,14 @@ impl RelaycastHttpClient {
             .as_ref()
             .context("SDK relay client not initialized")?;
         registration
-            .registered_agent_client(&self.agent_name, Some(&self.default_cli))
+            .registered_agent_client_with_authority(
+                &self.agent_name,
+                Some(&self.default_cli),
+                || {
+                    self.registration_authority(&self.agent_name)
+                        .map_err(|error| error.to_string())
+                },
+            )
             .await
             .map_err(|error| anyhow::anyhow!("{error}"))
     }
@@ -179,7 +225,14 @@ impl RelaycastHttpClient {
             .as_ref()
             .context("SDK relay client not initialized")?;
         registration
-            .registered_agent_client(agent_name, cli_hint.or(Some(self.default_cli.as_str())))
+            .registered_agent_client_with_authority(
+                agent_name,
+                cli_hint.or(Some(self.default_cli.as_str())),
+                || {
+                    self.registration_authority(agent_name)
+                        .map_err(|error| error.to_string())
+                },
+            )
             .await
             .map_err(|error| anyhow::anyhow!("{error}"))
     }
@@ -809,7 +862,13 @@ pub async fn retry_agent_registration(
             detail: "SDK relay client not initialized".to_string(),
         })
     })?;
-    sdk_retry_agent_registration(registration, name, cli).await
+    let authority = http.registration_authority(name).map_err(|error| {
+        RegRetryOutcome::Fatal(RelaycastRegistrationError::Transport {
+            agent_name: name.to_string(),
+            detail: error.to_string(),
+        })
+    })?;
+    sdk_retry_agent_registration_with_authority(registration, name, cli, authority).await
 }
 
 #[cfg(test)]
@@ -856,6 +915,23 @@ mod tests {
         let message = format_worker_preregistration_error("worker-a", &error);
         assert!(message.contains("worker-a"));
         assert!(message.contains("pre-register"));
+    }
+
+    #[test]
+    fn broker_reuses_root_but_workers_receive_derived_work_unit_keys() {
+        let client = RelaycastHttpClient::new(None, "rk_live_test", "broker", "codex")
+            .with_registration_work_unit_root(
+                "broker-root-000000000000000000000000000000000000000001",
+            );
+
+        assert_eq!(
+            client.registration_work_unit_key("broker").unwrap(),
+            "broker-root-000000000000000000000000000000000000000001"
+        );
+        assert_ne!(
+            client.registration_work_unit_key("worker-a").unwrap(),
+            client.registration_work_unit_key("worker-b").unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -249,6 +249,7 @@ impl BrokerRuntime {
         let default_workspace_id = &self.default_workspace_id;
         let self_names = &self.self_names;
         let relaycast_http = &self.relaycast_http;
+        let registration_work_unit_root = &self.registration_work_unit_root;
         let hosted_agent_event_tx = &self.hosted_agent_event_tx;
         let pty_observability = &mut self.pty_observability;
         let ws_control_tx = &self.ws_control_tx;
@@ -377,12 +378,24 @@ impl BrokerRuntime {
                     // `harnessConfig.session_id` registers as a resumable session
                     // rather than a fresh spawn. No invocation id exists on the
                     // HTTP path.
+                    let authority = match registration_authority_from_env(
+                        &derive_worker_work_unit_key(registration_work_unit_root, &name),
+                    ) {
+                        Ok(authority) => authority,
+                        Err(error) => {
+                            let _ = reply.send(Err(format!(
+                                "sponsor-bound agent registration unavailable: {error}"
+                            )));
+                            return;
+                        }
+                    };
                     match super::fleet::register_node_agent_token(
                         fleet_control_tx,
                         fleet_delivery_book,
                         name.as_str(),
                         None,
                         session_ref.clone(),
+                        authority,
                     )
                     .await
                     {
@@ -443,15 +456,10 @@ impl BrokerRuntime {
                                     Some(token)
                                 }
                                 Err(RegRetryOutcome::RetryableExhausted(error)) => {
-                                    let message =
-                                        format_worker_preregistration_error(&name, &error);
-                                    tracing::warn!(
-                                        worker = %name,
-                                        error = %error,
-                                        "continuing spawn without pre-registration after retries exhausted"
-                                    );
-                                    preregistration_warning = Some(message);
-                                    None
+                                    let _ = reply.send(Err(format_worker_preregistration_error(
+                                        &name, &error,
+                                    )));
+                                    return;
                                 }
                                 Err(RegRetryOutcome::Fatal(error)) => {
                                     let _ = reply.send(Err(format_worker_preregistration_error(

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -190,6 +190,7 @@ pub(crate) struct BrokerRuntime {
     pub(super) self_names: HashSet<String>,
     pub(super) ws_control_tx: mpsc::Sender<WsControl>,
     pub(super) relaycast_http: RelaycastHttpClient,
+    pub(super) registration_work_unit_root: String,
     pub(super) hosted_agent_event_tx: mpsc::Sender<HostedAgentEvent>,
     pub(super) pty_observability: HashMap<WorkerName, PtyObservabilityState>,
     pub(super) api_rx: mpsc::Receiver<ListenApiRequest>,

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -1154,6 +1154,7 @@ impl BrokerRuntime {
             session_ref,
             &self.hosted_agent_event_tx,
             &mut self.pty_observability,
+            &self.registration_work_unit_root,
         )
         .await;
 
@@ -1463,6 +1464,7 @@ pub(super) async fn register_node_agent_token(
     name: &str,
     invocation_id: Option<String>,
     session_ref: Option<String>,
+    registration_authority: relaycast::AgentRegistrationAuthority,
 ) -> Result<crate::node_control::AgentRegistrationToken, String> {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     fleet_control_tx
@@ -1474,6 +1476,7 @@ pub(super) async fn register_node_agent_token(
                 invocation_id,
                 session_ref: session_ref.clone(),
                 resumable: session_ref.as_ref().map(|_| true),
+                registration_authority: Some(registration_authority),
             },
             reply: reply_tx,
         })
@@ -2016,6 +2019,13 @@ mod tests {
     use super::*;
     use crate::protocol::PtyHarnessConfig;
 
+    fn test_registration_authority() -> relaycast::AgentRegistrationAuthority {
+        relaycast::AgentRegistrationAuthority {
+            sponsor_proof: "header.payload.signature".to_string(),
+            work_unit_key: "test-work-unit-key-000000000000000000000001".to_string(),
+        }
+    }
+
     fn test_agent_spec(session_id: Option<&str>, harness_session_id: Option<&str>) -> AgentSpec {
         AgentSpec {
             name: WorkerName::from("agent-a"),
@@ -2512,6 +2522,7 @@ mod tests {
                 "agent-a",
                 Some("inv-42".to_string()),
                 session_ref,
+                test_registration_authority(),
             )
             .await?;
             Ok::<_, String>((token, delivery_book))
@@ -2559,7 +2570,15 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<FleetControlCommand>(4);
         let register_handle = tokio::spawn(async move {
             let mut delivery_book = FleetDeliveryBook::default();
-            register_node_agent_token(&tx, &mut delivery_book, "agent-a", None, None).await?;
+            register_node_agent_token(
+                &tx,
+                &mut delivery_book,
+                "agent-a",
+                None,
+                None,
+                test_registration_authority(),
+            )
+            .await?;
             Ok::<_, String>(delivery_book)
         });
 

--- a/crates/broker/src/runtime/headless.rs
+++ b/crates/broker/src/runtime/headless.rs
@@ -243,6 +243,10 @@ pub(crate) async fn run_headless_worker(cmd: HeadlessCommand) -> Result<()> {
                         r#"{"*":"allow","external_directory":{"*":"allow"}}"#,
                     );
                 }
+                // Defense in depth: the outer worker wrapper already removes
+                // these values, but never let a directly-invoked headless
+                // worker pass broker registration authority to its provider.
+                crate::util::child_env::scrub_registration_authority(&mut child_cmd);
 
                 let mut child = match child_cmd.spawn() {
                     Ok(child) => child,

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -218,6 +218,17 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
     let self_names = default_workspace.self_names.clone();
     let ws_control_tx = default_workspace.ws_control_tx.clone();
     let relaycast_http = default_workspace.http_client.clone();
+    // Keep child-agent ownership under the same root that `connect_relay`
+    // used for the broker itself. An explicit RELAY_AGENT_IDENTITY_KEY is a
+    // deliberate work-unit override (fleet nodes use it to preserve identity
+    // across an isolated state rebuild); replacing it here with the persisted
+    // fallback would register the broker and its children under unrelated
+    // ownership roots, making a legitimate release/resume impossible.
+    let registration_work_unit_root = match agent_identity_key() {
+        Some(key) => key,
+        None => stable_node_identity_key(&paths.state)
+            .context("failed to reload the broker work-unit secret")?,
+    };
     let (hosted_agent_event_tx, hosted_agent_event_rx) = mpsc::channel::<HostedAgentEvent>(10_000);
     let hosted_event_client = relaycast_http.clone();
     let hosted_event_clients = workspaces
@@ -671,6 +682,7 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         self_names,
         ws_control_tx,
         relaycast_http,
+        registration_work_unit_root,
         hosted_agent_event_tx,
         pty_observability: HashMap::new(),
         api_rx,

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -36,10 +36,10 @@ use crate::{
         ProtocolEnvelope, RelayDelivery, ResolvedHarnessConfig, PROTOCOL_VERSION,
     },
     relaycast::{
-        agent_identity_key, format_worker_preregistration_error, registration_retry_after_secs,
-        retry_agent_registration, stable_node_identity_key, AuthClient, MultiWorkspaceSession,
-        RegRetryOutcome, RelaycastHttpClient, WorkspaceInboundMessage, WorkspaceMembershipSummary,
-        WsControl,
+        agent_identity_key, format_worker_preregistration_error, registration_authority_from_env,
+        registration_retry_after_secs, retry_agent_registration, stable_node_identity_key,
+        AuthClient, MultiWorkspaceSession, RegRetryOutcome, RelaycastHttpClient,
+        WorkspaceInboundMessage, WorkspaceMembershipSummary, WsControl,
     },
     replay_buffer::{ReplayBuffer, DEFAULT_REPLAY_CAPACITY},
     telemetry::{ActionSource, TelemetryClient, TelemetryEvent},
@@ -66,6 +66,15 @@ const DEFAULT_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: u64 = 20_000;
 const DEFAULT_HTTP_API_OBSERVER_TOKEN_TIMEOUT_MS: u64 = 20_000;
 const DEFAULT_HTTP_API_EVENT_EMIT_TIMEOUT_MS: u64 = 200;
 static TRACING_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+
+fn derive_worker_work_unit_key(root: &str, name: &WorkerName) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(root.as_bytes());
+    hasher.update([0]);
+    hasher.update(name.as_str().as_bytes());
+    format!("{:x}", hasher.finalize())
+}
 
 mod api;
 mod app_server;

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -36,7 +36,8 @@ use crate::{
         ProtocolEnvelope, RelayDelivery, ResolvedHarnessConfig, PROTOCOL_VERSION,
     },
     relaycast::{
-        agent_identity_key, format_worker_preregistration_error, registration_authority_from_env,
+        agent_identity_key, format_worker_preregistration_error, load_incumbent_credential_cache,
+        persist_incumbent_credential_cache, registration_authority_from_env,
         registration_retry_after_secs, retry_agent_registration, stable_node_identity_key,
         AuthClient, MultiWorkspaceSession, RegRetryOutcome, RelaycastHttpClient,
         WorkspaceInboundMessage, WorkspaceMembershipSummary, WsControl,

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -360,6 +360,7 @@ pub(super) async fn spawn_worker_from_request(
     session_ref: Option<String>,
     hosted_agent_event_tx: &mpsc::Sender<HostedAgentEvent>,
     pty_observability: &mut HashMap<WorkerName, PtyObservabilityState>,
+    registration_work_unit_root: &str,
 ) {
     let workspace_http = &workspace_state.http_client;
     eprintln!(
@@ -517,12 +518,27 @@ pub(super) async fn spawn_worker_from_request(
             }
             Some(token)
         } else {
+            let authority = match registration_authority_from_env(&derive_worker_work_unit_key(
+                registration_work_unit_root,
+                &name,
+            )) {
+                Ok(authority) => authority,
+                Err(error) => {
+                    tracing::warn!(
+                        worker = %name,
+                        error = %error,
+                        "rejecting spawn because sponsor-bound registration is unavailable"
+                    );
+                    return;
+                }
+            };
             match super::fleet::register_node_agent_token(
                 fleet_control_tx,
                 fleet_delivery_book,
                 name.as_str(),
                 invocation_id.clone(),
                 session_ref.clone(),
+                authority,
             )
             .await
             {
@@ -599,19 +615,19 @@ pub(super) async fn spawn_worker_from_request(
                             Some(token)
                         }
                         Ok(Err(error)) => {
-                            tracing::warn!(
+                            tracing::error!(
                                 worker = %name,
                                 error = %error,
-                                "WS spawn pre-registration failed; agent will self-register"
+                                "rejecting WS spawn because sponsor-bound pre-registration failed"
                             );
-                            None
+                            return;
                         }
                         Err(_) => {
-                            tracing::warn!(
+                            tracing::error!(
                                 worker = %name,
-                                "WS spawn pre-registration timed out (3s); agent will self-register"
+                                "rejecting WS spawn because sponsor-bound pre-registration timed out"
                             );
-                            None
+                            return;
                         }
                     }
                 }

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -287,8 +287,11 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
     // reaped would collide on its own name and be fail-closed rejected —
     // the spawn-admission gate can't tell "myself, restarting" from "a
     // stranger" unless something proves it.
-    let derived_identity_key =
-        agent_identity_key().unwrap_or_else(|| stable_node_identity_key(&opts.paths.state));
+    let derived_identity_key = match agent_identity_key() {
+        Some(key) => key,
+        None => stable_node_identity_key(&opts.paths.state)
+            .context("failed to load the broker work-unit secret")?,
+    };
     let sessions = {
         let mut attempt: u32 = 0;
         loop {
@@ -407,6 +410,7 @@ timestamp='{}'
         opts.read_mcp_identity,
         opts.runtime_cwd,
         crate::events::EventEmitter::new(false),
+        derived_identity_key,
     );
     log_startup_phase(
         startup_debug,

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -292,17 +292,20 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
         None => stable_node_identity_key(&opts.paths.state)
             .context("failed to load the broker work-unit secret")?,
     };
+    let incumbent_credentials = load_incumbent_credential_cache(&opts.paths.state)
+        .context("failed to load the broker incumbent credential cache")?;
     let sessions = {
         let mut attempt: u32 = 0;
         loop {
             attempt += 1;
             match timeout(
                 attempt_timeout,
-                auth.startup_session_set_with_identity(
+                auth.startup_session_set_with_identity_and_incumbents(
                     Some(opts.requested_name),
                     opts.strict_name,
                     opts.agent_type,
                     Some(derived_identity_key.as_str()),
+                    &incumbent_credentials,
                 ),
             )
             .await
@@ -349,6 +352,9 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
             sessions.memberships.len()
         ),
     );
+
+    persist_incumbent_credential_cache(&opts.paths.state, &sessions.credential_set())
+        .context("failed to persist the broker incumbent credential cache")?;
 
     let default_session = sessions
         .default_session()

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Map, Value};
 use tokio::process::Command;
 
 use crate::types::AgentResultMcpConfig;
+use crate::util::child_env::scrub_registration_authority;
 
 const AGENT_RELAY_MCP_PACKAGE: &str = "agent-relay";
 const AGENT_RELAY_MCP_SUBCOMMAND: &str = "mcp";
@@ -1274,6 +1275,7 @@ async fn remove_grok_mcp_servers(exe: &str) {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        scrub_registration_authority(&mut cmd);
         if let Ok(mut child) = cmd.spawn() {
             let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
         }
@@ -1310,6 +1312,7 @@ async fn configure_grok_mcp(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    scrub_registration_authority(&mut mcp_cmd);
 
     match mcp_cmd.spawn() {
         Ok(mut child) => match tokio::time::timeout(Duration::from_secs(15), child.wait()).await {
@@ -1388,6 +1391,7 @@ async fn remove_gemini_droid_mcp_servers(exe: &str) {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        scrub_registration_authority(&mut cmd);
         if let Ok(child) = cmd.spawn() {
             let _ = tokio::time::timeout(Duration::from_secs(5), child.wait_with_output()).await;
         }
@@ -1456,6 +1460,7 @@ async fn spawn_mcp_add(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+    scrub_registration_authority(&mut mcp_cmd);
 
     match mcp_cmd.spawn() {
         Ok(child) => {

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -15,6 +15,7 @@ use tokio::{
 
 use crate::cli::command_parse::parse_cli_command;
 use crate::types::CommitAttestation;
+use crate::util::child_env::scrub_registration_authority;
 
 const RELAY_ATTEST_JTI: &str = "RELAY_ATTEST_JTI";
 const RELAY_ATTEST_AGENT_ID: &str = "RELAY_ATTEST_AGENT_ID";
@@ -262,6 +263,9 @@ impl Spawner {
         if self.children.contains_key(child_name) {
             anyhow::bail!("child {child_name} already exists");
         }
+        let agent_token = agent_token.context(
+            "delegated spawn requires sponsor-bound pre-registration; refusing tokenless wrapper",
+        )?;
 
         let exe = std::env::current_exe().unwrap_or_else(|_| "agent-relay-broker".into());
         let mut cmd = Command::new(exe);
@@ -301,7 +305,7 @@ impl Spawner {
             base_url,
             &combined_args,
             &cwd,
-            agent_token,
+            Some(agent_token),
             workspaces_json,
             default_workspace,
         )
@@ -328,14 +332,17 @@ impl Spawner {
         }
         // Inject pre-registered agent token when available so the MCP server
         // starts already authenticated (same as main.rs WorkerRegistry::spawn).
-        if let Some(token) = agent_token {
-            cmd.env("RELAY_AGENT_TOKEN", token);
-        }
+        cmd.env("RELAY_AGENT_TOKEN", agent_token);
         // Disable Claude Code auto-suggestions to prevent accidental acceptance
         // when relay messages are injected into the PTY.
         cmd.env("CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION", "false");
         // Disable Claude Code auto-updater — it fails in sandboxes and can crash the process.
         cmd.env("DISABLE_AUTOUPDATER", "1");
+
+        // Delegated spawn admission is fail closed, so the wrapper always has
+        // this one-agent bootstrap credential and never needs the broader
+        // sponsor/reclaim capability.
+        scrub_registration_authority(&mut cmd);
 
         #[cfg(unix)]
         unsafe {
@@ -1080,7 +1087,7 @@ mod tests {
                 &["30".to_string()],
                 &env_vars,
                 Some("Parent"),
-                None,
+                Some("at_live_test_child"),
             )
             .await
             .unwrap();
@@ -1094,15 +1101,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn spawn_wrap_rejects_tokenless_delegated_spawn() {
+        let mut spawner = Spawner::new();
+        let error = spawner
+            .spawn_wrap_with_token("NoToken", "sleep", &[], &[], None, None)
+            .await
+            .expect_err("delegated spawn must fail closed before launching a wrapper");
+        assert!(error.to_string().contains("refusing tokenless wrapper"));
+        assert!(spawner.children.is_empty());
+    }
+
+    #[tokio::test]
     async fn spawn_wrap_rejects_duplicate_name() {
         let mut spawner = Spawner::new();
         let env_vars = vec![("RELAY_AGENT_NAME".to_string(), "Dup".to_string())];
         spawner
-            .spawn_wrap_with_token("Dup", "sleep", &["30".to_string()], &env_vars, None, None)
+            .spawn_wrap_with_token(
+                "Dup",
+                "sleep",
+                &["30".to_string()],
+                &env_vars,
+                None,
+                Some("at_live_test_child"),
+            )
             .await
             .unwrap();
         let result = spawner
-            .spawn_wrap_with_token("Dup", "sleep", &["30".to_string()], &env_vars, None, None)
+            .spawn_wrap_with_token(
+                "Dup",
+                "sleep",
+                &["30".to_string()],
+                &env_vars,
+                None,
+                Some("at_live_test_child"),
+            )
             .await;
         assert!(result.is_err());
         spawner.shutdown_all(Duration::from_millis(200)).await;
@@ -1120,7 +1152,7 @@ mod tests {
                 &["30".to_string()],
                 &env_vars,
                 None,
-                None,
+                Some("at_live_test_child"),
             )
             .await
             .unwrap();

--- a/crates/broker/src/util/child_env.rs
+++ b/crates/broker/src/util/child_env.rs
@@ -1,0 +1,61 @@
+use tokio::process::Command;
+
+/// Broker-only credential-authority inputs that must not cross into an agent
+/// harness process.
+///
+/// A workspace key is intentionally available to workers for ordinary Relay
+/// operations. The sponsor grant and work-unit root are different: together
+/// they authorize the broker to create or reclaim agent identities. Letting a
+/// spawned harness inherit them would hand that agent the broker's registration
+/// authority instead of only the already-issued `RELAY_AGENT_TOKEN` scoped to
+/// its own identity.
+pub(crate) const REGISTRATION_AUTHORITY_ENV_KEYS: &[&str] = &[
+    "RELAYAUTH_SPONSOR_PROOF",
+    "RELAYAUTH_SPONSOR_ID",
+    "RELAYAUTH_SPONSOR_ORG_ID",
+    "RELAYAUTH_ISSUER",
+    "RELAYAUTH_SIGNING_KEY_PEM_PUBLIC",
+    "RELAYAUTH_SIGNING_KEY_PEM_PRIVATE",
+    "RELAYAUTH_SIGNING_KEY_PEM",
+    "RELAYAUTH_TEST_SPONSOR_FIXTURE",
+    "RELAY_AGENT_IDENTITY_KEY",
+    "RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM",
+    "RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER",
+    "RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_AUDIENCE",
+];
+
+/// Remove broker registration authority after all caller-supplied environment
+/// has been applied. Keeping this as the final environment step prevents a
+/// harness-specific `env` block from adding the capability back.
+pub(crate) fn scrub_registration_authority(command: &mut Command) {
+    for key in REGISTRATION_AUTHORITY_ENV_KEYS {
+        command.env_remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_overrides_explicit_child_environment() {
+        let mut command = Command::new("unused");
+        for key in REGISTRATION_AUTHORITY_ENV_KEYS {
+            command.env(key, "must-not-reach-agent");
+        }
+
+        scrub_registration_authority(&mut command);
+
+        let overrides = command
+            .as_std()
+            .get_envs()
+            .collect::<std::collections::HashMap<_, _>>();
+        for key in REGISTRATION_AUTHORITY_ENV_KEYS {
+            assert_eq!(
+                overrides.get(std::ffi::OsStr::new(key)).copied(),
+                Some(None),
+                "{key} must be explicitly removed from the child environment"
+            );
+        }
+    }
+}

--- a/crates/broker/src/util/mod.rs
+++ b/crates/broker/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod child_env;
 pub(crate) mod fs;
 pub(crate) mod version;
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -32,6 +32,7 @@ use crate::{
     cli::command_parse::{normalize_cli_name, parse_cli_command},
     runtime::headless_provider_cli_name,
     spawner::terminate_child,
+    util::child_env::scrub_registration_authority,
 };
 
 const APP_SERVER_AUTH_ENV_KEYS: [&str; 4] = [
@@ -1054,13 +1055,18 @@ impl WorkerRegistry {
             direct_native_harness_sidecar,
             skip_relay_prompt,
         ) {
-            if let Some(relay_key) = worker_relay_api_key {
+            if let Some(relay_key) = worker_relay_api_key.as_deref() {
                 command.env("RELAY_AGENT_TOKEN", relay_key);
             }
             command.env("RELAY_AGENT_NAME", &spec.name);
             command.env("RELAY_AGENT_TYPE", "agent");
             command.env("RELAY_STRICT_AGENT_NAME", "1");
         }
+        // Spawn admission is fail closed before reaching this point, so every
+        // Relay participant receives an already-issued agent token. Sponsor and
+        // reclaim authority is parent-broker state and never crosses into the
+        // worker transport (or a direct native harness).
+        scrub_registration_authority(&mut command);
         // Remove CLAUDECODE from child env to prevent nested Claude Code instances
         // from interfering with the parent's session management
         command.env_remove("CLAUDECODE");
@@ -2124,12 +2130,10 @@ async fn codex_debug_models_output(resolved_cli: &str) -> std::io::Result<std::p
     let mut attempt: u32 = 0;
     loop {
         attempt += 1;
-        match Command::new(resolved_cli)
-            .arg("debug")
-            .arg("models")
-            .output()
-            .await
-        {
+        let mut command = Command::new(resolved_cli);
+        command.arg("debug").arg("models");
+        scrub_registration_authority(&mut command);
+        match command.output().await {
             Err(err)
                 if err.kind() == std::io::ErrorKind::ExecutableFileBusy
                     && attempt < MAX_ATTEMPTS =>

--- a/crates/broker/src/wrap.rs
+++ b/crates/broker/src/wrap.rs
@@ -35,6 +35,7 @@ use crate::runtime::{
 use crate::spawner::{spawn_env_vars, with_commit_attestation_env, Spawner};
 use crate::util::{
     ansi::{floor_char_boundary, strip_ansi, AnsiStripper},
+    child_env::REGISTRATION_AUTHORITY_ENV_KEYS,
     terminal::{
         detect_bypass_permissions_prompt, detect_claude_trust_prompt, detect_codex_model_prompt,
         detect_codex_trust_prompt, detect_gemini_action_required, detect_gemini_trust_prompt,
@@ -1011,11 +1012,12 @@ pub(crate) async fn run_wrap(
     let mut spawner = Spawner::new();
 
     // --- Spawn CLI in PTY ---
-    let (pty, mut pty_rx) = PtySession::spawn(
+    let (pty, mut pty_rx) = PtySession::spawn_with_env_removals(
         &resolved_cli,
         &effective_cli_args,
         terminal_rows().unwrap_or(24),
         terminal_cols().unwrap_or(80),
+        REGISTRATION_AUTHORITY_ENV_KEYS,
     )?;
     // Query responses (DSR/DA1/DA2/CPR) are answered by alacritty's
     // `RelayEventListener` inside `PtySession`.
@@ -1444,27 +1446,34 @@ pub(crate) async fn run_wrap(
                                     // starts with a valid token (avoiding "Not registered"
                                     // errors when non-claude CLIs like codex try to use
                                     // relay tools before calling register() themselves).
+                                    'spawn_admission: {
                                     let child_token = match retry_agent_registration(
                                         &workspace_child_http,
                                         &params.name,
                                         Some(&params.cli),
                                     ).await {
-                                        Ok(token) => Some(token),
+                                        Ok(token) => token,
                                         Err(RegRetryOutcome::RetryableExhausted(e)) => {
-                                            tracing::warn!(
+                                            tracing::error!(
                                                 child = %params.name,
                                                 error = %e,
-                                                "pre-registration failed after retries, spawning without token"
+                                                "rejecting delegated spawn after sponsor-bound pre-registration retries"
                                             );
-                                            None
+                                            completion_error = Some(format!(
+                                                "sponsor-bound pre-registration failed: {e}"
+                                            ));
+                                            break 'spawn_admission;
                                         }
                                         Err(RegRetryOutcome::Fatal(e)) => {
-                                            tracing::warn!(
+                                            tracing::error!(
                                                 child = %params.name,
                                                 error = %e,
-                                                "pre-registration fatal error, spawning without token"
+                                                "rejecting delegated spawn after sponsor-bound pre-registration failure"
                                             );
-                                            None
+                                            completion_error = Some(format!(
+                                                "sponsor-bound pre-registration failed: {e}"
+                                            ));
+                                            break 'spawn_admission;
                                         }
                                     };
                                     match spawner
@@ -1474,7 +1483,7 @@ pub(crate) async fn run_wrap(
                                             &params.args,
                                             &env_vars,
                                             Some(&action_ref.invoked_by),
-                                            child_token.as_deref(),
+                                            Some(&child_token),
                                         )
                                         .await
                                     {
@@ -1517,6 +1526,7 @@ pub(crate) async fn run_wrap(
                                                 params.name
                                             ));
                                         }
+                                    }
                                     }
                                 }
                             }

--- a/crates/relay-pty/src/pty.rs
+++ b/crates/relay-pty/src/pty.rs
@@ -515,6 +515,20 @@ impl PtySession {
         rows: u16,
         cols: u16,
     ) -> Result<(Self, mpsc::Receiver<Vec<u8>>)> {
+        Self::spawn_with_env_removals(command, args, rows, cols, &[])
+    }
+
+    /// Spawn a PTY child while explicitly removing selected inherited
+    /// environment variables. This keeps process-boundary policy with the
+    /// caller while giving PTY-backed harnesses the same final `env_remove`
+    /// semantics as `std::process::Command`/`tokio::process::Command`.
+    pub fn spawn_with_env_removals(
+        command: &str,
+        args: &[String],
+        rows: u16,
+        cols: u16,
+        env_removals: &[&str],
+    ) -> Result<(Self, mpsc::Receiver<Vec<u8>>)> {
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(PtySize {
@@ -530,6 +544,9 @@ impl PtySession {
         cmd.cwd(std::env::current_dir().context("failed to get current directory")?);
         if needs_sane_term_override() {
             cmd.env("TERM", "xterm-256color");
+        }
+        for key in env_removals {
+            cmd.env_remove(key);
         }
         for arg in args {
             cmd.arg(arg);
@@ -1249,6 +1266,39 @@ mod tests {
         }
         assert!(String::from_utf8_lossy(&collected).contains("hello"));
         let _ = pty.shutdown();
+    }
+
+    #[tokio::test]
+    async fn spawn_with_env_removals_does_not_expose_inherited_value() {
+        let key = "AGENT_RELAY_TEST_PTY_CHILD_SECRET";
+        unsafe {
+            env::set_var(key, "must-not-be-visible");
+        }
+
+        let (pty, mut rx) = PtySession::spawn_with_env_removals(
+            "sh",
+            &["-c".into(), format!("printf '%s' \"${{{key}:-missing}}\"")],
+            24,
+            80,
+            &[key],
+        )
+        .unwrap();
+
+        let mut collected = Vec::new();
+        while let Ok(Some(chunk)) = timeout(Duration::from_secs(2), rx.recv()).await {
+            collected.extend_from_slice(&chunk);
+            if String::from_utf8_lossy(&collected).contains("missing") {
+                break;
+            }
+        }
+
+        let _ = pty.shutdown();
+        unsafe {
+            env::remove_var(key);
+        }
+        let output = String::from_utf8_lossy(&collected);
+        assert!(output.contains("missing"));
+        assert!(!output.contains("must-not-be-visible"));
     }
 
     #[tokio::test]

--- a/scripts/mint-ci-sponsor-grant.mjs
+++ b/scripts/mint-ci-sponsor-grant.mjs
@@ -23,9 +23,9 @@ const payload = encode({
   sub: sponsorId,
   org: orgId,
   iat: now,
-  // The test authority intentionally grants two hours: macOS release builds
-  // can exceed 30 minutes before the broker smoke step reaches registration.
-  exp: now + 60 * 60 * 2,
+  // Match RelayAuth's production maximum grant lifetime. Each CI job mints the
+  // proof immediately before its own build/test sequence.
+  exp: now + 15 * 60,
   jti: `spg_ci_${randomUUID().replaceAll('-', '')}`,
   intent: 'identity.create',
   token_type: 'sponsor_grant',

--- a/scripts/mint-ci-sponsor-grant.mjs
+++ b/scripts/mint-ci-sponsor-grant.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs';
+import { createHash, createSign, generateKeyPairSync, randomUUID } from 'node:crypto';
+
+const issuer = 'https://auth.ci.agentrelay.test';
+const audience = 'relayauth:sponsor-binding';
+const sponsorId = 'user_ci_sponsor';
+const orgId = 'org_ci';
+const now = Math.floor(Date.now() / 1000);
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const publicJwk = publicKey.export({ format: 'jwk' });
+const publicKeyPem = publicKey.export({ format: 'pem', type: 'spki' }).toString();
+const thumbprintInput = JSON.stringify({ e: publicJwk.e, kty: publicJwk.kty, n: publicJwk.n });
+const kid = createHash('sha256').update(thumbprintInput).digest('base64url');
+
+const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+const header = encode({ alg: 'RS256', typ: 'JWT', kid });
+const payload = encode({
+  iss: issuer,
+  aud: audience,
+  sub: sponsorId,
+  org: orgId,
+  iat: now,
+  // The test authority intentionally grants two hours: macOS release builds
+  // can exceed 30 minutes before the broker smoke step reaches registration.
+  exp: now + 60 * 60 * 2,
+  jti: `spg_ci_${randomUUID().replaceAll('-', '')}`,
+  intent: 'identity.create',
+  token_type: 'sponsor_grant',
+  oidc: {
+    issuer: 'https://idp.ci.agentrelay.test',
+    subject: 'oidc_ci_sponsor',
+    iat: now,
+  },
+});
+const signingInput = `${header}.${payload}`;
+const signature = createSign('RSA-SHA256').update(signingInput).end().sign(privateKey, 'base64url');
+const proof = `${signingInput}.${signature}`;
+
+const output = process.env.GITHUB_ENV;
+if (!output) {
+  throw new Error('GITHUB_ENV is required; this signer is intentionally CI-only');
+}
+
+const write = (name, value) => {
+  const delimiter = `EOF_${name}_${randomUUID().replaceAll('-', '')}`;
+  appendFileSync(output, `${name}<<${delimiter}\n${value}\n${delimiter}\n`, { mode: 0o600 });
+};
+
+write('RELAYAUTH_SPONSOR_ID', sponsorId);
+write('RELAYAUTH_SPONSOR_ORG_ID', orgId);
+write('RELAYAUTH_ISSUER', issuer);
+write('RELAYAUTH_SIGNING_KEY_PEM_PUBLIC', publicKeyPem);
+write('RELAYAUTH_SPONSOR_PROOF', proof);
+write('RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM', publicKeyPem);
+write('RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER', issuer);
+write('RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_AUDIENCE', audience);

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { createHash, createSign, generateKeyPairSync, randomUUID } from 'node:crypto';
 import { createServer as createHttpServer } from 'node:http';
 import { createServer as createNetServer } from 'node:net';
 import {
@@ -30,6 +31,91 @@ export const NODE_B_FILE = path.join(HERE, 'nodes', 'node-b.ts');
 export const CLOUD_ENROLLED_NODE_FILE = path.join(HERE, 'nodes', 'cloud-enrolled.ts');
 
 const CLI_ENTRY = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'index.js');
+
+const FLEET_SPONSOR_ISSUER = 'https://auth.fleet-e2e.agentrelay.test';
+const FLEET_SPONSOR_AUDIENCE = 'relayauth:sponsor-binding';
+const FLEET_SPONSOR_ID = 'user_fleet_e2e';
+const FLEET_SPONSOR_ORG = 'org_fleet_e2e';
+const FLEET_SPONSOR_KEYS = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const FLEET_SPONSOR_PUBLIC_KEY_PEM = FLEET_SPONSOR_KEYS.publicKey
+  .export({ format: 'pem', type: 'spki' })
+  .toString();
+const FLEET_SPONSOR_JWK = FLEET_SPONSOR_KEYS.publicKey.export({ format: 'jwk' });
+const FLEET_SPONSOR_KID = createHash('sha256')
+  .update(
+    JSON.stringify({
+      e: FLEET_SPONSOR_JWK.e,
+      kty: FLEET_SPONSOR_JWK.kty,
+      n: FLEET_SPONSOR_JWK.n,
+    })
+  )
+  .digest('base64url');
+
+function mintFleetSponsorProof(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  const header = encode({ alg: 'RS256', typ: 'JWT', kid: FLEET_SPONSOR_KID });
+  const payload = encode({
+    iss: FLEET_SPONSOR_ISSUER,
+    aud: FLEET_SPONSOR_AUDIENCE,
+    sub: FLEET_SPONSOR_ID,
+    org: FLEET_SPONSOR_ORG,
+    iat: now,
+    exp: now + 60 * 30,
+    jti: `spg_fleet_${randomUUID().replaceAll('-', '')}`,
+    intent: 'identity.create',
+    token_type: 'sponsor_grant',
+    oidc: {
+      issuer: 'https://idp.fleet-e2e.agentrelay.test',
+      subject: 'oidc_fleet_e2e',
+      iat: now,
+    },
+  });
+  const signingInput = `${header}.${payload}`;
+  const signature = createSign('RSA-SHA256')
+    .update(signingInput)
+    .end()
+    .sign(FLEET_SPONSOR_KEYS.privateKey, 'base64url');
+  return `${signingInput}.${signature}`;
+}
+
+const FLEET_SPONSOR_PROOF = mintFleetSponsorProof();
+const FLEET_BROKER_SPONSOR_ENV = {
+  RELAYAUTH_SPONSOR_ID: FLEET_SPONSOR_ID,
+  RELAYAUTH_SPONSOR_ORG_ID: FLEET_SPONSOR_ORG,
+  RELAYAUTH_ISSUER: FLEET_SPONSOR_ISSUER,
+  RELAYAUTH_SIGNING_KEY_PEM_PUBLIC: FLEET_SPONSOR_PUBLIC_KEY_PEM,
+  RELAYAUTH_SPONSOR_PROOF: FLEET_SPONSOR_PROOF,
+};
+
+function fleetAgentAuthority(name: string): {
+  sponsor_proof: string;
+  work_unit_key: string;
+} {
+  return {
+    sponsor_proof: FLEET_SPONSOR_PROOF,
+    work_unit_key: `fleet-e2e-agent-${name}-00000000000000000000000000000001`,
+  };
+}
+
+function fleetNodeWorkUnitRoot(nodeId: string): string {
+  return `fleet-e2e-node-root-${nodeId}-00000000000000000000000000000001`;
+}
+
+function fleetNodeAgentAuthority(
+  nodeId: string,
+  agentName: string
+): {
+  sponsor_proof: string;
+  work_unit_key: string;
+} {
+  const workUnitKey = createHash('sha256')
+    .update(fleetNodeWorkUnitRoot(nodeId))
+    .update(Buffer.from([0]))
+    .update(agentName)
+    .digest('hex');
+  return { sponsor_proof: FLEET_SPONSOR_PROOF, work_unit_key: workUnitKey };
+}
 
 /**
  * Locate a built relaycast engine `serve` bin. CI sets RELAYCAST_ENGINE_DIR to a
@@ -160,6 +246,12 @@ export interface EngineHandle {
   fetchJson(pathname: string, init?: RequestInit): Promise<{ status: number; body: any }>;
 }
 
+function engineStartupFailure(child: ChildProcess, stderr: string): Error | null {
+  if (child.exitCode === null && child.signalCode === null) return null;
+  const detail = stderr.trim() || `exit=${String(child.exitCode)} signal=${String(child.signalCode)}`;
+  return new Error(`relaycast engine exited before becoming ready: ${detail}`);
+}
+
 export async function startEngine(
   serveBin: string,
   tmpRoot: string,
@@ -171,29 +263,50 @@ export async function startEngine(
     process.execPath,
     [serveBin, '--port', String(port), '--db', path.join(tmpRoot, 'relaycast.db'), '--env', 'test'],
     {
-      env: cleanEnv({ HOME: tmpRoot, ...extraEnv }),
+      env: cleanEnv({
+        HOME: tmpRoot,
+        RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM: FLEET_SPONSOR_PUBLIC_KEY_PEM,
+        RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER: FLEET_SPONSOR_ISSUER,
+        RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_AUDIENCE: FLEET_SPONSOR_AUDIENCE,
+        ...extraEnv,
+      }),
       stdio: ['ignore', 'pipe', 'pipe'],
     }
   );
+  let startupStderr = '';
   child.stdout?.on('data', () => {});
-  child.stderr?.on('data', () => {});
+  child.stderr?.on('data', (chunk: Buffer) => {
+    startupStderr = `${startupStderr}${chunk.toString()}`.slice(-16_384);
+  });
 
   const fetchJson = async (pathname: string, init: RequestInit = {}) => {
     const res = await fetch(`${baseUrl}${pathname}`, init);
     return { status: res.status, body: await res.json().catch(() => ({})) };
   };
 
-  await waitFor(
-    async () => {
-      try {
-        const res = await fetch(`${baseUrl}/`);
-        return res.status > 0;
-      } catch {
-        return false;
-      }
-    },
-    { timeoutMs: 20_000, label: 'engine ready' }
-  );
+  const exitBeforeReady = new Promise<never>((_resolve, reject) => {
+    const rejectWithFailure = () =>
+      reject(
+        engineStartupFailure(child, startupStderr) ??
+          new Error('relaycast engine exited before becoming ready')
+      );
+    if (child.exitCode !== null || child.signalCode !== null) rejectWithFailure();
+    else child.once('exit', rejectWithFailure);
+  });
+  await Promise.race([
+    waitFor(
+      async () => {
+        try {
+          const res = await fetch(`${baseUrl}/health`);
+          return res.status > 0;
+        } catch {
+          return false;
+        }
+      },
+      { timeoutMs: 20_000, label: 'engine ready' }
+    ),
+    exitBeforeReady,
+  ]);
 
   return {
     baseUrl,
@@ -209,7 +322,10 @@ export async function createWorkspace(engine: EngineHandle, name: string): Promi
   const { status, body } = await engine.fetchJson('/v1/workspaces', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({
+      name,
+      registration_authority: { sponsor_proof: FLEET_SPONSOR_PROOF },
+    }),
   });
   if (status >= 300) throw new Error(`createWorkspace ${status}`);
   return body.data.api_key as string;
@@ -485,6 +601,8 @@ export class FleetNode {
         BROKER_BINARY_PATH: o.brokerBinary,
         RELAYCAST_BASE_URL: o.engineBaseUrl,
         RELAY_BASE_URL: o.engineBaseUrl,
+        ...FLEET_BROKER_SPONSOR_ENV,
+        RELAY_AGENT_IDENTITY_KEY: fleetNodeWorkUnitRoot(o.nodeId),
         ...(o.usePersistedEnrollment
           ? {
               AGENT_RELAY_HOME: this.enrollmentHome,
@@ -565,7 +683,7 @@ export async function registerAgent(
   const { status, body } = await engine.fetchJson('/v1/agents', {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ name, registration_authority: fleetAgentAuthority(name) }),
   });
   if (status >= 300) throw new Error(`registerAgent ${status}: ${JSON.stringify(body)}`);
   return (body.data.token ?? body.data.agent_token) as string;
@@ -674,11 +792,17 @@ export async function releaseAgent(
   workspaceKey: string,
   name: string
 ): Promise<number> {
-  const { status } = await engine.fetchJson(`/v1/agents/${name}`, {
-    method: 'DELETE',
-    headers: { authorization: `Bearer ${workspaceKey}` },
-  });
-  return status;
+  let lastStatus = 409;
+  for (const nodeId of ['node_a', 'node_b']) {
+    const { status } = await engine.fetchJson(`/v1/agents/${name}`, {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
+      body: JSON.stringify({ registration_authority: fleetNodeAgentAuthority(nodeId, name) }),
+    });
+    lastStatus = status;
+    if (status < 300) return status;
+  }
+  return lastStatus;
 }
 
 export async function sendDm(

--- a/tests/e2e/fleet/harness.ts
+++ b/tests/e2e/fleet/harness.ts
@@ -61,7 +61,7 @@ function mintFleetSponsorProof(): string {
     sub: FLEET_SPONSOR_ID,
     org: FLEET_SPONSOR_ORG,
     iat: now,
-    exp: now + 60 * 30,
+    exp: now + 15 * 60,
     jti: `spg_fleet_${randomUUID().replaceAll('-', '')}`,
     intent: 'identity.create',
     token_type: 'sponsor_grant',


### PR DESCRIPTION
## 🛑 DO NOT MERGE

1. **Depends on `AgentWorkforce/relaycast#324`, which is an unmerged draft with zero reviews.** This is not a soft dependency — see "Dependency — hard merge blocker" below.
2. **`crates/broker/Cargo.toml` pins `relaycast` at the tip of that draft branch** (`a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2`). That commit is not on relaycast's `main` and can be rebased or force-pushed away at any time. It must be repinned to a released version or a commit reachable from relaycast `main` before this can merge.
3. **The authority check is fail-open.** Every entry point in relaycast#324 (`authorizeNewAgentCredential`, `authorizeExistingAgentCredential`, `bindLegacyAgentCredential`) starts with `if (!enforced) return { mode: 'unenforced' }`. Absent both `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM` and `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER` configured on the deployed relaycast server, merging and deploying this PR enforces nothing — silently, with no error or warning. Green CI and `mergeable=MERGEABLE` on this PR do not mean the security boundary is live.
4. **Production cannot currently mint a sponsor proof at all — this is not a 15-minute-expiry problem, it is a cannot-produce-one-in-the-first-place problem, for two independent reasons, either alone sufficient:**
   - Cloud IaC never binds `RELAYAUTH_SPONSOR_FEDERATIONS` (`infra/relayauth.ts:106-136,145-285` in the RelayAuth repo — the key is simply absent from the Worker env construction). Absent that key, RelayAuth resolves every org to `LEGACY` mode (`sponsor-binding.ts:152-175`), and `POST /sponsors/proof` rejects any request when the org's mode is not `oidc` (`routes/sponsors.ts:65-73`).
   - There is no `id_token` source to feed it even if that were fixed: Cloud's Google auth requests `access_type=online` and retains only an `access_token`, never an OIDC `id_token` (`packages/web/lib/auth/google.ts:17-33,36-63`; callback route `:60-73`), and `/proof` requires a recent verified `id_token`.
   - Cloud's broker env construction (`box-manager.ts:2223-2284`, passed at `:2037-2065` / `:2126-2137`) contains no sponsor-proof field, and there is no scheduled remint or broker-reload path anywhere in relaycast-cloud main. `mint-relayauth-api-key.yml` mints a long-lived API key — never a sponsor proof.
   - **Consequence:** with this merged and deployed, brokers cannot spawn agents at all, from the first spawn, independent of relaycast#324, relaycast-cloud#60, secrets provisioning, or the arming sequence discussed elsewhere in this body.
   - **Prerequisite, stated plainly:** either a durable one-time broker binding that later authorizes with the incumbent scoped credential — the pattern RelayAuth uses for its own identities, consuming the sponsor proof only at identity creation — or an automated fresh-`id_token`-to-proof remint plus broker reload. Neither exists today.
   - **Open item, not resolved either way:** a manually-added Cloudflare Worker binding for `RELAYAUTH_SPONSOR_FEDERATIONS` would not appear in IaC and cannot be ruled out from any repo. Determining whether one exists needs read-only inspection of the live Worker bindings — that's Khaliq to run or authorize, not something checkable from source.
   - **This PR already contains the working pattern for its own broker identity**, applied only to the broker's own credential, not to the agents it spawns: `IncumbentCredentialCache`, `persist_incumbent_credential_cache`, `incumbent_token_for`, and `startup_session_set_with_identity_and_incumbents` in `crates/broker/src/relaycast/auth.rs`. The expiring-grant pattern above is what this PR applies to spawned agents; the durable-binding pattern already exists in the same file for the broker itself. A reader should not have to rediscover that both shapes are present.

## Security boundary fixed

This is the coordinated Relay-side security fix for #1497. It does **not** treat the Relay `AuthClient` as the authority. It pins the matching Relaycast authority change (`AgentWorkforce/relaycast#324`) and passes a signed sponsor grant plus a secret work-unit key on every credential-issuing path:

- normal REST registration and rotation
- `agent-relay mcp-args --register`
- broker child pre-registration
- node-control registration
- A2A registration
- destructive release aliases are enforced by the pinned server authority

The authority rejects workspace-key-only calls and stores sponsor/work-unit ownership in server-controlled immutable state, not agent metadata. Client processes no longer inherit sponsor proofs, signing material, workspace keys, or the broker root work-unit secret.

## Dependency — hard merge blocker

Depends on `AgentWorkforce/relaycast#324` and must not merge before it. This is mechanical, not a judgement call: `crates/broker/Cargo.toml` pins `relaycast` as a git dependency at rev `a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2`, which is the current tip of relaycast#324 — a **draft, unmerged, zero-review** branch in a separate repo. That commit is not reachable from relaycast's `main` and can be rebased or force-pushed out of existence at any time. Merging #1505 while pinned this way would put relay's `main` on a dependency that only exists on someone else's feature branch.

Required sequence: relaycast#324 merges and is released (a real published `relaycast` version, or at minimum a commit reachable from relaycast `main`) → #1505 repins `crates/broker/Cargo.toml` off the draft-branch git rev → #1505 merges. Do not work around this by vendoring the crate or pinning harder against the draft branch.

## Findings addressed

- Direct REST/CLI/node/A2A calls cannot bypass sponsor enforcement once the authority PR is deployed.
- Caller-editable metadata is no longer an ownership input.
- Relay pins Relaycast authority commit `a87e6e7fbbca4d1da453f9ab681f0e2ae86f70c2`, including database mutation-boundary guards against stale concurrent claim decisions.
- Missing/expired sponsor proofs fail before workspace creation or any startup request.
- Same-name reclaim uses a random persisted work-unit secret, not a predictable state-path digest.
- Existing legacy agents have a guarded migration: an incumbent agent token is required for the one-time server binding; a workspace key is insufficient.
- Both client and authority reject signed grants beyond RelayAuth’s 15-minute maximum lifetime.
- CI mints a real short-lived RS256 test sponsor grant and starts the pinned local authority with its public key. There is no test bypass.

## Legacy migration rollout (required order)

Older clients did not retain their incumbent agent token, so deployment must be staged:

1. Release/deploy this client while the old registration authority is still active.
2. Restart every persistent broker once. Successful startup atomically persists its scoped token beside broker state. Selection is bound to a SHA-256 workspace-key fingerprint plus exact agent name. The token and random work-unit key are owner-only on Unix and DPAPI-encrypted to the current user on Windows.
3. Verify pre-staging across the fleet.
4. Publish the matching Relaycast packages, apply the authority DB migration, and enable pinned sponsor-verification configuration.
5. On the next restart, the client authenticates `/v1/agent` with the incumbent token and invokes the one-time server binding. It does not rotate via the workspace key.

A host that skips pre-staging must be given its incumbent `RELAY_AGENT_TOKEN` explicitly. It fails closed instead of reopening workspace-key-only reclaim.

## CI/test changes

- Shared action checks out the exact authority commit and generates an ephemeral RSA key pair/grant in the runner temp directory.
- E2E, package validation, macOS smoke, and fleet jobs receive valid test sponsor credentials.
- Fleet harness fails fast with broker stderr and health context instead of waiting for a secondary symptom.

## Verification

- `cargo test --workspace`: broker 942 passed / 4 ignored; broker integration 16 passed; relay-pty 223 passed; doc test ignored
- auth regression suite: 40/40 passed, including a true two-start old-server → enforced-server migration
- `cargo clippy -p agent-relay-broker --lib -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- Node typecheck/lint/build/Vitest and live E2E were run earlier on this branch: 1,884 passed / 23 skipped; live E2E 27 passed / 4 skipped
- full `cargo clippy --workspace --all-targets -- -D warnings` currently hits an unrelated pre-existing test-only lint in `crates/relay-pty/src/pty.rs:2130` (`cloned_ref_to_slice_refs`); production broker lint is green
- local macOS→Windows cross-check reaches the pre-existing `ring` native build and stops for lack of Windows C headers; GitHub's native Windows package gate is the authoritative DPAPI compile check

## Deployment blockers / residual boundary

Do not merge/deploy this in isolation:

- Requires `AgentWorkforce/relaycast#324` (see Dependency section above — currently draft/unmerged, this alone blocks merge) and `AgentWorkforce/relaycast-cloud#60`.
- relaycast-cloud currently needs the matching Relaycast packages published before its normal lockfile CI can go green.
- **The authority check fails open, silently, if unconfigured.** In relaycast#324, every entry point (`authorizeNewAgentCredential`, `authorizeExistingAgentCredential`, `bindLegacyAgentCredential`) begins with `const enforced = authorityConfig(config); if (!enforced) return { mode: 'unenforced' }`. Absent both `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM` and `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER` in the deployed relaycast environment, registration/rotation/reclaim enforcement is a complete no-op — any caller can register, rotate, or reclaim any agent — with **no error, warning, or other signal that enforcement is inert**. Confirming those two vars are actually set in the production relaycast deployment is a precondition for this PR closing the hole in practice, not just in code, and is being tracked separately with whoever owns that deployment.
- The deprecated `api.relaycast.dev` / `gateway.relaycast.dev` legacy authorities are a separate deployment boundary from canonical `cast.agentrelay.com`; they need explicit cutover/decommission or equivalent server enforcement before anyone claims all hosted endpoints are closed.
- Sponsor grants expire. Long-running brokers need Chief/RelayAuth to refresh the grant before a later credential-issuance event.

No merge or deployment is performed by this PR.

## Relationship to #1497 — guarantee-by-guarantee

#1497 (`agent/soc2-hole1-sso-sponsor`) targeted the same vulnerability class via a different, client-side architecture. #1497 will be closed in favor of this PR; this section is the record of what that decision does and does not carry forward, so a future reader doesn't have to reconstruct it from two diffs.

- **G1 — registration requires an authenticated SSO sponsor** (a workspace key alone is insufficient). CARRIED — #1505 has a near-identical `require_authenticated_sponsor()` gate with the same error text.
- **G2 — the sponsor proof must be a cryptographically valid, unexpired signed JWT**, verified against a configured public key (issuer/audience/subject/org/intent/token_type checked). CARRIED — #1505's `verify_sponsor_proof` is effectively the same check, same claim shape, same constants.
- **G3 — the sponsor id must be human-shaped** (`user_` prefix pattern), not a service/workspace id. CARRIED — identical `is_human_sponsor_id` check.
- **G4 — registrations stamp the agent with sponsor identity for later comparison.** DELIBERATELY REPLACED. #1497 wrote `relayauth_sponsor_id` / `relayauth_sponsor_binding` / `relayauth_sponsor_proof_sha256` into client-visible, client-writable agent metadata. #1505 stores the equivalent binding (`sponsorOrgId`, `sponsorId`, `sponsorOidcIssuer`, `sponsorOidcSubject`, `workUnitKeyHash`) as immutable server-side state in relaycast's own DB, and the relaycast#324 server actively rejects any client attempt to set those metadata keys (`RESERVED_METADATA_KEYS`). This is the correct direction (client-writable metadata was never trustworthy ownership data) but only takes effect once relaycast#324 is merged, deployed, and configured — see "DO NOT MERGE" above.
- **G5 — same-name reclaim must match the existing agent's sponsor, not just its work-unit identity.** **G6 — token rotation must refuse a caller authenticated as a different sponsor than the one the agent is bound to.** NEITHER IS ENFORCED ANYWHERE TODAY, by either PR. #1497's version of G5/G6 is a client-side courtesy check inside the relay CLI: it does `GET /v1/agents/:name`, compares metadata to the locally-authenticated sponsor, and only then calls `rotate_agent_token`/`register_agent` — but that underlying wire call itself carries no sponsor proof and is authenticated only by workspace key, so any caller that isn't this specific CLI (curl, another SDK, a modified client) rotates or reclaims across sponsor boundaries today unimpeded, regardless of what #1497 does. It was a convention observed by one client, not a boundary. #1505 does not reimplement it client-side — deliberately: relaycast#324's server now withholds sponsor-binding data from the client-visible agent-fetch response specifically to stop this class of client-side check from being spoofed, so #1505's client has no data left to check even if it wanted to. G5/G6 will only be real once `AgentWorkforce/relaycast#324` is merged, deployed, **and** configured with `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_PUBLIC_KEY_PEM` + `RELAYCAST_AGENT_CREDENTIAL_AUTHORITY_ISSUER` (see "DO NOT MERGE" above) — that work is server-side, tracked in relaycast#324, not in this PR.


