### PR TITLE
fix(fleet): stop redundant client-side merge on declared metadata publish

### DIFF
--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -144,7 +144,7 @@ impl RelaycastHttpClient {
     }
 
     /// Publish caller-declared workforce metadata onto an already-registered
-    /// agent, merging it over whatever the engine already holds.
+    /// agent. The engine merges it over whatever it already holds.
     ///
     /// This is how declared metadata reaches the engine on the node
     /// registration path. It deliberately does NOT ride the `agent.register`
@@ -175,20 +175,23 @@ impl RelaycastHttpClient {
                 agent_name: name.to_string(),
                 detail: "SDK relay client not initialized".to_string(),
             })?;
-        // Read-merge-write rather than a bare overwrite: the engine owns other
-        // keys on this record (the `fleet` placement record among them) and a
-        // replacing update would drop them.
-        let existing = relay
-            .get_agent(name)
-            .await
-            .map_err(|error| registration_metadata_error(name, error))?;
-        let mut merged = existing.metadata;
-        merged.extend(declared_metadata);
+        // Send ONLY the declared keys. `PATCH /v1/agents/:name` merges them over
+        // the record's existing metadata server-side — verified in the engine at
+        // both the ref fleet-e2e pins (v7.0.0, eb7563ff) and relaycast `main`
+        // (`packages/engine/src/routes/agent.ts`:
+        // `nextMetadata = { ...existing.metadata, ...body.metadata }`) — so the
+        // engine-owned keys, the `fleet` placement record among them, are
+        // preserved without us resending them.
+        //
+        // Reading the record first and writing the merge back from here would be
+        // worse than redundant: this call is detached from the spawn, so a write
+        // that lands between our read and our write (the node bind, the engine's
+        // own placement record) would be clobbered by our stale snapshot.
         relay
             .update_agent(
                 name,
                 UpdateAgentRequest {
-                    metadata: Some(merged),
+                    metadata: Some(declared_metadata),
                     ..Default::default()
                 },
             )
@@ -965,34 +968,23 @@ mod tests {
         assert!(message.contains("pre-register"));
     }
 
-    /// The node path's replacement for putting metadata on `agent.register`:
-    /// read the agent, merge the declared fields over what the engine already
-    /// holds, write it back. The PATCH body is matched exactly, so dropping an
-    /// engine-owned key would fail here.
+    /// A single PATCH carrying ONLY the declared keys. The engine merges them
+    /// over the record's existing metadata, so resending engine-owned keys from
+    /// here would be redundant and would risk clobbering a concurrent write with
+    /// a stale snapshot. The body is matched exactly, so a stray key — or a
+    /// re-introduced read-merge-write — fails here.
     #[tokio::test]
-    async fn publish_declared_metadata_merges_over_engine_owned_fields() {
+    async fn publish_declared_metadata_sends_only_the_declared_keys() {
         let server = MockServer::start();
-        let existing = server.mock(|when, then| {
+        let read = server.mock(|when, then| {
             when.method(GET).path("/v1/agents/worker-a");
-            then.status(200).json_body(json!({
-                "ok": true,
-                "data": {
-                    "id": "agent_worker_a",
-                    "name": "worker-a",
-                    "type": "agent",
-                    "status": "online",
-                    "persona": null,
-                    "metadata": { "cli": "codex", "fleet": { "node": "sf-mini" } }
-                }
-            }));
+            then.status(500);
         });
         let update = server.mock(|when, then| {
             when.method(PATCH)
                 .path("/v1/agents/worker-a")
                 .json_body(json!({
                     "metadata": {
-                        "cli": "codex",
-                        "fleet": { "node": "sf-mini" },
                         "organization": "Agent Workforce",
                         "project": "Relay",
                         "objective": "Publish registration metadata"
@@ -1026,7 +1018,8 @@ mod tests {
             .await
             .expect("publishing declared metadata should succeed");
 
-        existing.assert_hits(1);
+        // No read at all: the merge is the engine's job.
+        read.assert_hits(0);
         update.assert_hits(1);
     }
 

--- a/tests/e2e/fleet/fleet-e2e.test.ts
+++ b/tests/e2e/fleet/fleet-e2e.test.ts
@@ -699,6 +699,11 @@ describe.skipIf(!pre.ok)('two-node fleet scenario matrix', () => {
     );
     expect(settled.status).toBe('completed');
 
+    // Snapshot whatever the engine already owns on this record, so the merge
+    // assertion below is against real engine-owned keys rather than a guess at
+    // which ones exist.
+    const before = (await getAgent(engine, workspaceKey, agent))?.metadata ?? {};
+
     // Poll rather than read once: the publish is intentionally detached from the
     // spawn so it cannot extend the broker's inline registration await.
     const metadata = await waitFor(
@@ -708,6 +713,14 @@ describe.skipIf(!pre.ok)('two-node fleet scenario matrix', () => {
       },
       { label: 'declared metadata published to the engine', timeoutMs: 20_000 }
     );
+
+    // The publish sends ONLY the declared keys and relies on the engine to merge
+    // them over what it already holds. Assert that reliance against the real
+    // engine: nothing it owned before the publish may be lost.
+    for (const [key, value] of Object.entries(before)) {
+      expect(metadata).toHaveProperty(key);
+      expect(metadata![key]).toEqual(value);
+    }
 
     expect(metadata).toMatchObject({
       organization: 'Agent Workforce',


### PR DESCRIPTION
## Defect

`#1504` (merged as `592d371a8`) introduced `RelaycastHttpClient::publish_declared_metadata` (`crates/broker/src/relaycast/ws.rs:159-191`), which does a client-side read-merge-write: `get_agent` → merge declared fields over the existing metadata → `update_agent` (PATCH).

This is redundant and worse: `PATCH /v1/agents/:name` already merges metadata server-side (shallow merge, confirmed against `packages/engine/src/routes/agent.ts:291`). Because this call runs detached from the spawn (fire-and-forget `tokio::spawn`, by design — see `spawn_declared_metadata_publish`), there is a real window between the client's `get_agent` read and its `update_agent` write in which another write can land (the node bind, the engine's own `fleet` placement record). The client's PATCH — built from the earlier, now-stale snapshot — silently clobbers that intervening write.

A test at `ws.rs:973` (`publish_declared_metadata_merges_over_engine_owned_fields`, pre-fix name) encoded the read-merge-write as intended behavior rather than testing for its absence.

## Fix

Send only the declared keys in the PATCH body and let the engine's server-side merge preserve everything else. No read, no stale-snapshot window.

- `publish_declared_metadata` no longer calls `get_agent` before `update_agent`.
- Test renamed to `publish_declared_metadata_sends_only_the_declared_keys`; the mock GET now returns 500 and the test asserts it is never hit (`read.assert_hits(0)`), and the PATCH body is matched exactly against only the declared fields (no `cli`, no `fleet.node`).
- `tests/e2e/fleet/fleet-e2e.test.ts` updated accordingly (not re-run in this verification pass — needs the full broker/engine e2e harness).

## Verification

- `cargo test -p agent-relay-broker --lib --no-run`: clean build, no new warnings.
- `relaycast::ws::tests` suite: 7 passed, 0 failed, 2 pre-existing unrelated ignores (DM-mode fixture mismatches predating this branch).
  - `publish_declared_metadata_sends_only_the_declared_keys` — passes, confirms no GET occurs and the PATCH body carries only declared keys.
  - `publish_declared_metadata_makes_no_request_when_nothing_is_declared` — passes, no regression.
- Full broker lib suite and the fleet e2e test were not run in this pass (out of scope for verifying this specific code path); flagging for reviewer awareness rather than claiming full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)