### PR TITLE
fix(cli): dm send no longer blocks on a workspace-only roster read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay message dm send` no longer fails with "Workspace key required" for agent-scoped credentials that can send but aren't authorized to list the workspace roster; recipient-name verification now degrades gracefully instead of blocking the send.
 
 ## [11.6.2] - 2026-08-14
 

--- a/packages/cli/src/cli/commands/message.ts
+++ b/packages/cli/src/cli/commands/message.ts
@@ -133,7 +133,16 @@ export function registerMessageCommands(
     await runSdk(deps, async () => {
       const mode = o.mode as 'wait' | 'steer' | undefined;
       const relay = deps.createAgentRelay(opts(o));
-      const resolvedRecipient = resolveExactAgentName(await relay.agents.list(), agent);
+      // Recipient-name verification is a best-effort nicety on top of the send,
+      // not a precondition for it: agents.list() is a workspace-wide roster
+      // read and can be unavailable to a credential that is otherwise fully
+      // authorized to send this DM (e.g. an agent-scoped token). Losing this
+      // lookup must degrade to `resolvedRecipient: null` in the receipt
+      // (handled by directMessageReceipt) rather than block the send itself.
+      const resolvedRecipient = await relay.agents
+        .list()
+        .then((agents) => resolveExactAgentName(agents, agent))
+        .catch(() => undefined);
       printJson(
         deps,
         directMessageReceipt(

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -120,7 +120,7 @@ function harness(register: (p: Command, o: Partial<SdkCommandDeps>) => void) {
   const program = new Command();
   program.exitOverride();
   register(program, deps);
-  return { program, relay, log, error };
+  return { program, relay, log, error, exit };
 }
 
 describe('SDK-backed CLI groups', () => {
@@ -160,6 +160,27 @@ describe('SDK-backed CLI groups', () => {
     await program.parseAsync(['message', 'dm', 'send', 'missing-agent', 'hi'], { from: 'user' });
 
     expect(relay.messages.direct).toHaveBeenCalledWith({ to: 'missing-agent', text: 'hi' });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"status": "recipient_unresolved"'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"resolvedRecipient": null'));
+  });
+
+  // Regression for the workspace-key-required DM outage: an agent-scoped
+  // credential can send a DM (messages.direct only needs requireAgentClient)
+  // but is not authorized to read the workspace-wide roster
+  // (agents.list — see packages/sdk/src/messaging/relaycast.ts). Before the
+  // fix, that rejection propagated out of the action and aborted the send
+  // entirely instead of just degrading the receipt's recipient resolution.
+  it('message dm send still enqueues when agents.list itself is rejected (agent-scoped credential)', async () => {
+    const { program, relay, log, error, exit } = harness(registerMessageCommands);
+    relay.agents.list.mockRejectedValueOnce(
+      new Error('Workspace key required (rk_live_...) for this operation')
+    );
+
+    await program.parseAsync(['message', 'dm', 'send', 'lead', 'hi'], { from: 'user' });
+
+    expect(relay.messages.direct).toHaveBeenCalledWith({ to: 'lead', text: 'hi' });
+    expect(exit).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('"status": "recipient_unresolved"'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('"resolvedRecipient": null'));
   });


### PR DESCRIPTION
## Summary

`agent-relay message dm send` fails with `Workspace key required (rk_live_...)` for every credential type — env var, `--workspace-key`, `--token` — even though the recipient roster claims are contradicted below. This shipped in the 11.5.5 → 11.6.2 delta; `message post` (channel send) was and is unaffected.

## Root cause (file:line)

The only behavioral change to the DM path between v11.5.5 and v11.6.2 is in `packages/cli/src/cli/commands/message.ts`. The `dm send` action gained a pre-send lookup:

```
const resolvedRecipient = resolveExactAgentName(await relay.agents.list(), agent);
```
— `packages/cli/src/cli/commands/message.ts:136` (pre-fix)

`relay.agents.list()` reaches `RelaycastMessagingClient.agents.list` (`packages/sdk/src/messaging/relaycast.ts:162-166`), which calls `this.relaycast.agents.list(...)` directly on the underlying `@relaycast/sdk` client — a workspace-wide roster read that requires a genuine workspace-level credential.

The client handed to that call comes from `createAgentRelay` (`packages/cli/src/cli/lib/sdk-client.ts:70-86`), which by design prefers an ambient agent token (`RELAY_AGENT_TOKEN` env or `--token`) over any workspace key:

```ts
export function createAgentRelay(options: SdkClientOptions = {}): AgentRelayAgent {
  const token = resolveAgentToken(options);
  if (token) {
    return new AgentRelay({ agentToken: token, baseUrl: resolveBaseUrl(options) });
  }
  return new AgentRelay({ workspaceKey: resolveWorkspaceKey(options), baseUrl: resolveBaseUrl(options) });
}
```
— `packages/cli/src/cli/lib/sdk-client.ts:70-86`

Every fleet-spawned agent normally carries an ambient `RELAY_AGENT_TOKEN` (that's how it authenticates as itself), so `createAgentRelay()` builds an **agent-scoped** client regardless of whether a valid `rk_live_` workspace key is also present in the environment or passed explicitly via `--workspace-key` — `resolveAgentToken` never even consults the workspace-key options, so the explicit flag is silently shadowed once an ambient token exists. `createRelaycastClient` (`packages/sdk/src/messaging/relaycast-client.ts:221`) then hands that agent token to the underlying `@relaycast/sdk` client as its sole credential.

`messages.direct`/`messages.send` only need `requireAgentClient` (`packages/sdk/src/messaging/relaycast.ts:937-942`) and work fine with that agent-scoped client — which is why `message post` was never affected. Only the new roster read needed genuine workspace-level authorization.

The lookup was already designed as best-effort: `directMessageReceipt` (`packages/cli/src/cli/lib/message-delivery-receipts.ts`) already has a documented "recipient resolution unavailable" degraded path used when the agent isn't found in the roster. The regression is that `agents.list()`'s *rejection* was unguarded and propagated out of the action, aborting the send entirely via `runSdk`'s catch-all, instead of degrading into that existing path the same way an empty/no-match roster already does.

## Fix

Catch the roster-read failure and degrade to `resolvedRecipient: undefined` (already handled), instead of letting it block the send.

## Test

Added `message dm send still enqueues when agents.list itself is rejected (agent-scoped credential)` in `packages/cli/src/cli/commands/relaycast-groups.test.ts`. Verified both directions locally:
- Against pre-fix code: fails — `relay.messages.direct` is never called (0 calls recorded), reproducing the outage exactly.
- Against the fix: passes — the send still goes through and the receipt reports `recipient_unresolved`.

## Test plan

- [x] `npx vitest run packages/cli/src/cli/commands/relaycast-groups.test.ts` — 24/24 pass
- [x] `npx vitest run packages/cli/src/cli/commands/` — 417 pass, 1 pre-existing unrelated failure (`integration-relayfile-contract.test.ts`, missing local `lsof` binary — unrelated to messaging/auth)
- [x] `npm run build:sdk` — clean
- [ ] CI on this branch (verify via `gh run list -R AgentWorkforce/relay --branch fix/dm-send-workspace-key-regression`)

Not merging — merge gate is Khaliq's.