### PR TITLE
fix(broker): release queued startup work when the prompt is never recognised

### DIFF
--- a/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/summary.md
+++ b/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/summary.md
@@ -19,15 +19,17 @@ Implemented relay #1507: node agent attach redeems cloud-issued, scope-bound wor
 ## Key Decisions
 
 ### Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
+
 - **Chose:** Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
-- **Reasoning:** The cloud branch defines POST /v1/workspace/join-tickets/redeem with an rjt_live_ ticket scoped to node, agent, and mode. Persisting its workspace key makes later commands work, while explicitly passing it into the current attach prevents a higher-precedence ambient env key from winning.
+- **Reasoning:** The cloud branch defines POST /v1/workspace/join-tickets/redeem with an rjt*live* ticket scoped to node, agent, and mode. Persisting its workspace key makes later commands work, while explicitly passing it into the current attach prevents a higher-precedence ambient env key from winning.
 
 ---
 
 ## Chapters
 
 ### 1. Initial work
-*Agent: ar-1507-impl-relay*
+
+_Agent: ar-1507-impl-relay_
 
 - Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach: Match the relaycast-cloud #61 redemption contract and pass the redeemed key explicitly to attach
 - Cloud #61 defined a scope-bound rjt_live contract; the CLI now redeems, validates, persists, redacts, and uses the credential explicitly. Focused, full CLI, cloud, typecheck, and lint validation are green.

--- a/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/trajectory.json
+++ b/.agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/trajectory.json
@@ -44,11 +44,7 @@
           "type": "reflection",
           "content": "Cloud #61 defined a scope-bound rjt_live contract; the CLI now redeems, validates, persists, redacts, and uses the credential explicitly. Focused, full CLI, cloud, typecheck, and lint validation are green.",
           "raw": {
-            "focalPoints": [
-              "wire-contract",
-              "credential-safety",
-              "attach-precedence"
-            ],
+            "focalPoints": ["wire-contract", "credential-safety", "attach-precedence"],
             "confidence": 0.92
           },
           "significance": "high",
@@ -67,9 +63,7 @@
     "approach": "Matched relaycast-cloud #61's concrete HTTP contract, reused the existing workspace-session persistence path, kept the one-time ticket out of persistence and logs, and added contract, dispatch, precedence, error, persistence, and redaction tests.",
     "confidence": 0.92
   },
-  "commits": [
-    "c789886e4"
-  ],
+  "commits": ["c789886e4"],
   "filesChanged": [
     ".agentworkforce/trajectories/task-1507/active/traj_esvqzlbnhqbt/trajectory.json",
     "CHANGELOG.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Spawned agents receive their brief again when the harness prompt is not
+  recognised. Readiness detection reads a vendor TUI and could reject a healthy
+  session indefinitely, leaving the agent idle holding work it was never handed;
+  injected messages were withheld the same way. Queued startup work is now
+  released once the harness is live and a bounded deadline passes, with a
+  warning. A deliberate veto, such as an unanswered trust prompt, is still never
+  timed out past.
+
+
 ## [11.6.4] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   warning. A deliberate veto, such as an unanswered trust prompt, is still never
   timed out past.
 
-
 ## [11.6.4] - 2026-08-15
 
 ### Added

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -300,6 +300,18 @@ fn evaluate_startup_gate(
     }
 }
 
