### PR TITLE
chore: stop format-gating generated trajectory artifacts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ packages/*/dist/
 web/content/docs/
 packages/config/src/cli-registry.generated.ts
 tests/benchmarks/head-to-head.ts
+.agentworkforce/trajectories/


### PR DESCRIPTION
`format:check` currently fails on `main`, so **every open PR fails Prettier regardless of what it changes**:

```
[warn] .agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/summary.md
[warn] .agentworkforce/trajectories/task-1507/completed/2026-08/traj_esvqzlbnhqbt/trajectory.json
```

Those files were committed by #1520 at 2026-08-15 20:34 and are **generated agent runtime output, not source**. `.prettierignore` had no rule covering them.

**Reformatting them would be the wrong fix** — they are regenerated on every run, so the next trajectory reintroduces the failure. Ignoring the directory matches how the file already treats `dist/`, `target/` and `packages/config/src/cli-registry.generated.ts`.

Verified: with this rule, `prettier --check` on both named files reports `All matched files use Prettier code style!`

Related: **#1385** adds the matching `.gitignore` rule; this is the formatter half. Unblocks **#1529**, which touches one Rust file and fails only on this.

Not merged — Khaliq owns the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

