### PR TITLE
fix(broker): model the startup gate as a verdict, not two booleans

### DIFF
--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -308,6 +308,24 @@ fn evaluate_startup_gate(
 /// interstitial means the harness is deliberately not accepting work yet, and
 /// typing into it would answer a security question on the operator's behalf.
 /// `evaluate_startup_gate` vetoes it for exactly that reason.
+/// The startup gate's verdict.
+///
+/// Three states, not two booleans: `Ready && Blocked` is not representable,
+/// and the difference between "we could not recognise the prompt" and "the
+/// harness is deliberately refusing work" decides whether the deadline may
+/// release queued work at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StartupGate {
+    /// A real input prompt was proven.
+    Ready,
+    /// No prompt recognised yet. Our heuristic may simply be blind, so the
+    /// deadline is allowed to release queued work.
+    Unrecognised,
+    /// A known blocking dialog is on screen — the harness is deliberately not
+    /// accepting input. Never released by any deadline.
+    Blocked,
+}
+
 fn startup_gate_blocked(pty: &PtySession) -> bool {
     detect_codex_trust_prompt(&pty.screen_text())
 }
@@ -460,8 +478,7 @@ async fn try_emit_worker_ready(
     init_request_id: &mut Option<RequestId>,
     init_received_at: Option<Instant>,
     readiness: &mut StartupReadinessState,
-    startup_ready: bool,
-    startup_blocked: bool,
+    gate: StartupGate,
 ) {
     // init_received_at is Some only after init_worker has been received.
     // We use it (not init_request_id) as the gate because the broker sends
@@ -473,7 +490,11 @@ async fn try_emit_worker_ready(
     // A deliberate veto is not a blind spot: never time out past a known
     // blocking dialog, or the brief is typed into a trust prompt and answers a
     // security question nobody asked us to answer.
-    let timed_out = !startup_blocked
+    let startup_ready = gate == StartupGate::Ready;
+    // A deliberate veto is not a blind spot: never time out past a known
+    // blocking dialog, or the brief is typed into a trust prompt and answers a
+    // security question nobody asked us to answer.
+    let timed_out = gate != StartupGate::Blocked
         && init_received_at.is_some_and(|started| started.elapsed() >= STARTUP_READY_TIMEOUT);
 
     if !startup_ready && !timed_out {
@@ -842,7 +863,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     &post_boot_output,
                                     &pty,
                                 );
-                                let startup_blocked = startup_gate_blocked(&pty);
+                                let gate = if startup_ready {
+                                    StartupGate::Ready
+                                } else if startup_gate_blocked(&pty) {
+                                    StartupGate::Blocked
+                                } else {
+                                    StartupGate::Unrecognised
+                                };
                                 try_emit_worker_ready(
                                     &out_tx,
                                     &worker_name,
@@ -850,8 +877,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                     &mut init_request_id,
                                     init_received_at,
                                     &mut startup_readiness,
-                                    startup_ready,
-                                    startup_blocked,
+                                    gate,
                                 )
                                 .await;
                             }
@@ -1236,7 +1262,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             &post_boot_output,
                             &pty,
                         );
-                                let startup_blocked = startup_gate_blocked(&pty);
+                                let gate = if startup_ready {
+                                    StartupGate::Ready
+                                } else if startup_gate_blocked(&pty) {
+                                    StartupGate::Blocked
+                                } else {
+                                    StartupGate::Unrecognised
+                                };
                         try_emit_worker_ready(
                             &out_tx,
                             &worker_name,
@@ -1244,8 +1276,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             &mut init_request_id,
                             init_received_at,
                             &mut startup_readiness,
-                            startup_ready,
-                            startup_blocked,
+                            gate,
                         )
                         .await;
 
@@ -1808,7 +1839,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     &post_boot_output,
                     &pty,
                 );
-                                let startup_blocked = startup_gate_blocked(&pty);
+                                let gate = if startup_ready {
+                                    StartupGate::Ready
+                                } else if startup_gate_blocked(&pty) {
+                                    StartupGate::Blocked
+                                } else {
+                                    StartupGate::Unrecognised
+                                };
                 try_emit_worker_ready(
                     &out_tx,
                     &worker_name,
@@ -1816,8 +1853,7 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     &mut init_request_id,
                     init_received_at,
                     &mut startup_readiness,
-                    startup_ready,
-                    startup_blocked,
+                    gate,
                 )
                 .await;
 
@@ -2231,8 +2267,7 @@ mod tests {
             &mut request_id,
             Some(started),
             &mut readiness,
-            false, // prompt never recognised
-            false, // and no blocking dialog on screen
+            StartupGate::Unrecognised,
         )
         .await;
 
@@ -2265,8 +2300,7 @@ mod tests {
             &mut request_id,
             Some(started),
             &mut readiness,
-            false, // prompt not ready
-            true,  // ...because a known blocking dialog is on screen
+            StartupGate::Blocked,
         )
         .await;
 