+/// Whether a KNOWN blocking dialog is on screen, as opposed to a prompt we
+/// simply failed to recognise.
+///
+/// The two must not be conflated. An unrecognised prompt means our heuristic is
+/// blind and the timeout should eventually release the brief anyway. A trust
+/// interstitial means the harness is deliberately not accepting work yet, and
+/// typing into it would answer a security question on the operator's behalf.
+/// `evaluate_startup_gate` vetoes it for exactly that reason.
+fn startup_gate_blocked(pty: &PtySession) -> bool {
+    detect_codex_trust_prompt(&pty.screen_text())
+}
+
 fn startup_gate_ready(
     resolved_cli: &str,
     startup_output: &str,
@@ -449,6 +461,7 @@ async fn try_emit_worker_ready(
     init_received_at: Option<Instant>,
     readiness: &mut StartupReadinessState,
     startup_ready: bool,
+    startup_blocked: bool,
 ) {
     // init_received_at is Some only after init_worker has been received.
     // We use it (not init_request_id) as the gate because the broker sends
@@ -457,8 +470,11 @@ async fn try_emit_worker_ready(
         return;
     }
 
-    let timed_out =
-        init_received_at.is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
+    // A deliberate veto is not a blind spot: never time out past a known
+    // blocking dialog, or the brief is typed into a trust prompt and answers a
+    // security question nobody asked us to answer.
+    let timed_out = !startup_blocked
+        && init_received_at.is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
 
     if !startup_ready && !timed_out {
         if !readiness.wait_warned
@@ -826,6 +842,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     &post_boot_output,
                                     &pty,
                                 );
+                                let startup_blocked = startup_gate_blocked(&pty);
                                 try_emit_worker_ready(
                                     &out_tx,
                                     &worker_name,
@@ -834,6 +851,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     init_received_at,
                                     &mut startup_readiness,
                                     startup_ready,
+                                    startup_blocked,
                                 )
                                 .await;
                             }
@@ -1218,6 +1236,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             &post_boot_output,
                             &pty,
                         );
+                                let startup_blocked = startup_gate_blocked(&pty);
                         try_emit_worker_ready(
                             &out_tx,
                             &worker_name,
@@ -1226,6 +1245,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             init_received_at,
                             &mut startup_readiness,
                             startup_ready,
+                            startup_blocked,
                         )
                         .await;
 
@@ -1788,6 +1808,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     &post_boot_output,
                     &pty,
                 );
+                                let startup_blocked = startup_gate_blocked(&pty);
                 try_emit_worker_ready(
                     &out_tx,
                     &worker_name,
@@ -1796,6 +1817,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     init_received_at,
                     &mut startup_readiness,
                     startup_ready,
+                    startup_blocked,
                 )
                 .await;
 
@@ -2210,6 +2232,7 @@ mod tests {
             Some(started),
             &mut readiness,
             false, // prompt never recognised
+            false, // and no blocking dialog on screen
         )
         .await;
 
@@ -2219,6 +2242,42 @@ mod tests {
         );
         let frame = rx.try_recv().expect("worker_ready must be emitted");
         assert_eq!(frame.msg_type, "worker_ready");
+    }
+
+    #[tokio::test]
+    async fn a_blocking_dialog_is_never_timed_out_past() {
+        // Must-not-fire. The deadline exists for a prompt we FAILED TO
+        // RECOGNISE; it must never fire past a dialog the gate deliberately
+        // vetoed. Codex's directory-trust interstitial is the case in point:
+        // releasing the brief into it would answer a security question on the
+        // operator's behalf. Raised in review on relay#1529 by two reviewers
+        // independently, and they were right — the first cut conflated
+        // "unrecognised" with "blocked".
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut request_id = None;
+        let started = Instant::now() - STARTUP_READY_TIMEOUT - Duration::from_secs(60);
+        let mut readiness = StartupReadinessState::default();
+
+        try_emit_worker_ready(
+            &tx,
+            "trust-menu-worker",
+            Some(42),
+            &mut request_id,
+            Some(started),
+            &mut readiness,
+            false, // prompt not ready
+            true,  // ...because a known blocking dialog is on screen
+        )
+        .await;
+
+        assert!(
+            !readiness.ready_sent,
+            "a deliberate veto must outlast any deadline"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no worker_ready frame may escape a trust prompt"
+        );
     }
 
     #[tokio::test]
@@ -2235,6 +2294,7 @@ mod tests {
             &mut request_id,
             Some(started),
             &mut readiness,
+            false,
             false,
         )
         .await;
