### PR TITLE
1524: [factory] Agent identity recovery is broken end to end: null-reason seat release, register_agent loop/hang, agent remove SQL leak

### DIFF
--- a/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/summary.md
+++ b/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/summary.md
@@ -19,15 +19,17 @@ Implemented relay #1507: node agent attach redeems cloud-issued, scope-bound wor
 ## Key Decisions
 
 ### Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
+
 - **Chose:** Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
-- **Reasoning:** The cloud branch defines POST /v1/workspace/join-tickets/redeem with an rjt_live_ ticket scoped to node, agent, and mode. Persisting its workspace key makes later commands work, while explicitly passing it into the current attach prevents a higher-precedence ambient env key from winning.
+- **Reasoning:** The cloud branch defines POST /v1/workspace/join-tickets/redeem with an rjt*live* ticket scoped to node, agent, and mode. Persisting its workspace key makes later commands work, while explicitly passing it into the current attach prevents a higher-precedence ambient env key from winning.
 
 ---
 
 ## Chapters
 
 ### 1. Initial work
-*Agent: ar-1507-impl-relay*
+
+_Agent: ar-1507-impl-relay_
 
 - Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach: Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
 - Cloud #61 defined a scope-bound rjt_live contract; the CLI now redeems, validates, persists, redacts, and uses the credential explicitly. Focused, full CLI, cloud, typecheck, and lint validation are green.

--- a/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/trajectory.json
+++ b/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/trajectory.json
@@ -44,11 +44,7 @@
           "type": "reflection",
           "content": "Cloud #61 defined a scope-bound rjt_live contract; the CLI now redeems, validates, persists, redacts, and uses the credential explicitly. Focused, full CLI, cloud, typecheck, and lint validation are green.",
           "raw": {
-            "focalPoints": [
-              "wire-contract",
-              "credential-safety",
-              "attach-precedence"
-            ],
+            "focalPoints": ["wire-contract", "credential-safety", "attach-precedence"],
             "confidence": 0.92
           },
           "significance": "high",
@@ -67,9 +63,7 @@
     "approach": "Matched relaycast-cloud #61's concrete HTTP contract, reused the existing workspace-session persistence path, kept the one-time ticket out of persistence and logs, and added contract, dispatch, precedence, error, persistence, and redaction tests.",
     "confidence": 0.92
   },
-  "commits": [
-    "c789886e4"
-  ],
+  "commits": ["c789886e4"],
   "filesChanged": [
     ".agentworkforce/trajectories/task-1507/active/traj_esvqzlbnhqbt/trajectory.json",
     "CHANGELOG.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Agent identity recovery no longer releases seats during ordinary offline presence updates, bounds registration and token rotation instead of hanging indefinitely, and makes `agent remove` preserve attributed history without exposing database queries or parameters on failure.
+- Agent identity recovery no longer releases seats or rotates tokens during ordinary offline presence updates.
+- Agent registration and token rotation are bounded by a deadline instead of hanging indefinitely on an existing broken record.
+- `agent remove` preserves attributed message history and no longer exposes raw database queries or bound parameters when the removal fails.
 
 ## [11.6.3] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- `agent-relay agent rotate` now provides an explicit recovery path for an existing agent name whose token is stale or invalid.
+
+### Fixed
+
+- Agent identity recovery no longer releases seats during ordinary offline presence updates, bounds registration and token rotation instead of hanging indefinitely, and makes `agent remove` preserve attributed history without exposing database queries or parameters on failure.
 
 ## [11.6.3] - 2026-08-14
 

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -381,8 +381,11 @@ impl RelaycastHttpClient {
         } else {
             tracing::warn!(agent = %agent_name, "SDK relay client not initialized; cannot mark agent offline");
         }
-        // Always invalidate local cache so a future spawn uses a fresh registration.
-        self.invalidate_cached_registration(agent_name);
+        // Deliberately do NOT invalidate the cached registration here: this is
+        // a presence-only transition and the process holding the identity may
+        // still be alive or may restart with the same token. Invalidating the
+        // cache would force a token rotation on next use, disconnecting a
+        // still-valid identity. Only an explicit release should do that.
         Ok(())
     }
 
@@ -409,6 +412,13 @@ impl RelaycastHttpClient {
                 reason: Some(attributed_reason),
                 delete_agent: None,
             };
