### PR TITLE
fix(broker): reconcile live fleet inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Live broker workers missing from the Relaycast reconnect inventory are now restored from their existing agent identity, so a node-control reconnect no longer makes a still-running terminal permanently unreachable.
+
 ## [11.6.9] - 2026-08-16
 
 ### Fixed

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -233,7 +233,8 @@ pub(crate) struct BrokerRuntime {
     pub(super) fleet_inventory: HashMap<WorkerName, InventoryAgent>,
     /// Per-worker retry deadlines for failed Relaycast identity lookups while
     /// rebuilding the reconnect inventory.
-    pub(super) fleet_inventory_reconcile_retry_after: HashMap<WorkerName, Instant>,
+    pub(super) fleet_inventory_reconcile_retry_after:
+        HashMap<WorkerName, super::fleet::FleetInventoryRetry>,
     pub(super) sdk_out_tx: mpsc::Sender<ProtocolEnvelope<Value>>,
     pub(super) worker_event_rx: mpsc::Receiver<WorkerEvent>,
     pub(super) worker_events_open: bool,

--- a/crates/broker/src/runtime/event_loop.rs
+++ b/crates/broker/src/runtime/event_loop.rs
@@ -231,6 +231,9 @@ pub(crate) struct BrokerRuntime {
     pub(super) fleet_delivery_book: FleetDeliveryBook,
     pub(super) fleet_max_agents: u32,
     pub(super) fleet_inventory: HashMap<WorkerName, InventoryAgent>,
+    /// Per-worker retry deadlines for failed Relaycast identity lookups while
+    /// rebuilding the reconnect inventory.
+    pub(super) fleet_inventory_reconcile_retry_after: HashMap<WorkerName, Instant>,
     pub(super) sdk_out_tx: mpsc::Sender<ProtocolEnvelope<Value>>,
     pub(super) worker_event_rx: mpsc::Receiver<WorkerEvent>,
     pub(super) worker_events_open: bool,

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -21,6 +21,12 @@ const TERMINAL_INPUT_MAX_BASE64_BYTES: usize = TERMINAL_INPUT_MAX_BYTES * 4 / 3 
 const TERMINAL_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 const TERMINAL_INPUT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 const TERMINAL_INPUT_MAX_IN_FLIGHT_PER_SESSION: usize = 16;
+// Reconciliation runs from the broker's single event loop. Keep a transient
+// Relaycast outage or a large inventory gap from monopolizing a maintenance
+// tick; deferred workers are revisited on later ticks.
+const FLEET_INVENTORY_RECONCILE_BATCH_SIZE: usize = 2;
+const FLEET_INVENTORY_RECONCILE_LOOKUP_TIMEOUT: Duration = Duration::from_secs(2);
+const FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF: Duration = Duration::from_secs(60);
 // Relaycast currently limits a node to 32 terminal sessions. Keep that many
 // slots free from high-volume frames so every affected session can still get a
 // terminal.closed notification when the output lane applies backpressure.
@@ -1706,34 +1712,62 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
     relaycast_http: &RelaycastHttpClient,
     fleet_delivery_book: &mut FleetDeliveryBook,
     fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
+    retry_after: &mut HashMap<WorkerName, Instant>,
     live_workers: Vec<(WorkerName, Option<String>)>,
+    now: Instant,
 ) -> usize {
+    let live_worker_names: HashSet<_> = live_workers.iter().map(|(name, _)| name.clone()).collect();
+    // A worker that exits or has since been restored needs no retained retry
+    // state. This also bounds the failure cache to live, missing workers.
+    retry_after
+        .retain(|name, _| live_worker_names.contains(name) && !fleet_inventory.contains_key(name));
     let missing_workers: Vec<_> = live_workers
         .into_iter()
-        .filter(|(name, _)| !fleet_inventory.contains_key(name))
+        .filter(|(name, _)| {
+            !fleet_inventory.contains_key(name)
+                && retry_after
+                    .get(name)
+                    .is_none_or(|next_attempt| *next_attempt <= now)
+        })
+        .take(FLEET_INVENTORY_RECONCILE_BATCH_SIZE)
         .collect();
     if missing_workers.is_empty() {
         return 0;
     }
 
     let Some(relay) = relaycast_http.relay_client() else {
-        tracing::warn!(
-            missing_workers = missing_workers.len(),
-            "cannot reconcile fleet inventory without a Relaycast client"
-        );
+        // Relaycast is optional for local broker mode. Do not turn every
+        // maintenance tick into a warning when a client is not configured.
         return 0;
     };
 
     let mut repaired = 0;
     for (name, session_ref) in missing_workers {
-        let agent = match relay.get_agent(name.as_str()).await {
-            Ok(agent) => agent,
-            Err(error) => {
+        let agent = match timeout(
+            FLEET_INVENTORY_RECONCILE_LOOKUP_TIMEOUT,
+            relay.get_agent(name.as_str()),
+        )
+        .await
+        {
+            Ok(Ok(agent)) => agent,
+            Ok(Err(error)) => {
                 tracing::warn!(
                     worker = %name,
                     error = %error,
-                    "could not resolve live worker for fleet inventory reconciliation"
+                    retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
+                    "could not resolve live worker for fleet inventory reconciliation; will retry later"
                 );
+                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+                continue;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    worker = %name,
+                    timeout_secs = FLEET_INVENTORY_RECONCILE_LOOKUP_TIMEOUT.as_secs(),
+                    retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
+                    "timed out resolving live worker for fleet inventory reconciliation; will retry later"
+                );
+                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
                 continue;
             }
         };
@@ -1741,12 +1775,15 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
             tracing::warn!(
                 worker = %name,
                 resolved_name = %agent.name,
-                "refusing to reconcile fleet inventory with a mismatched Relaycast identity"
+                retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
+                "refusing to reconcile fleet inventory with a mismatched Relaycast identity; will retry later"
             );
+            retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
             continue;
         }
 
         fleet_delivery_book.bind_authoritative_identity(agent.name.clone(), agent.id.clone());
+        retry_after.remove(&name);
         fleet_inventory.insert(
             name,
             InventoryAgent {
@@ -3178,16 +3215,19 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(2);
         let mut inventory = HashMap::new();
         let mut delivery_book = FleetDeliveryBook::default();
+        let mut retry_after = HashMap::new();
 
         let repaired = reconcile_fleet_inventory_with_live_workers(
             &tx,
             &relaycast_http,
             &mut delivery_book,
             &mut inventory,
+            &mut retry_after,
             vec![(
                 WorkerName::from("live-worker"),
                 Some("session-live".to_string()),
             )],
+            Instant::now(),
         )
         .await;
 
@@ -3241,13 +3281,16 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(2);
         let mut inventory = HashMap::new();
         let mut delivery_book = FleetDeliveryBook::default();
+        let mut retry_after = HashMap::new();
 
         let repaired = reconcile_fleet_inventory_with_live_workers(
             &tx,
             &relaycast_http,
             &mut delivery_book,
             &mut inventory,
+            &mut retry_after,
             vec![(WorkerName::from("live-worker"), None)],
+            Instant::now(),
         )
         .await;
 
@@ -3259,6 +3302,206 @@ mod tests {
             "a rejected identity must not publish"
         );
         lookup.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_defers_workers_past_the_per_tick_batch() {
+        let server = MockServer::start();
+        let worker_names: Vec<_> = (0..=FLEET_INVENTORY_RECONCILE_BATCH_SIZE)
+            .map(|index| format!("live-worker-{index}"))
+            .collect();
+        let lookups: Vec<_> = worker_names
+            .iter()
+            .map(|worker_name| {
+                let path = format!("/v1/agents/{worker_name}");
+                let resolved_name = worker_name.clone();
+                let agent_id = format!("agent-{worker_name}");
+                server.mock(move |when, then| {
+                    when.method(GET)
+                        .path(path)
+                        .header("authorization", "Bearer rk_live_test");
+                    then.status(200).json_body(serde_json::json!({
+                        "ok": true,
+                        "data": {
+                            "id": agent_id,
+                            "name": resolved_name,
+                            "type": "agent",
+                            "status": "offline",
+                            "persona": null,
+                            "metadata": {}
+                        }
+                    }));
+                })
+            })
+            .collect();
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+        let mut retry_after = HashMap::new();
+        let live_workers = || {
+            worker_names
+                .iter()
+                .map(|name| (WorkerName::from(name.as_str()), None))
+                .collect()
+        };
+        let now = Instant::now();
+
+        let first_repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            &mut retry_after,
+            live_workers(),
+            now,
+        )
+        .await;
+
+        assert_eq!(first_repaired, FLEET_INVENTORY_RECONCILE_BATCH_SIZE);
+        assert_eq!(inventory.len(), FLEET_INVENTORY_RECONCILE_BATCH_SIZE);
+        for lookup in lookups.iter().take(FLEET_INVENTORY_RECONCILE_BATCH_SIZE) {
+            lookup.assert_hits(1);
+        }
+        lookups[FLEET_INVENTORY_RECONCILE_BATCH_SIZE].assert_hits(0);
+        let _ = rx.recv().await.expect("expected first batch snapshot");
+
+        let second_repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            &mut retry_after,
+            live_workers(),
+            now,
+        )
+        .await;
+
+        assert_eq!(second_repaired, 1);
+        assert_eq!(inventory.len(), FLEET_INVENTORY_RECONCILE_BATCH_SIZE + 1);
+        lookups[FLEET_INVENTORY_RECONCILE_BATCH_SIZE].assert_hits(1);
+        let _ = rx.recv().await.expect("expected second batch snapshot");
+    }
+
+    #[tokio::test]
+    async fn reconciliation_backs_off_failed_identity_lookups() {
+        let server = MockServer::start();
+        let lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/missing-worker")
+                .header("authorization", "Bearer rk_live_test");
+            then.status(404).json_body(serde_json::json!({
+                "ok": false,
+                "error": { "code": "agent_not_found", "message": "not found" }
+            }));
+        });
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, _rx) = mpsc::channel(1);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+        let mut retry_after = HashMap::new();
+        let live_workers = || vec![(WorkerName::from("missing-worker"), None)];
+        let now = Instant::now();
+
+        assert_eq!(
+            reconcile_fleet_inventory_with_live_workers(
+                &tx,
+                &relaycast_http,
+                &mut delivery_book,
+                &mut inventory,
+                &mut retry_after,
+                live_workers(),
+                now,
+            )
+            .await,
+            0
+        );
+        assert_eq!(lookup.hits(), 1);
+        assert_eq!(
+            retry_after.get(&WorkerName::from("missing-worker")),
+            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+        );
+
+        assert_eq!(
+            reconcile_fleet_inventory_with_live_workers(
+                &tx,
+                &relaycast_http,
+                &mut delivery_book,
+                &mut inventory,
+                &mut retry_after,
+                live_workers(),
+                now + Duration::from_secs(1),
+            )
+            .await,
+            0
+        );
+        assert_eq!(lookup.hits(), 1, "the backoff must suppress the next tick");
+
+        assert_eq!(
+            reconcile_fleet_inventory_with_live_workers(
+                &tx,
+                &relaycast_http,
+                &mut delivery_book,
+                &mut inventory,
+                &mut retry_after,
+                live_workers(),
+                now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            )
+            .await,
+            0
+        );
+        assert_eq!(lookup.hits(), 2, "the worker is retried after backoff");
+    }
+
+    #[tokio::test]
+    async fn reconciliation_times_out_a_slow_lookup_and_schedules_backoff() {
+        let server = MockServer::start();
+        let lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/slow-worker")
+                .header("authorization", "Bearer rk_live_test");
+            then.status(200)
+                .delay(Duration::from_secs(4))
+                .json_body(serde_json::json!({
+                    "ok": true,
+                    "data": {
+                        "id": "agent-slow-id",
+                        "name": "slow-worker",
+                        "type": "agent",
+                        "status": "offline",
+                        "persona": null,
+                        "metadata": {}
+                    }
+                }));
+        });
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, _rx) = mpsc::channel(1);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+        let mut retry_after = HashMap::new();
+        let now = Instant::now();
+
+        let repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            &mut retry_after,
+            vec![(WorkerName::from("slow-worker"), None)],
+            now,
+        )
+        .await;
+
+        assert_eq!(repaired, 0);
+        assert!(inventory.is_empty());
+        assert_eq!(lookup.hits(), 1);
+        assert_eq!(
+            retry_after.get(&WorkerName::from("slow-worker")),
+            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+        );
     }
 
     #[tokio::test]

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -1782,7 +1782,22 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
             continue;
         }
 