@@ -2257,6 +2317,7 @@ mod tests {
             Some(started),
             &mut readiness,
             true,
+            false,
         )
         .await;
 

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -156,6 +156,20 @@ fn cli_basename(command: &str) -> &str {
 /// into startup UI and silently consumed. Harness liveness is reported to the
 /// broker independently so a live but unrecognized prompt is not reaped.
 const STARTUP_READY_WARNING: Duration = Duration::from_secs(25);
+/// Deliver queued startup work even when the prompt was never recognised.
+///
+/// Prompt detection is heuristic — it reads a vendor TUI we do not control, and
+/// Claude Code's greeting banner (which `claude_grid_ready` keys on) is not
+/// rendered on every launch. Making that heuristic load-bearing means a single
+/// upstream cosmetic change silently strands every spawned agent: the brief is
+/// held forever, nothing is injected, and the only symptom is an idle process.
+///
+/// Elapsed time is genuinely not proof of a ready prompt, which is why this is a
+/// LAST RESORT behind the real detector and why it logs at warn. But an agent
+/// that never receives its task is a total loss, while a brief typed a little
+/// early is recoverable. Bounded below `WORKER_READY_DEADLINE` (90s) so the work
+/// is released before an unready harness is reaped.
+const STARTUP_READY_TIMEOUT: Duration = Duration::from_secs(60);
 const STARTUP_BUFFER_MAX: usize = 12_000;
 const STARTUP_BUFFER_KEEP: usize = 8_000;
 const PROMPT_WINDOW_BYTES: usize = 800;
@@ -443,7 +457,10 @@ async fn try_emit_worker_ready(
         return;
     }
 
-    if !startup_ready {
+    let timed_out = init_received_at
+        .is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
+
+    if !startup_ready && !timed_out {
         if !readiness.wait_warned
             && init_received_at.is_some_and(|started| started.elapsed() >= STARTUP_READY_WARNING)
         {
@@ -456,6 +473,17 @@ async fn try_emit_worker_ready(
             readiness.wait_warned = true;
         }
         return;
+    }
+
+    if !startup_ready {
+        // Fail open, loudly. Holding the brief forever is the worse failure:
+        // it presents as a live, idle agent that silently never does its work.
+        tracing::warn!(
+            target: "agent_relay::worker::pty",
+            worker = %worker_name,
+            timeout_secs = STARTUP_READY_TIMEOUT.as_secs(),
+            "harness prompt never recognised; releasing queued startup work anyway"
+        );
     }
 
     let request_id = init_request_id.take();
@@ -2156,6 +2184,41 @@ mod tests {
                 cursor: Some((2, 1)),
             },
         ));
+    }
+
+    #[tokio::test]
+    async fn unrecognised_prompt_releases_queued_work_after_the_deadline() {
+        // The 2026-08-15 fleet outage. `claude_grid_ready` requires the literal
+        // "Welcome back" / "Welcome to " greeting, and Claude Code stopped
+        // rendering it on routine launches — three consecutive live launches on
+        // finn-mini showed a composer and no banner. With no deadline, readiness
+        // was never proven, `initial_tasks` was never released, and every
+        // spawned agent sat idle holding a brief it was never handed.
+        //
+        // Detection is heuristic against a vendor TUI. It must not be the only
+        // thing standing between a spawn and its task.
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut request_id = None;
+        let started = Instant::now() - STARTUP_READY_TIMEOUT - Duration::from_secs(1);
+        let mut readiness = StartupReadinessState::default();
+
+        try_emit_worker_ready(
+            &tx,
+            "unrecognised-prompt",
+            Some(42),
+            &mut request_id,
+            Some(started),
+            &mut readiness,
+            false, // prompt never recognised
+        )
+        .await;
+
+        assert!(
+            readiness.ready_sent,
+            "past the deadline the brief must go out; a held brief is a total loss"
+        );
+        let frame = rx.try_recv().expect("worker_ready must be emitted");
+        assert_eq!(frame.msg_type, "worker_ready");
     }
 
     #[tokio::test]

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -457,8 +457,8 @@ async fn try_emit_worker_ready(
         return;
     }
 