+            // Invalidate the cached token before the call so an ambiguous
+            // response (e.g. a timeout after Relaycast committed the release)
+            // can never leave a dead token cached for reuse. Worst case on
+            // failure is a redundant re-registration on next use, which is
+            // safe; the alternative — a stale cache reusing a released token
+            // — is the bug this fixes.
+            self.invalidate_cached_registration(agent_name);
             match relay.release_agent(request).await {
                 Ok(_) => {
                     tracing::info!(agent = %agent_name, "released agent identity");

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -352,15 +352,25 @@ impl RelaycastHttpClient {
             .map_err(|error| anyhow::anyhow!("{error}"))
     }
 
-    /// Mark a specific agent offline via the release endpoint.
+    /// Mark a specific agent offline without releasing its identity.
+    ///
+    /// Presence transitions must not use the release endpoint: release rotates
+    /// or invalidates the agent credential and records a lifecycle tombstone.
+    /// Broker shutdown, worker exit, and maintenance reaping only need to make
+    /// the roster honest; the process holding the identity may still be alive
+    /// or may restart with the same token.
     pub async fn mark_agent_offline(&self, agent_name: &str) -> Result<()> {
         if let Some(relay) = (*self.relay).as_ref() {
-            let request = ReleaseAgentRequest {
-                name: agent_name.to_string(),
-                reason: None,
-                delete_agent: None,
-            };
-            match relay.release_agent(request).await {
+            match relay
+                .update_agent(
+                    agent_name,
+                    UpdateAgentRequest {
+                        status: Some("offline".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
                 Ok(_) => {
                     tracing::info!(agent = %agent_name, "marked agent offline");
                 }
@@ -376,7 +386,45 @@ impl RelaycastHttpClient {
         Ok(())
     }
 
-    /// Mark the broker agent as offline via the release endpoint.
+    /// Release an agent identity through the lifecycle endpoint.
+    ///
+    /// Unlike a presence transition, an explicit broker release intentionally
+    /// invalidates the current credential. Relaycast's wire shape has one audit
+    /// string rather than separate reason/actor fields, so preserve both facts
+    /// in that durable value and never emit a null-reason release.
+    pub async fn release_agent_identity(
+        &self,
+        agent_name: &str,
+        reason: Option<&str>,
+    ) -> Result<()> {
+        if let Some(relay) = (*self.relay).as_ref() {
+            let reason = reason
+                .map(str::trim)
+                .filter(|reason| !reason.is_empty())
+                .unwrap_or("agent explicitly released through broker API");
+            let attributed_reason =
+                format!("{reason} (actor: Agent Relay broker {})", self.agent_name);
+            let request = ReleaseAgentRequest {
+                name: agent_name.to_string(),
+                reason: Some(attributed_reason),
+                delete_agent: None,
+            };
+            match relay.release_agent(request).await {
+                Ok(_) => {
+                    tracing::info!(agent = %agent_name, "released agent identity");
+                }
+                Err(error) => {
+                    tracing::warn!(agent = %agent_name, error = %error, "failed to release agent identity");
+                    return Err(anyhow::anyhow!(
+                        "failed to release agent '{agent_name}': {error}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Mark the broker agent offline without invalidating its identity.
     /// Called during graceful shutdown to prevent ghost agents in the dashboard.
     pub async fn mark_offline(&self) -> Result<()> {
         self.mark_agent_offline(&self.agent_name).await
@@ -1060,6 +1108,87 @@ mod tests {
 
         any_read.assert_hits(0);
         any_write.assert_hits(0);
+    }
+
+    /// A presence update used to call POST /v1/agents/release with no reason.
+    /// That invalidated the credential of a participant that could still be
+    /// running, and left an unattributable `release.reason = null` record. The
+    /// exact wire assertion matters here: a successful helper return alone
+    /// would not prove the destructive endpoint was avoided.
+    #[tokio::test]
+    async fn mark_agent_offline_updates_presence_without_releasing_the_identity() {
+        let server = MockServer::start();
+        let update = server.mock(|when, then| {
+            when.method(PATCH)
+                .path("/v1/agents/worker-a")
+                .header("authorization", "Bearer rk_live_test")
+                .json_body(json!({ "status": "offline" }));
+            then.status(200).json_body(json!({
+                "ok": true,
+                "data": {
+                    "id": "agent_worker_a",
+                    "name": "worker-a",
+                    "type": "agent",
+                    "status": "offline",
+                    "persona": null,
+                    "metadata": {}
+                }
+            }));
+        });
+        let release = server.mock(|when, then| {
+            when.method(POST).path("/v1/agents/release");
+            then.status(500).json_body(json!({
+                "ok": false,
+                "error": { "code": "must_not_release", "message": "must not release" }
+            }));
+        });
+
+        let client = seeded_http_client(&server.base_url());
+        client
+            .mark_agent_offline("worker-a")
+            .await
+            .expect("offline presence update should succeed");
+
+        update.assert_hits(1);
+        release.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn explicit_agent_release_records_a_reason_and_actor() {
+        let server = MockServer::start();
+        let release = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents/release")
+                .header("authorization", "Bearer rk_live_test")
+                .json_body(json!({
+                    "name": "worker-a",
+                    "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)"
+                }));
+            then.status(200).json_body(json!({
+                "ok": true,
+                "data": {
+                    "invocation_id": "inv_release_1",
+                    "action_name": "release",
+                    "handler_agent_id": null,
+                    "handler_node_id": "node_1",
+                    "dispatched_node_id": "node_1",
+                    "input": {
+                        "name": "worker-a",
+                        "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)"
+                    },
+                    "status": "dispatched",
+                    "created_at": "2026-08-15T00:00:00.000Z"
+                }
+            }));
+        });
+
+        let client = seeded_http_client(&server.base_url());
+        client
+            .release_agent_identity("worker-a", None)
+            .await
+            .expect("explicit release should succeed");
+
+        release.assert_hits(1);
     }
 
     #[tokio::test]

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -885,16 +885,20 @@ impl BrokerRuntime {
                                 "released worker fleet deregistration was not queued; retaining its identity for retry"
                             );
                         }
-                        if let Err(error) = relaycast_http
+                        let relaycast_release_error = match relaycast_http
                             .release_agent_identity(&name, reason.as_deref())
                             .await
                         {
-                            tracing::warn!(
-                                worker = %name,
-                                error = %error,
-                                "failed to release worker identity in relaycast"
-                            );
-                        }
+                            Ok(()) => None,
+                            Err(error) => {
+                                tracing::warn!(
+                                    worker = %name,
+                                    error = %error,
+                                    "failed to release worker identity in relaycast"
+                                );
+                                Some(error.to_string())
+                            }
+                        };
                         let dropped = take_pending_for_worker(pending_deliveries, &name);
                         if !dropped.is_empty() {
                             let _ = send_event(
@@ -978,11 +982,15 @@ impl BrokerRuntime {
                             Some("http_api_release"),
                         )
                         .await;
-                        let response = match fleet_deregistration_error {
-                            Some(error) => Err(format!(
+                        let response = match (fleet_deregistration_error, relaycast_release_error)
+                        {
+                            (Some(error), _) => Err(format!(
                                 "failed to deregister released worker from fleet control: {error}"
                             )),
-                            None => Ok(json!({ "success": true, "name": name })),
+                            (None, Some(error)) => Err(format!(
+                                "worker process was released, but its Relaycast identity could not be released ({error}); the seat may still be held and re-registration may rotate a live token"
+                            )),
+                            (None, None) => Ok(json!({ "success": true, "name": name })),
                         };
                         let _ = reply.send(response);
                     }

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -885,11 +885,14 @@ impl BrokerRuntime {
                                 "released worker fleet deregistration was not queued; retaining its identity for retry"
                             );
                         }
-                        if let Err(error) = relaycast_http.mark_agent_offline(&name).await {
+                        if let Err(error) = relaycast_http
+                            .release_agent_identity(&name, reason.as_deref())
+                            .await
+                        {
                             tracing::warn!(
                                 worker = %name,
                                 error = %error,
-                                "failed to mark released worker offline in relaycast"
+                                "failed to release worker identity in relaycast"
                             );
                         }
                         let dropped = take_pending_for_worker(pending_deliveries, &name);

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1011,7 +1011,28 @@ impl BrokerRuntime {
                                     "already-exited worker fleet deregistration was not queued; retaining its identity for retry"
                                 );
                             }
-                            relaycast_http.forget_agent_registration(&name);
+                            // The local worker is already gone, but that says
+                            // nothing about whether its Relaycast identity was
+                            // ever actually released — this branch is reached
+                            // on every retry after a first attempt whose
+                            // relaycast release failed. Retry the release
+                            // itself rather than only forgetting the cached
+                            // token, or a retry can never actually free the
+                            // seat.
+                            let relaycast_release_error = match relaycast_http
+                                .release_agent_identity(&name, reason.as_deref())
+                                .await
+                            {
+                                Ok(()) => None,
+                                Err(error) => {
+                                    tracing::warn!(
+                                        worker = %name,
+                                        error = %error,
+                                        "failed to release already-exited worker identity in relaycast"
+                                    );
+                                    Some(error.to_string())
+                                }
+                            };
                             state.agents.remove(&name);
                             if paths.persist {
                                 let _ = state.save(&paths.state);
@@ -1044,11 +1065,15 @@ impl BrokerRuntime {
                                 worker = %name,
                                 "ignoring duplicate HTTP API release for already exited worker"
                             );
-                            let response = match fleet_deregistration_error {
-                                Some(error) => Err(format!(
+                            let response = match (fleet_deregistration_error, relaycast_release_error)
+                            {
+                                (Some(error), _) => Err(format!(
                                     "failed to deregister released worker from fleet control: {error}"
                                 )),
-                                None => Ok(json!({ "success": true, "name": name })),
+                                (None, Some(error)) => Err(format!(
+                                    "worker was already gone locally, but its Relaycast identity could not be released ({error}); the seat may still be held"
+                                )),
+                                (None, None) => Ok(json!({ "success": true, "name": name })),
                             };
                             let _ = reply.send(response);
                         } else {

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -22,6 +22,13 @@ pub(crate) struct ResizeOwner {
 /// immediately, so this window never fires in the normal path.
 pub(crate) const RESIZE_OWNER_STALE: Duration = Duration::from_secs(300);
 
+/// Bound on each best-effort Relaycast presence call made during shutdown
+/// (per-worker `mark_agent_offline` plus the broker's own `mark_offline`).
+/// Kept well under callers' external shutdown deadlines (the CLI's `node
+/// down` graceful-shutdown window is 10s) so an unresponsive backend cannot
+/// turn a bounded number of these calls into an unbounded shutdown hang.
+const SHUTDOWN_RELAYCAST_CALL_TIMEOUT: Duration = Duration::from_secs(3);
+
 pub(crate) struct HostedAgentEvent {
     pub(super) name: String,
     pub(super) event_type: String,
@@ -459,20 +466,54 @@ impl BrokerRuntime {
         });
         self.telemetry.shutdown();
 
+        // Bounded: these are best-effort presence updates to an external
+        // service. A slow or unresponsive Relaycast backend must never block
+        // process shutdown — a caller waiting on `node down` has its own,
+        // shorter deadline, and a broker that outlives it becomes a stuck
+        // "still running" process the caller then has to force-kill.
         let active_workers: Vec<WorkerName> = self.workers.workers.keys().cloned().collect();
         for worker_name in active_workers {
-            if let Err(error) = self.relaycast_http.mark_agent_offline(&worker_name).await {
-                tracing::warn!(
-                    worker = %worker_name,
-                    error = %error,
-                    "failed to mark worker offline during shutdown"
-                );
+            match timeout(
+                SHUTDOWN_RELAYCAST_CALL_TIMEOUT,
+                self.relaycast_http.mark_agent_offline(&worker_name),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        worker = %worker_name,
+                        error = %error,
+                        "failed to mark worker offline during shutdown"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        worker = %worker_name,
+                        timeout_ms = SHUTDOWN_RELAYCAST_CALL_TIMEOUT.as_millis(),
+                        "timed out marking worker offline during shutdown; proceeding"
+                    );
+                }
             }
         }
 
         // Mark broker agent offline in Relaycast before shutting down WS
-        if let Err(error) = self.relaycast_http.mark_offline().await {
-            tracing::warn!(error = %error, "failed to mark broker offline during shutdown");
+        match timeout(
+            SHUTDOWN_RELAYCAST_CALL_TIMEOUT,
+            self.relaycast_http.mark_offline(),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::warn!(error = %error, "failed to mark broker offline during shutdown");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_ms = SHUTDOWN_RELAYCAST_CALL_TIMEOUT.as_millis(),
+                    "timed out marking broker offline during shutdown; proceeding"
+                );
+            }
         }
 
         if let Err(error) = self.ws_control_tx.send(WsControl::Shutdown).await {

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use futures_util::future::{join, join_all};
+
 /// Current PTY resize owner for a worker under the single-resizer policy.
 ///
 /// `session_id` is the client-generated id that currently owns resizing;
@@ -22,12 +24,15 @@ pub(crate) struct ResizeOwner {
 /// immediately, so this window never fires in the normal path.
 pub(crate) const RESIZE_OWNER_STALE: Duration = Duration::from_secs(300);
 
-/// Bound on each best-effort Relaycast presence call made during shutdown
-/// (per-worker `mark_agent_offline` plus the broker's own `mark_offline`).
-/// Kept well under callers' external shutdown deadlines (the CLI's `node
-/// down` graceful-shutdown window is 10s) so an unresponsive backend cannot
-/// turn a bounded number of these calls into an unbounded shutdown hang.
-const SHUTDOWN_RELAYCAST_CALL_TIMEOUT: Duration = Duration::from_secs(3);
+/// Bound on the *entire* best-effort Relaycast presence-update phase during
+/// shutdown (every worker's `mark_agent_offline` plus the broker's own
+/// `mark_offline`, all run concurrently under this one deadline). Kept well
+/// under callers' external shutdown deadlines (the CLI's `node down`
+/// graceful-shutdown window defaults to 5s) so an unresponsive backend can
+/// delay shutdown by at most this much, regardless of how many identities
+/// are involved — a per-call timeout applied to each of N calls in sequence
+/// would instead cost up to N times this much.
+const SHUTDOWN_RELAYCAST_PHASE_TIMEOUT: Duration = Duration::from_millis(2500);
 
 pub(crate) struct HostedAgentEvent {
     pub(super) name: String,
@@ -469,51 +474,40 @@ impl BrokerRuntime {
         // Bounded: these are best-effort presence updates to an external
         // service. A slow or unresponsive Relaycast backend must never block
         // process shutdown — a caller waiting on `node down` has its own,
-        // shorter deadline, and a broker that outlives it becomes a stuck
-        // "still running" process the caller then has to force-kill.
+        // shorter deadline (5s by default), and a broker that outlives it
+        // becomes a stuck "still running" process the caller then has to
+        // force-kill. Every worker's update and the broker's own run
+        // *concurrently* under one shared deadline, so N stalled identities
+        // cost the same wall-clock time as one, not N times as much.
         let active_workers: Vec<WorkerName> = self.workers.workers.keys().cloned().collect();
-        for worker_name in active_workers {
-            match timeout(
-                SHUTDOWN_RELAYCAST_CALL_TIMEOUT,
-                self.relaycast_http.mark_agent_offline(&worker_name),
-            )
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    tracing::warn!(
-                        worker = %worker_name,
-                        error = %error,
-                        "failed to mark worker offline during shutdown"
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        worker = %worker_name,
-                        timeout_ms = SHUTDOWN_RELAYCAST_CALL_TIMEOUT.as_millis(),
-                        "timed out marking worker offline during shutdown; proceeding"
-                    );
-                }
-            }
-        }
-
-        // Mark broker agent offline in Relaycast before shutting down WS
-        match timeout(
-            SHUTDOWN_RELAYCAST_CALL_TIMEOUT,
-            self.relaycast_http.mark_offline(),
-        )
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => {
-                tracing::warn!(error = %error, "failed to mark broker offline during shutdown");
-            }
-            Err(_) => {
+        let worker_count = active_workers.len();
+        let relaycast_http = &self.relaycast_http;
+        let workers_phase = join_all(active_workers.iter().map(|worker_name| async move {
+            if let Err(error) = relaycast_http.mark_agent_offline(worker_name).await {
                 tracing::warn!(
-                    timeout_ms = SHUTDOWN_RELAYCAST_CALL_TIMEOUT.as_millis(),
-                    "timed out marking broker offline during shutdown; proceeding"
+                    worker = %worker_name,
+                    error = %error,
+                    "failed to mark worker offline during shutdown"
                 );
             }
+        }));
+        let broker_phase = async {
+            if let Err(error) = relaycast_http.mark_offline().await {
+                tracing::warn!(error = %error, "failed to mark broker offline during shutdown");
+            }
+        };
+        if timeout(
+            SHUTDOWN_RELAYCAST_PHASE_TIMEOUT,
+            join(workers_phase, broker_phase),
+        )
+        .await
+        .is_err()
+        {
+            tracing::warn!(
+                worker_count,
+                timeout_ms = SHUTDOWN_RELAYCAST_PHASE_TIMEOUT.as_millis(),
+                "timed out marking agents offline during shutdown; proceeding"
+            );
         }
 
         if let Err(error) = self.ws_control_tx.send(WsControl::Shutdown).await {

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -724,6 +724,41 @@ describe('createAgentRelayMcpServer', () => {
     });
   });
 
+  it('retries removal with workspace auth when the active agent token is itself the stale one', async () => {
+    // remove_agent exists to recover a broken identity. If that identity's
+    // own token is the invalid one, authenticating the release as that same
+    // identity dead-ends on the exact error being recovered from. It must
+    // fall back to the workspace key rather than fail closed.
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mocks.behavior.releaseImpl = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Invalid agent token'), { statusCode: 401 }))
+      .mockResolvedValueOnce({ name: 'chief', released: true, deleted: true, reason: 'recovered' });
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_stale',
+      agentName: 'chief',
+    });
+    const server = mocks.serverInstances[0];
+
+    const result = await server.tools.get('remove_agent')?.handler({
+      name: 'chief',
+      reason: 'recover stale identity',
+      delete_agent: true,
+    });
+
+    expect(mocks.behavior.releaseImpl).toHaveBeenCalledTimes(2);
+    expect(result.structuredContent.invocation).toMatchObject({ released: true, deleted: true });
+    const workspaceAuthenticated = mocks.relayInstances.find(
+      (instance) => instance.config.apiKey === 'rk_live_existing'
+    );
+    expect(workspaceAuthenticated?.release).toHaveBeenCalledWith({
+      name: 'chief',
+      reason: expect.stringContaining('recover stale identity'),
+      deleteAgent: true,
+    });
+  });
+
   it('redacts SQL diagnostics from MCP removal failures', async () => {
     const { mod, mocks } = await loadAgentRelayMcpModule();
     mocks.behavior.releaseImpl = vi.fn(async () => {

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -10,6 +10,12 @@ type RelayBehavior = {
   createWorkspaceImpl: (name: string) => Promise<Record<string, unknown>>;
   inboxImpl: (token: string) => Promise<unknown>;
   registerImpl: (input: { name: string; type?: string }) => Promise<{ name?: string; token: string }>;
+  releaseImpl: (input: {
+    name: string;
+    reason?: string;
+    deleteAgent?: boolean;
+  }) => Promise<Record<string, unknown>>;
+  sendImpl: (token: string, channel: string, text: string) => Promise<unknown>;
 };
 
 function assertToolsListDiscoversAndStripsMetadata(
@@ -71,6 +77,13 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
       recentReactions: [],
     })),
     registerImpl: vi.fn(async ({ name }) => ({ name, token: `at_live_${name}` })),
+    releaseImpl: vi.fn(async (input) => ({
+      name: input.name,
+      released: true,
+      deleted: Boolean(input.deleteAgent),
+      reason: input.reason ?? null,
+    })),
+    sendImpl: vi.fn(async (_token, channel, text) => ({ id: 'msg_1', channel, text })),
   };
 
   class FakeTransport {}
@@ -175,7 +188,7 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
         output: { spawned: true, ready: true },
       })),
     },
-    send: vi.fn(async (channel: string, text: string) => ({ id: 'msg_1', channel, text })),
+    send: vi.fn(async (channel: string, text: string) => behavior.sendImpl(token, channel, text)),
     messages: vi.fn(async () => []),
     reply: vi.fn(async (messageId: string, text: string) => ({ id: 'reply_1', messageId, text })),
     thread: vi.fn(async () => ({ parent: {}, replies: [] })),
@@ -216,12 +229,9 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
       },
     ]);
     const spawn = vi.fn(async (input: unknown) => ({ spawned: true, input }));
-    const release = vi.fn(async (input: { name: string; reason?: string; deleteAgent?: boolean }) => ({
-      name: input.name,
-      released: true,
-      deleted: Boolean(input.deleteAgent),
-      reason: input.reason ?? null,
-    }));
+    const release = vi.fn((input: { name: string; reason?: string; deleteAgent?: boolean }) =>
+      behavior.releaseImpl(input)
+    );
     const as = vi.fn((token: string) => createAgentClient(token));
     relayInstances.push({ config, registerOrRotate, agentsList, nodesList, spawn, release, as });
     return {
@@ -633,6 +643,113 @@ describe('createAgentRelayMcpServer', () => {
     expect(promptResult.messages[0].content.text).toContain('query_nodes');
     expect(promptResult.messages[0].content.text).toContain('spawn');
     expect(promptResult.messages[0].content.text).not.toContain('workspace.create');
+  });
+
+  it('executes the invalid-token recovery instruction end to end', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    const staleError = Object.assign(new Error('Invalid agent token'), {
+      code: 'agent_token_invalid',
+      status: 401,
+    });
+    mocks.behavior.sendImpl = vi.fn(async (token, channel, text) => {
+      if (token === 'at_live_stale') throw staleError;
+      return { id: 'msg_recovered', channel, text };
+    });
+    mocks.behavior.registerImpl = vi.fn(async ({ name }) => ({
+      name,
+      token: 'at_live_fresh',
+    }));
+
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_stale',
+      agentName: 'chief',
+      strictAgentName: true,
+    });
+    const server = mocks.serverInstances[0];
+
+    const failed = await server.tools.get('post_message')?.handler({
+      channel: 'general',
+      text: 'before rotation',
+    });
+    expect(failed.isError).toBe(true);
+    expect(failed.content.map((entry: { text?: string }) => entry.text).join('\n')).toContain(
+      'Call the "register_agent" tool'
+    );
+
+    const registration = await server.tools.get('register_agent')?.handler({
+      name: 'chief',
+      type: 'human',
+    });
+    expect(registration.structuredContent).toMatchObject({
+      registered_name: 'chief',
+      token: 'at_live_fresh',
+    });
+
+    const retried = await server.tools.get('post_message')?.handler({
+      channel: 'general',
+      text: 'after rotation',
+    });
+    expect(retried.structuredContent).toMatchObject({
+      id: 'msg_recovered',
+      channel: 'general',
+      text: 'after rotation',
+    });
+    expect(mocks.behavior.sendImpl).toHaveBeenNthCalledWith(1, 'at_live_stale', 'general', 'before rotation');
+    expect(mocks.behavior.sendImpl).toHaveBeenNthCalledWith(2, 'at_live_fresh', 'general', 'after rotation');
+  });
+
+  it('attributes removal and authenticates it as the active agent', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_operator',
+      agentName: 'operator',
+    });
+    const server = mocks.serverInstances[0];
+
+    await server.tools.get('remove_agent')?.handler({
+      name: 'chief-dmcheck-1536',
+      reason: 'test cleanup',
+      delete_agent: true,
+    });
+
+    const agentAuthenticated = mocks.relayInstances.find(
+      (instance) => instance.config.apiKey === 'at_live_operator'
+    );
+    expect(agentAuthenticated?.release).toHaveBeenCalledWith({
+      name: 'chief-dmcheck-1536',
+      reason: 'test cleanup (actor: operator)',
+      deleteAgent: true,
+    });
+  });
+
+  it('redacts SQL diagnostics from MCP removal failures', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mocks.behavior.releaseImpl = vi.fn(async () => {
+      throw new Error(
+        'Failed query: delete from "agents" where "agents"."id" = ?\nparams: 214015171589668864'
+      );
+    });
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_operator',
+      agentName: 'operator',
+    });
+    const server = mocks.serverInstances[0];
+
+    await expect(
+      server.tools.get('remove_agent')?.handler({
+        name: 'chief-dmcheck-1536',
+        delete_agent: true,
+      })
+    ).rejects.toThrow('Relay service could not complete the request');
+    await expect(
+      server.tools.get('remove_agent')?.handler({
+        name: 'chief-dmcheck-1536',
+        delete_agent: true,
+      })
+    ).rejects.not.toThrow(/delete from|params:|214015171589668864/);
   });
 
   it('sends an unresolved DM from an agent-token-only session', async () => {

--- a/packages/cli/src/cli/agent-relay-mcp.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.test.ts
@@ -237,6 +237,39 @@ describe('registerAgentWithRebind', () => {
     expect(payload.warnings[0]).toContain('workspace unreachable');
   });
 
+  it('bounds the metadata read-back so a hung listing cannot hang verify_metadata forever', async () => {
+    // The register call is bounded by withAgentRegistrationDeadline, but the
+    // verification read-back is a separate upstream call — it must be bounded
+    // too, or `verify_metadata: true` reintroduces the same class of hang the
+    // registration deadline was added to fix.
+    vi.useFakeTimers();
+    try {
+      const relay = fakeRelay();
+      relay.agents.list = vi.fn(() => new Promise(() => {})) as never;
+
+      const pending = registerAgentWithRebind({
+        session: strictSession(),
+        setSession: vi.fn(),
+        getRelay: () => relay as never,
+        name: 'WorkerA',
+        metadata: IDENTITY,
+        verifyMetadata: true,
+        strictAgentName: true,
+        preferredAgentName: 'WorkerA',
+        registrationTimeoutMs: 50,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      const payload = await pending;
+
+      expect(payload.metadata_verified).toBe(false);
+      expect(payload.warnings[0]).toContain('could not read the record back');
+      expect(payload.warnings[0]).toContain('did not complete within 50ms');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('writes a supplied persona through, and claims no metadata verification', async () => {
     const relay = fakeRelay();
 

--- a/packages/cli/src/cli/agent-relay-mcp.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.test.ts
@@ -439,6 +439,30 @@ describe('registerAgentWithRebind', () => {
       warnings: [],
     });
   });
+
+  it('returns promptly with the real recovery path when rotation hangs', async () => {
+    const never = new Promise<never>(() => undefined);
+
+    await expect(
+      registerAgentWithRebind({
+        session: {
+          workspaceKey: 'rk_live_test',
+          agentToken: null,
+          agentName: 'chief',
+          agents: new Map(),
+        },
+        setSession: vi.fn(),
+        getRelay: () =>
+          ({
+            agents: { registerOrRotate: vi.fn(() => never) },
+          }) as never,
+        name: 'chief',
+        strictAgentName: true,
+        preferredAgentName: 'chief',
+        registrationTimeoutMs: 10,
+      })
+    ).rejects.toThrow(/did not complete within 10ms.*agent rotate.*agent remove/s);
+  });
 });
 
 describe('optionsFromEnv', () => {

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -22,7 +22,11 @@ import {
 } from '@agent-relay/sdk';
 import { z } from 'zod';
 import { declaredWorkforceMetadata } from './lib/registration-metadata.js';
-import { withAgentRegistrationDeadline } from './lib/agent-registration.js';
+import {
+  DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS,
+  withAgentRegistrationDeadline,
+  withDeadline,
+} from './lib/agent-registration.js';
 import { attributableReleaseReason } from './lib/release-reason.js';
 import { initTelemetry, shutdown as shutdownTelemetry } from './telemetry/index.js';
 import { RealtimeResourceBridge, SubscriptionManager, registerResourceDefinitions } from './mcp/resources.js';
@@ -566,7 +570,7 @@ export async function registerAgentWithRebind({
   let metadataVerified: boolean | 'unchecked' | undefined;
   if (metadata) {
     if (verifyMetadata) {
-      const verification = await verifyMetadataLanded(relay, reboundName, metadata);
+      const verification = await verifyMetadataLanded(relay, reboundName, metadata, registrationTimeoutMs);
       metadataVerified = verification.verified;
       if (!verification.verified) warnings.push(verification.warning);
     } else {
@@ -676,14 +680,25 @@ async function invokeVerifiedPersonaSpawn(
 async function verifyMetadataLanded(
   relay: RelayCastLike,
   name: string,
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
+  timeoutMs = DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS
 ): Promise<{ verified: boolean; warning: string }> {
   const keys = Object.keys(metadata);
   if (keys.length === 0) return { verified: true, warning: '' };
 
   let agents: unknown[];
   try {
-    agents = await relay.agents.list();
+    // The registration call itself is bounded by withAgentRegistrationDeadline,
+    // but this read-back is a separate upstream call and must be bounded too —
+    // otherwise `verify_metadata: true` can still hang indefinitely.
+    agents = await withDeadline(
+      () => relay.agents.list(),
+      (effectiveTimeoutMs) =>
+        new Error(
+          `Reading back the agent listing to verify metadata for "${name}" did not complete within ${effectiveTimeoutMs}ms.`
+        ),
+      timeoutMs
+    );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     return {
@@ -1150,11 +1165,21 @@ function registerAgentRelayTools(
         : getRelay();
       const actor = as ?? session.agentName ?? preferredAgentName ?? 'agent-relay MCP session';
       const attributableReason = attributableReleaseReason(reason, actor, 'agent removed');
-      const invocation = await releaseRelay.agents.release({
-        name,
-        reason: attributableReason,
-        deleteAgent: delete_agent,
-      });
+      const releaseInput = { name, reason: attributableReason, deleteAgent: delete_agent };
+      let invocation;
+      try {
+        invocation = await releaseRelay.agents.release(releaseInput);
+      } catch (error) {
+        // The selected identity's own token can itself be the stale/invalid
+        // credential we're trying to recover from — that's precisely the
+        // state `remove_agent` exists to fix. Retry once with workspace
+        // authentication rather than dead-ending on the same invalid token.
+        if (releaseToken && isInvalidAgentTokenError(error)) {
+          invocation = await getRelay().agents.release(releaseInput);
+        } else {
+          throw error;
+        }
+      }
       return jsonContent({ invocation });
     }
   );

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -22,6 +22,8 @@ import {
 } from '@agent-relay/sdk';
 import { z } from 'zod';
 import { declaredWorkforceMetadata } from './lib/registration-metadata.js';
+import { withAgentRegistrationDeadline } from './lib/agent-registration.js';
+import { attributableReleaseReason } from './lib/release-reason.js';
 import { initTelemetry, shutdown as shutdownTelemetry } from './telemetry/index.js';
 import { RealtimeResourceBridge, SubscriptionManager, registerResourceDefinitions } from './mcp/resources.js';
 import { jsonContent, jsonResult, textContent } from './mcp/tool-results.js';
@@ -254,6 +256,8 @@ type RegisterAgentWithRebindArgs = {
   strictAgentName?: boolean;
   preferredAgentName?: string | null;
   forcedAgentType?: AgentType;
+  /** Test/embedding override; production defaults to the bounded CLI deadline. */
+  registrationTimeoutMs?: number;
 };
 
 /** Return env var value, or undefined if missing / an unresolved ${...} template. */
@@ -480,6 +484,7 @@ export async function registerAgentWithRebind({
   strictAgentName,
   preferredAgentName,
   forcedAgentType,
+  registrationTimeoutMs,
 }: RegisterAgentWithRebindArgs): Promise<Record<string, unknown>> {
   requireWorkspaceKey(session);
 
@@ -526,12 +531,17 @@ export async function registerAgentWithRebind({
   }
 
   const relay = getRelay();
-  const result = await relay.agents.registerOrRotate({
-    name: effectiveName,
-    type: effectiveType,
-    persona,
-    metadata,
-  });
+  const result = await withAgentRegistrationDeadline(
+    () =>
+      relay.agents.registerOrRotate({
+        name: effectiveName,
+        type: effectiveType,
+        persona,
+        metadata,
+      }),
+    effectiveName,
+    registrationTimeoutMs
+  );
   const reboundName = result.name?.trim() ? result.name : effectiveName;
   setSession({ agentToken: result.token, agentName: reboundName });
 
@@ -1115,14 +1125,36 @@ function registerAgentRelayTools(
         'Returns an `invocation` record acknowledging the request, which is processed asynchronously. Releasing keeps the agent registered and re-spawnable; passing `delete_agent` removes the identity permanently.',
       inputSchema: {
         name: z.string().describe('Agent name'),
-        reason: z.string().optional().describe('Removal reason'),
+        reason: z
+          .string()
+          .optional()
+          .describe('Removal reason; defaults to an attributable Agent Relay MCP reason'),
         delete_agent: z.boolean().optional().describe('Permanently delete the agent'),
+        ...identityOverrideInputShape,
       },
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    async ({ name, reason, delete_agent }) => {
-      const invocation = await getRelay().agents.release({ name, reason, deleteAgent: delete_agent });
+    async ({ name, reason, delete_agent, as }) => {
+      const session = getSession();
+      const selected = as ? session.agents.get(as) : undefined;
+      if (as && !selected) {
+        throw new Error(`Unknown agent identity "${as}". Register it first.`);
+      }
+      const releaseToken = selected?.agentToken ?? (!as ? session.agentToken : null);
+      // Authenticate the release as the selected participant when possible so
+      // Relaycast records caller_name on the action invocation. Workspace auth
+      // remains the recovery fallback after a stale token has been cleared.
+      const releaseRelay = releaseToken
+        ? createWorkspaceClient({ workspaceKey: releaseToken, baseUrl })
+        : getRelay();
+      const actor = as ?? session.agentName ?? preferredAgentName ?? 'agent-relay MCP session';
+      const attributableReason = attributableReleaseReason(reason, actor, 'agent removed');
+      const invocation = await releaseRelay.agents.release({
+        name,
+        reason: attributableReason,
+        deleteAgent: delete_agent,
+      });
       return jsonContent({ invocation });
     }
   );
@@ -1357,10 +1389,14 @@ export async function resolveStdioBootstrapOptions(
 
   const relay = createWorkspaceClient({ workspaceKey, baseUrl: options.baseUrl });
 
-  const registered = await relay.agents.registerOrRotate({
-    name: options.agentName,
-    type: options.agentType,
-  });
+  const registered = await withAgentRegistrationDeadline(
+    () =>
+      relay.agents.registerOrRotate({
+        name: options.agentName!,
+        type: options.agentType,
+      }),
+    options.agentName
+  );
   return {
     ...options,
     agentToken: registered.token,

--- a/packages/cli/src/cli/bootstrap.test.ts
+++ b/packages/cli/src/cli/bootstrap.test.ts
@@ -91,6 +91,7 @@ const expectedLeafCommands = [
   'workspace rebind',
   // workspace agents
   'agent register',
+  'agent rotate',
   'agent list',
   'agent add',
   'agent remove',

--- a/packages/cli/src/cli/commands/agent.test.ts
+++ b/packages/cli/src/cli/commands/agent.test.ts
@@ -170,7 +170,9 @@ describe('agent identity lifecycle commands', () => {
 
   it('rejects rotation of a name that does not already exist instead of minting a new identity', async () => {
     const { program, workspaceRelay, error } = createHarness();
-    workspaceRelay.agents.get.mockRejectedValueOnce(new Error('Agent "ghost" not found'));
+    workspaceRelay.agents.get.mockRejectedValueOnce(
+      Object.assign(new Error('Agent "ghost" not found'), { statusCode: 404 })
+    );
 
     await expect(
       program.parseAsync([
@@ -188,6 +190,60 @@ describe('agent identity lifecycle commands', () => {
     const rendered = error.mock.calls.flat().join('\n');
     expect(rendered).toContain('does not exist');
     expect(rendered).toContain('agent register');
+  });
+
+  it('rethrows a non-404 existence-check failure unchanged instead of claiming the agent does not exist', async () => {
+    // A network/auth/5xx failure means "unknown", not "does not exist" —
+    // translating it to the latter would point the caller at `agent
+    // register` (create-or-rotate), which would rotate and disconnect a
+    // still-valid token for an identity that does exist but was merely
+    // unreachable.
+    const { program, workspaceRelay, error } = createHarness();
+    workspaceRelay.agents.get.mockRejectedValueOnce(new Error('upstream connection reset'));
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'agent-relay',
+        'agent',
+        'rotate',
+        'chief',
+        '--workspace-key',
+        'rk_live_test',
+      ])
+    ).rejects.toThrow('exit:1');
+
+    expect(workspaceRelay.workspace.register).not.toHaveBeenCalled();
+    const rendered = error.mock.calls.flat().join('\n');
+    expect(rendered).toContain('upstream connection reset');
+    expect(rendered).not.toContain('does not exist');
+  });
+
+  it('bounds the rotate existence check so a hung agents.get cannot hang the command', async () => {
+    const { program, workspaceRelay, error } = createHarness();
+    workspaceRelay.agents.get.mockReturnValueOnce(new Promise(() => {}));
+
+    vi.useFakeTimers();
+    try {
+      const run = program.parseAsync([
+        'node',
+        'agent-relay',
+        'agent',
+        'rotate',
+        'chief',
+        '--workspace-key',
+        'rk_live_test',
+      ]);
+      const assertion = expect(run).rejects.toThrow('exit:1');
+      await vi.advanceTimersByTimeAsync(15_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(workspaceRelay.workspace.register).not.toHaveBeenCalled();
+    const rendered = error.mock.calls.flat().join('\n');
+    expect(rendered).toContain('did not complete within 15000ms');
   });
 
   it('removes through the lifecycle endpoint with a reason and actor', async () => {

--- a/packages/cli/src/cli/commands/agent.test.ts
+++ b/packages/cli/src/cli/commands/agent.test.ts
@@ -10,20 +10,40 @@ function createHarness() {
       presence: vi.fn(async () => [{ agent: 'room-human', status: 'online' }]),
     },
   };
+  const workspaceRelay = {
+    workspace: {
+      register: vi.fn(async ({ name }: { name: string }) => ({
+        id: 'agent_rotated',
+        name,
+        token: 'at_live_rotated',
+      })),
+      release: vi.fn(async () => ({ status: 'completed' })),
+    },
+  };
   const createAgentRelay = vi.fn(() => agentRelay);
-  const createWorkspaceRelay = vi.fn();
+  const createWorkspaceRelay = vi.fn(() => workspaceRelay);
+  const log = vi.fn();
+  const error = vi.fn();
   const program = new Command();
   program.exitOverride();
   registerAgentCommands(program, {
     createAgentRelay: createAgentRelay as never,
     createWorkspaceRelay: createWorkspaceRelay as never,
-    log: vi.fn(),
-    error: vi.fn(),
+    log,
+    error,
     exit: ((code: number) => {
       throw new Error(`exit:${code}`);
     }) as never,
   });
-  return { program, agentRelay, createAgentRelay, createWorkspaceRelay };
+  return {
+    program,
+    agentRelay,
+    workspaceRelay,
+    createAgentRelay,
+    createWorkspaceRelay,
+    log,
+    error,
+  };
 }
 
 describe('agent-scoped identity commands', () => {
@@ -53,5 +73,94 @@ describe('agent-scoped identity commands', () => {
     });
     expect(createWorkspaceRelay).not.toHaveBeenCalled();
     expect(agentRelay.agents[method]).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('agent identity lifecycle commands', () => {
+  it('register adopts an existing name by rotating its token', async () => {
+    const { program, workspaceRelay, log } = createHarness();
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'agent',
+      'register',
+      'chief',
+      '--workspace-key',
+      'rk_live_test',
+    ]);
+
+    expect(workspaceRelay.workspace.register).toHaveBeenCalledWith(
+      { name: 'chief', type: undefined, persona: undefined },
+      { strict: false }
+    );
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      id: 'agent_rotated',
+      name: 'chief',
+      token: 'at_live_rotated',
+    });
+  });
+
+  it('exposes an explicit token rotation command for an existing name', async () => {
+    const { program, workspaceRelay } = createHarness();
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'agent',
+      'rotate',
+      'chief',
+      '--workspace-key',
+      'rk_live_test',
+    ]);
+
+    expect(workspaceRelay.workspace.register).toHaveBeenCalledWith({ name: 'chief' });
+  });
+
+  it('removes through the lifecycle endpoint with a reason and actor', async () => {
+    const { program, workspaceRelay } = createHarness();
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'agent',
+      'remove',
+      'chief-dmcheck-1536',
+      '--reason',
+      'test cleanup',
+      '--workspace-key',
+      'rk_live_test',
+    ]);
+
+    expect(workspaceRelay.workspace.release).toHaveBeenCalledWith({
+      name: 'chief-dmcheck-1536',
+      reason: expect.stringMatching(/^test cleanup \(actor: .+\)$/),
+      deleteAgent: true,
+    });
+  });
+
+  it('redacts SQL and bound parameters when removal fails', async () => {
+    const { program, workspaceRelay, error } = createHarness();
+    workspaceRelay.workspace.release.mockRejectedValueOnce(
+      new Error('Failed query: delete from "agents" where "agents"."id" = ?\nparams: 214015171589668864')
+    );
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'agent-relay',
+        'agent',
+        'remove',
+        'chief-dmcheck-1536',
+        '--workspace-key',
+        'rk_live_test',
+      ])
+    ).rejects.toThrow('exit:1');
+
+    const rendered = error.mock.calls.flat().join('\n');
+    expect(rendered).toContain('Relay service could not complete the request');
+    expect(rendered).not.toContain('delete from');
+    expect(rendered).not.toContain('params:');
+    expect(rendered).not.toContain('214015171589668864');
   });
 });

--- a/packages/cli/src/cli/commands/agent.test.ts
+++ b/packages/cli/src/cli/commands/agent.test.ts
@@ -11,6 +11,9 @@ function createHarness() {
     },
   };
   const workspaceRelay = {
+    agents: {
+      get: vi.fn(async (name: string) => ({ id: 'agent_existing', name, status: 'online' })),
+    },
     workspace: {
       register: vi.fn(async ({ name }: { name: string }) => ({
         id: 'agent_rotated',
@@ -101,6 +104,53 @@ describe('agent identity lifecycle commands', () => {
     });
   });
 
+  it('register --strict fails on a name conflict instead of rotating', async () => {
+    const { program, workspaceRelay } = createHarness();
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'agent',
+      'register',
+      'chief',
+      '--strict',
+      '--workspace-key',
+      'rk_live_test',
+    ]);
+
+    expect(workspaceRelay.workspace.register).toHaveBeenCalledWith(
+      { name: 'chief', type: undefined, persona: undefined },
+      { strict: true }
+    );
+  });
+
+  it('register surfaces the bounded-registration timeout instead of hanging on a broken existing name', async () => {
+    const { program, workspaceRelay, error } = createHarness();
+    workspaceRelay.workspace.register.mockReturnValueOnce(new Promise(() => {}));
+
+    vi.useFakeTimers();
+    try {
+      const run = program.parseAsync([
+        'node',
+        'agent-relay',
+        'agent',
+        'register',
+        'chief',
+        '--workspace-key',
+        'rk_live_test',
+      ]);
+      const assertion = expect(run).rejects.toThrow('exit:1');
+      await vi.advanceTimersByTimeAsync(15_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const rendered = error.mock.calls.flat().join('\n');
+    expect(rendered).toContain('did not complete within 15000ms');
+    expect(rendered).toContain('agent rotate');
+  });
+
   it('exposes an explicit token rotation command for an existing name', async () => {
     const { program, workspaceRelay } = createHarness();
 
@@ -114,7 +164,30 @@ describe('agent identity lifecycle commands', () => {
       'rk_live_test',
     ]);
 
+    expect(workspaceRelay.agents.get).toHaveBeenCalledWith('chief');
     expect(workspaceRelay.workspace.register).toHaveBeenCalledWith({ name: 'chief' });
+  });
+
+  it('rejects rotation of a name that does not already exist instead of minting a new identity', async () => {
+    const { program, workspaceRelay, error } = createHarness();
+    workspaceRelay.agents.get.mockRejectedValueOnce(new Error('Agent "ghost" not found'));
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'agent-relay',
+        'agent',
+        'rotate',
+        'ghost',
+        '--workspace-key',
+        'rk_live_test',
+      ])
+    ).rejects.toThrow('exit:1');
+
+    expect(workspaceRelay.workspace.register).not.toHaveBeenCalled();
+    const rendered = error.mock.calls.flat().join('\n');
+    expect(rendered).toContain('does not exist');
+    expect(rendered).toContain('agent register');
   });
 
   it('removes through the lifecycle endpoint with a reason and actor', async () => {
@@ -137,6 +210,25 @@ describe('agent identity lifecycle commands', () => {
       reason: expect.stringMatching(/^test cleanup \(actor: .+\)$/),
       deleteAgent: true,
     });
+  });
+
+  it('reports removal as initiated, not completed, when the release invocation is still pending', async () => {
+    const { program, workspaceRelay, log } = createHarness();
+    workspaceRelay.workspace.release.mockResolvedValueOnce({ status: 'dispatched' });
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'agent',
+      'remove',
+      'chief-dmcheck-1536',
+      '--workspace-key',
+      'rk_live_test',
+    ]);
+
+    const rendered = log.mock.calls.flat().join('\n');
+    expect(rendered).toContain('initiated');
+    expect(rendered).not.toContain('Removed agent');
   });
 
   it('redacts SQL and bound parameters when removal fails', async () => {

--- a/packages/cli/src/cli/commands/agent.ts
+++ b/packages/cli/src/cli/commands/agent.ts
@@ -8,8 +8,19 @@ import {
   withSdkDefaults,
   type SdkCommandDeps,
 } from '../lib/sdk-command.js';
-import { withAgentRegistrationDeadline } from '../lib/agent-registration.js';
+import { RelayError } from '@agent-relay/sdk';
+
+import { withAgentRegistrationDeadline, withDeadline } from '../lib/agent-registration.js';
 import { attributableReleaseReason } from '../lib/release-reason.js';
+
+function isNotFoundError(error: unknown): boolean {
+  if (error instanceof RelayError) return error.code === 'not_found' || error.statusCode === 404;
+  const statusCode =
+    error && typeof error === 'object'
+      ? ((error as { statusCode?: unknown }).statusCode ?? (error as { status?: unknown }).status)
+      : undefined;
+  return Number(statusCode) === 404;
+}
 
 export type AgentCommandDependencies = SdkCommandDeps;
 
@@ -65,8 +76,22 @@ export function registerAgentCommands(
       // `register()` is create-or-rotate by default, so without this existence
       // check a typo'd/never-registered name would silently mint a brand-new
       // identity instead of failing — surprising for a command documented as
-      // rotating an *existing* one.
-      await relay.agents.get(name).catch((error: unknown) => {
+      // rotating an *existing* one. Bounded like the registration call below,
+      // so a hung upstream `agents.get` can't reintroduce the hang class this
+      // PR's deadline wrapper exists to prevent. Only a confirmed "not found"
+      // is translated to the existence-check error — a network/auth/5xx
+      // failure is rethrown as-is, since treating those as "does not exist"
+      // and pointing at `agent register` (create-or-rotate) would rotate and
+      // disconnect a still-valid token for an identity that does exist but
+      // was merely unreachable.
+      await withDeadline(
+        () => relay.agents.get(name),
+        (effectiveTimeoutMs) =>
+          new Error(
+            `Checking whether agent "${name}" exists did not complete within ${effectiveTimeoutMs}ms.`
+          )
+      ).catch((error: unknown) => {
+        if (!isNotFoundError(error)) throw error;
         const detail = error instanceof Error ? error.message : String(error);
         throw new Error(`Agent "${name}" does not exist; use "agent register" to create it. (${detail})`);
       });

--- a/packages/cli/src/cli/commands/agent.ts
+++ b/packages/cli/src/cli/commands/agent.ts
@@ -62,6 +62,14 @@ export function registerAgentCommands(
   ).action(async (name: string, opts: Record<string, unknown>) => {
     await runSdk(deps, async () => {
       const relay = deps.createWorkspaceRelay(sdkOptionsFromOpts(opts));
+      // `register()` is create-or-rotate by default, so without this existence
+      // check a typo'd/never-registered name would silently mint a brand-new
+      // identity instead of failing — surprising for a command documented as
+      // rotating an *existing* one.
+      await relay.agents.get(name).catch((error: unknown) => {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`Agent "${name}" does not exist; use "agent register" to create it. (${detail})`);
+      });
       const registration = await withAgentRegistrationDeadline(
         () => relay.workspace.register({ name }),
         name
@@ -127,8 +135,18 @@ export function registerAgentCommands(
         process.env.RELAY_AGENT_NAME ?? 'agent-relay CLI',
         'agent removed'
       );
-      await relay.workspace.release({ name, reason, deleteAgent: true });
-      deps.log(`Removed agent ${name}.`);
+      const result = await relay.workspace.release({ name, reason, deleteAgent: true });
+      // The release endpoint acknowledges an async action invocation — a
+      // resolved promise means the request was accepted, not that the
+      // deletion has finished. Only claim "Removed" once the invocation
+      // itself reports completion; otherwise say what actually happened.
+      if (result.status === 'completed') {
+        deps.log(`Removed agent ${name}.`);
+      } else {
+        deps.log(
+          `Removal of agent ${name} was initiated (status: ${result.status ?? 'pending'}) and is processed asynchronously.`
+        );
+      }
     });
   });
 }

--- a/packages/cli/src/cli/commands/agent.ts
+++ b/packages/cli/src/cli/commands/agent.ts
@@ -8,6 +8,8 @@ import {
   withSdkDefaults,
   type SdkCommandDeps,
 } from '../lib/sdk-command.js';
+import { withAgentRegistrationDeadline } from '../lib/agent-registration.js';
+import { attributableReleaseReason } from '../lib/release-reason.js';
 
 export type AgentCommandDependencies = SdkCommandDeps;
 
@@ -28,19 +30,43 @@ export function registerAgentCommands(
   addSdkOptions(
     group
       .command('register')
-      .description('Register a new agent and print its token')
+      .description('Register an agent, rotating an existing identity token when needed')
       .argument('<name>', 'Agent name')
       .option('--type <type>', 'Agent type (agent | human | system)')
       .option('--persona <persona>', 'Persona string')
+      .option('--strict', 'Fail instead of rotating the token when the name already exists')
   ).action(async (name: string, opts: Record<string, unknown>) => {
     await runSdk(deps, async () => {
       const relay = deps.createWorkspaceRelay(sdkOptionsFromOpts(opts));
-      const registration = await relay.agents.register({
-        name,
-        type: opts.type as 'agent' | 'human' | 'system' | undefined,
-        persona: opts.persona as string | undefined,
-      });
-      printJson(deps, registration);
+      const registration = await withAgentRegistrationDeadline(
+        () =>
+          relay.workspace.register(
+            {
+              name,
+              type: opts.type as 'agent' | 'human' | 'system' | undefined,
+              persona: opts.persona as string | undefined,
+            },
+            { strict: opts.strict === true }
+          ),
+        name
+      );
+      printJson(deps, { id: registration.id, name: registration.name, token: registration.token });
+    });
+  });
+
+  addSdkOptions(
+    group
+      .command('rotate')
+      .description('Rotate the token for an existing agent name')
+      .argument('<name>', 'Agent name')
+  ).action(async (name: string, opts: Record<string, unknown>) => {
+    await runSdk(deps, async () => {
+      const relay = deps.createWorkspaceRelay(sdkOptionsFromOpts(opts));
+      const registration = await withAgentRegistrationDeadline(
+        () => relay.workspace.register({ name }),
+        name
+      );
+      printJson(deps, { id: registration.id, name: registration.name, token: registration.token });
     });
   });
 
@@ -88,11 +114,20 @@ export function registerAgentCommands(
   });
 
   addSdkOptions(
-    group.command('remove').description('Remove an agent').argument('<name>', 'Agent name')
+    group
+      .command('remove')
+      .description('Remove an agent while preserving attributed message history')
+      .argument('<name>', 'Agent name')
+      .option('--reason <reason>', 'Removal reason')
   ).action(async (name: string, opts: Record<string, unknown>) => {
     await runSdk(deps, async () => {
       const relay = deps.createWorkspaceRelay(sdkOptionsFromOpts(opts));
-      await relay.agents.delete(name);
+      const reason = attributableReleaseReason(
+        opts.reason,
+        process.env.RELAY_AGENT_NAME ?? 'agent-relay CLI',
+        'agent removed'
+      );
+      await relay.workspace.release({ name, reason, deleteAgent: true });
       deps.log(`Removed agent ${name}.`);
     });
   });

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -740,7 +740,7 @@ describe('fleet command support', () => {
     expect(createFleetWorkspaceClient).not.toHaveBeenCalled();
   });
 
-  it('fleet release delegates to the workspace lifecycle API', async () => {
+  it('fleet release delegates to the workspace lifecycle API with a default reason and actor', async () => {
     const release = vi.fn(async () => ({
       name: 'api-worker',
       released: true,
@@ -766,14 +766,13 @@ describe('fleet command support', () => {
       error: () => undefined,
     });
 
-    await program.parseAsync(
-      ['fleet', 'release', 'api-worker', '--reason', 'Work accepted', '--workspace-key', 'rk_live_test'],
-      { from: 'user' }
-    );
+    await program.parseAsync(['fleet', 'release', 'api-worker', '--workspace-key', 'rk_live_test'], {
+      from: 'user',
+    });
 
     expect(release).toHaveBeenCalledWith({
       name: 'api-worker',
-      reason: 'Work accepted',
+      reason: expect.stringMatching(/^fleet agent released \(actor: .+\)$/),
       deleteAgent: false,
     });
     expect(JSON.parse(logs[0]!)).toMatchObject({ name: 'api-worker', released: true });

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -778,6 +778,53 @@ describe('fleet command support', () => {
     expect(JSON.parse(logs[0]!)).toMatchObject({ name: 'api-worker', released: true });
   });
 
+  it('fleet release passes an explicit --reason through unchanged, with the actor still attributed', async () => {
+    const release = vi.fn(async () => ({
+      name: 'api-worker',
+      released: true,
+      deleted: false,
+      reason: 'Work accepted',
+    }));
+    const createFleetWorkspaceClient = vi.fn(() => ({ agents: { release } }));
+    const logs: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: (message: unknown) => logs.push(String(message)),
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+      createFleetWorkspaceClient: createFleetWorkspaceClient as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await program.parseAsync(
+      [
+        'fleet',
+        'release',
+        'api-worker',
+        '--reason',
+        'Work accepted',
+        '--delete-agent',
+        '--workspace-key',
+        'rk_live_test',
+      ],
+      { from: 'user' }
+    );
+
+    expect(release).toHaveBeenCalledWith({
+      name: 'api-worker',
+      reason: expect.stringMatching(/^Work accepted \(actor: .+\)$/),
+      deleteAgent: true,
+    });
+  });
+
   it('fleet status output redacts the node token and workspace key from the session', async () => {
     const logs: string[] = [];
     const nodes = { list: vi.fn(async () => [{ name: 'live-node', status: 'online', capabilities: [] }]) };

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -6,6 +6,7 @@ import { withDefaults, type CoreDependencies } from './core.js';
 import { readBrokerConnection } from '../lib/broker-lifecycle.js';
 import { declaredWorkforceMetadata } from '../lib/registration-metadata.js';
 import { redactSecrets } from '../lib/redact.js';
+import { attributableReleaseReason } from '../lib/release-reason.js';
 import {
   resolveAgentToken,
   resolveBaseUrl,
@@ -223,10 +224,14 @@ export function registerFleetCommands(
     await runSdk(deps.sdk, async () => {
       warnIfInferredFromProjectSession(options, deps.warn);
       const workspace = deps.createFleetWorkspaceClient(sdkOptionsFromOpts(options));
-      const reason = optionalText(options.reason, 'Reason');
+      const reason = attributableReleaseReason(
+        optionalText(options.reason, 'Reason'),
+        process.env.RELAY_AGENT_NAME ?? 'agent-relay fleet CLI',
+        'fleet agent released'
+      );
       const released = await workspace.agents.release({
         name: requiredText(name, 'Worker name'),
-        ...(reason ? { reason } : {}),
+        reason,
         deleteAgent: options.deleteAgent === true,
       });
       printJson(deps.sdk, released);

--- a/packages/cli/src/cli/commands/relaycast-groups.test.ts
+++ b/packages/cli/src/cli/commands/relaycast-groups.test.ts
@@ -35,6 +35,12 @@ afterEach(() => {
 });
 
 function createRelayMock() {
+  const register = vi.fn(async (i: { name: string }) => ({
+    id: 'a1',
+    token: 't1',
+    name: i.name,
+    status: 'online',
+  }));
   return {
     agents: {
       register: vi.fn(async (i: { name: string }) => ({
@@ -45,6 +51,10 @@ function createRelayMock() {
       })),
       list: vi.fn(async () => [{ id: 'a1', name: 'lead' }]),
       delete: vi.fn(async () => undefined),
+    },
+    workspace: {
+      register,
+      release: vi.fn(async () => ({ status: 'completed' })),
     },
     channels: {
       create: vi.fn(async (i: { name: string }) => ({ id: 'c1', name: i.name })),
@@ -124,11 +134,12 @@ function harness(register: (p: Command, o: Partial<SdkCommandDeps>) => void) {
 }
 
 describe('SDK-backed CLI groups', () => {
-  it('agent register calls agents.register and prints the registration', async () => {
+  it('agent register calls workspace.register and prints the registration', async () => {
     const { program, relay, log } = harness(registerAgentCommands);
     await program.parseAsync(['agent', 'register', 'reviewer', '--type', 'agent'], { from: 'user' });
-    expect(relay.agents.register).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'reviewer', type: 'agent' })
+    expect(relay.workspace.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'reviewer', type: 'agent' }),
+      { strict: false }
     );
     expect(log).toHaveBeenCalled();
   });

--- a/packages/cli/src/cli/lib/agent-registration.test.ts
+++ b/packages/cli/src/cli/lib/agent-registration.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS,
+  withAgentRegistrationDeadline,
+} from './agent-registration.js';
+
+describe('withAgentRegistrationDeadline', () => {
+  it('resolves with the register() result when it completes before the deadline', async () => {
+    const result = await withAgentRegistrationDeadline(async () => 'token', 'chief', 50);
+    expect(result).toBe('token');
+  });
+
+  it('rejects once the deadline elapses without register() settling', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = withAgentRegistrationDeadline(() => new Promise(() => {}), 'chief', 50);
+      const assertion = expect(pending).rejects.toThrow(/did not complete within 50ms/);
+      await vi.advanceTimersByTimeAsync(50);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the default timeout for a non-finite timeoutMs instead of firing near-instantly', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = withAgentRegistrationDeadline(
+        () => new Promise(() => {}),
+        'chief',
+        Number.POSITIVE_INFINITY
+      );
+      const assertion = expect(pending).rejects.toThrow(
+        new RegExp(`did not complete within ${DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS}ms`)
+      );
+      await vi.advanceTimersByTimeAsync(DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the default timeout for a non-positive timeoutMs', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = withAgentRegistrationDeadline(() => new Promise(() => {}), 'chief', -5);
+      const assertion = expect(pending).rejects.toThrow(
+        new RegExp(`did not complete within ${DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS}ms`)
+      );
+      await vi.advanceTimersByTimeAsync(DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clamps an oversized timeoutMs to the max setTimeout delay instead of overflowing', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = withAgentRegistrationDeadline(
+        () => new Promise(() => {}),
+        'chief',
+        Number.MAX_SAFE_INTEGER
+      );
+      const assertion = expect(pending).rejects.toThrow(/did not complete within 2147483647ms/);
+      await vi.advanceTimersByTimeAsync(2_147_483_647);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shell-escapes a name containing command substitution syntax in the recovery command', async () => {
+    vi.useFakeTimers();
+    try {
+      const maliciousName = '$(rm -rf /)`whoami`';
+      const pending = withAgentRegistrationDeadline(() => new Promise(() => {}), maliciousName, 50);
+      const assertion = pending.catch((error: Error) => error.message);
+      await vi.advanceTimersByTimeAsync(50);
+      const message = await assertion;
+      // The recovery commands must wrap the name in single quotes so a shell
+      // treats it as a literal argument rather than executing it.
+      expect(message).toContain(`agent-relay agent rotate '$(rm -rf /)\`whoami\`'`);
+      expect(message).not.toMatch(/rotate \$\(rm -rf \/\)/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/cli/src/cli/lib/agent-registration.ts
+++ b/packages/cli/src/cli/lib/agent-registration.ts
@@ -1,5 +1,50 @@
 export const DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS = 15_000;
 
+// setTimeout coerces its delay with ToNumber and silently clamps non-finite,
+// negative, or >2^31-1 values to ~1ms (or fires on the next tick), so a bad
+// caller-supplied timeoutMs must not reach it directly — it would turn
+// "bounded registration" into "registration always times out immediately".
+const MAX_SETTIMEOUT_DELAY_MS = 2_147_483_647;
+
+function normalizeTimeoutMs(timeoutMs: number): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS;
+  }
+  return Math.min(timeoutMs, MAX_SETTIMEOUT_DELAY_MS);
+}
+
+// Single-quote the name for safe inclusion in a copy-pasteable shell command:
+// close the quote, emit an escaped literal quote, reopen. Without this, a
+// name containing `$(...)` or backticks would execute command substitution
+// if a user copies the recovery command as-is into a shell.
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Bound an arbitrary async operation so a hung upstream call cannot hang the
+ * caller forever. `buildTimeoutError` receives the normalized timeout so
+ * callers can render an accurate message.
+ */
+export async function withDeadline<T>(
+  operation: () => Promise<T>,
+  buildTimeoutError: (effectiveTimeoutMs: number) => Error,
+  timeoutMs = DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS
+): Promise<T> {
+  const effectiveTimeoutMs = normalizeTimeoutMs(timeoutMs);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(buildTimeoutError(effectiveTimeoutMs)), effectiveTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /**
  * Bound identity registration/rotation so an existing broken record cannot
  * hang an MCP or CLI caller forever.
@@ -13,25 +58,17 @@ export async function withAgentRegistrationDeadline<T>(
   name: string,
   timeoutMs = DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS
 ): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      register(),
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => {
-          const renderedName = JSON.stringify(name);
-          reject(
-            new Error(
-              `Agent registration or token rotation for ${renderedName} did not complete within ${timeoutMs}ms. ` +
-                'The request outcome is unknown. Retry with ' +
-                `\`agent-relay agent rotate ${renderedName}\`; if rotation continues to time out, run ` +
-                `\`agent-relay agent remove ${renderedName} --reason "recover stale token"\` and then register again.`
-            )
-          );
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+  return withDeadline(
+    register,
+    (effectiveTimeoutMs) => {
+      const renderedName = shellQuote(name);
+      return new Error(
+        `Agent registration or token rotation for ${JSON.stringify(name)} did not complete within ${effectiveTimeoutMs}ms. ` +
+          'The request outcome is unknown. Retry with ' +
+          `\`agent-relay agent rotate ${renderedName}\`; if rotation continues to time out, run ` +
+          `\`agent-relay agent remove ${renderedName} --reason "recover stale token"\` and then register again.`
+      );
+    },
+    timeoutMs
+  );
 }

--- a/packages/cli/src/cli/lib/agent-registration.ts
+++ b/packages/cli/src/cli/lib/agent-registration.ts
@@ -1,0 +1,37 @@
+export const DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS = 15_000;
+
+/**
+ * Bound identity registration/rotation so an existing broken record cannot
+ * hang an MCP or CLI caller forever.
+ *
+ * The upstream request may have reached the service before the local deadline,
+ * so the error is explicit that the outcome is unknown and points at the
+ * supported rotation and remove/re-register recovery paths.
+ */
+export async function withAgentRegistrationDeadline<T>(
+  register: () => Promise<T>,
+  name: string,
+  timeoutMs = DEFAULT_AGENT_REGISTRATION_TIMEOUT_MS
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      register(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          const renderedName = JSON.stringify(name);
+          reject(
+            new Error(
+              `Agent registration or token rotation for ${renderedName} did not complete within ${timeoutMs}ms. ` +
+                'The request outcome is unknown. Retry with ' +
+                `\`agent-relay agent rotate ${renderedName}\`; if rotation continues to time out, run ` +
+                `\`agent-relay agent remove ${renderedName} --reason "recover stale token"\` and then register again.`
+            )
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/cli/src/cli/lib/release-reason.test.ts
+++ b/packages/cli/src/cli/lib/release-reason.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { attributableReleaseReason } from './release-reason.js';
+
+describe('attributableReleaseReason', () => {
+  it('preserves a caller-supplied reason and appends the actor', () => {
+    expect(attributableReleaseReason('cleanup', 'chief', 'fallback reason')).toBe('cleanup (actor: chief)');
+  });
+
+  it('trims surrounding whitespace on a string reason', () => {
+    expect(attributableReleaseReason('  cleanup  ', 'chief', 'fallback reason')).toBe(
+      'cleanup (actor: chief)'
+    );
+  });
+
+  it('falls back to the fallback reason for a non-string reason', () => {
+    expect(attributableReleaseReason(undefined, 'chief', 'fallback reason')).toBe(
+      'fallback reason (actor: chief)'
+    );
+    expect(attributableReleaseReason(42, 'chief', 'fallback reason')).toBe('fallback reason (actor: chief)');
+    expect(attributableReleaseReason(null, 'chief', 'fallback reason')).toBe(
+      'fallback reason (actor: chief)'
+    );
+  });
+
+  it('falls back to the fallback reason for a whitespace-only reason', () => {
+    expect(attributableReleaseReason('   ', 'chief', 'fallback reason')).toBe(
+      'fallback reason (actor: chief)'
+    );
+  });
+
+  it('never emits a null/empty reason — a missing reason always uses the fallback', () => {
+    const result = attributableReleaseReason(null, undefined, 'fallback reason');
+    expect(result).not.toContain('null');
+    expect(result.startsWith('fallback reason')).toBe(true);
+  });
+
+  it('falls back to "unknown Agent Relay operator" for a missing or whitespace-only actor', () => {
+    expect(attributableReleaseReason('cleanup', undefined, 'fallback reason')).toBe(
+      'cleanup (actor: unknown Agent Relay operator)'
+    );
+    expect(attributableReleaseReason('cleanup', null, 'fallback reason')).toBe(
+      'cleanup (actor: unknown Agent Relay operator)'
+    );
+    expect(attributableReleaseReason('cleanup', '   ', 'fallback reason')).toBe(
+      'cleanup (actor: unknown Agent Relay operator)'
+    );
+  });
+});

--- a/packages/cli/src/cli/lib/release-reason.ts
+++ b/packages/cli/src/cli/lib/release-reason.ts
@@ -1,0 +1,15 @@
+/**
+ * Relaycast's release request currently has one audit string rather than
+ * separate reason/actor fields. Keep both facts in that durable field so an
+ * operator can identify why a release happened and which Relay surface asked
+ * for it.
+ */
+export function attributableReleaseReason(
+  reason: unknown,
+  actor: string | null | undefined,
+  fallbackReason: string
+): string {
+  const normalizedReason = typeof reason === 'string' ? reason.trim() : '';
+  const normalizedActor = actor?.trim() || 'unknown Agent Relay operator';
+  return `${normalizedReason || fallbackReason} (actor: ${normalizedActor})`;
+}

--- a/packages/cli/src/cli/lib/sdk-command.ts
+++ b/packages/cli/src/cli/lib/sdk-command.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 
-import { AgentRelay, type AgentRelayAgent } from '@agent-relay/sdk';
+import { AgentRelay, safeRelayErrorMessage, type AgentRelayAgent } from '@agent-relay/sdk';
 
 import { defaultExit } from './exit.js';
 import { createAgentRelay, createWorkspaceRelay, type SdkClientOptions } from './sdk-client.js';
@@ -70,7 +70,7 @@ export async function runSdk(deps: SdkCommandDeps, fn: () => Promise<void>): Pro
   try {
     await fn();
   } catch (err) {
-    deps.error(err instanceof Error ? err.message : String(err));
+    deps.error(safeRelayErrorMessage(err));
     deps.exit(1);
   }
 }

--- a/packages/cli/src/cli/mcp/telemetry.test.ts
+++ b/packages/cli/src/cli/mcp/telemetry.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { enableInboxPiggyback } from './telemetry.js';
+import type { SessionState } from './types.js';
+
+const SQL_ERROR_MESSAGE =
+  'Failed query: delete from "agents" where "agents"."id" = ?\nparams: 214015171589668864';
+
+function harness() {
+  const tools = new Map<string, (input: unknown) => Promise<unknown>>();
+  const server = {
+    registerTool: vi.fn((name: string, _config: unknown, handler: (input: unknown) => Promise<unknown>) => {
+      tools.set(name, handler);
+    }),
+  };
+  const session: SessionState = {
+    workspaceKey: null,
+    agentToken: null,
+    agentName: null,
+    agents: undefined,
+    wsBridge: null,
+    subscriptions: null,
+    wsInitAttempted: false,
+  };
+  enableInboxPiggyback(
+    server as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer,
+    () => session,
+    () => ({ inbox: vi.fn(async () => ({})) }) as never,
+    vi.fn()
+  );
+
+  // Register through the now-wrapped registerTool so `tools` ends up holding
+  // the wrapper (which does the redaction), not the raw handler.
+  function register(name: string, rawHandler: (input: unknown) => Promise<unknown>) {
+    server.registerTool(name, {}, rawHandler);
+    return tools.get(name)!;
+  }
+
+  return { register };
+}
+
+describe('enableInboxPiggyback SQL/diagnostic redaction', () => {
+  it("redacts an isError result's structuredContent, not just content[].text", async () => {
+    const { register } = harness();
+    // Models exactly what action-tools.ts's jsonContent(...) produces for a
+    // relay failure: the SQL leak lands in both content[].text and
+    // structuredContent.error.
+    const wrapped = register('some_tool', async () => ({
+      content: [{ type: 'text', text: SQL_ERROR_MESSAGE }],
+      structuredContent: { ok: false, error: SQL_ERROR_MESSAGE },
+      isError: true,
+    }));
+    const result = (await wrapped({})) as {
+      content: Array<{ text: string }>;
+      structuredContent: { ok: boolean; error: string };
+    };
+
+    expect(result.content[0].text).not.toContain('delete from');
+    expect(result.content[0].text).not.toContain('params:');
+    expect(result.structuredContent.error).not.toContain('delete from');
+    expect(result.structuredContent.error).not.toContain('214015171589668864');
+  });
+
+  it('redacts nested string leaves inside structuredContent, not just a top-level "error" field', async () => {
+    const { register } = harness();
+    const wrapped = register('some_tool', async () => ({
+      content: [{ type: 'text', text: 'redacted already' }],
+      structuredContent: { ok: false, detail: { cause: SQL_ERROR_MESSAGE, code: 'db_error' } },
+      isError: true,
+    }));
+    const result = (await wrapped({})) as {
+      structuredContent: { detail: { cause: string; code: string } };
+    };
+
+    expect(result.structuredContent.detail.cause).not.toContain('delete from');
+    expect(result.structuredContent.detail.code).toBe('db_error');
+  });
+
+  it('does not touch structuredContent on a successful (non-isError) result', async () => {
+    const { register } = harness();
+    const wrapped = register('some_tool', async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: { note: SQL_ERROR_MESSAGE },
+    }));
+    const result = (await wrapped({})) as { structuredContent: { note: string } };
+
+    // Not an error result, so nothing here is a diagnostic to redact — the
+    // sanitizer must be scoped to isError results only.
+    expect(result.structuredContent.note).toBe(SQL_ERROR_MESSAGE);
+  });
+
+  it('preserves the original error object when no redaction is needed', async () => {
+    const { register } = harness();
+    const original = new Error('Agent "chief" not found');
+    const wrapped = register('some_tool', async () => {
+      throw original;
+    });
+
+    await expect(wrapped({})).rejects.toBe(original);
+  });
+
+  it('throws a sanitized error whose message and stack contain no SQL', async () => {
+    const { register } = harness();
+    class CustomRelayError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomRelayError';
+      }
+    }
+    const wrapped = register('some_tool', async () => {
+      throw new CustomRelayError(SQL_ERROR_MESSAGE);
+    });
+
+    let caught: unknown;
+    try {
+      await wrapped({});
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const error = caught as Error;
+    expect(error.message).not.toContain('delete from');
+    expect(error.message).not.toContain('params:');
+    // Type (name) is preserved even though the object identity is not (a
+    // fresh Error is constructed so the sanitized message, not the raw SQL,
+    // is what ends up baked into the new stack's header line).
+    expect(error.name).toBe('CustomRelayError');
+    expect(error.stack).not.toContain('delete from');
+  });
+});

--- a/packages/cli/src/cli/mcp/telemetry.ts
+++ b/packages/cli/src/cli/mcp/telemetry.ts
@@ -161,7 +161,12 @@ export function enableInboxPiggyback(
           });
         }
         const safeMessage = safeRelayErrorMessage(err);
-        if (err instanceof Error && safeMessage === err.message) throw err;
+        if (err instanceof Error) {
+          // Replace only the message, so the sanitized error keeps its
+          // original type, stack, and cause — those never contain SQL.
+          if (safeMessage !== err.message) err.message = safeMessage;
+          throw err;
+        }
         throw new Error(safeMessage);
       }
 
@@ -198,8 +203,19 @@ export function enableInboxPiggyback(
         }
       }
 
+      const resultIsError = isErrorToolResult(result);
+      if (resultIsError && hasContentArray(result)) {
+        // A relay failure surfaced as an `isError` tool result (rather than
+        // a thrown error, e.g. via action-tools.ts) bypasses the catch block
+        // above entirely, so it needs the same SQL/diagnostic redaction here.
+        for (const entry of result.content) {
+          if (entry && typeof entry === 'object' && entry.type === 'text' && typeof entry.text === 'string') {
+            entry.text = safeRelayErrorMessage(entry.text);
+          }
+        }
+      }
+
       if (toolMetadata) {
-        const resultIsError = isErrorToolResult(result);
         trackAgentRelayToolCall({
           toolName: name,
           toolType: toolMetadata.toolType,

--- a/packages/cli/src/cli/mcp/telemetry.ts
+++ b/packages/cli/src/cli/mcp/telemetry.ts
@@ -3,6 +3,7 @@ import {
   agentTokenRecoveryMessage,
   isInvalidAgentTokenError,
   isInvalidAgentTokenToolResult,
+  safeRelayErrorMessage,
 } from '@agent-relay/sdk';
 
 import { track, type AgentRelayToolCallCategory, type AgentRelayToolCallType } from '../telemetry/index.js';
@@ -159,7 +160,9 @@ export function enableInboxPiggyback(
             errorClass: errorClassName(err),
           });
         }
-        throw err;
+        const safeMessage = safeRelayErrorMessage(err);
+        if (err instanceof Error && safeMessage === err.message) throw err;
+        throw new Error(safeMessage);
       }
 
       if (name !== 'register_agent' && isInvalidAgentTokenToolResult(result)) {

--- a/packages/cli/src/cli/mcp/telemetry.ts
+++ b/packages/cli/src/cli/mcp/telemetry.ts
@@ -89,6 +89,29 @@ function trackAgentRelayToolCall(input: {
   });
 }
 
+const SANITIZE_STRUCTURED_CONTENT_MAX_DEPTH = 5;
+
+/**
+ * Recursively redact SQL/diagnostic text from an `isError` tool result's
+ * `structuredContent`. Shapes vary by tool (action-tools.ts's `jsonContent`
+ * wraps arbitrary error payloads), so this walks every string leaf rather
+ * than targeting a single known field.
+ */
+function sanitizeStructuredContent(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return safeRelayErrorMessage(value);
+  if (depth >= SANITIZE_STRUCTURED_CONTENT_MAX_DEPTH || value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeStructuredContent(entry, depth + 1));
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    sanitized[key] = sanitizeStructuredContent(entry, depth + 1);
+  }
+  return sanitized;
+}
+
 function readAsIdentity(args: unknown[]): string | undefined {
   const [input] = args;
   if (typeof input !== 'object' || input === null) return undefined;
@@ -161,11 +184,19 @@ export function enableInboxPiggyback(
           });
         }
         const safeMessage = safeRelayErrorMessage(err);
+        if (err instanceof Error && safeMessage === err.message) throw err;
         if (err instanceof Error) {
-          // Replace only the message, so the sanitized error keeps its
-          // original type, stack, and cause — those never contain SQL.
-          if (safeMessage !== err.message) err.message = safeMessage;
-          throw err;
+          // A materialized `.stack` embeds the original message in its
+          // header line (`${name}: ${message}`) at the point the stack was
+          // captured — mutating `.message` afterward does not retroactively
+          // scrub that. Construct a fresh Error with the sanitized message
+          // instead, preserving `name`/`cause` (never SQL) but not the stack.
+          const sanitized = new Error(
+            safeMessage,
+            err.cause !== undefined ? { cause: err.cause } : undefined
+          );
+          sanitized.name = err.name;
+          throw sanitized;
         }
         throw new Error(safeMessage);
       }
@@ -204,14 +235,33 @@ export function enableInboxPiggyback(
       }
 
       const resultIsError = isErrorToolResult(result);
-      if (resultIsError && hasContentArray(result)) {
+      if (resultIsError) {
         // A relay failure surfaced as an `isError` tool result (rather than
         // a thrown error, e.g. via action-tools.ts) bypasses the catch block
-        // above entirely, so it needs the same SQL/diagnostic redaction here.
-        for (const entry of result.content) {
-          if (entry && typeof entry === 'object' && entry.type === 'text' && typeof entry.text === 'string') {
-            entry.text = safeRelayErrorMessage(entry.text);
+        // above entirely, so it needs the same SQL/diagnostic redaction here
+        // — applied to both `content[].text` (what a human/LLM reads) and
+        // `structuredContent` (what action-tools.ts's `jsonContent(...)`
+        // also serializes to the client, e.g. `{ ok: false, error: <msg> }`).
+        if (hasContentArray(result)) {
+          for (const entry of result.content) {
+            if (
+              entry &&
+              typeof entry === 'object' &&
+              entry.type === 'text' &&
+              typeof entry.text === 'string'
+            ) {
+              entry.text = safeRelayErrorMessage(entry.text);
+            }
           }
+        }
+        if (
+          result &&
+          typeof result === 'object' &&
+          'structuredContent' in result &&
+          result.structuredContent &&
+          typeof result.structuredContent === 'object'
+        ) {
+          result.structuredContent = sanitizeStructuredContent(result.structuredContent);
         }
       }
 

--- a/packages/sdk/src/__tests__/facade.test.ts
+++ b/packages/sdk/src/__tests__/facade.test.ts
@@ -253,3 +253,24 @@ describe('workspace.register idempotency', () => {
     });
   });
 });
+
+describe('workspace.release', () => {
+  it('routes removal through the lifecycle release surface', async () => {
+    const { messaging } = createMessagingMock();
+    const release = vi.fn(async () => ({ status: 'completed' }));
+    (messaging.agents as typeof messaging.agents & { release: typeof release }).release = release;
+    const relay = new AgentRelay({ messaging, createAgentMessaging: () => messaging });
+
+    await relay.workspace.release({
+      name: 'talkative-agent',
+      reason: 'cleanup (actor: test)',
+      deleteAgent: true,
+    });
+
+    expect(release).toHaveBeenCalledWith({
+      name: 'talkative-agent',
+      reason: 'cleanup (actor: test)',
+      deleteAgent: true,
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/facade.test.ts
+++ b/packages/sdk/src/__tests__/facade.test.ts
@@ -273,4 +273,20 @@ describe('workspace.release', () => {
       deleteAgent: true,
     });
   });
+
+  it('rejects on an agent-scoped client, which backs its workspace facade without deps', async () => {
+    // createWorkspaceFacade() without `deps` is what an agent-scoped client
+    // (returned by workspace.register()/reconnect()) gets for its own
+    // `.workspace` facade — it must not be able to release agents either.
+    const { messaging, agents } = createMessagingMock();
+    const release = vi.fn(async () => ({ status: 'completed' }));
+    (agents as typeof agents & { release: typeof release }).release = release;
+    const relay = new AgentRelay({ messaging, createAgentMessaging: () => messaging });
+    const sender = await relay.workspace.register({ name: 'sender' });
+
+    await expect(
+      sender.workspace.release({ name: 'talkative-agent', reason: 'cleanup', deleteAgent: true })
+    ).rejects.toThrow(/release\(\) is only available on the workspace client/);
+    expect(release).not.toHaveBeenCalled();
+  });
 });

--- a/packages/sdk/src/__tests__/messaging.test.ts
+++ b/packages/sdk/src/__tests__/messaging.test.ts
@@ -40,6 +40,12 @@ function createWorkspace() {
         ...input,
       })),
       delete: vi.fn(async () => undefined),
+      release: vi.fn(async (input: unknown) => ({
+        invocation_id: 'inv_release_1',
+        action_name: 'release',
+        status: 'completed',
+        input,
+      })),
       presence: vi.fn(async () => [{ agent_id: 'agent-1', agent_name: 'WorkerA', status: 'online' }]),
       events: {
         emit: vi.fn(async (_name: string, data: unknown) => data),
@@ -345,6 +351,25 @@ describe('RelaycastMessagingClient', () => {
 
     expect(workspace.agents.register).toHaveBeenCalledWith({ name: 'WorkerB' });
     expect(registration).toMatchObject({ name: 'WorkerB', token: 'at_live_worker_b' });
+  });
+
+  it('agents.release delegates to the lifecycle endpoint instead of direct deletion', async () => {
+    const workspace = createWorkspace();
+    const client = new RelaycastMessagingClient({ relaycast: workspace });
+
+    const result = await client.agents.release({
+      name: 'WorkerB',
+      reason: 'cleanup (actor: test)',
+      deleteAgent: true,
+    });
+
+    expect(workspace.agents.release).toHaveBeenCalledWith({
+      name: 'WorkerB',
+      reason: 'cleanup (actor: test)',
+      deleteAgent: true,
+    });
+    expect(workspace.agents.delete).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ action_name: 'release', status: 'completed' });
   });
 
   it('normalizes agents, channels, and channel messages from Relaycast', async () => {

--- a/packages/sdk/src/__tests__/messaging.test.ts
+++ b/packages/sdk/src/__tests__/messaging.test.ts
@@ -369,7 +369,11 @@ describe('RelaycastMessagingClient', () => {
       deleteAgent: true,
     });
     expect(workspace.agents.delete).not.toHaveBeenCalled();
-    expect(result).toMatchObject({ action_name: 'release', status: 'completed' });
+    expect(result).toMatchObject({
+      invocationId: 'inv_release_1',
+      actionName: 'release',
+      status: 'completed',
+    });
   });
 
   it('normalizes agents, channels, and channel messages from Relaycast', async () => {

--- a/packages/sdk/src/__tests__/observer-source.test.ts
+++ b/packages/sdk/src/__tests__/observer-source.test.ts
@@ -511,6 +511,16 @@ describe('AgentRelay observer mode', () => {
     );
   });
 
+  it('workspace.release() throws a read-only error instead of reaching the messaging client', async () => {
+    // Regression guard: the observer-mode facade overrides register/reconnect
+    // but historically forwarded release() through the `...facade` spread
+    // unguarded, letting a read-only observer token release/delete agents.
+    const relay = createObserverRelay();
+    await expect(
+      relay.workspace.release({ name: 'chief', reason: 'test', deleteAgent: true })
+    ).rejects.toThrow(/observer tokens are read-only; use a workspace key to register agents/);
+  });
+
   it('keeps the token out of the URL on Node and reports abnormal closes', async () => {
     // Security regression guard: a pre-open close on Node (which supports header
     // auth) must not permanently downgrade to a `?token=` URL, and abnormal

--- a/packages/sdk/src/__tests__/relaycast-errors.test.ts
+++ b/packages/sdk/src/__tests__/relaycast-errors.test.ts
@@ -124,4 +124,20 @@ describe('safeRelayErrorMessage', () => {
   it('preserves ordinary actionable Relay errors', () => {
     expect(safeRelayErrorMessage(new Error('Agent "chief" not found'))).toBe('Agent "chief" not found');
   });
+
+  it('redacts unprefixed, unquoted SQL that lacks a "Failed query:" prefix', () => {
+    const message = safeRelayErrorMessage(new Error('delete from agents where id = 214015171589668864'));
+    expect(message).toBe(RELAY_SERVICE_FAILURE_MESSAGE);
+  });
+
+  it('redacts "parameters:" diagnostic fields, not just "params:"', () => {
+    const message = safeRelayErrorMessage(new Error('query failed\nparameters: 214015171589668864'));
+    expect(message).toBe(RELAY_SERVICE_FAILURE_MESSAGE);
+  });
+
+  it('does not mask ordinary prose that happens to contain a SQL verb', () => {
+    expect(safeRelayErrorMessage(new Error('Please select a valid workspace before continuing'))).toBe(
+      'Please select a valid workspace before continuing'
+    );
+  });
 });

--- a/packages/sdk/src/__tests__/relaycast-errors.test.ts
+++ b/packages/sdk/src/__tests__/relaycast-errors.test.ts
@@ -140,4 +140,16 @@ describe('safeRelayErrorMessage', () => {
       'Please select a valid workspace before continuing'
     );
   });
+
+  it('does not mask prose ending in "<verb> <identifier>" with no SQL continuation', () => {
+    expect(safeRelayErrorMessage(new Error('Could not select file'))).toBe('Could not select file');
+    expect(safeRelayErrorMessage(new Error('Failed to update account'))).toBe('Failed to update account');
+  });
+
+  it('redacts canonical unquoted "select <col> from <table>" SQL', () => {
+    const message = safeRelayErrorMessage(
+      new Error('select id from users where email = ? params: someone@example.com')
+    );
+    expect(message).toBe(RELAY_SERVICE_FAILURE_MESSAGE);
+  });
 });

--- a/packages/sdk/src/__tests__/relaycast-errors.test.ts
+++ b/packages/sdk/src/__tests__/relaycast-errors.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   INVALID_AGENT_TOKEN_CODE,
   INVALID_AGENT_TOKEN_MESSAGE,
+  RELAY_SERVICE_FAILURE_MESSAGE,
   agentTokenRecoveryMessage,
   isInvalidAgentTokenError,
   isInvalidAgentTokenToolResult,
+  safeRelayErrorMessage,
 } from '../relaycast-errors.js';
 
 describe('isInvalidAgentTokenError', () => {
@@ -104,5 +106,22 @@ describe('agentTokenRecoveryMessage', () => {
     const msg = agentTokenRecoveryMessage();
     expect(msg).toContain(INVALID_AGENT_TOKEN_CODE);
     expect(msg).toContain('register_agent');
+  });
+});
+
+describe('safeRelayErrorMessage', () => {
+  it('redacts raw SQL and bound parameters from an upstream failure', () => {
+    const message = safeRelayErrorMessage(
+      new Error('Failed query: delete from "agents" where "agents"."id" = ?\nparams: 214015171589668864')
+    );
+
+    expect(message).toBe(RELAY_SERVICE_FAILURE_MESSAGE);
+    expect(message).not.toContain('delete from');
+    expect(message).not.toContain('params:');
+    expect(message).not.toContain('214015171589668864');
+  });
+
+  it('preserves ordinary actionable Relay errors', () => {
+    expect(safeRelayErrorMessage(new Error('Agent "chief" not found'))).toBe('Agent "chief" not found');
   });
 });

--- a/packages/sdk/src/agent-relay.ts
+++ b/packages/sdk/src/agent-relay.ts
@@ -313,6 +313,9 @@ export class AgentRelay implements AgentRelayAgent {
             register: (async () => {
               throw new Error(observerReadOnlyMessage('register()'));
             }) as RelayWorkspace['register'],
+            release: async () => {
+              throw new Error(observerReadOnlyMessage('release()'));
+            },
             reconnect: async () => {
               throw new Error(observerReadOnlyMessage('reconnect()'));
             },

--- a/packages/sdk/src/facade.ts
+++ b/packages/sdk/src/facade.ts
@@ -365,7 +365,12 @@ export function createWorkspaceFacade(messaging: RelayMessaging, deps?: Workspac
     info: () => messaging.workspace.info(),
     fleetNodes: messaging.workspace.fleetNodes,
     register: register as RelayWorkspace['register'],
-    release: (input) => messaging.agents.release(input),
+    release: (input) => {
+      if (!deps) {
+        throw new Error('release() is only available on the workspace client.');
+      }
+      return messaging.agents.release(input);
+    },
     reconnect: async ({ apiToken }) => {
       if (!deps) {
         throw new Error('reconnect() is only available on the workspace client.');

--- a/packages/sdk/src/facade.ts
+++ b/packages/sdk/src/facade.ts
@@ -9,6 +9,8 @@ import type {
   RelayMessageAttachmentInput,
   RelayMessageBlock,
   RelayMessageMode,
+  RelayReleaseAgentInput,
+  RelayAgentReleaseResult,
   RelaySendChannelMessageInput,
   RelayWorkspaceInfo,
   RelayWorkspaceFleetNodesConfig,
@@ -195,6 +197,8 @@ export interface RelayWorkspace {
     agents: T,
     options?: RelayRegisterOptions
   ): Promise<T extends AgentLike[] ? RelayAgentClient[] : RelayAgentClient>;
+  /** Release an agent, optionally freeing its name for re-registration. */
+  release(input: RelayReleaseAgentInput): Promise<RelayAgentReleaseResult>;
   reconnect(input: { apiToken: string }): Promise<RelayAgentClient>;
   info(): Promise<RelayWorkspaceInfo>;
   fleetNodes: {
@@ -361,6 +365,7 @@ export function createWorkspaceFacade(messaging: RelayMessaging, deps?: Workspac
     info: () => messaging.workspace.info(),
     fleetNodes: messaging.workspace.fleetNodes,
     register: register as RelayWorkspace['register'],
+    release: (input) => messaging.agents.release(input),
     reconnect: async ({ apiToken }) => {
       if (!deps) {
         throw new Error('reconnect() is only available on the workspace client.');

--- a/packages/sdk/src/facade.ts
+++ b/packages/sdk/src/facade.ts
@@ -365,7 +365,11 @@ export function createWorkspaceFacade(messaging: RelayMessaging, deps?: Workspac
     info: () => messaging.workspace.info(),
     fleetNodes: messaging.workspace.fleetNodes,
     register: register as RelayWorkspace['register'],
-    release: (input) => {
+    release: async (input) => {
+      // async so an unavailable-on-this-client error is always a rejected
+      // Promise, matching register()/reconnect() below — a plain (non-async)
+      // arrow function would throw synchronously instead, breaking every
+      // caller that assumes `.catch(...)`/`.rejects` semantics.
       if (!deps) {
         throw new Error('release() is only available on the workspace client.');
       }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,7 +10,9 @@ export { RelayError, type RelayErrorCode } from '@relaycast/sdk';
 export {
   INVALID_AGENT_TOKEN_CODE,
   INVALID_AGENT_TOKEN_MESSAGE,
+  RELAY_SERVICE_FAILURE_MESSAGE,
   agentTokenRecoveryMessage,
   isInvalidAgentTokenError,
   isInvalidAgentTokenToolResult,
+  safeRelayErrorMessage,
 } from './relaycast-errors.js';

--- a/packages/sdk/src/messaging/relaycast-client.ts
+++ b/packages/sdk/src/messaging/relaycast-client.ts
@@ -31,6 +31,7 @@ export type RelaycastWorkspaceLike = {
     registerOrRotate?: (data: unknown) => Promise<unknown>;
     update(name: string, input: unknown): Promise<unknown>;
     delete(name: string): Promise<void>;
+    release(input: unknown): Promise<unknown>;
     presence(): Promise<unknown[]>;
     events?: {
       emit(name: string, data: { type: string; payload?: Record<string, unknown> }): Promise<unknown>;

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -93,6 +93,8 @@ import type {
   RelayListDirectMessagesInput,
   RelayMessage,
   RelayMessageListOptions,
+  RelayReleaseAgentInput,
+  RelayAgentReleaseResult,
   RelayMessageReaction,
   RelayMessagingCapabilities,
   RelayMessagingClient,
@@ -235,6 +237,8 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     delete: async (name: string): Promise<void> => {
       await this.relaycast.agents.delete(name);
     },
+    release: async (input: RelayReleaseAgentInput): Promise<RelayAgentReleaseResult> =>
+      (await this.relaycast.agents.release(input)) as RelayAgentReleaseResult,
     presence: async (): Promise<RelayAgentPresence[]> => {
       const presence = await this.relaycast.agents.presence();
       return presence.map(normalizeAgentPresence);

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -237,8 +237,10 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     delete: async (name: string): Promise<void> => {
       await this.relaycast.agents.delete(name);
     },
-    release: async (input: RelayReleaseAgentInput): Promise<RelayAgentReleaseResult> =>
-      (await this.relaycast.agents.release(input)) as RelayAgentReleaseResult,
+    release: async (input: RelayReleaseAgentInput): Promise<RelayAgentReleaseResult> => {
+      const ack = normalizeActionInvocationAck(await this.relaycast.agents.release(input));
+      return { ...ack };
+    },
     presence: async (): Promise<RelayAgentPresence[]> => {
       const presence = await this.relaycast.agents.presence();
       return presence.map(normalizeAgentPresence);

--- a/packages/sdk/src/messaging/thin-client.ts
+++ b/packages/sdk/src/messaging/thin-client.ts
@@ -28,6 +28,7 @@ import type {
   RelayMessageListOptions,
   RelayMessageMode,
   RelayRegisterAgentInput,
+  RelayReleaseAgentInput,
 } from './types.js';
 
 export type { RelaycastTelemetryOptions } from '../relaycast-telemetry.js';
@@ -59,14 +60,6 @@ export interface RelaySpawnAgentInput {
    * which the broker extracts to pass `--model` to the launched CLI).
    */
   metadata?: Record<string, unknown>;
-}
-
-/** Input for `agents.release`. */
-export interface RelayReleaseAgentInput {
-  name: string;
-  reason?: string;
-  /** Permanently delete the agent instead of just releasing it. */
-  deleteAgent?: boolean;
 }
 
 /** Raw payload returned by `agents.release`. */

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -321,6 +321,20 @@ export interface RelayUpdateAgentInput {
   metadata?: wire.UpdateAgentRequest['metadata'];
 }
 
+export interface RelayReleaseAgentInput {
+  name: wire.ReleaseAgentRequest['name'];
+  reason?: NonNullable<wire.ReleaseAgentRequest['reason']>;
+  deleteAgent?: wire.ReleaseAgentRequest['delete_agent'];
+}
+
+/** Raw action-invocation acknowledgement returned by the release endpoint. */
+export interface RelayAgentReleaseResult {
+  invocationId?: string;
+  actionName?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
 export interface RelayListChannelsOptions {
   includeArchived?: boolean;
 }
@@ -891,6 +905,8 @@ export interface RelayMessagingClient {
     me(): Promise<RelayAgent>;
     update(name: string, input: RelayUpdateAgentInput): Promise<RelayAgent>;
     delete(name: string): Promise<void>;
+    /** Release an agent lifecycle, optionally freeing its registered name. */
+    release(input: RelayReleaseAgentInput): Promise<RelayAgentReleaseResult>;
     presence(): Promise<RelayAgentPresence[]>;
   };
   /** Durable canonical harness events stored on the Relaycast agent record. */

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -15,6 +15,11 @@
 
 export const INVALID_AGENT_TOKEN_CODE = 'agent_token_invalid';
 export const INVALID_AGENT_TOKEN_MESSAGE = 'Invalid agent token';
+export const RELAY_SERVICE_FAILURE_MESSAGE =
+  'Relay service could not complete the request. Retry, or contact the workspace operator if the problem persists.';
+
+const DATABASE_DIAGNOSTIC_PATTERN =
+  /(?:failed\s+query\s*:|\bparams?\s*:|\bsqlstate\b|\b(?:select|insert\s+into|update|delete\s+from)\s+["`[])/i;
 
 interface MaybeError {
   code?: unknown;
@@ -23,6 +28,19 @@ interface MaybeError {
   message?: unknown;
   body?: unknown;
   cause?: unknown;
+}
+
+/**
+ * Format an upstream Relay error for a user-facing CLI/MCP boundary.
+ *
+ * Service/framework exceptions can include raw SQL and bound parameters in
+ * `error.message`. Those details are useful only inside the service and can
+ * contain identifiers or other caller data, so collapse database diagnostics
+ * to a stable actionable message while preserving ordinary API errors.
+ */
+export function safeRelayErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return DATABASE_DIAGNOSTIC_PATTERN.test(message) ? RELAY_SERVICE_FAILURE_MESSAGE : message;
 }
 
 function normalizeCode(value: unknown): string | null {

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -20,11 +20,14 @@ export const RELAY_SERVICE_FAILURE_MESSAGE =
 
 // Matches driver/query-builder diagnostics that can carry raw SQL text and
 // bound parameter values. The unquoted-identifier branch requires a trailing
-// SQL keyword (where/set/values/`(`/`;`/end-of-string) so ordinary prose that
-// happens to contain "select"/"update" (e.g. "select a workspace") does not
-// trip it — only `<verb> <identifier> <sql-continuation>` does.
+// SQL keyword (from/where/set/values/`(`/`;`) so ordinary prose that happens
+// to end in "<verb> <identifier>" (e.g. "Could not select file", "Failed to
+// update account") does not trip it — only `<verb> <identifier>
+// <sql-continuation>` does. `from\s+<identifier>` is included so canonical
+// `select <col> from <table>` is still caught even though `<col>` isn't
+// itself followed by one of the other continuation keywords.
 const DATABASE_DIAGNOSTIC_PATTERN =
-  /(?:failed\s+query\s*:|\bparams?\s*:|\bparameters\s*:|\bsqlstate\b|\b(?:select|insert\s+into|update|delete\s+from|drop\s+table|truncate\s+table|alter\s+table)\s+(?:["`[*]|[a-z_][\w.]*\s*(?:where|set|values|\(|;|$)))/i;
+  /(?:failed\s+query\s*:|\bparams?\s*:|\bparameters\s*:|\bsqlstate\b|\b(?:select|insert\s+into|update|delete\s+from|drop\s+table|truncate\s+table|alter\s+table)\s+(?:["`[*]|[a-z_][\w.]*\s*(?:from\s+[a-z_][\w.]*|where|set|values|\(|;)))/i;
 
 interface MaybeError {
   code?: unknown;

--- a/packages/sdk/src/relaycast-errors.ts
+++ b/packages/sdk/src/relaycast-errors.ts
@@ -18,8 +18,13 @@ export const INVALID_AGENT_TOKEN_MESSAGE = 'Invalid agent token';
 export const RELAY_SERVICE_FAILURE_MESSAGE =
   'Relay service could not complete the request. Retry, or contact the workspace operator if the problem persists.';
 
+// Matches driver/query-builder diagnostics that can carry raw SQL text and
+// bound parameter values. The unquoted-identifier branch requires a trailing
+// SQL keyword (where/set/values/`(`/`;`/end-of-string) so ordinary prose that
+// happens to contain "select"/"update" (e.g. "select a workspace") does not
+// trip it — only `<verb> <identifier> <sql-continuation>` does.
 const DATABASE_DIAGNOSTIC_PATTERN =
-  /(?:failed\s+query\s*:|\bparams?\s*:|\bsqlstate\b|\b(?:select|insert\s+into|update|delete\s+from)\s+["`[])/i;
+  /(?:failed\s+query\s*:|\bparams?\s*:|\bparameters\s*:|\bsqlstate\b|\b(?:select|insert\s+into|update|delete\s+from|drop\s+table|truncate\s+table|alter\s+table)\s+(?:["`[*]|[a-z_][\w.]*\s*(?:where|set|values|\(|;|$)))/i;
 
 interface MaybeError {
   code?: unknown;


### PR DESCRIPTION
Closes #1524.

## Why this PR was opened by hand

The implementer for #1524 completed its work and pushed `0b275149d` to this branch at **2026-08-15 18:41:18 +0200**, but **no PR was ever opened** and the branch sat orphaned for ~1.5 hours.

Cause: no `ar-1524-babysit-relay` lane was ever spawned. Compare the sibling dispatch for #1523, which got `impl` + `review` + `babysit` and produced #1525 normally; #1524 got `impl` + `review` only. The babysitter is the component that opens and reconciles the PR, so when the PR-open step didn't complete there was nothing to retry it.

**This is the failure mode already filed as `AgentWorkforce/factory#243`** ("One failed PR-snapshot read permanently orphans a PR from the babysitter — no retry, no reconcile").

`factory#250` ("retry and reconcile PR-open snapshot reads so a failed read cannot orphan a PR") **was merged shortly after this branch was stranded**, so the fix is now on `main`. Note that merged is not deployed: `factory#251` exists precisely because production ran 37 versions behind `main`, so this class of orphaning can recur until the running Factory picks up #250.

The working tree was clean and the branch was already pushed — no work was lost or recreated here. This PR only creates the missing pull request so CI runs and review has a target.

## What the commit changes

`0b275149d "fix: restore agent identity recovery"` — 26 files, +702 −66, spanning the Rust broker and the TypeScript CLI/SDK:

- `crates/broker/src/relaycast/ws.rs` (+145) and `crates/broker/src/runtime/api.rs`
- `packages/cli/src/cli/commands/agent.ts`, `agent-relay-mcp.ts`, `lib/agent-registration.ts`, new `lib/release-reason.ts`
- `packages/sdk/src/messaging/*`, new `packages/sdk/src/relaycast-errors.ts`
- Tests alongside each, plus `CHANGELOG.md`

The commit message is a bare subject line with no body, so the mapping from these changes to the three reported defects is not documented anywhere. **Reviewer: please confirm each of the three is actually addressed**, rather than inferring it from the file list.

## The three defects this must fix (from #1524)

1. **A seat can be released with `reason: null` and no actor** — the `chief` record carries `release: { reason: null, released_at: "2026-08-14T12:06:00.842Z" }`, which invalidated its token. Releases should carry a reason and an actor. The new `lib/release-reason.ts` looks aimed at this; confirm it covers the write path that produced the null, not only the read path.
2. **`register_agent` on an existing broken name hangs** (>120s on 11.6.3; on 11.6.2 it returned the *same dead token* instantly, making the error message's own prescribed recovery a closed loop). Fresh names register in under a second. The `ws.rs` changes are the plausible site; confirm the hang is gone **and** that the call either mints a usable token or points at the real recovery path.
3. **`agent remove` fails and leaks raw SQL** — returns `Failed query: delete from "agents" where "agents"."id" = ?` plus the bound parameter to the caller. Both halves need fixing: the delete must work, and the error boundary must stop emitting the query and its parameters. Please confirm sibling commands were audited for the same unguarded path rather than only this call site.

## Verification this PR has NOT had

Flagging honestly rather than letting green CI imply more than it proves:

- **The definition of done in #1524 is that the `chief` seat becomes usable again**, demonstrated by that identity sending a message that is *received*. That has not been shown. As of now `chief` still returns `Invalid agent token`.
- **Do not verify with a `messageId`.** DM delivery is separately broken (#1523, fix in #1525) such that sends return success while `delivery.status` is `recipient_unresolved`. Verify by finding a unique marker in the recipient's session transcript.
- `chief-dmcheck-1536` (`id 214015171589668864`) was registered to prove the DM path and could not be deleted because `agent remove` is broken. #1524's definition of done includes removing it from `rw_7ccfea89`. Still present.
- The review lane `ar-1524-review-relay` started at **18:08**, thirty-three minutes *before* the implementer's commit at **18:41** — so it began against a branch that did not yet contain this work. Any review it produced should be re-run against `0b275149d`.

## Scope note

26 files and +702 lines across two languages is larger than three defects of this shape would suggest. Not an objection — the broker/CLI/SDK split is plausible given the defects span registration, removal, and release — but worth a deliberate look for scope creep before merge, since the commit message documents none of it.

## Related

- #1523 / #1525 — DM send reports success while `delivery.status` is `recipient_unresolved`
- #1522 — replay id + relayhistory↔relaycast join (unlabelled, blocked on a retention read)
- `AgentWorkforce/factory#243`, `#249`, `#250` — the orphaned-PR bug that stranded this branch
- `AgentWorkforce/skip#1` — Skip heartbeat crash that kills the resident Chief


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

