### PR TITLE
fix(broker): stamp resolved harness session on commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Spawned broker workers now derive `RELAY_ATTEST_SESSION_ID` from the harness session they actually run, stamp `Session-Id:` trailers across HTTP and node-control spawn paths, and log when session attribution is unavailable.
 - Agent identity recovery no longer releases seats or rotates tokens during ordinary offline presence updates.
 - Agent registration and token rotation are bounded by a deadline instead of hanging indefinitely on an existing broken record.
 - `agent remove` preserves attributed message history and no longer exposes raw database queries or bound parameters when the removal fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Spawned broker workers now derive `RELAY_ATTEST_SESSION_ID` from the harness session they actually run, stamp `Session-Id:` trailers across HTTP and node-control spawn paths, and log when session attribution is unavailable.
-- The broker's commit-attribution git hook no longer silently disables a repository's other hooks (`pre-commit`, `commit-msg`, etc.) while active, and a hook-installation failure now falls back to spawning without commit trailers instead of failing the whole worker spawn.
+- Spawned broker workers now derive `RELAY_ATTEST_SESSION_ID` from the harness session they actually run and stamp `Session-Id:` git trailers across HTTP and node-control spawn paths.
+- The broker now logs when a spawned worker has no usable session reference, instead of silently skipping `RELAY_ATTEST_SESSION_ID` injection.
+- The broker's commit-attribution git hook no longer silently disables a repository's other hooks (`pre-commit`, `commit-msg`, etc.) while active.
+- A commit-attribution hook-installation failure now falls back to spawning without commit trailers instead of failing the whole worker spawn.
 
 ## [11.6.5] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Spawned broker workers now derive `RELAY_ATTEST_SESSION_ID` from the harness session they actually run, stamp `Session-Id:` trailers across HTTP and node-control spawn paths, and log when session attribution is unavailable.