-        fleet_delivery_book.bind_authoritative_identity(agent.name.clone(), agent.id.clone());
+        if let Some(bound_agent_id) = fleet_delivery_book.active_agent_id(name.as_str()) {
+            if bound_agent_id != agent.id {
+                tracing::warn!(
+                    worker = %name,
+                    bound_agent_id,
+                    resolved_agent_id = %agent.id,
+                    retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
+                    "refusing to replace a live worker's authoritative fleet identity; will retry later"
+                );
+                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+                continue;
+            }
+        } else {
+            fleet_delivery_book.bind_authoritative_identity(agent.name.clone(), agent.id.clone());
+        }
+
         retry_after.remove(&name);
         fleet_inventory.insert(
             name,
@@ -3300,6 +3315,62 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "a rejected identity must not publish"
+        );
+        lookup.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_does_not_replace_an_existing_authoritative_identity() {
+        let server = MockServer::start();
+        let lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/live-worker")
+                .header("authorization", "Bearer rk_live_test");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "data": {
+                    "id": "agent-reused-name-id",
+                    "name": "live-worker",
+                    "type": "agent",
+                    "status": "offline",
+                    "persona": null,
+                    "metadata": {}
+                }
+            }));
+        });
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+        delivery_book.bind_authoritative_identity("live-worker", "agent-live-id");
+        let mut retry_after = HashMap::new();
+        let now = Instant::now();
+
+        let repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            &mut retry_after,
+            vec![(WorkerName::from("live-worker"), None)],
+            now,
+        )
+        .await;
+
+        assert_eq!(repaired, 0, "a reused name must not replace live identity");
+        assert!(inventory.is_empty());
+        assert_eq!(
+            delivery_book.active_agent_id("live-worker"),
+            Some("agent-live-id")
+        );
+        assert_eq!(
+            retry_after.get(&WorkerName::from("live-worker")),
+            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a rejected replacement must not publish"
         );
         lookup.assert_hits(1);
     }

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -31,7 +31,7 @@ const FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF: Duration = Duration::from_secs(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct FleetInventoryRetry {
-    process_id: u32,
+    generation: Uuid,
     retry_after: Instant,
 }
 // Relaycast currently limits a node to 32 terminal sessions. Keep that many
@@ -1717,13 +1717,13 @@ pub(super) async fn record_fleet_inventory_agent(
 fn schedule_fleet_inventory_retry(
     retry_after: &mut HashMap<WorkerName, FleetInventoryRetry>,
     name: WorkerName,
-    process_id: u32,
+    generation: Uuid,
     now: Instant,
 ) {
     retry_after.insert(
         name,
         FleetInventoryRetry {
-            process_id,
+            generation,
             retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
         },
     );
@@ -1738,15 +1738,15 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
     live_workers: Vec<LiveFleetInventoryCandidate>,
     now: Instant,
 ) -> usize {
-    let live_worker_processes: HashMap<_, _> = live_workers
+    let live_worker_generations: HashMap<_, _> = live_workers
         .iter()
-        .map(|worker| (worker.name.clone(), worker.process_id))
+        .map(|worker| (worker.name.clone(), worker.generation))
         .collect();
     // A worker that exits or has since been restored needs no retained retry
-    // state. A restarted same-name worker has a different PID and must not
+    // state. A restarted same-name worker has a different generation and must not
     // inherit the old process's retry deadline.
     retry_after.retain(|name, retry| {
-        live_worker_processes.get(name) == Some(&retry.process_id)
+        live_worker_generations.get(name) == Some(&retry.generation)
             && !fleet_inventory.contains_key(name)
     });
     let missing_workers: Vec<_> = live_workers
@@ -1773,7 +1773,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
     for LiveFleetInventoryCandidate {
         name,
         session_ref,
-        process_id,
+        generation,
     } in missing_workers
     {
         let agent = match timeout(
@@ -1790,7 +1790,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "could not resolve live worker for fleet inventory reconciliation; will retry later"
                 );
-                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
+                schedule_fleet_inventory_retry(retry_after, name, generation, now);
                 continue;
             }
             Err(_) => {
@@ -1800,7 +1800,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "timed out resolving live worker for fleet inventory reconciliation; will retry later"
                 );
-                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
+                schedule_fleet_inventory_retry(retry_after, name, generation, now);
                 continue;
             }
         };
@@ -1811,7 +1811,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                 retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                 "refusing to reconcile fleet inventory with a mismatched Relaycast identity; will retry later"
             );