@@ -2294,8 +2328,7 @@ mod tests {
             &mut request_id,
             Some(started),
             &mut readiness,
-            false,
-            false,
+            StartupGate::Unrecognised,
         )
         .await;
 
@@ -2316,8 +2349,7 @@ mod tests {
             &mut request_id,
             Some(started),
             &mut readiness,
-            true,
-            false,
+            StartupGate::Ready,
         )
         .await;
 

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -300,14 +300,6 @@ fn evaluate_startup_gate(
     }
 }
 
-/// Whether a KNOWN blocking dialog is on screen, as opposed to a prompt we
-/// simply failed to recognise.
-///
-/// The two must not be conflated. An unrecognised prompt means our heuristic is
-/// blind and the timeout should eventually release the brief anyway. A trust
-/// interstitial means the harness is deliberately not accepting work yet, and
-/// typing into it would answer a security question on the operator's behalf.
-/// `evaluate_startup_gate` vetoes it for exactly that reason.
 /// The startup gate's verdict.
 ///
 /// Three states, not two booleans: `Ready && Blocked` is not representable,
@@ -326,6 +318,14 @@ pub(crate) enum StartupGate {
     Blocked,
 }
 
+/// Whether a KNOWN blocking dialog is on screen, as opposed to a prompt we
+/// simply failed to recognise.
+///
+/// The two must not be conflated. An unrecognised prompt means our heuristic is
+/// blind and the timeout should eventually release the brief anyway. A trust
+/// interstitial means the harness is deliberately not accepting work yet, and
+/// typing into it would answer a security question on the operator's behalf.
+/// `evaluate_startup_gate` vetoes it for exactly that reason.
 fn startup_gate_blocked(pty: &PtySession) -> bool {
     detect_codex_trust_prompt(&pty.screen_text())
 }
@@ -487,9 +487,6 @@ async fn try_emit_worker_ready(
         return;
     }
 
-    // A deliberate veto is not a blind spot: never time out past a known
-    // blocking dialog, or the brief is typed into a trust prompt and answers a
-    // security question nobody asked us to answer.
     let startup_ready = gate == StartupGate::Ready;
     // A deliberate veto is not a blind spot: never time out past a known
     // blocking dialog, or the brief is typed into a trust prompt and answers a
@@ -1262,13 +1259,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                             &post_boot_output,
                             &pty,
                         );
-                                let gate = if startup_ready {
-                                    StartupGate::Ready
-                                } else if startup_gate_blocked(&pty) {
-                                    StartupGate::Blocked
-                                } else {
-                                    StartupGate::Unrecognised
-                                };
+                        let gate = if startup_ready {
+                            StartupGate::Ready
+                        } else if startup_gate_blocked(&pty) {
+                            StartupGate::Blocked
+                        } else {
+                            StartupGate::Unrecognised
+                        };
                         try_emit_worker_ready(
                             &out_tx,
                             &worker_name,
@@ -1839,13 +1836,13 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                     &post_boot_output,
                     &pty,
                 );
-                                let gate = if startup_ready {
-                                    StartupGate::Ready
-                                } else if startup_gate_blocked(&pty) {
-                                    StartupGate::Blocked
-                                } else {
-                                    StartupGate::Unrecognised
-                                };
+                let gate = if startup_ready {
+                    StartupGate::Ready
+                } else if startup_gate_blocked(&pty) {
+                    StartupGate::Blocked
+                } else {
+                    StartupGate::Unrecognised
+                };
                 try_emit_worker_ready(
                     &out_tx,
                     &worker_name,


### PR DESCRIPTION
**Main is red.** `cargo clippy -- -D warnings` fails: `try_emit_worker_ready` has **8 arguments against a limit of 7**. My own #1529 added the eighth. Local `cargo test` does not run clippy, which is why it reached main — that is on me.

Rather than silence the lint with an `allow`, this collapses the two booleans clippy flagged into the tri-state they always were:

```rust
enum StartupGate { Ready, Unrecognised, Blocked }
```

Back to 7 arguments, and strictly better modelling. `ready && blocked` was representable and meaningless. More importantly the distinction that actually governs behaviour — **a heuristic that failed to recognise the prompt may be overridden by the deadline; a harness deliberately refusing input never may** — now lives in the type rather than a comment two call frames away. That was the exact hole two reviewers caught in #1529's first cut, so it is worth making unrepresentable.

**No behaviour change.** `Ready` is the old `startup_ready`, `Blocked` the old `startup_blocked`, `Unrecognised` the remaining case.

**Verified:** `cargo clippy -p agent-relay-broker --lib -- -D warnings` clean; `24 passed, 0 failed`, including the veto guard.

**Unrelated, for the record:** the same CI run shows `snippets::tests::mcp_preflight_requires_core_coordination_tools` failing with `Text file busy (os error 26)` — a runner race writing the MCP executable while executing it, untouched by this change. And the `Publish Package` failure on `Verify Standalone (macOS)` was **environmental**: re-running the job with no code change passed all three standalone verifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