-    let timed_out = init_received_at
-        .is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
+    let timed_out =
+        init_received_at.is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
 
     if !startup_ready && !timed_out {
         if !readiness.wait_warned


### PR DESCRIPTION
**This is the fleet-wide dispatch outage.** Spawned agents receive no brief and agent-to-agent DMs never arrive, because both ride the same injection path and that path is gated behind a readiness check that can no longer pass.

## What broke

`claude_grid_ready` (`crates/relay-pty/src/readiness.rs`) requires a literal greeting on screen:

```rust
let has_welcome = grid.screen.contains("Welcome back") || grid.screen.contains("Welcome to ");
has_welcome && claude_prompt_row(grid)
```

**Claude Code does not render that greeting on every launch** — it depends on release / what's-new state. Three consecutive live launches on `finn-mini` on 2026-08-15 rendered a composer and **no banner**, so the gate returned `false` every time. Reproducible on demand.

Since `7ca5e2dc6` (2026-08-09) there is no escape from that verdict. `try_emit_worker_ready` returns early forever → `worker_ready` never fires → `worker_events.rs` never reaches `initial_tasks.remove(&name)`.

**The observable symptom is an agent that looks healthy and does nothing:** it boots, registers, holds a brief it is never handed, sits at 0% CPU, and writes no session transcript. Two lanes spawned this way received nothing — while the objective was present and correct on the agent record the entire time (7371 characters of it). `session_ref: null` on every spawn response was the API reporting this all along.

## How it used to work

`7ca5e2dc6` deleted exactly this:

```rust
-    let timed_out = init_received_at
-        .map(|started| started.elapsed() >= STARTUP_READY_TIMEOUT)
-        .unwrap_or(false);
-    if !startup_ready && !timed_out { return }
-    if timed_out && !startup_ready {
-        tracing::warn!("startup readiness timed out; emitting worker_ready fallback");
-    }
```

Screen detection was the fast path; a timeout was the escape hatch. Detection has always been heuristic against a vendor TUI we do not control — the timeout is what made it survivable. Removing it turned a cosmetic-string dependency into a permanent, silent outage.

## The fix

Prompt detection stays the fast path. Waiting for a real composer genuinely avoids typing into a booting TUI, and `detect_cli_ready_claude_menu_rows_not_ready` matters because Claude renders the same `❯` glyph for menu selections — releasing a brief into a trust dialog would be worse than waiting. **What changes is that the heuristic stops being load-bearing.**

Bounded at **60s**, deliberately below the existing `WORKER_READY_DEADLINE` (90s), so the work is released *before* an unready harness is reaped.

*"Elapsed time is not proof of a ready prompt"* — the removal commit was right about that, which is why this sits behind the real detector and logs at `warn`. But the tradeoff is asymmetric: **a brief typed slightly early is recoverable; an agent that never receives its task is a total loss that presents as a healthy idle process and logs nothing at an enabled level.**

## Considered and rejected

Deleting the `has_welcome` conjunct. It breaks `detect_cli_ready_claude_menu_rows_not_ready` for the reason above. The right fix is not a better cosmetic matcher — it is not depending on one.

## Verification

`unrecognised_prompt_releases_queued_work_after_the_deadline`, built from the live capture: with `startup_ready = false` past the deadline, `worker_ready` **must** be emitted. `startup_warning_preserves_work_until_real_readiness` still pins the before-deadline behaviour, so the fallback cannot fire early.

**Local `cargo test -p agent-relay-broker --lib pty_worker` is still compiling as I open this** — I will confirm the result in a comment rather than leave it implied. CI is authoritative either way.

## Not merged

Khaliq owns the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