-            schedule_fleet_inventory_retry(retry_after, name, process_id, now);
+            schedule_fleet_inventory_retry(retry_after, name, generation, now);
             continue;
         }
 
@@ -1824,7 +1824,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "refusing to replace a live worker's authoritative fleet identity; will retry later"
                 );
-                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
+                schedule_fleet_inventory_retry(retry_after, name, generation, now);
                 continue;
             }
         } else {
@@ -2277,12 +2277,12 @@ mod tests {
     fn live_fleet_worker(
         name: &str,
         session_ref: Option<&str>,
-        process_id: u32,
+        generation: u128,
     ) -> LiveFleetInventoryCandidate {
         LiveFleetInventoryCandidate {
             name: WorkerName::from(name),
             session_ref: session_ref.map(ToOwned::to_owned),
-            process_id,
+            generation: Uuid::from_u128(generation),
         }
     }
 
@@ -3409,7 +3409,7 @@ mod tests {
         assert_eq!(
             retry_after.get(&WorkerName::from("live-worker")),
             Some(&FleetInventoryRetry {
-                process_id: 103,
+                generation: Uuid::from_u128(103),
                 retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
             })
         );
@@ -3460,7 +3460,7 @@ mod tests {
             worker_names
                 .iter()
                 .enumerate()
-                .map(|(index, name)| live_fleet_worker(name, None, index as u32 + 1))
+                .map(|(index, name)| live_fleet_worker(name, None, index as u128 + 1))
                 .collect()
         };
         let now = Instant::now();
@@ -3519,7 +3519,7 @@ mod tests {
         let mut inventory = HashMap::new();
         let mut delivery_book = FleetDeliveryBook::default();
         let mut retry_after = HashMap::new();
-        let live_workers = |process_id| vec![live_fleet_worker("missing-worker", None, process_id)];
+        let live_workers = |generation| vec![live_fleet_worker("missing-worker", None, generation)];
         let now = Instant::now();
 
         assert_eq!(
@@ -3539,7 +3539,7 @@ mod tests {
         assert_eq!(
             retry_after.get(&WorkerName::from("missing-worker")),
             Some(&FleetInventoryRetry {
-                process_id: 104,
+                generation: Uuid::from_u128(104),
                 retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
             })
         );
@@ -3580,7 +3580,7 @@ mod tests {
         assert_eq!(
             retry_after.get(&WorkerName::from("missing-worker")),
             Some(&FleetInventoryRetry {
-                process_id: 105,
+                generation: Uuid::from_u128(105),
                 retry_after: now
                     + Duration::from_secs(2)
                     + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
@@ -3649,7 +3649,7 @@ mod tests {
         assert_eq!(
             retry_after.get(&WorkerName::from("slow-worker")),
             Some(&FleetInventoryRetry {
-                process_id: 106,
+                generation: Uuid::from_u128(106),
                 retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
             })
         );

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -1693,6 +1693,78 @@ pub(super) async fn record_fleet_inventory_agent(
     publish_fleet_inventory_snapshot(fleet_control_tx, fleet_inventory).await;
 }
 
+/// Restore reconnect-inventory entries for broker-owned workers that are still
+/// live locally. A successful process launch and a successful inventory write
+/// happen on separate asynchronous paths, so the inventory is a projection of
+/// the live worker registry rather than an independently authoritative list.
+///
+/// This deliberately resolves an existing Relaycast identity by name instead
+/// of calling `register_agent_token`: reconciliation must never rotate a live
+/// worker's credential merely to rebuild the reconnect snapshot.
+pub(super) async fn reconcile_fleet_inventory_with_live_workers(
+    fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
+    relaycast_http: &RelaycastHttpClient,
+    fleet_delivery_book: &mut FleetDeliveryBook,
+    fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
+    live_workers: Vec<(WorkerName, Option<String>)>,
+) -> usize {
+    let missing_workers: Vec<_> = live_workers
+        .into_iter()
+        .filter(|(name, _)| !fleet_inventory.contains_key(name))
+        .collect();
+    if missing_workers.is_empty() {
+        return 0;
+    }
+
+    let Some(relay) = relaycast_http.relay_client() else {
+        tracing::warn!(
+            missing_workers = missing_workers.len(),
+            "cannot reconcile fleet inventory without a Relaycast client"
+        );
+        return 0;
+    };
+
+    let mut repaired = 0;
+    for (name, session_ref) in missing_workers {
+        let agent = match relay.get_agent(name.as_str()).await {
+            Ok(agent) => agent,
+            Err(error) => {
+                tracing::warn!(
+                    worker = %name,
+                    error = %error,
+                    "could not resolve live worker for fleet inventory reconciliation"
+                );
+                continue;
+            }
+        };
+        if agent.name != name.as_str() {
+            tracing::warn!(
+                worker = %name,
+                resolved_name = %agent.name,
+                "refusing to reconcile fleet inventory with a mismatched Relaycast identity"
+            );
+            continue;
+        }
+
+        fleet_delivery_book.bind_authoritative_identity(agent.name.clone(), agent.id.clone());
+        fleet_inventory.insert(
+            name,
+            InventoryAgent {
+                agent_id: agent.id,
+                name: agent.name,
+                invocation_id: None,
+                session_ref,
+            },
+        );
+        repaired += 1;
+    }
+
+    if repaired > 0 {
+        publish_fleet_inventory_snapshot(fleet_control_tx, fleet_inventory).await;
+    }
+    repaired
+}
+
 /// Resolve an opaque agent token to the authoritative identity required by
 /// `inventory.sync` and delivery bookkeeping.
 ///
@@ -2115,6 +2187,7 @@ pub(super) fn fleet_initial_session_ref(spec: &AgentSpec) -> Option<String> {
 mod tests {
     use super::*;
     use crate::protocol::PtyHarnessConfig;
+    use httpmock::{Method::GET, Method::POST, MockServer};
 
     #[cfg(unix)]
     #[tokio::test]
@@ -3070,6 +3143,122 @@ mod tests {
             }
             other => panic!("expected inventory update, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn reconciliation_restores_a_live_worker_missing_from_inventory_without_reregistering() {
+        let server = MockServer::start();
+        let lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/live-worker")
+                .header("authorization", "Bearer rk_live_test");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "data": {
+                    "id": "agent-live-id",
+                    "name": "live-worker",
+                    "type": "agent",
+                    "status": "offline",
+                    "persona": null,
+                    "metadata": {}
+                }
+            }));
+        });
+        // A reconciliation must only look the already-running worker up. Any
+        // registration request can rotate its token and would recreate #1545.
+        let registration = server.mock(|when, then| {
+            when.method(POST).path("/v1/agents");
+            then.status(500).json_body(serde_json::json!({
+                "ok": false,
+                "error": { "code": "must_not_register", "message": "must not register" }
+            }));
+        });
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+
+        let repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            vec![(
+                WorkerName::from("live-worker"),
+                Some("session-live".to_string()),
+            )],
+        )
+        .await;
+
+        assert_eq!(repaired, 1, "the live orphan must be restored");
+        assert_eq!(
+            inventory.get(&WorkerName::from("live-worker")),
+            Some(&InventoryAgent {
+                agent_id: "agent-live-id".to_string(),
+                name: "live-worker".to_string(),
+                invocation_id: None,
+                session_ref: Some("session-live".to_string()),
+            })
+        );
+        assert_eq!(
+            delivery_book.active_agent_id("live-worker"),
+            Some("agent-live-id")
+        );
+        match rx.recv().await {
+            Some(FleetControlCommand::UpdateInventory(agents)) => {
+                assert_eq!(agents.len(), 1);
+                assert_eq!(agents[0].name, "live-worker");
+                assert_eq!(agents[0].agent_id, "agent-live-id");
+            }
+            other => panic!("expected repaired inventory snapshot, got {other:?}"),
+        }
+        lookup.assert_hits(1);
+        registration.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_rejects_a_name_mismatch_instead_of_binding_the_wrong_identity() {
+        let server = MockServer::start();
+        let lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/agents/live-worker")
+                .header("authorization", "Bearer rk_live_test");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "data": {
+                    "id": "agent-other-id",
+                    "name": "other-worker",
+                    "type": "agent",
+                    "status": "offline",
+                    "persona": null,
+                    "metadata": {}
+                }
+            }));
+        });
+        let relaycast_http =
+            RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "claude");
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut inventory = HashMap::new();
+        let mut delivery_book = FleetDeliveryBook::default();
+
+        let repaired = reconcile_fleet_inventory_with_live_workers(
+            &tx,
+            &relaycast_http,
+            &mut delivery_book,
+            &mut inventory,
+            vec![(WorkerName::from("live-worker"), None)],
+        )
+        .await;
+
+        assert_eq!(repaired, 0, "a mismatched name must not be reconciled");
+        assert!(inventory.is_empty());
+        assert_eq!(delivery_book.active_agent_id("live-worker"), None);
+        assert!(
+            rx.try_recv().is_err(),
+            "a rejected identity must not publish"
+        );
+        lookup.assert_hits(1);
     }
 
     #[tokio::test]

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -11,6 +11,7 @@ use crate::{
         TerminalControlCommand, TerminalControlEvent, TerminalFromCloud, TerminalMode,
         TerminalToCloud,
     },
+    worker::LiveFleetInventoryCandidate,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
@@ -27,6 +28,12 @@ const TERMINAL_INPUT_MAX_IN_FLIGHT_PER_SESSION: usize = 16;
 const FLEET_INVENTORY_RECONCILE_BATCH_SIZE: usize = 2;
 const FLEET_INVENTORY_RECONCILE_LOOKUP_TIMEOUT: Duration = Duration::from_secs(2);
 const FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct FleetInventoryRetry {
+    process_id: u32,
+    retry_after: Instant,
+}
 // Relaycast currently limits a node to 32 terminal sessions. Keep that many
 // slots free from high-volume frames so every affected session can still get a
 // terminal.closed notification when the output lane applies backpressure.
@@ -1707,27 +1714,48 @@ pub(super) async fn record_fleet_inventory_agent(
 /// This deliberately resolves an existing Relaycast identity by name instead
 /// of calling `register_agent_token`: reconciliation must never rotate a live
 /// worker's credential merely to rebuild the reconnect snapshot.
+fn schedule_fleet_inventory_retry(
+    retry_after: &mut HashMap<WorkerName, FleetInventoryRetry>,
+    name: WorkerName,
+    process_id: u32,
+    now: Instant,
+) {
+    retry_after.insert(
+        name,
+        FleetInventoryRetry {
+            process_id,
+            retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+        },
+    );
+}
+
 pub(super) async fn reconcile_fleet_inventory_with_live_workers(
     fleet_control_tx: &mpsc::Sender<FleetControlCommand>,
     relaycast_http: &RelaycastHttpClient,
     fleet_delivery_book: &mut FleetDeliveryBook,
     fleet_inventory: &mut HashMap<WorkerName, InventoryAgent>,
-    retry_after: &mut HashMap<WorkerName, Instant>,
-    live_workers: Vec<(WorkerName, Option<String>)>,
+    retry_after: &mut HashMap<WorkerName, FleetInventoryRetry>,
+    live_workers: Vec<LiveFleetInventoryCandidate>,
     now: Instant,
 ) -> usize {
-    let live_worker_names: HashSet<_> = live_workers.iter().map(|(name, _)| name.clone()).collect();
+    let live_worker_processes: HashMap<_, _> = live_workers
+        .iter()
+        .map(|worker| (worker.name.clone(), worker.process_id))
+        .collect();
     // A worker that exits or has since been restored needs no retained retry
-    // state. This also bounds the failure cache to live, missing workers.
-    retry_after
-        .retain(|name, _| live_worker_names.contains(name) && !fleet_inventory.contains_key(name));
+    // state. A restarted same-name worker has a different PID and must not
+    // inherit the old process's retry deadline.
+    retry_after.retain(|name, retry| {
+        live_worker_processes.get(name) == Some(&retry.process_id)
+            && !fleet_inventory.contains_key(name)
+    });
     let missing_workers: Vec<_> = live_workers
         .into_iter()
-        .filter(|(name, _)| {
-            !fleet_inventory.contains_key(name)
+        .filter(|worker| {
+            !fleet_inventory.contains_key(&worker.name)
                 && retry_after
-                    .get(name)
-                    .is_none_or(|next_attempt| *next_attempt <= now)
+                    .get(&worker.name)
+                    .is_none_or(|retry| retry.retry_after <= now)
         })
         .take(FLEET_INVENTORY_RECONCILE_BATCH_SIZE)
         .collect();
@@ -1742,7 +1770,12 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
     };
 
     let mut repaired = 0;
-    for (name, session_ref) in missing_workers {
+    for LiveFleetInventoryCandidate {
+        name,
+        session_ref,
+        process_id,
+    } in missing_workers
+    {
         let agent = match timeout(
             FLEET_INVENTORY_RECONCILE_LOOKUP_TIMEOUT,
             relay.get_agent(name.as_str()),
@@ -1757,7 +1790,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "could not resolve live worker for fleet inventory reconciliation; will retry later"
                 );
-                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
                 continue;
             }
             Err(_) => {
@@ -1767,7 +1800,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "timed out resolving live worker for fleet inventory reconciliation; will retry later"
                 );
-                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
                 continue;
             }
         };
@@ -1778,7 +1811,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                 retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                 "refusing to reconcile fleet inventory with a mismatched Relaycast identity; will retry later"
             );
-            retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+            schedule_fleet_inventory_retry(retry_after, name, process_id, now);
             continue;
         }
 
@@ -1791,7 +1824,7 @@ pub(super) async fn reconcile_fleet_inventory_with_live_workers(
                     retry_after_secs = FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF.as_secs(),
                     "refusing to replace a live worker's authoritative fleet identity; will retry later"
                 );
-                retry_after.insert(name, now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF);
+                schedule_fleet_inventory_retry(retry_after, name, process_id, now);
                 continue;
             }
         } else {
@@ -2240,6 +2273,18 @@ mod tests {
     use super::*;
     use crate::protocol::PtyHarnessConfig;
     use httpmock::{Method::GET, Method::POST, MockServer};
+
+    fn live_fleet_worker(
+        name: &str,
+        session_ref: Option<&str>,
+        process_id: u32,
+    ) -> LiveFleetInventoryCandidate {
+        LiveFleetInventoryCandidate {
+            name: WorkerName::from(name),
+            session_ref: session_ref.map(ToOwned::to_owned),
+            process_id,
+        }
+    }
 
     #[cfg(unix)]
     #[tokio::test]
@@ -3238,10 +3283,7 @@ mod tests {
             &mut delivery_book,
             &mut inventory,
             &mut retry_after,
-            vec![(
-                WorkerName::from("live-worker"),
-                Some("session-live".to_string()),
-            )],
+            vec![live_fleet_worker("live-worker", Some("session-live"), 101)],
             Instant::now(),
         )
         .await;
@@ -3304,7 +3346,7 @@ mod tests {
             &mut delivery_book,
             &mut inventory,
             &mut retry_after,
-            vec![(WorkerName::from("live-worker"), None)],
+            vec![live_fleet_worker("live-worker", None, 102)],
             Instant::now(),
         )
         .await;
@@ -3353,7 +3395,7 @@ mod tests {
             &mut delivery_book,
             &mut inventory,
             &mut retry_after,
-            vec![(WorkerName::from("live-worker"), None)],
+            vec![live_fleet_worker("live-worker", None, 103)],
             now,
         )
         .await;
@@ -3366,7 +3408,10 @@ mod tests {
         );
         assert_eq!(
             retry_after.get(&WorkerName::from("live-worker")),
-            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+            Some(&FleetInventoryRetry {
+                process_id: 103,
+                retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            })
         );
         assert!(
             rx.try_recv().is_err(),
@@ -3414,7 +3459,8 @@ mod tests {
         let live_workers = || {
             worker_names
                 .iter()
-                .map(|name| (WorkerName::from(name.as_str()), None))
+                .enumerate()
+                .map(|(index, name)| live_fleet_worker(name, None, index as u32 + 1))
                 .collect()
         };
         let now = Instant::now();
@@ -3473,7 +3519,7 @@ mod tests {
         let mut inventory = HashMap::new();
         let mut delivery_book = FleetDeliveryBook::default();
         let mut retry_after = HashMap::new();
-        let live_workers = || vec![(WorkerName::from("missing-worker"), None)];
+        let live_workers = |process_id| vec![live_fleet_worker("missing-worker", None, process_id)];
         let now = Instant::now();
 
         assert_eq!(
@@ -3483,7 +3529,7 @@ mod tests {
                 &mut delivery_book,
                 &mut inventory,
                 &mut retry_after,
-                live_workers(),
+                live_workers(104),
                 now,
             )
             .await,
@@ -3492,7 +3538,10 @@ mod tests {
         assert_eq!(lookup.hits(), 1);
         assert_eq!(
             retry_after.get(&WorkerName::from("missing-worker")),
-            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+            Some(&FleetInventoryRetry {
+                process_id: 104,
+                retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            })
         );
 
         assert_eq!(
@@ -3502,7 +3551,7 @@ mod tests {
                 &mut delivery_book,
                 &mut inventory,
                 &mut retry_after,
-                live_workers(),
+                live_workers(104),
                 now + Duration::from_secs(1),
             )
             .await,
@@ -3517,13 +3566,41 @@ mod tests {
                 &mut delivery_book,
                 &mut inventory,
                 &mut retry_after,
-                live_workers(),
-                now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+                live_workers(105),
+                now + Duration::from_secs(2),
             )
             .await,
             0
         );
-        assert_eq!(lookup.hits(), 2, "the worker is retried after backoff");
+        assert_eq!(
+            lookup.hits(),
+            2,
+            "a restarted same-name worker bypasses the old retry deadline"
+        );
+        assert_eq!(
+            retry_after.get(&WorkerName::from("missing-worker")),
+            Some(&FleetInventoryRetry {
+                process_id: 105,
+                retry_after: now
+                    + Duration::from_secs(2)
+                    + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            })
+        );
+
+        assert_eq!(
+            reconcile_fleet_inventory_with_live_workers(
+                &tx,
+                &relaycast_http,
+                &mut delivery_book,
+                &mut inventory,
+                &mut retry_after,
+                live_workers(105),
+                now + Duration::from_secs(2) + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            )
+            .await,
+            0
+        );
+        assert_eq!(lookup.hits(), 3, "the worker is retried after backoff");
     }
 
     #[tokio::test]
@@ -3561,7 +3638,7 @@ mod tests {
             &mut delivery_book,
             &mut inventory,
             &mut retry_after,
-            vec![(WorkerName::from("slow-worker"), None)],
+            vec![live_fleet_worker("slow-worker", None, 106)],
             now,
         )
         .await;
@@ -3571,7 +3648,10 @@ mod tests {
         assert_eq!(lookup.hits(), 1);
         assert_eq!(
             retry_after.get(&WorkerName::from("slow-worker")),
-            Some(&(now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF))
+            Some(&FleetInventoryRetry {
+                process_id: 106,
+                retry_after: now + FLEET_INVENTORY_RECONCILE_FAILURE_BACKOFF,
+            })
         );
     }
 

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -697,6 +697,7 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         // field); 0 means unlimited, matching the register manifest.
         fleet_max_agents: node_max_agents().unwrap_or(0),
         fleet_inventory: HashMap::new(),
+        fleet_inventory_reconcile_retry_after: HashMap::new(),
         sdk_out_tx,
         worker_event_rx,
         worker_events_open: true,

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -696,6 +696,20 @@ impl BrokerRuntime {
             }
         }
 
+        let live_fleet_workers = workers.live_fleet_inventory_candidates();
+        if super::fleet::reconcile_fleet_inventory_with_live_workers(
+            fleet_control_tx,
+            relaycast_http,
+            fleet_delivery_book,
+            fleet_inventory,
+            live_fleet_workers,
+        )
+        .await
+            > 0
+        {
+            fleet_load_changed = true;
+        }
+
         // Publish the fleet load snapshot once, after both reaping and restart
         // handling, so the broadcast count reflects the final post-restart live
         // worker set rather than a same-tick post-reap intermediate.

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -14,6 +14,7 @@ impl BrokerRuntime {
         let workers = &mut self.workers;
         let fleet_control_tx = &self.fleet_control_tx;
         let fleet_inventory = &mut self.fleet_inventory;
+        let fleet_inventory_reconcile_retry_after = &mut self.fleet_inventory_reconcile_retry_after;
         let fleet_delivery_book = &mut self.fleet_delivery_book;
         let fleet_max_agents = self.fleet_max_agents;
         // The broker provider's capacity handlers are live whenever it is
@@ -702,7 +703,9 @@ impl BrokerRuntime {
             relaycast_http,
             fleet_delivery_book,
             fleet_inventory,
+            fleet_inventory_reconcile_retry_after,
             live_fleet_workers,
+            now,
         )
         .await
             > 0

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -502,6 +502,30 @@ impl WorkerRegistry {
         }
     }
 
+    /// Return the live broker-owned workers that must remain present in the
+    /// Relaycast reconnect inventory. The parent marker is set by the two
+    /// production spawn surfaces (Dashboard and Relaycast); workers without it
+    /// are local-only and must not cause a fleet identity lookup.
+    pub(crate) fn live_fleet_inventory_candidates(&self) -> Vec<(WorkerName, Option<String>)> {
+        self.workers
+            .iter()
+            .filter_map(|(name, handle)| {
+                if handle.parent.is_none() || !self.is_worker_live(name) {
+                    return None;
+                }
+                let session_ref = handle.spec.session_id.clone().or_else(|| {
+                    handle
+                        .spec
+                        .harness_config
+                        .as_ref()
+                        .and_then(ResolvedHarnessConfig::session_id)
+                        .map(ToOwned::to_owned)
+                });
+                Some((name.clone(), session_ref))
+            })
+            .collect()
+    }
+
     pub(crate) fn worker_pid(&self, name: &str) -> Option<u32> {
         self.workers.get(name).and_then(|h| h.child.id())
     }

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -238,6 +238,15 @@ pub(crate) enum WorkerEvent {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveFleetInventoryCandidate {
+    pub(crate) name: WorkerName,
+    pub(crate) session_ref: Option<String>,
+    /// The wrapper PID distinguishes a restarted same-name worker from the
+    /// process whose failed Relaycast lookup is currently being backed off.
+    pub(crate) process_id: u32,
+}
+
 pub(crate) struct WorkerRegistry {
     pub(crate) workers: HashMap<WorkerName, WorkerHandle>,
     event_tx: mpsc::Sender<WorkerEvent>,
@@ -506,13 +515,14 @@ impl WorkerRegistry {
     /// Relaycast reconnect inventory. The parent marker is set by the two
     /// production spawn surfaces (Dashboard and Relaycast); workers without it
     /// are local-only and must not cause a fleet identity lookup.
-    pub(crate) fn live_fleet_inventory_candidates(&self) -> Vec<(WorkerName, Option<String>)> {
+    pub(crate) fn live_fleet_inventory_candidates(&self) -> Vec<LiveFleetInventoryCandidate> {
         self.workers
             .iter()
             .filter_map(|(name, handle)| {
                 if handle.parent.is_none() || !self.is_worker_live(name) {
                     return None;
                 }
+                let process_id = handle.child.id()?;
                 let session_ref = handle.spec.session_id.clone().or_else(|| {
                     handle
                         .spec
@@ -521,7 +531,11 @@ impl WorkerRegistry {
                         .and_then(ResolvedHarnessConfig::session_id)
                         .map(ToOwned::to_owned)
                 });
-                Some((name.clone(), session_ref))
+                Some(LiveFleetInventoryCandidate {
+                    name: name.clone(),
+                    session_ref,
+                    process_id,
+                })
             })
             .collect()
     }

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -242,9 +242,9 @@ pub(crate) enum WorkerEvent {
 pub(crate) struct LiveFleetInventoryCandidate {
     pub(crate) name: WorkerName,
     pub(crate) session_ref: Option<String>,
-    /// The wrapper PID distinguishes a restarted same-name worker from the
+    /// The process generation distinguishes a restarted same-name worker from the
     /// process whose failed Relaycast lookup is currently being backed off.
-    pub(crate) process_id: u32,
+    pub(crate) generation: Uuid,
 }
 
 pub(crate) struct WorkerRegistry {
@@ -522,7 +522,6 @@ impl WorkerRegistry {
                 if handle.parent.is_none() || !self.is_worker_live(name) {
                     return None;
                 }
-                let process_id = handle.child.id()?;
                 let session_ref = handle.spec.session_id.clone().or_else(|| {
                     handle
                         .spec
@@ -534,7 +533,7 @@ impl WorkerRegistry {
                 Some(LiveFleetInventoryCandidate {
                     name: name.clone(),
                     session_ref,
-                    process_id,
+                    generation: handle.generation,
                 })
             })
             .collect()


### PR DESCRIPTION
Fixes #1539.

## What changes

The broker maintenance tick now treats the reconnect inventory as a projection of the live worker registry:

- Enumerates only live broker-owned workers (Dashboard/Relaycast parent marker).
- For workers missing from `fleet_inventory`, resolves their existing Relaycast agent by name with read-only `get_agent`.
- Verifies the returned name, binds the existing delivery identity, restores the inventory entry, then emits one updated snapshot.
- Does not call `register_agent_token`, so repair cannot rotate a worker credential (the #1545 failure mode).
- Does not prune inventory. Lookup/client/name failures leave the entry absent and retry on the next maintenance tick; no identity is fabricated.
- Processes at most two lookups per tick, times each lookup out after two seconds, and backs off failed names for 60 seconds. This keeps a large gap or unavailable Relaycast service off the broker event loop.
- Keys retry state to the registry's UUID worker generation, so a supervisor-restarted same-name worker bypasses the old process's retry deadline immediately.
- Refuses a same-name Relaycast result whose immutable agent ID conflicts with an already-authoritative live binding; it retains the live binding and retries instead of silently changing delivery identity.

## Controlled experiment (lead hypothesis: negative)

A fresh `relay-1539-rereg-probe-0817` on finn-mini streamed before and after a cache-empty re-registration request was driven through the sf-mini broker:

| Probe | Target | Nonexistent control |
|---|---:|---:|
| Before | exit 124, 2815 bytes of PTY grid | exit 1, 417 bytes |
| After token grace expired | exit 124, 4156 bytes of PTY grid | exit 1, 434 bytes |

The cache-empty `POST /api/preflight` returned HTTP 200 / 12 bytes, and the target's original credential transitioned to HTTP 401 / 83 bytes after the grace period, proving that re-registration/token rotation actually happened. It did **not** remove the inventory route. So the #1545 mechanism is not the #1539 transition.

The frozen reproduction `verify-1535-fixtest-e-0816` was not attached, reaped, released, or restarted.

## Verification

- `cargo fmt --check`
- `cargo test -p agent-relay-broker reconciliation_ -- --nocapture` — 6 passed.
- Must-fire: temporarily removed the inventory insertion. Restore test failed, exit 101, with `left: None`, `right: Some(InventoryAgent { ... })`.
- Must-not-fire (identity): temporarily inverted the returned-name guard. Mismatch test failed, exit 101, with `left: 1`, `right: 0`.
- Must-not-fire (no re-registration): temporarily injected `register_agent_token`. The mock assertion failed, exit 101: expected 0 matching POSTs, observed 3.
- Review follow-up mutation proofs: removing the per-tick batch limit failed `3 != 2`; changing the retry boundary failed `1 != 2`; lengthening the lookup timeout failed `1 != 0`.
- Identity-reuse mutation proof: inverting the authoritative ID comparison failed `1 != 0`.
- Restart-generation mutation proof: removing PID-based retry invalidation failed `1 != 2`.
- Full `cargo test -p agent-relay-broker`: 969 passed, 9 failed, 4 ignored. Four `snippets::mcp_preflight_*` failures passed when rerun in isolation; the five persistent failures are `spawner::tests::broker_hook_*` hook-chain tests, outside this change. Details are in the follow-up PR comments.

No merge performed.