+- The broker's commit-attribution git hook no longer silently disables a repository's other hooks (`pre-commit`, `commit-msg`, etc.) while active, and a hook-installation failure now falls back to spawning without commit trailers instead of failing the whole worker spawn.
 
 ## [11.6.5] - 2026-08-15
 

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -453,6 +453,7 @@ fn should_block_pending_injection(
         && pending.queued_at.elapsed() < AUTO_SUGGESTION_BLOCK_TIMEOUT
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn try_emit_worker_ready(
     out_tx: &mpsc::Sender<ProtocolEnvelope<Value>>,
     worker_name: &str,

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -634,6 +634,7 @@ impl BrokerRuntime {
                         skip_relay_prompt,
                         spawn_workspace_id.clone(),
                         agent_result.clone(),
+                        None,
                     )
                     .await
                 {

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -620,6 +620,7 @@ impl BrokerRuntime {
                         rst.payload.skip_relay_prompt,
                         None,
                         rst.payload.agent_result.clone(),
+                        None,
                     )
                     .await
                 {

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -64,6 +64,20 @@ pub(super) fn relaycast_spawn_session_ref(ws_value: &Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+/// Read the dispatcher-issued commit attestation from an active node-control
+/// spawn request. The legacy workspace-stream bridge deserializes the same
+/// field into `SpawnParams`, but node-only `action.invoke` spawns bypass that
+/// bridge and must carry it explicitly into `WorkerRegistry::spawn`.
+pub(super) fn relaycast_spawn_commit_attestation(
+    ws_value: &Value,
+) -> Result<Option<crate::types::CommitAttestation>, serde_json::Error> {
+    let raw = ws_value
+        .pointer("/metadata/attestation")
+        .or_else(|| ws_value.pointer("/agent/metadata/attestation"))
+        .or_else(|| ws_value.get("attestation"));
+    raw.cloned().map(serde_json::from_value).transpose()
+}
+
 pub(super) fn relaycast_spawn_spec_session_id(
     cli: &str,
     session_ref: Option<&str>,
@@ -418,6 +432,19 @@ pub(super) async fn spawn_worker_from_request(
             return Err(anyhow::anyhow!(error));
         }
     };
+    let commit_attestation = match relaycast_spawn_commit_attestation(ws_value) {
+        Ok(Some(attestation)) => Some(attestation),
+        Ok(None) => None,
+        Err(error) => {
+            tracing::warn!(
+                target = "broker::spawn",
+                worker = %name,
+                error = %error,
+                "spawn request has invalid commit attestation; ledger trailers will be unavailable, but harness session attribution will still be derived"
+            );
+            None
+        }
+    };
     let require_node_registration = harness_config.as_ref().is_some_and(|config| {
         harness_metadata_flag(
             config,
@@ -668,6 +695,7 @@ pub(super) async fn spawn_worker_from_request(
             false,
             Some(workspace_id.clone()),
             None,
+            commit_attestation,
         )
         .await
     {
@@ -919,6 +947,42 @@ mod tests {
             .expect("inline config should return config");
 
         assert_eq!(config.runtime(), AgentRuntime::Pty);
+    }
+
+    #[test]
+    fn node_control_spawn_reads_nested_commit_attestation() {
+        let value = json!({
+            "metadata": {
+                "attestation": {
+                    "jti": "jti-node-control",
+                    "agentId": "agent-worker",
+                    "sponsorId": "user-owner"
+                }
+            }
+        });
+
+        let attestation = relaycast_spawn_commit_attestation(&value)
+            .expect("attestation should deserialize")
+            .expect("attestation should be present");
+
+        assert_eq!(attestation.jti, "jti-node-control");
+        assert_eq!(attestation.agent_id, "agent-worker");
+        assert_eq!(attestation.sponsor_id, "user-owner");
+        assert_eq!(attestation.session_ref, None);
+    }
+
+    #[test]
+    fn node_control_spawn_reports_malformed_commit_attestation() {
+        let value = json!({
+            "metadata": {
+                "attestation": {
+                    "jti": "jti-node-control",
+                    "agentId": "agent-worker"
+                }
+            }
+        });
+
+        assert!(relaycast_spawn_commit_attestation(&value).is_err());
     }
 
     #[test]

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -100,7 +100,13 @@ if [ -n "$RELAY_ATTEST_BROKER_HOOK_PATH" ] && [ "$existing_hooks_dir" = "$RELAY_
   exit 0
 fi
 repo_hook="$existing_hooks_dir/$hook_name"
-if [ -x "$repo_hook" ]; then
+# Guard against self-exec even if RELAY_ATTEST_BROKER_HOOK_PATH is unset or
+# stale (e.g. core.hooksPath was persisted into the repository's own config
+# by a prior spawn instead of only supplied through env): comparing against
+# $0 — this script's own invoked path — is authoritative and needs no
+# externally supplied value, so a misconfigured guard can never turn into an
+# infinite self-exec.
+if [ -x "$repo_hook" ] && [ "$repo_hook" != "$0" ]; then
   exec "$repo_hook" "$@"
 fi
 "#;
@@ -802,6 +808,54 @@ mod tests {
             !commit.status.success(),
             "the repository's pre-commit hook must still reject the commit while the broker's \
              core.hooksPath is active for attestation"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn broker_hook_never_self_execs_when_hookspath_resolves_to_its_own_directory() {
+        // Regression test for a self-recursion hang: if core.hooksPath ever
+        // resolves back to the broker's own hooks directory while
+        // RELAY_ATTEST_BROKER_HOOK_PATH is absent (e.g. a prior run persisted
+        // hooksPath into the repository's real .git/config instead of only
+        // supplying it via the ephemeral GIT_CONFIG_* env override), the
+        // forwarder must not exec itself — that recurses forever. Bounded by
+        // a timeout so a regression fails this test instead of hanging CI.
+        let repo = fixture_repository();
+        let hooks_dir = tempdir().expect("broker hooks directory");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hooks");
+        assert!(git(
+            repo.path(),
+            &[
+                "config",
+                "core.hooksPath",
+                &hooks_dir.path().to_string_lossy(),
+            ],
+            &[],
+        )
+        .status
+        .success());
+
+        let repo_path = repo.path().to_path_buf();
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            tokio::task::spawn_blocking(move || {
+                git(
+                    &repo_path,
+                    &["commit", "--allow-empty", "-m", "self-loop guard"],
+                    &[],
+                )
+            }),
+        )
+        .await;
+
+        let commit = result
+            .expect("broker hook must not hang when core.hooksPath resolves to its own directory")
+            .expect("blocking git task must not panic");
+        assert!(
+            commit.status.success(),
+            "commit must still succeed even when the hook chain can't safely forward: {}",
+            String::from_utf8_lossy(&commit.stderr)
         );
     }
 

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -16,14 +16,14 @@ use tokio::{
 use crate::cli::command_parse::parse_cli_command;
 use crate::types::CommitAttestation;
 
-const RELAY_ATTEST_JTI: &str = "RELAY_ATTEST_JTI";
-const RELAY_ATTEST_AGENT_ID: &str = "RELAY_ATTEST_AGENT_ID";
-const RELAY_ATTEST_SPONSOR_ID: &str = "RELAY_ATTEST_SPONSOR_ID";
-/// Optional: the ai-hist session UUID for the spawned agent's Claude Code or
-/// Codex session. Injected when `CommitAttestation::session_ref` is present.
-/// The hook stamps it as a `Session-Id:` git trailer so every commit carries
-/// an auditor-readable reference to the session that produced it.
-const RELAY_ATTEST_SESSION_ID: &str = "RELAY_ATTEST_SESSION_ID";
+pub(crate) const RELAY_ATTEST_JTI: &str = "RELAY_ATTEST_JTI";
+pub(crate) const RELAY_ATTEST_AGENT_ID: &str = "RELAY_ATTEST_AGENT_ID";
+pub(crate) const RELAY_ATTEST_SPONSOR_ID: &str = "RELAY_ATTEST_SPONSOR_ID";
+/// The ai-hist session UUID for the spawned agent's Claude Code or Codex
+/// session. Active worker spawns derive it from the harness session the broker
+/// resolves; legacy wrap spawns may receive it through `CommitAttestation`.
+/// The hook stamps it as a `Session-Id:` git trailer.
+pub(crate) const RELAY_ATTEST_SESSION_ID: &str = "RELAY_ATTEST_SESSION_ID";
 const RELAY_ATTEST_GIT_CONFIG_COUNT: &str = "RELAY_ATTEST_GIT_CONFIG_COUNT";
 const RELAY_ATTEST_GIT_CONFIG_INDEX: &str = "RELAY_ATTEST_GIT_CONFIG_INDEX";
 const RELAY_ATTEST_BROKER_HOOK_PATH: &str = "RELAY_ATTEST_BROKER_HOOK_PATH";
@@ -33,11 +33,15 @@ const PREPARE_COMMIT_MSG_HOOK: &str = r#"#!/bin/sh
 # chain: core.hooksPath normally replaces them entirely.
 
 message_file="$1"
-if [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; then
-  printf '\nAgent-Id: %s\nSponsor-Id: %s\nRelay-Attestation: %s\n' \
-    "$RELAY_ATTEST_AGENT_ID" \
-    "$RELAY_ATTEST_SPONSOR_ID" \
-    "$RELAY_ATTEST_JTI" >> "$message_file"
+if { [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; } || \
+   [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
+  printf '\n' >> "$message_file"
+  if [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; then
+    printf 'Agent-Id: %s\nSponsor-Id: %s\nRelay-Attestation: %s\n' \
+      "$RELAY_ATTEST_AGENT_ID" \
+      "$RELAY_ATTEST_SPONSOR_ID" \
+      "$RELAY_ATTEST_JTI" >> "$message_file"
+  fi
   if [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
     printf 'Session-Id: %s\n' "$RELAY_ATTEST_SESSION_ID" >> "$message_file"
   fi
@@ -76,8 +80,8 @@ fi
 /// Add the public commit-attribution environment supplied by a dispatcher.
 ///
 /// No metadata, or incomplete metadata, leaves the spawn environment exactly
-/// as it was. The hook path is added only by `spawn_wrap_with_token` after the
-/// broker has created its private hooks directory.
+/// as it was. Spawn paths add the hook after creating their private hooks
+/// directory.
 pub fn with_commit_attestation_env(
     mut env_vars: Vec<(String, String)>,
     attestation: Option<&CommitAttestation>,
@@ -125,7 +129,7 @@ pub fn with_commit_attestation_env(
     env_vars
 }
 
-fn attestation_env_present(env_vars: &[(String, String)]) -> bool {
+pub(crate) fn attestation_env_present(env_vars: &[(String, String)]) -> bool {
     [
         RELAY_ATTEST_JTI,
         RELAY_ATTEST_AGENT_ID,
@@ -141,11 +145,11 @@ fn attestation_env_present(env_vars: &[(String, String)]) -> bool {
     })
 }
 
-fn is_valid_attestation_value(value: &str) -> bool {
+pub(crate) fn is_valid_attestation_value(value: &str) -> bool {
     !value.trim().is_empty() && !value.chars().any(|character| character.is_control())
 }
 
-fn write_prepare_commit_msg_hook(hooks_dir: &Path) -> Result<PathBuf> {
+pub(crate) fn write_prepare_commit_msg_hook(hooks_dir: &Path) -> Result<PathBuf> {
     fs::create_dir_all(hooks_dir).context("creating broker git hooks directory")?;
     let hook_path = hooks_dir.join("prepare-commit-msg");
     fs::write(&hook_path, PREPARE_COMMIT_MSG_HOOK)
@@ -187,7 +191,7 @@ fn git_config_count_with_inherited(
     inherited_count.unwrap_or(0)
 }
 
-fn add_broker_hooks_path(env_vars: &mut Vec<(String, String)>, hooks_dir: &Path) {
+pub(crate) fn add_broker_hooks_path(env_vars: &mut Vec<(String, String)>, hooks_dir: &Path) {
     let count = git_config_count(env_vars);
     let hook_path = hooks_dir.join("prepare-commit-msg");
     env_vars.push((RELAY_ATTEST_GIT_CONFIG_COUNT.to_string(), count.to_string()));
@@ -662,6 +666,27 @@ mod tests {
         let message = commit_message(repo.path());
         assert!(message.contains("Relay-Attestation: jti-public-123"));
         assert!(message.contains(&format!("Session-Id: {session}")));
+    }
+
+    #[test]
+    fn broker_hook_appends_session_id_without_ledger_attestation() {
+        let repo = fixture_repository();
+        let hooks_dir = tempdir().expect("broker hooks directory");
+        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        let session = "session-http-spawn-1528";
+        let mut env = vec![(RELAY_ATTEST_SESSION_ID.to_string(), session.to_string())];
+        add_broker_hooks_path(&mut env, hooks_dir.path());
+
+        let commit = git(repo.path(), &["commit", "-m", "session only"], &env);
+        assert!(
+            commit.status.success(),
+            "git commit must succeed with session-only broker hook"
+        );
+        let message = commit_message(repo.path());
+        assert!(message.contains(&format!("Session-Id: {session}")));
+        assert!(!message.contains("Agent-Id:"));
+        assert!(!message.contains("Sponsor-Id:"));
+        assert!(!message.contains("Relay-Attestation:"));
     }
 
     #[test]

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -44,6 +44,10 @@ const GIT_HOOK_NAMES: &[&str] = &[
     "post-rewrite",
     "post-index-change",
     "sendemail-validate",
+    "p4-changelist",
+    "p4-prepare-changelist",
+    "p4-post-changelist",
+    "p4-pre-submit",
 ];
 
 const BROKER_GIT_HOOK: &str = r#"#!/bin/sh
@@ -105,8 +109,10 @@ repo_hook="$existing_hooks_dir/$hook_name"
 # by a prior spawn instead of only supplied through env): comparing against
 # $0 — this script's own invoked path — is authoritative and needs no
 # externally supplied value, so a misconfigured guard can never turn into an
-# infinite self-exec.
-if [ -x "$repo_hook" ] && [ "$repo_hook" != "$0" ]; then
+# infinite self-exec. Use -ef (same file, by device+inode) rather than a
+# string compare so a relative/symlinked alias of the broker's own directory
+# still resolves to "same file" instead of exec'ing (and double-stamping) it.
+if [ -x "$repo_hook" ] && ! [ "$repo_hook" -ef "$0" ]; then
   exec "$repo_hook" "$@"
 fi
 "#;
@@ -836,22 +842,23 @@ mod tests {
         .status
         .success());
 
-        let repo_path = repo.path().to_path_buf();
+        // kill_on_drop(true) makes the timeout an actual bound: unlike
+        // spawn_blocking (which tokio cannot cancel), dropping this future on
+        // timeout kills the still-running git process instead of leaking a
+        // recursive hook chain into the background.
         let result = tokio::time::timeout(
             Duration::from_secs(10),
-            tokio::task::spawn_blocking(move || {
-                git(
-                    &repo_path,
-                    &["commit", "--allow-empty", "-m", "self-loop guard"],
-                    &[],
-                )
-            }),
+            Command::new("git")
+                .current_dir(repo.path())
+                .args(["commit", "--allow-empty", "-m", "self-loop guard"])
+                .kill_on_drop(true)
+                .output(),
         )
         .await;
 
         let commit = result
             .expect("broker hook must not hang when core.hooksPath resolves to its own directory")
-            .expect("blocking git task must not panic");
+            .expect("git command must not fail to run");
         assert!(
             commit.status.success(),
             "commit must still succeed even when the hook chain can't safely forward: {}",

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -42,6 +42,7 @@ const GIT_HOOK_NAMES: &[&str] = &[
     "pre-push",
     "pre-auto-gc",
     "post-rewrite",
+    "post-index-change",
     "sendemail-validate",
 ];
 
@@ -202,6 +203,25 @@ pub(crate) fn write_broker_git_hooks(hooks_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Lazily create (or reuse) a broker git-hooks directory cached in `slot`.
+/// Shared by `Spawner` and `WorkerRegistry`, which differ only in which
+/// struct owns the cached `TempDir` handle.
+pub(crate) fn resolve_commit_hooks_dir(slot: &mut Option<tempfile::TempDir>) -> Result<&Path> {
+    if slot.is_none() {
+        let hooks_dir = tempfile::Builder::new()
+            .prefix("agent-relay-git-hooks-")
+            .tempdir()
+            .context("creating broker git hooks directory")?;
+        write_broker_git_hooks(hooks_dir.path())?;
+        *slot = Some(hooks_dir);
+    }
+
+    Ok(slot
+        .as_ref()
+        .expect("commit hooks directory is initialized")
+        .path())
+}
+
 fn git_config_count(env_vars: &[(String, String)]) -> usize {
     let inherited_count = std::env::var("GIT_CONFIG_COUNT").ok();
     git_config_count_with_inherited(env_vars, inherited_count.as_deref())
@@ -269,20 +289,7 @@ impl Spawner {
     }
 
     fn commit_hooks_dir(&mut self) -> Result<&Path> {
-        if self.commit_hooks_dir.is_none() {
-            let hooks_dir = tempfile::Builder::new()
-                .prefix("agent-relay-git-hooks-")
-                .tempdir()
-                .context("creating broker git hooks directory")?;
-            write_broker_git_hooks(hooks_dir.path())?;
-            self.commit_hooks_dir = Some(hooks_dir);
-        }
-
-        Ok(self
-            .commit_hooks_dir
-            .as_ref()
-            .expect("commit hooks directory is initialized")
-            .path())
+        resolve_commit_hooks_dir(&mut self.commit_hooks_dir)
     }
 
     pub async fn spawn_wrap_with_token(

--- a/crates/broker/src/spawner.rs
+++ b/crates/broker/src/spawner.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    fs,
-    path::{Path, PathBuf},
-    process::Stdio,
-    time::Duration,
-};
+use std::{collections::HashMap, fs, path::Path, process::Stdio, time::Duration};
 
 use crate::relaycast::configure_agent_relay_mcp_with_token;
 use anyhow::{Context, Result};
@@ -28,28 +22,58 @@ const RELAY_ATTEST_GIT_CONFIG_COUNT: &str = "RELAY_ATTEST_GIT_CONFIG_COUNT";
 const RELAY_ATTEST_GIT_CONFIG_INDEX: &str = "RELAY_ATTEST_GIT_CONFIG_INDEX";
 const RELAY_ATTEST_BROKER_HOOK_PATH: &str = "RELAY_ATTEST_BROKER_HOOK_PATH";
 
-const PREPARE_COMMIT_MSG_HOOK: &str = r#"#!/bin/sh
-# Installed by the broker through core.hooksPath. Keep repository hooks in the
-# chain: core.hooksPath normally replaces them entirely.
+/// Standard client-side git hooks (see githooks(5)). `core.hooksPath` is a
+/// single directory that replaces git's entire hook lookup, not just
+/// `prepare-commit-msg` — so the broker must install a forwarder under every
+/// name a repository might use, or an installed `pre-commit`/`commit-msg`/etc.
+/// hook silently stops firing for every attested spawn.
+const GIT_HOOK_NAMES: &[&str] = &[
+    "applypatch-msg",
+    "pre-applypatch",
+    "post-applypatch",
+    "pre-commit",
+    "pre-merge-commit",
+    "prepare-commit-msg",
+    "commit-msg",
+    "post-commit",
+    "pre-rebase",
+    "post-checkout",
+    "post-merge",
+    "pre-push",
+    "pre-auto-gc",
+    "post-rewrite",
+    "sendemail-validate",
+];
 
-message_file="$1"
-if { [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; } || \
-   [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
-  printf '\n' >> "$message_file"
-  if [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; then
-    printf 'Agent-Id: %s\nSponsor-Id: %s\nRelay-Attestation: %s\n' \
-      "$RELAY_ATTEST_AGENT_ID" \
-      "$RELAY_ATTEST_SPONSOR_ID" \
-      "$RELAY_ATTEST_JTI" >> "$message_file"
-  fi
-  if [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
-    printf 'Session-Id: %s\n' "$RELAY_ATTEST_SESSION_ID" >> "$message_file"
+const BROKER_GIT_HOOK: &str = r#"#!/bin/sh
+# Installed by the broker through core.hooksPath. One copy of this script is
+# installed under every standard hook name so core.hooksPath replacing git's
+# hook lookup doesn't silently drop hooks besides prepare-commit-msg; it
+# forwards to the repository's own same-named hook after acting.
+
+hook_name="$(basename "$0")"
+
+if [ "$hook_name" = "prepare-commit-msg" ]; then
+  message_file="$1"
+  if { [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; } || \
+     [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
+    printf '\n' >> "$message_file"
+    if [ -n "$RELAY_ATTEST_AGENT_ID" ] && [ -n "$RELAY_ATTEST_SPONSOR_ID" ] && [ -n "$RELAY_ATTEST_JTI" ]; then
+      printf 'Agent-Id: %s\nSponsor-Id: %s\nRelay-Attestation: %s\n' \
+        "$RELAY_ATTEST_AGENT_ID" \
+        "$RELAY_ATTEST_SPONSOR_ID" \
+        "$RELAY_ATTEST_JTI" >> "$message_file"
+    fi
+    if [ -n "$RELAY_ATTEST_SESSION_ID" ]; then
+      printf 'Session-Id: %s\n' "$RELAY_ATTEST_SESSION_ID" >> "$message_file"
+    fi
   fi
 fi
 
 # Resolve hooks with the broker's temporary core.hooksPath setting removed.
 # This retains both an inherited GIT_CONFIG_* hooks path and a repository's
-# configured/default hooks directory.
+# configured/default hooks directory, then chains to the same-named hook
+# there if one exists.
 original_count="${RELAY_ATTEST_GIT_CONFIG_COUNT:-0}"
 broker_index="${RELAY_ATTEST_GIT_CONFIG_INDEX:-}"
 case "$original_count" in
@@ -71,8 +95,11 @@ else
   git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
   existing_hooks_dir="$git_common_dir/hooks"
 fi
-repo_hook="$existing_hooks_dir/prepare-commit-msg"
-if [ -x "$repo_hook" ] && [ "$repo_hook" != "$RELAY_ATTEST_BROKER_HOOK_PATH" ]; then
+if [ -n "$RELAY_ATTEST_BROKER_HOOK_PATH" ] && [ "$existing_hooks_dir" = "$RELAY_ATTEST_BROKER_HOOK_PATH" ]; then
+  exit 0
+fi
+repo_hook="$existing_hooks_dir/$hook_name"
+if [ -x "$repo_hook" ]; then
   exec "$repo_hook" "$@"
 fi
 "#;
@@ -149,25 +176,30 @@ pub(crate) fn is_valid_attestation_value(value: &str) -> bool {
     !value.trim().is_empty() && !value.chars().any(|character| character.is_control())
 }
 
-pub(crate) fn write_prepare_commit_msg_hook(hooks_dir: &Path) -> Result<PathBuf> {
+/// Install the broker's forwarding hook under every name in [`GIT_HOOK_NAMES`]
+/// so pointing `core.hooksPath` at `hooks_dir` doesn't drop any hook type the
+/// target repository relies on.
+pub(crate) fn write_broker_git_hooks(hooks_dir: &Path) -> Result<()> {
     fs::create_dir_all(hooks_dir).context("creating broker git hooks directory")?;
-    let hook_path = hooks_dir.join("prepare-commit-msg");
-    fs::write(&hook_path, PREPARE_COMMIT_MSG_HOOK)
-        .context("writing broker prepare-commit-msg hook")?;
+    for name in GIT_HOOK_NAMES {
+        let hook_path = hooks_dir.join(name);
+        fs::write(&hook_path, BROKER_GIT_HOOK)
+            .with_context(|| format!("writing broker {name} hook"))?;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
 
-        let mut permissions = fs::metadata(&hook_path)
-            .context("reading broker prepare-commit-msg permissions")?
-            .permissions();
-        permissions.set_mode(0o700);
-        fs::set_permissions(&hook_path, permissions)
-            .context("making broker prepare-commit-msg hook executable")?;
+            let mut permissions = fs::metadata(&hook_path)
+                .with_context(|| format!("reading broker {name} hook permissions"))?
+                .permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(&hook_path, permissions)
+                .with_context(|| format!("making broker {name} hook executable"))?;
+        }
     }
 
-    Ok(hook_path)
+    Ok(())
 }
 
 fn git_config_count(env_vars: &[(String, String)]) -> usize {
@@ -193,12 +225,11 @@ fn git_config_count_with_inherited(
 
 pub(crate) fn add_broker_hooks_path(env_vars: &mut Vec<(String, String)>, hooks_dir: &Path) {
     let count = git_config_count(env_vars);
-    let hook_path = hooks_dir.join("prepare-commit-msg");
     env_vars.push((RELAY_ATTEST_GIT_CONFIG_COUNT.to_string(), count.to_string()));
     env_vars.push((RELAY_ATTEST_GIT_CONFIG_INDEX.to_string(), count.to_string()));
     env_vars.push((
         RELAY_ATTEST_BROKER_HOOK_PATH.to_string(),
-        hook_path.to_string_lossy().into_owned(),
+        hooks_dir.to_string_lossy().into_owned(),
     ));
     env_vars.push(("GIT_CONFIG_COUNT".to_string(), (count + 1).to_string()));
     env_vars.push((
@@ -243,7 +274,7 @@ impl Spawner {
                 .prefix("agent-relay-git-hooks-")
                 .tempdir()
                 .context("creating broker git hooks directory")?;
-            write_prepare_commit_msg_hook(hooks_dir.path())?;
+            write_broker_git_hooks(hooks_dir.path())?;
             self.commit_hooks_dir = Some(hooks_dir);
         }
 
@@ -324,8 +355,17 @@ impl Spawner {
 
         let mut child_env = env_vars.to_vec();
         if attestation_env_present(&child_env) {
-            let hooks_dir = self.commit_hooks_dir()?;
-            add_broker_hooks_path(&mut child_env, hooks_dir);
+            match self.commit_hooks_dir() {
+                Ok(hooks_dir) => add_broker_hooks_path(&mut child_env, hooks_dir),
+                Err(error) => {
+                    tracing::warn!(
+                        target = "broker::spawn",
+                        worker = %child_name,
+                        error = %error,
+                        "git attribution hook could not be installed; spawning without commit trailers"
+                    );
+                }
+            }
         }
         for (key, value) in &child_env {
             cmd.env(key, value);
@@ -518,9 +558,9 @@ mod tests {
 
     use super::{
         add_broker_hooks_path, attestation_env_present, git_config_count_with_inherited,
-        spawn_env_vars, terminate_child, with_commit_attestation_env,
-        write_prepare_commit_msg_hook, Spawner, RELAY_ATTEST_AGENT_ID, RELAY_ATTEST_JTI,
-        RELAY_ATTEST_SESSION_ID, RELAY_ATTEST_SPONSOR_ID,
+        spawn_env_vars, terminate_child, with_commit_attestation_env, write_broker_git_hooks,
+        Spawner, RELAY_ATTEST_AGENT_ID, RELAY_ATTEST_JTI, RELAY_ATTEST_SESSION_ID,
+        RELAY_ATTEST_SPONSOR_ID,
     };
 
     fn git(repo: &Path, args: &[&str], env: &[(String, String)]) -> std::process::Output {
@@ -632,7 +672,7 @@ mod tests {
     fn broker_hook_appends_all_attestation_trailers_verbatim() {
         let repo = fixture_repository();
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let values = attestation();
         let env = broker_hook_env(&values, hooks_dir.path());
 
@@ -653,7 +693,7 @@ mod tests {
     fn broker_hook_appends_session_id_trailer_when_session_ref_present() {
         let repo = fixture_repository();
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let session = "ai-hist:claudecode-abc123";
         let attest = attestation_with_session(session);
         let env = broker_hook_env(&attest, hooks_dir.path());
@@ -672,7 +712,7 @@ mod tests {
     fn broker_hook_appends_session_id_without_ledger_attestation() {
         let repo = fixture_repository();
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let session = "session-http-spawn-1528";
         let mut env = vec![(RELAY_ATTEST_SESSION_ID.to_string(), session.to_string())];
         add_broker_hooks_path(&mut env, hooks_dir.path());
@@ -707,7 +747,7 @@ mod tests {
             .expect("make repository hook executable");
 
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let env = broker_hook_env(&attestation(), hooks_dir.path());
         let commit = git(repo.path(), &["commit", "-m", "preserve local hook"], &env);
         assert!(
@@ -722,6 +762,39 @@ mod tests {
         assert!(
             message.contains("Repository-Hook: preserved"),
             "commit message: {message}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn broker_hook_chain_execs_the_repositorys_pre_commit_hook() {
+        // Regression test: core.hooksPath replaces git's entire hook lookup,
+        // not just prepare-commit-msg. Before installing forwarders for every
+        // hook name, pointing core.hooksPath at the broker's directory made
+        // git stop seeing a repository's pre-commit hook entirely, silently
+        // granting every attested spawn the same bypass `git commit -n` gives.
+        let repo = fixture_repository();
+        let repository_hook = repo.path().join(".git/hooks/pre-commit");
+        fs::write(
+            &repository_hook,
+            "#!/bin/sh\nprintf 'pre-commit rejected\\n' >&2\nexit 1\n",
+        )
+        .expect("write repository pre-commit hook");
+        let mut permissions = fs::metadata(&repository_hook)
+            .expect("repository pre-commit hook metadata")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&repository_hook, permissions)
+            .expect("make repository pre-commit hook executable");
+
+        let hooks_dir = tempdir().expect("broker hooks directory");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hooks");
+        let env = broker_hook_env(&attestation(), hooks_dir.path());
+        let commit = git(repo.path(), &["commit", "-m", "should be rejected"], &env);
+        assert!(
+            !commit.status.success(),
+            "the repository's pre-commit hook must still reject the commit while the broker's \
+             core.hooksPath is active for attestation"
         );
     }
 
@@ -752,7 +825,7 @@ mod tests {
             .expect("make configured repository hook executable");
 
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let env = broker_hook_env(&attestation(), hooks_dir.path());
         let commit = git(
             repo.path(),
@@ -796,7 +869,7 @@ mod tests {
             .expect("make home-relative repository hook executable");
 
         let hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(hooks_dir.path()).expect("write broker hook");
         let mut env = broker_hook_env(&attestation(), hooks_dir.path());
         env.push((
             "HOME".to_string(),
@@ -838,6 +911,24 @@ mod tests {
             "GIT_CONFIG_VALUE_1".to_string(),
             hooks_dir.path().to_string_lossy().into_owned(),
         )));
+    }
+
+    #[test]
+    fn write_broker_git_hooks_reports_an_unwritable_target_instead_of_panicking() {
+        // A regular file blocking the target path makes create_dir_all fail
+        // deterministically. Callers (Spawner::commit_hooks_dir,
+        // WorkerRegistry::commit_hooks_dir) must surface this as an Err they
+        // can downgrade to a warning rather than a spawn-time panic.
+        let parent = tempdir().expect("parent directory");
+        let blocking_file = parent.path().join("not-a-directory");
+        fs::write(&blocking_file, b"blocking").expect("write blocking file");
+        let unwritable_target = blocking_file.join("hooks");
+
+        let result = write_broker_git_hooks(&unwritable_target);
+        assert!(
+            result.is_err(),
+            "writing hooks under a file (not a directory) must fail"
+        );
     }
 
     #[test]
@@ -1038,7 +1129,7 @@ mod tests {
         fs::set_permissions(&inherited_hook, permissions).expect("make inherited hook executable");
 
         let broker_hooks_dir = tempdir().expect("broker hooks directory");
-        write_prepare_commit_msg_hook(broker_hooks_dir.path()).expect("write broker hook");
+        write_broker_git_hooks(broker_hooks_dir.path()).expect("write broker hook");
         let mut env = vec![
             ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
             ("GIT_CONFIG_KEY_0".to_string(), "core.hooksPath".to_string()),

--- a/crates/broker/src/types.rs
+++ b/crates/broker/src/types.rs
@@ -187,7 +187,8 @@ pub struct SpawnParams {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpawnMetadata {
     /// Public commit-attribution values supplied by the dispatcher. The broker
-    /// installs its git hook only when this complete value is present.
+    /// uses these for ledger trailers when this complete value is present.
+    /// Session trailers are derived independently from the resolved harness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attestation: Option<CommitAttestation>,
 }
@@ -198,14 +199,13 @@ pub struct CommitAttestation {
     pub jti: String,
     pub agent_id: String,
     pub sponsor_id: String,
-    /// The ai-hist session UUID for the Claude Code / Codex session in which
-    /// the spawned agent is running. When set, the broker injects it as
-    /// `RELAY_ATTEST_SESSION_ID` so the embedded `prepare-commit-msg` hook
-    /// can stamp a `Session-Id:` git trailer on every commit.
+    /// Optional dispatcher hint for the ai-hist session UUID. Active worker
+    /// spawns prefer the session resolved by the broker and inject it as
+    /// `RELAY_ATTEST_SESSION_ID` so the embedded `prepare-commit-msg` hook can
+    /// stamp a `Session-Id:` git trailer on every commit.
     ///
-    /// Populated by the dispatcher (factory) after it has a stable session
-    /// reference for the child agent. Absent for agents whose dispatcher does
-    /// not yet carry session provenance.
+    /// This remains useful to legacy spawn paths and as a fallback when the
+    /// broker already receives a stable session reference from its dispatcher.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_ref: Option<String>,
 }

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -33,7 +33,7 @@ use crate::{
     runtime::headless_provider_cli_name,
     spawner::{
         add_broker_hooks_path, attestation_env_present, is_valid_attestation_value,
-        terminate_child, with_commit_attestation_env, write_broker_git_hooks,
+        resolve_commit_hooks_dir, terminate_child, with_commit_attestation_env,
         RELAY_ATTEST_AGENT_ID, RELAY_ATTEST_JTI, RELAY_ATTEST_SESSION_ID, RELAY_ATTEST_SPONSOR_ID,
     },
 };
@@ -356,20 +356,7 @@ impl WorkerRegistry {
     }
 
     fn commit_hooks_dir(&mut self) -> Result<&Path> {
-        if self.commit_hooks_dir.is_none() {
-            let hooks_dir = tempfile::Builder::new()
-                .prefix("agent-relay-git-hooks-")
-                .tempdir()
-                .context("creating broker git hooks directory")?;
-            write_broker_git_hooks(hooks_dir.path())?;
-            self.commit_hooks_dir = Some(hooks_dir);
-        }
-
-        Ok(self
-            .commit_hooks_dir
-            .as_ref()
-            .expect("commit hooks directory is initialized")
-            .path())
+        resolve_commit_hooks_dir(&mut self.commit_hooks_dir)
     }
 
     pub(crate) fn worker_log_path(&self, worker_name: &str) -> Option<PathBuf> {

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -33,7 +33,7 @@ use crate::{
     runtime::headless_provider_cli_name,
     spawner::{
         add_broker_hooks_path, attestation_env_present, is_valid_attestation_value,
-        terminate_child, with_commit_attestation_env, write_prepare_commit_msg_hook,
+        terminate_child, with_commit_attestation_env, write_broker_git_hooks,
         RELAY_ATTEST_AGENT_ID, RELAY_ATTEST_JTI, RELAY_ATTEST_SESSION_ID, RELAY_ATTEST_SPONSOR_ID,
     },
 };
@@ -361,7 +361,7 @@ impl WorkerRegistry {
                 .prefix("agent-relay-git-hooks-")
                 .tempdir()
                 .context("creating broker git hooks directory")?;
-            write_prepare_commit_msg_hook(hooks_dir.path())?;
+            write_broker_git_hooks(hooks_dir.path())?;
             self.commit_hooks_dir = Some(hooks_dir);
         }
 
@@ -1114,8 +1114,20 @@ impl WorkerRegistry {
             );
         }
         if core_attestation_present || resolved_session_ref.is_some() {
-            let hooks_dir = self.commit_hooks_dir()?.to_path_buf();
-            add_broker_hooks_path(&mut child_env, &hooks_dir);
+            match self.commit_hooks_dir() {
+                Ok(hooks_dir) => {
+                    let hooks_dir = hooks_dir.to_path_buf();
+                    add_broker_hooks_path(&mut child_env, &hooks_dir);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target = "broker::spawn",
+                        worker = %spec.name,
+                        error = %error,
+                        "git attribution hook could not be installed; spawning without commit trailers"
+                    );
+                }
+            }
         } else if commit_attestation.is_some() {
             // Keep the attribution failure explicit even though the earlier
             // warnings name each unavailable component separately.

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     relaycast::configure_agent_relay_mcp_with_result,
     supervisor::Supervisor,
-    types::AgentResultMcpConfig,
+    types::{AgentResultMcpConfig, CommitAttestation},
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,11 @@ use uuid::Uuid;
 use crate::{
     cli::command_parse::{normalize_cli_name, parse_cli_command},
     runtime::headless_provider_cli_name,
-    spawner::terminate_child,
+    spawner::{
+        add_broker_hooks_path, attestation_env_present, is_valid_attestation_value,
+        terminate_child, with_commit_attestation_env, write_prepare_commit_msg_hook,
+        RELAY_ATTEST_AGENT_ID, RELAY_ATTEST_JTI, RELAY_ATTEST_SESSION_ID, RELAY_ATTEST_SPONSOR_ID,
+    },
 };
 
 const APP_SERVER_AUTH_ENV_KEYS: [&str; 4] = [
@@ -239,6 +243,7 @@ pub(crate) struct WorkerRegistry {
     event_tx: mpsc::Sender<WorkerEvent>,
     worker_env: Vec<(String, String)>,
     worker_logs_dir: PathBuf,
+    commit_hooks_dir: Option<tempfile::TempDir>,
     pub(crate) initial_tasks: HashMap<WorkerName, String>,
     pub(crate) supervisor: Supervisor,
     pub(crate) metrics: MetricsCollector,
@@ -343,10 +348,28 @@ impl WorkerRegistry {
             event_tx,
             worker_env,
             worker_logs_dir,
+            commit_hooks_dir: None,
             initial_tasks: HashMap::new(),
             supervisor: Supervisor::new(),
             metrics: MetricsCollector::new(broker_start),
         }
+    }
+
+    fn commit_hooks_dir(&mut self) -> Result<&Path> {
+        if self.commit_hooks_dir.is_none() {
+            let hooks_dir = tempfile::Builder::new()
+                .prefix("agent-relay-git-hooks-")
+                .tempdir()
+                .context("creating broker git hooks directory")?;
+            write_prepare_commit_msg_hook(hooks_dir.path())?;
+            self.commit_hooks_dir = Some(hooks_dir);
+        }
+
+        Ok(self
+            .commit_hooks_dir
+            .as_ref()
+            .expect("commit hooks directory is initialized")
+            .path())
     }
 
     pub(crate) fn worker_log_path(&self, worker_name: &str) -> Option<PathBuf> {
@@ -525,6 +548,7 @@ impl WorkerRegistry {
         skip_relay_prompt: bool,
         workspace_id: Option<crate::ids::WorkspaceId>,
         agent_result: Option<AgentResultMcpConfig>,
+        commit_attestation: Option<CommitAttestation>,
     ) -> Result<AgentSpec> {
         let mut spec = spec;
         if self.workers.contains_key(&spec.name) {
@@ -1011,11 +1035,102 @@ impl WorkerRegistry {
             },
         }
 
+        // All active spawn paths create or resolve the harness session inside
+        // this method. Hydrate attribution only after that happens so
+        // Session-Id always names the session the child process actually runs,
+        // rather than depending on a value that did not exist at dispatch.
+        let mut child_env = self.worker_env.clone();
+        for key in [
+            RELAY_ATTEST_JTI,
+            RELAY_ATTEST_AGENT_ID,
+            RELAY_ATTEST_SPONSOR_ID,
+            RELAY_ATTEST_SESSION_ID,
+        ] {
+            // A broker may itself be launched by an attested parent. Never let
+            // that parent's identity leak into an unattested or differently
+            // attested child through Command's inherited environment.
+            command.env_remove(key);
+        }
+        child_env.retain(|(key, _)| {
+            !matches!(
+                key.as_str(),
+                RELAY_ATTEST_JTI
+                    | RELAY_ATTEST_AGENT_ID
+                    | RELAY_ATTEST_SPONSOR_ID
+                    | RELAY_ATTEST_SESSION_ID
+            )
+        });
+        harness_env.retain(|(key, _)| {
+            !matches!(
+                key.as_str(),
+                RELAY_ATTEST_JTI
+                    | RELAY_ATTEST_AGENT_ID
+                    | RELAY_ATTEST_SPONSOR_ID
+                    | RELAY_ATTEST_SESSION_ID
+            )
+        });
+        let resolved_session_ref = spec
+            .session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| is_valid_attestation_value(value))
+            .map(str::to_string)
+            .or_else(|| {
+                commit_attestation
+                    .as_ref()
+                    .and_then(|attestation| attestation.session_ref.as_deref())
+                    .map(str::trim)
+                    .filter(|value| is_valid_attestation_value(value))
+                    .map(str::to_string)
+            });
+        child_env = with_commit_attestation_env(child_env, commit_attestation.as_ref());
+        // Session provenance belongs to the harness the broker actually
+        // launches. It is useful even when the dispatcher did not supply the
+        // optional commit-attestation envelope (the Factory HTTP spawn path),
+        // so inject it independently of the three ledger trailer values.
+        child_env.retain(|(key, _)| key != RELAY_ATTEST_SESSION_ID);
+        if let Some(session_ref) = resolved_session_ref.as_deref() {
+            child_env.push((RELAY_ATTEST_SESSION_ID.to_string(), session_ref.to_string()));
+            tracing::info!(
+                target = "broker::spawn",
+                worker = %spec.name,
+                session_ref,
+                "injecting harness session reference into spawned worker"
+            );
+        } else {
+            tracing::warn!(
+                target = "broker::spawn",
+                worker = %spec.name,
+                "spawned worker has no usable session_ref; RELAY_ATTEST_SESSION_ID will not be injected"
+            );
+        }
+
+        let core_attestation_present = attestation_env_present(&child_env);
+        if commit_attestation.is_some() && !core_attestation_present {
+            tracing::warn!(
+                target = "broker::spawn",
+                worker = %spec.name,
+                "commit attestation metadata is incomplete or invalid; Agent-Id, Sponsor-Id, and Relay-Attestation trailers will be unavailable"
+            );
+        }
+        if core_attestation_present || resolved_session_ref.is_some() {
+            let hooks_dir = self.commit_hooks_dir()?.to_path_buf();
+            add_broker_hooks_path(&mut child_env, &hooks_dir);
+        } else if commit_attestation.is_some() {
+            // Keep the attribution failure explicit even though the earlier
+            // warnings name each unavailable component separately.
+            tracing::warn!(
+                target = "broker::spawn",
+                worker = %spec.name,
+                "git attribution hook was not installed because no valid attestation values were available"
+            );
+        }
+
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        for (key, value) in &self.worker_env {
+        for (key, value) in &child_env {
             if suppress_worker_env.contains(&key.as_str()) {
                 continue;
             }
@@ -2324,11 +2439,138 @@ fn spawn_worker_reader<R>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{AppServerHarnessAuth, AppServerHarnessHost};
+    use crate::protocol::{AppServerHarnessAuth, AppServerHarnessHost, NativeHarnessConfig};
 
     fn make_registry(env: Vec<(String, String)>) -> WorkerRegistry {
         let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
         WorkerRegistry::new(tx, env, PathBuf::from("/tmp/worker-tests"), Instant::now())
+    }
+
+    #[cfg(unix)]
+    fn git(repo: &Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("git should run")
+    }
+
+    /// Exercise the production WorkerRegistry process boundary: the broker
+    /// launches a real native child, the child's live process environment has
+    /// RELAY_ATTEST_SESSION_ID, and a git commit from that process receives the
+    /// Session-Id trailer through the installed prepare-commit-msg hook.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawned_worker_environment_and_commit_carry_resolved_session_id() {
+        let repo = tempfile::tempdir().expect("fixture repository");
+        assert!(git(repo.path(), &["init", "--quiet"]).status.success());
+        assert!(git(repo.path(), &["config", "user.name", "Relay Test"])
+            .status
+            .success());
+        assert!(git(
+            repo.path(),
+            &["config", "user.email", "relay-test@example.com"]
+        )
+        .status
+        .success());
+        std::fs::write(repo.path().join("proof.txt"), "spawned worker proof\n")
+            .expect("write commit fixture");
+
+        let session_id = "session-live-spawn-1528";
+        let script = r#"
+printf '%s\n' "$RELAY_ATTEST_SESSION_ID" > observed-session.txt
+git add proof.txt observed-session.txt
+git commit --quiet -m 'attested spawned worker'
+sleep 30
+"#;
+        let spec = AgentSpec {
+            name: WorkerName::from("attested-native-worker"),
+            runtime: AgentRuntime::Headless,
+            provider: None,
+            cli: Some("sh".to_string()),
+            session_id: None,
+            harness_config: Some(ResolvedHarnessConfig::Native(NativeHarnessConfig {
+                command: "sh".to_string(),
+                args: vec!["-c".to_string(), script.to_string()],
+                cwd: Some(repo.path().to_string_lossy().into_owned()),
+                env: None,
+                session_id: session_id.to_string(),
+                metadata: None,
+            })),
+            model: None,
+            cwd: None,
+            team: None,
+            shadow_of: None,
+            shadow_mode: None,
+            args: Vec::new(),
+            channels: Vec::new(),
+            restart_policy: None,
+        };
+        let mut registry = make_registry(Vec::new());
+
+        let effective_spec = registry
+            .spawn(spec, None, None, None, true, None, None, None)
+            .await
+            .expect("attested worker should spawn");
+        assert_eq!(effective_spec.session_id.as_deref(), Some(session_id));
+
+        let pid = registry
+            .worker_pid("attested-native-worker")
+            .expect("spawned worker pid");
+        let mut observed_session = String::new();
+        for _ in 0..50 {
+            if let Ok(value) = std::fs::read_to_string(repo.path().join("observed-session.txt")) {
+                observed_session = value;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert_eq!(observed_session.trim(), session_id);
+
+        let process = std::process::Command::new("ps")
+            // BSD ps needs the third `w` to avoid truncating a long spawned
+            // command before the environment block; Linux accepts it too.
+            .args(["ewww", "-p", &pid.to_string(), "-o", "command="])
+            .output()
+            .expect("read live spawned process environment");
+        let process_environment = String::from_utf8_lossy(&process.stdout);
+        let ps_exposes_session =
+            process_environment.contains(&format!("RELAY_ATTEST_SESSION_ID={session_id}"));
+        #[cfg(target_os = "linux")]
+        assert!(
+            ps_exposes_session,
+            "spawned pid {pid} environment did not contain session id: {process_environment}"
+        );
+
+        let mut message = String::new();
+        for _ in 0..50 {
+            let output = git(repo.path(), &["log", "-1", "--format=%B"]);
+            if output.status.success() {
+                message = String::from_utf8_lossy(&output.stdout).into_owned();
+                if message.contains(&format!("Session-Id: {session_id}")) {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            message.contains(&format!("Session-Id: {session_id}")),
+            "spawned worker commit did not contain Session-Id trailer: {message}"
+        );
+
+        if ps_exposes_session {
+            eprintln!("ps eww -p {pid}: RELAY_ATTEST_SESSION_ID={session_id}");
+        } else {
+            eprintln!(
+                "ps eww -p {pid}: <platform did not expose child env>; live child recorded RELAY_ATTEST_SESSION_ID={session_id}"
+            );
+        }
+        eprintln!("git log -1 --format=%B: Session-Id: {session_id}");
+
+        registry
+            .release("attested-native-worker")
+            .await
+            .expect("release spawned worker");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `RELAY_ATTEST_SESSION_ID` was only ever injected from the dispatcher-supplied `CommitAttestation::session_ref`, which no real spawn path populates — so across all live spawns it silently stayed unset and no commit ever carried a `Session-Id:` trailer.
- The broker now derives the session reference from the harness session it actually resolves at spawn time (`spec.session_id`), falling back to the legacy `CommitAttestation::session_ref` hint only when the resolved value is unusable. This applies uniformly across all three `WorkerRegistry::spawn` call sites: the HTTP dispatch path (`runtime/api.rs`), maintenance/restart path (`runtime/maintenance.rs`), and the node-control `action.invoke` spawn path (`runtime/relaycast_events.rs`, which previously never even read the attestation envelope for the active-worker flow).
- Injection is now observable when it doesn't happen: a `tracing::warn!` fires naming the worker whenever no usable `session_ref` is available, and a separate warning fires when a dispatcher-supplied `CommitAttestation` is present but incomplete/invalid, distinguishing the two failure modes named in the issue.
- `prepare-commit-msg` hook installation and ledger-trailer stamping (`Agent-Id`/`Sponsor-Id`/`Relay-Attestation`) are now independent of `Session-Id` stamping — the hook installs whenever *either* is available, so an agent with only a resolved session (no ledger attestation) still gets its commits stamped.

## Root cause (per the issue's ask)

`CommitAttestation::session_ref` was never populated by any spawn path the broker actually takes — it existed only as a dispatcher-optional hint. The fix stops depending on that hint as the primary source and instead sources `RELAY_ATTEST_SESSION_ID` from the session the broker itself resolves for the spawned harness, which is always available for an active worker.

## Verification

- `cargo test` (full workspace: `crates/broker` + `crates/relay-pty`) — 964 + 222 passed, 0 failed.
- `crates/broker/src/worker.rs::spawned_worker_environment_and_commit_carry_resolved_session_id` is a real black-box regression test at the process boundary: it spawns a genuine native child process via `WorkerRegistry::spawn`, has that live child write its own `$RELAY_ATTEST_SESSION_ID` to a file, independently reads the live process's environment via `ps ewww -p <pid>` (the exact command form the issue's DoD specifies), and then verifies a real `git commit` made from inside that process carries `Session-Id: <session>` via `git log -1 --format=%B`. It does not use synthesized state — the environment observation and the git trailer are both read back from the live OS process/repo, matching the issue's "verify by reading the env of a live spawned process, not by reading the code" requirement.
  ```
  ps eww -p <pid>: <platform did not expose child env>; live child recorded RELAY_ATTEST_SESSION_ID=session-live-spawn-1528
  git log -1 --format=%B: Session-Id: session-live-spawn-1528
  test worker::tests::spawned_worker_environment_and_commit_carry_resolved_session_id ... ok
  ```
  (macOS `ps` does not expose a child's env block to a non-root parent, which the test documents and only hard-asserts on Linux; the in-process file write is the platform-independent proof of the live env value, and it matches what a Linux `ps eww` will show in CI.)
- `cargo fmt --check` — clean.

## Definition of done

- [x] A newly spawned agent has `RELAY_ATTEST_SESSION_ID` set in its environment (verified against a live process, not code reading).
- [x] A commit made by that agent carries a `Session-Id:` git trailer (verified via `git log --format=%B`).
- [x] When `session_ref` is genuinely unavailable, that is logged (`tracing::warn!`) rather than silently skipped.
- [ ] `factory#260` can demonstrate a real `session_ref` on a published PR — this is downstream of this fix shipping; unblocks once merged and released.

Closes AgentWorkforce/relay#1528.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

