### PR TITLE
fix(attach): close views when targets are released

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_h0wnqnadvrr8/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_h0wnqnadvrr8/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Harden relay#1548 release teardown after review
+
+> **Status:** ✅ Completed
+> **Task:** relay#1548-review
+> **Confidence:** 97%
+> **Started:** August 17, 2026 at 12:21 PM
+> **Completed:** August 17, 2026 at 12:21 PM
+
+---
+
+## Summary
+
+Addressed PR review by preserving terminal close frames through writer backpressure, clearing resize leases in the shared release lifecycle, and closing stale sessions on idempotent HTTP release.
+
+**Approach:** Verified each review finding against the transport and repo rules, added a dedicated final-frame queue with deterministic mutation-backed coverage, kept the required patch changelog heading, and reran the full broker and attach suites.
+
+---
+
+## Key Decisions
+
+### Give terminal.closed a dedicated bounded writer lane
+- **Chose:** Give terminal.closed a dedicated bounded writer lane
+- **Rejected:** Increase the shared writer queue, Block all output writes, Ignore the saturated-writer case
+- **Reasoning:** The outer queue reserved close capacity, but the inner WebSocket writer still shed every Send frame when bulk output filled its queue. A final-frame lane prioritized ahead of output preserves teardown without making output unbounded.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Give terminal.closed a dedicated bounded writer lane: Give terminal.closed a dedicated bounded writer lane

--- a/.agentworkforce/trajectories/completed/2026-08/traj_h0wnqnadvrr8/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_h0wnqnadvrr8/trajectory.json
@@ -1,0 +1,70 @@
+{
+  "id": "traj_h0wnqnadvrr8",
+  "version": 1,
+  "task": {
+    "title": "Harden relay#1548 release teardown after review",
+    "source": {
+      "system": "plain",
+      "id": "relay#1548-review"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-17T10:21:45.810Z",
+  "completedAt": "2026-08-17T10:21:47.401Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-17T10:21:46.698Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_d07hc2jdhbls",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-17T10:21:46.698Z",
+      "endedAt": "2026-08-17T10:21:47.401Z",
+      "events": [
+        {
+          "ts": 1786962106698,
+          "type": "decision",
+          "content": "Give terminal.closed a dedicated bounded writer lane: Give terminal.closed a dedicated bounded writer lane",
+          "raw": {
+            "question": "Give terminal.closed a dedicated bounded writer lane",
+            "chosen": "Give terminal.closed a dedicated bounded writer lane",
+            "alternatives": [
+              {
+                "option": "Increase the shared writer queue",
+                "reason": ""
+              },
+              {
+                "option": "Block all output writes",
+                "reason": ""
+              },
+              {
+                "option": "Ignore the saturated-writer case",
+                "reason": ""
+              }
+            ],
+            "reasoning": "The outer queue reserved close capacity, but the inner WebSocket writer still shed every Send frame when bulk output filled its queue. A final-frame lane prioritized ahead of output preserves teardown without making output unbounded."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR review by preserving terminal close frames through writer backpressure, clearing resize leases in the shared release lifecycle, and closing stale sessions on idempotent HTTP release.",
+    "approach": "Verified each review finding against the transport and repo rules, added a dedicated final-frame queue with deterministic mutation-backed coverage, kept the required patch changelog heading, and reran the full broker and attach suites.",
+    "confidence": 0.97
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "8391b6b6800a771ffabe8adccfa1015b98ae9e34",
+    "endRef": "8391b6b6800a771ffabe8adccfa1015b98ae9e34"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_hx6d4m1gz0wt/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_hx6d4m1gz0wt/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Finalize relay#1548 teardown review
+
+> **Status:** ✅ Completed
+> **Task:** relay#1548-review-2
+> **Confidence:** 98%
+> **Started:** August 17, 2026 at 12:40 PM
+> **Completed:** August 17, 2026 at 12:41 PM
+
+---
+
+## Summary
+
+Resolved the final teardown review findings: release closes remain nonblocking at the reserved outer queue, and shutdown now reliably sends its queued WebSocket close even when the final-frame lane is empty. Added a loopback WebSocket regression test and proved its mutation fails.
+
+**Approach:** Audited both queue layers and the biased writer select, restored nonblocking outer enqueueing, retained the inner final-frame lane, removed the premature sender drop, and validated with the full broker suite plus targeted mutation.
+
+---
+
+## Key Decisions
+
+### Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown
+- **Chose:** Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown
+- **Rejected:** Await outer queue admission and risk stalling broker events, Drop final_tx before awaiting the writer and risk suppressing the WebSocket close
+- **Reasoning:** The broker event loop must not await a congested transport queue; its 1,024-slot queue reserves 32 slots for the maximum 32 live terminal sessions, while the dedicated inner final lane protects close frames from bulk output backpressure. Keeping final_tx alive prevents an empty closed final lane from winning the biased writer select before the queued priority WebSocket Close.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown: Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown

--- a/.agentworkforce/trajectories/completed/2026-08/traj_hx6d4m1gz0wt/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_hx6d4m1gz0wt/trajectory.json
@@ -1,0 +1,66 @@
+{
+  "id": "traj_hx6d4m1gz0wt",
+  "version": 1,
+  "task": {
+    "title": "Finalize relay#1548 teardown review",
+    "source": {
+      "system": "plain",
+      "id": "relay#1548-review-2"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-17T10:40:55.690Z",
+  "completedAt": "2026-08-17T10:41:15.595Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-17T10:41:09.798Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_0wa33hy1f7dr",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-17T10:41:09.798Z",
+      "endedAt": "2026-08-17T10:41:15.595Z",
+      "events": [
+        {
+          "ts": 1786963269799,
+          "type": "decision",
+          "content": "Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown: Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown",
+          "raw": {
+            "question": "Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown",
+            "chosen": "Keep worker-release finalization nonblocking at the outer queue and preserve the final-frame sender through WebSocket shutdown",
+            "alternatives": [
+              {
+                "option": "Await outer queue admission and risk stalling broker events",
+                "reason": ""
+              },
+              {
+                "option": "Drop final_tx before awaiting the writer and risk suppressing the WebSocket close",
+                "reason": ""
+              }
+            ],
+            "reasoning": "The broker event loop must not await a congested transport queue; its 1,024-slot queue reserves 32 slots for the maximum 32 live terminal sessions, while the dedicated inner final lane protects close frames from bulk output backpressure. Keeping final_tx alive prevents an empty closed final lane from winning the biased writer select before the queued priority WebSocket Close."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Resolved the final teardown review findings: release closes remain nonblocking at the reserved outer queue, and shutdown now reliably sends its queued WebSocket close even when the final-frame lane is empty. Added a loopback WebSocket regression test and proved its mutation fails.",
+    "approach": "Audited both queue layers and the biased writer select, restored nonblocking outer enqueueing, retained the inner final-frame lane, removed the premature sender drop, and validated with the full broker suite plus targeted mutation.",
+    "confidence": 0.98
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "3ca237f782869f4d2e323cbf666001a4c578741b",
+    "endRef": "3ca237f782869f4d2e323cbf666001a4c578741b"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_vud9qvfm0vwg/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_vud9qvfm0vwg/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix view attach teardown signal when target disappears
+
+> **Status:** ✅ Completed
+> **Task:** relay#1548
+> **Confidence:** 96%
+> **Started:** August 17, 2026 at 11:41 AM
+> **Completed:** August 17, 2026 at 12:07 PM
+
+---
+
+## Summary
+
+Fixed fleet view attach teardown on released targets, added paired must-fire/must-not-fire coverage and mutation proofs, reproduced the defect live against a Daytona target, and validated broker plus CLI surfaces.
+
+**Approach:** Traced the shared terminal adapter and release paths, established resume semantics, centralized terminal-session finalization at successful worker release, reused it for local HTTP release, and tested both broker lifecycle output and client-visible WebSocket close behavior.
+
+---
+
+## Key Decisions
+
+### Fix the fleet action-release lifecycle rather than adding a view-client-only close
+- **Chose:** Fix the fleet action-release lifecycle rather than adding a view-client-only close
+- **Reasoning:** Drive and view already share terminal.closed -> WS 1011 handling. Fleet action release is the only examined worker-disappearance path that omits dependent terminal-session finalization; transient terminal-lane disconnect retains its existing resume path.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Fix the fleet action-release lifecycle rather than adding a view-client-only close: Fix the fleet action-release lifecycle rather than adding a view-client-only close
+- The asymmetry is release-lifecycle-specific: fleet release omitted terminal finalization, while drive only surfaced closure after input failure. The fix now centralizes worker terminal cleanup, preserves transient transport resume, and paired lifecycle plus loopback tests prove target close and healthy-idle non-close. Both deliberate mutations failed at the intended assertions, and the live pre-fix run reproduced silence versus drive 1011.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_vud9qvfm0vwg/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_vud9qvfm0vwg/trajectory.json
@@ -1,0 +1,82 @@
+{
+  "id": "traj_vud9qvfm0vwg",
+  "version": 1,
+  "task": {
+    "title": "Fix view attach teardown signal when target disappears",
+    "source": {
+      "system": "plain",
+      "id": "relay#1548"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-17T09:41:29.295Z",
+  "completedAt": "2026-08-17T10:07:46.348Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-17T09:44:37.363Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_od89sarsbfdl",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-17T09:44:37.363Z",
+      "endedAt": "2026-08-17T10:07:46.348Z",
+      "events": [
+        {
+          "ts": 1786959877363,
+          "type": "decision",
+          "content": "Fix the fleet action-release lifecycle rather than adding a view-client-only close: Fix the fleet action-release lifecycle rather than adding a view-client-only close",
+          "raw": {
+            "question": "Fix the fleet action-release lifecycle rather than adding a view-client-only close",
+            "chosen": "Fix the fleet action-release lifecycle rather than adding a view-client-only close",
+            "alternatives": [],
+            "reasoning": "Drive and view already share terminal.closed -> WS 1011 handling. Fleet action release is the only examined worker-disappearance path that omits dependent terminal-session finalization; transient terminal-lane disconnect retains its existing resume path."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1786961265804,
+          "type": "reflection",
+          "content": "The asymmetry is release-lifecycle-specific: fleet release omitted terminal finalization, while drive only surfaced closure after input failure. The fix now centralizes worker terminal cleanup, preserves transient transport resume, and paired lifecycle plus loopback tests prove target close and healthy-idle non-close. Both deliberate mutations failed at the intended assertions, and the live pre-fix run reproduced silence versus drive 1011.",
+          "raw": {
+            "focalPoints": [
+              "protocol trace",
+              "resume semantics",
+              "paired tests",
+              "mutation proof",
+              "live reproduction"
+            ],
+            "adjustments": "Kept transport reconnect behavior unchanged; moved finalization into release_worker_locally so every caller gets the worker-disappearance signal.",
+            "confidence": 0.96
+          },
+          "significance": "high",
+          "tags": [
+            "focal:protocol trace",
+            "focal:resume semantics",
+            "focal:paired tests",
+            "focal:mutation proof",
+            "focal:live reproduction",
+            "confidence:0.96"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed fleet view attach teardown on released targets, added paired must-fire/must-not-fire coverage and mutation proofs, reproduced the defect live against a Daytona target, and validated broker plus CLI surfaces.",
+    "approach": "Traced the shared terminal adapter and release paths, established resume semantics, centralized terminal-session finalization at successful worker release, reused it for local HTTP release, and tested both broker lifecycle output and client-visible WebSocket close behavior.",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "e3217d29001a7d3688dc62ba42ccfd1b80aac15e",
+    "endRef": "e3217d29001a7d3688dc62ba42ccfd1b80aac15e"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Live broker workers missing from the Relaycast reconnect inventory are now restored from their existing agent identity, so a node-control reconnect no longer makes a still-running terminal permanently unreachable.
+- Fleet view attach now closes with a code and reason when its target is released instead of remaining silently open like a healthy idle stream.
 
 ## [11.6.10] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Live broker workers missing from the Relaycast reconnect inventory are now restored from their existing agent identity, so a node-control reconnect no longer makes a still-running terminal permanently unreachable.
-- Fleet view attach now closes with a code and reason when its target is released instead of remaining silently open like a healthy idle stream.
+- `agent-relay node agent attach --node` view sessions now close with a terminal code and reason immediately when their target worker is released.
 
 ## [11.6.10] - 2026-08-17
 

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1,7 +1,5 @@
-use super::fleet::try_send_terminal;
 use super::*;
 use crate::relaycast::retry_agent_registration;
-use crate::terminal_control::TerminalToCloud;
 use relaycast::{
     CreateObserverTokenRequest, ObserverScope, ObserverToken, ObserverTokenFilters, RelayError,
 };
@@ -929,28 +927,15 @@ impl BrokerRuntime {
                         fail_pending_requests_for_worker(pending_requests, &name, "agent_released");
                         resize_owners.remove(&name);
                         pty_observability.remove(&name);
-                        let terminal_session_ids: Vec<String> = terminal_sessions
-                            .iter()
-                            .filter(|(_, session)| session.agent == name)
-                            .map(|(session_id, _)| session_id.clone())
-                            .collect();
-                        for session_id in terminal_session_ids {
-                            terminal_sessions.remove(&session_id);
-                            terminal_snapshot_requests
-                                .retain(|_, pending| pending.session_id != session_id);
-                            terminal_input_requests
-                                .retain(|_, pending| pending.session_id != session_id);
-                            if !try_send_terminal(
-                                terminal_control_tx,
-                                TerminalToCloud::Closed {
-                                    session_id: session_id.clone(),
-                                    code: Some("agent_released".into()),
-                                    message: Some("terminal worker was released".into()),
-                                },
-                            ) {
-                                tracing::warn!(target = "relay_broker::terminal", session_id = %session_id, "terminal queue full or closed while closing released worker session");
-                            }
-                        }
+                        super::fleet::close_terminal_sessions_for_worker(
+                            terminal_control_tx,
+                            terminal_sessions,
+                            terminal_snapshot_requests,
+                            terminal_input_requests,
+                            &name,
+                            "agent_released",
+                            "terminal worker was released",
+                        );
                         delivery_states.remove(&name);
                         agent_result_tokens.retain(|_, agent| agent != &name);
                         state.agents.remove(&name);

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -935,8 +935,7 @@ impl BrokerRuntime {
                             &name,
                             "agent_released",
                             "terminal worker was released",
-                        )
-                        .await;
+                        );
                         delivery_states.remove(&name);
                         agent_result_tokens.retain(|_, agent| agent != &name);
                         state.agents.remove(&name);
@@ -1044,8 +1043,7 @@ impl BrokerRuntime {
                                 &name,
                                 "agent_released",
                                 "terminal worker was released",
-                            )
-                            .await;
+                            );
                             state.agents.remove(&name);
                             if paths.persist {
                                 let _ = state.save(&paths.state);

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1031,6 +1031,19 @@ impl BrokerRuntime {
                                     Some(error.to_string())
                                 }
                             };
+                            // Idempotent release is still terminal for any stale
+                            // attach state left behind after the process exited.
+                            resize_owners.remove(&name);
+                            pty_observability.remove(&name);
+                            super::fleet::close_terminal_sessions_for_worker(
+                                terminal_control_tx,
+                                terminal_sessions,
+                                terminal_snapshot_requests,
+                                terminal_input_requests,
+                                &name,
+                                "agent_released",
+                                "terminal worker was released",
+                            );
                             state.agents.remove(&name);
                             if paths.persist {
                                 let _ = state.save(&paths.state);

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -935,7 +935,8 @@ impl BrokerRuntime {
                             &name,
                             "agent_released",
                             "terminal worker was released",
-                        );
+                        )
+                        .await;
                         delivery_states.remove(&name);
                         agent_result_tokens.retain(|_, agent| agent != &name);
                         state.agents.remove(&name);
@@ -1043,7 +1044,8 @@ impl BrokerRuntime {
                                 &name,
                                 "agent_released",
                                 "terminal worker was released",
-                            );
+                            )
+                            .await;
                             state.agents.remove(&name);
                             if paths.persist {
                                 let _ = state.save(&paths.state);

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -108,6 +108,48 @@ pub(super) fn fail_terminal_session(
     }
 }
 
+/// End every terminal session bound to a worker that has permanently gone away.
+///
+/// A terminal-lane disconnect is intentionally handled elsewhere so Relaycast
+/// can resume the same live session. Worker release is different: there is no
+/// target left for a view or drive client to resume, so every dependent session
+/// must receive a final `terminal.closed` frame.
+pub(super) fn close_terminal_sessions_for_worker(
+    terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
+    terminal_sessions: &mut HashMap<String, TerminalSession>,
+    terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
+    terminal_input_requests: &mut HashMap<String, TerminalInputRequest>,
+    agent: &WorkerName,
+    code: &str,
+    message: &str,
+) {
+    let session_ids: Vec<String> = terminal_sessions
+        .iter()
+        .filter(|(_, session)| session.agent == *agent)
+        .map(|(session_id, _)| session_id.clone())
+        .collect();
+    for session_id in session_ids {
+        terminal_sessions.remove(&session_id);
+        terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
+        terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
+        if !try_send_terminal(
+            terminal_control_tx,
+            TerminalToCloud::Closed {
+                session_id: session_id.clone(),
+                code: Some(code.into()),
+                message: Some(message.into()),
+            },
+        ) {
+            tracing::warn!(
+                target = "relay_broker::terminal",
+                session_id = %session_id,
+                worker = %agent,
+                "terminal queue full or closed while closing disappeared worker session"
+            );
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct PendingVerifiedSpawn {
     pub(super) invocation_id: String,
@@ -1287,6 +1329,10 @@ impl BrokerRuntime {
             &mut self.pending_requests,
             &mut self.delivery_states,
             &mut self.agent_result_tokens,
+            &self.terminal_control_tx,
+            &mut self.terminal_sessions,
+            &mut self.terminal_snapshot_requests,
+            &mut self.terminal_input_requests,
         )
         .await;
 

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -109,7 +109,7 @@ pub(super) fn fail_terminal_session(
 /// can resume the same live session. Worker release is different: there is no
 /// target left for a view or drive client to resume, so every dependent session
 /// must receive a final `terminal.closed` frame.
-pub(super) async fn close_terminal_sessions_for_worker(
+pub(super) fn close_terminal_sessions_for_worker(
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     terminal_sessions: &mut HashMap<String, TerminalSession>,
     terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
@@ -127,20 +127,19 @@ pub(super) async fn close_terminal_sessions_for_worker(
         terminal_sessions.remove(&session_id);
         terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
         terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
-        if terminal_control_tx
-            .send(TerminalControlCommand::Send(TerminalToCloud::Closed {
+        if !try_send_terminal(
+            terminal_control_tx,
+            TerminalToCloud::Closed {
                 session_id: session_id.clone(),
                 code: Some(code.into()),
                 message: Some(message.into()),
-            }))
-            .await
-            .is_err()
-        {
+            },
+        ) {
             tracing::warn!(
                 target = "relay_broker::terminal",
                 session_id = %session_id,
                 worker = %agent,
-                "terminal queue closed while closing disappeared worker session"
+                "terminal queue full or closed while closing disappeared worker session"
             );
         }
     }

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -9,7 +9,7 @@ use crate::{
     node_control::{delivery_ack, handler_unavailable_result, DeliveryDecision},
     terminal_control::{
         TerminalControlCommand, TerminalControlEvent, TerminalFromCloud, TerminalMode,
-        TerminalToCloud,
+        TerminalToCloud, TERMINAL_CLOSE_RESERVE,
     },
     worker::LiveFleetInventoryCandidate,
 };
@@ -34,11 +34,6 @@ pub(super) struct FleetInventoryRetry {
     generation: Uuid,
     retry_after: Instant,
 }
-// Relaycast currently limits a node to 32 terminal sessions. Keep that many
-// slots free from high-volume frames so every affected session can still get a
-// terminal.closed notification when the output lane applies backpressure.
-const TERMINAL_CLOSE_RESERVE: usize = 32;
-
 pub(super) fn try_send_terminal(
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     message: TerminalToCloud,
@@ -1329,6 +1324,7 @@ impl BrokerRuntime {
             &mut self.pending_requests,
             &mut self.delivery_states,
             &mut self.agent_result_tokens,
+            &mut self.resize_owners,
             &self.terminal_control_tx,
             &mut self.terminal_sessions,
             &mut self.terminal_snapshot_requests,
@@ -1336,9 +1332,6 @@ impl BrokerRuntime {
         )
         .await;
 
-        // Drop any resize ownership for the released worker so a later worker
-        // reusing the name isn't rejected by a stale single-resizer entry.
-        self.resize_owners.remove(&name);
         self.pty_observability.remove(&name);
 
         let mut deregistration_failed = false;

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -109,7 +109,7 @@ pub(super) fn fail_terminal_session(
 /// can resume the same live session. Worker release is different: there is no
 /// target left for a view or drive client to resume, so every dependent session
 /// must receive a final `terminal.closed` frame.
-pub(super) fn close_terminal_sessions_for_worker(
+pub(super) async fn close_terminal_sessions_for_worker(
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     terminal_sessions: &mut HashMap<String, TerminalSession>,
     terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
@@ -127,19 +127,20 @@ pub(super) fn close_terminal_sessions_for_worker(
         terminal_sessions.remove(&session_id);
         terminal_snapshot_requests.retain(|_, pending| pending.session_id != session_id);
         terminal_input_requests.retain(|_, pending| pending.session_id != session_id);
-        if !try_send_terminal(
-            terminal_control_tx,
-            TerminalToCloud::Closed {
+        if terminal_control_tx
+            .send(TerminalControlCommand::Send(TerminalToCloud::Closed {
                 session_id: session_id.clone(),
                 code: Some(code.into()),
                 message: Some(message.into()),
-            },
-        ) {
+            }))
+            .await
+            .is_err()
+        {
             tracing::warn!(
                 target = "relay_broker::terminal",
                 session_id = %session_id,
                 worker = %agent,
-                "terminal queue full or closed while closing disappeared worker session"
+                "terminal queue closed while closing disappeared worker session"
             );
         }
     }

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -218,6 +218,7 @@ impl BrokerRuntime {
                 pending_requests,
                 delivery_states,
                 agent_result_tokens,
+                resize_owners,
                 terminal_control_tx,
                 terminal_sessions,
                 terminal_snapshot_requests,

--- a/crates/broker/src/runtime/maintenance.rs
+++ b/crates/broker/src/runtime/maintenance.rs
@@ -218,6 +218,10 @@ impl BrokerRuntime {
                 pending_requests,
                 delivery_states,
                 agent_result_tokens,
+                terminal_control_tx,
+                terminal_sessions,
+                terminal_snapshot_requests,
+                terminal_input_requests,
             )
             .await;
             match super::fleet::deregister_fleet_agent(fleet_control_tx, fleet_delivery_book, name)

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -394,8 +394,7 @@ pub(super) async fn release_worker_locally(
             &name,
             "agent_released",
             "terminal worker was released",
-        )
-        .await;
+        );
     }
     outcome
 }

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -290,6 +290,7 @@ pub(super) async fn release_worker_locally(
     pending_requests: &mut HashMap<String, worker_request::PendingRequest>,
     delivery_states: &mut HashMap<WorkerName, InboundDeliveryState>,
     agent_result_tokens: &mut HashMap<String, WorkerName>,
+    resize_owners: &mut HashMap<WorkerName, ResizeOwner>,
     terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
     terminal_sessions: &mut HashMap<String, TerminalSession>,
     terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
@@ -382,6 +383,9 @@ pub(super) async fn release_worker_locally(
         }
     };
     if outcome == ReleaseOutcome::Released {
+        // Worker disappearance invalidates every resize lease for that target,
+        // including a stale lease whose session was already pruned.
+        resize_owners.remove(&name);
         super::fleet::close_terminal_sessions_for_worker(
             terminal_control_tx,
             terminal_sessions,
@@ -1006,10 +1010,31 @@ mod tests {
             ),
         ]);
         let mut terminal_input_requests = HashMap::new();
+        let now = Instant::now();
+        let mut resize_owners = HashMap::from([
+            (
+                released_agent.clone(),
+                ResizeOwner {
+                    session_id: released_session_id.clone(),
+                    last_seen: now,
+                    rows: 24,
+                    cols: 80,
+                },
+            ),
+            (
+                WorkerName::from("healthy-idle-view-target"),
+                ResizeOwner {
+                    session_id: healthy_session_id.clone(),
+                    last_seen: now,
+                    rows: 30,
+                    cols: 100,
+                },
+            ),
+        ]);
         let (terminal_control_tx, mut terminal_control_rx) = mpsc::channel(8);
 
         let outcome = release_worker_locally(
-            released_agent,
+            released_agent.clone(),
             &workspace,
             &mut workers,
             &mut state,
@@ -1021,6 +1046,7 @@ mod tests {
             &mut pending_requests,
             &mut delivery_states,
             &mut agent_result_tokens,
+            &mut resize_owners,
             &terminal_control_tx,
             &mut terminal_sessions,
             &mut terminal_snapshot_requests,
@@ -1045,10 +1071,12 @@ mod tests {
         )));
         assert!(!terminal_sessions.contains_key(&released_session_id));
         assert!(!terminal_snapshot_requests.contains_key("released-snapshot"));
+        assert!(!resize_owners.contains_key(&released_agent));
 
         // MUST NOT FIRE: an unrelated healthy view may be legitimately idle.
         assert!(terminal_sessions.contains_key(&healthy_session_id));
         assert!(terminal_snapshot_requests.contains_key("healthy-snapshot"));
+        assert!(resize_owners.contains_key(&WorkerName::from("healthy-idle-view-target")));
         assert!(
             !terminal_messages.iter().any(|message| matches!(
                 message,

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -290,6 +290,10 @@ pub(super) async fn release_worker_locally(
     pending_requests: &mut HashMap<String, worker_request::PendingRequest>,
     delivery_states: &mut HashMap<WorkerName, InboundDeliveryState>,
     agent_result_tokens: &mut HashMap<String, WorkerName>,
+    terminal_control_tx: &mpsc::Sender<TerminalControlCommand>,
+    terminal_sessions: &mut HashMap<String, TerminalSession>,
+    terminal_snapshot_requests: &mut HashMap<String, TerminalSnapshotRequest>,
+    terminal_input_requests: &mut HashMap<String, TerminalInputRequest>,
 ) -> ReleaseOutcome {
     let workspace_http = &workspace_state.http_client;
     if is_relaycast_self_control_target(
@@ -306,7 +310,7 @@ pub(super) async fn release_worker_locally(
     }
     workers.supervisor.unregister(&name);
     workers.metrics.on_release(&name);
-    match workers.release(&name).await {
+    let outcome = match workers.release(&name).await {
         Ok(()) => {
             workspace_http.forget_agent_registration(&name);
             let dropped = take_pending_for_worker(pending_deliveries, &name);
@@ -376,7 +380,19 @@ pub(super) async fn release_worker_locally(
                 ReleaseOutcome::Failed
             }
         }
+    };
+    if outcome == ReleaseOutcome::Released {
+        super::fleet::close_terminal_sessions_for_worker(
+            terminal_control_tx,
+            terminal_sessions,
+            terminal_snapshot_requests,
+            terminal_input_requests,
+            &name,
+            "agent_released",
+            "terminal worker was released",
+        );
     }
+    outcome
 }
 
 /// Spawn a worker the fleet/node control plane requested.
@@ -859,7 +875,189 @@ pub(super) async fn spawn_worker_from_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::terminal_control::TerminalToCloud;
     use ::relaycast::WsEvent;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn released_view_target_emits_close_while_healthy_idle_view_stays_open() {
+        let temp = tempfile::tempdir().expect("test tempdir");
+        let (worker_event_tx, _worker_event_rx) = mpsc::channel::<WorkerEvent>(4);
+        let mut workers = WorkerRegistry::new(
+            worker_event_tx,
+            Vec::new(),
+            temp.path().join("worker-logs"),
+            Instant::now(),
+        );
+        let released_agent = WorkerName::from("released-view-target");
+        let healthy_agent = WorkerName::from("healthy-idle-view-target");
+        let child = tokio::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("release target should spawn");
+        let (command_tx, command_rx) = mpsc::channel(1);
+        drop(command_rx);
+        workers.workers.insert(
+            released_agent.clone(),
+            WorkerHandle {
+                generation: Uuid::new_v4(),
+                spec: AgentSpec {
+                    name: released_agent.clone(),
+                    runtime: AgentRuntime::Pty,
+                    provider: None,
+                    cli: Some("sh".to_string()),
+                    session_id: None,
+                    harness_config: None,
+                    model: None,
+                    cwd: None,
+                    team: None,
+                    shadow_of: None,
+                    shadow_mode: None,
+                    args: Vec::new(),
+                    channels: Vec::new(),
+                    restart_policy: None,
+                },
+                parent: Some("Relaycast".to_string()),
+                workspace_id: None,
+                child,
+                command_tx,
+                harness_pid: None,
+                spawned_at: Instant::now(),
+                ready_at: Some(Instant::now()),
+                last_activity_at: Instant::now(),
+                context_budget_pct: None,
+                state: crate::worker::AgentWorkState::Working,
+                exit_reason: None,
+            },
+        );
+
+        let workspace_id = WorkspaceId::from("ws_release_view_test".to_string());
+        let (ws_control_tx, _ws_control_rx) = mpsc::channel::<WsControl>(4);
+        let workspace = RelayWorkspace {
+            workspace_id,
+            workspace_alias: None,
+            relay_workspace_key: "rk_live_test".to_string(),
+            self_name: "broker".to_string(),
+            self_agent_id: AgentId::from("agent_broker".to_string()),
+            self_names: HashSet::from(["broker".to_string()]),
+            self_agent_ids: HashSet::from([AgentId::from("agent_broker".to_string())]),
+            http_client: RelaycastHttpClient::new(
+                Some("http://127.0.0.1:9".to_string()),
+                "rk_live_test",
+                "broker",
+                "codex",
+            ),
+            ws_control_tx,
+        };
+        let paths = ensure_ephemeral_paths(temp.path(), "release-view-target")
+            .expect("ephemeral runtime paths");
+        let mut state = broker::BrokerState::default();
+        let telemetry = TelemetryClient::default();
+        let (sdk_out_tx, _sdk_out_rx) = mpsc::channel(8);
+        let mut pending_deliveries = HashMap::new();
+        let mut dead_letters = DeadLetterStore::default();
+        let mut pending_requests = HashMap::new();
+        let mut delivery_states = HashMap::new();
+        let mut agent_result_tokens = HashMap::new();
+        let released_session_id = "released-view-session".to_string();
+        let healthy_session_id = "healthy-idle-view-session".to_string();
+        let mut terminal_sessions = HashMap::from([
+            (
+                released_session_id.clone(),
+                TerminalSession {
+                    agent: released_agent.clone(),
+                    mode: TerminalMode::View,
+                    ready: true,
+                    pending_output: Vec::new(),
+                    pending_output_bytes: 0,
+                },
+            ),
+            (
+                healthy_session_id.clone(),
+                TerminalSession {
+                    agent: healthy_agent,
+                    mode: TerminalMode::View,
+                    ready: true,
+                    pending_output: Vec::new(),
+                    pending_output_bytes: 0,
+                },
+            ),
+        ]);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut terminal_snapshot_requests = HashMap::from([
+            (
+                "released-snapshot".to_string(),
+                TerminalSnapshotRequest {
+                    session_id: released_session_id.clone(),
+                    client_request_id: None,
+                    deadline,
+                },
+            ),
+            (
+                "healthy-snapshot".to_string(),
+                TerminalSnapshotRequest {
+                    session_id: healthy_session_id.clone(),
+                    client_request_id: None,
+                    deadline,
+                },
+            ),
+        ]);
+        let mut terminal_input_requests = HashMap::new();
+        let (terminal_control_tx, mut terminal_control_rx) = mpsc::channel(8);
+
+        let outcome = release_worker_locally(
+            released_agent,
+            &workspace,
+            &mut workers,
+            &mut state,
+            &paths,
+            &telemetry,
+            &sdk_out_tx,
+            &mut pending_deliveries,
+            &mut dead_letters,
+            &mut pending_requests,
+            &mut delivery_states,
+            &mut agent_result_tokens,
+            &terminal_control_tx,
+            &mut terminal_sessions,
+            &mut terminal_snapshot_requests,
+            &mut terminal_input_requests,
+        )
+        .await;
+
+        assert_eq!(outcome, ReleaseOutcome::Released);
+        // MUST FIRE: releasing the target through the same lifecycle function
+        // used by the fleet action emits a final code and reason for its view.
+        let terminal_messages: Vec<TerminalControlCommand> =
+            std::iter::from_fn(|| terminal_control_rx.try_recv().ok()).collect();
+        assert!(terminal_messages.iter().any(|message| matches!(
+            message,
+            TerminalControlCommand::Send(TerminalToCloud::Closed {
+                session_id,
+                code: Some(code),
+                message: Some(message),
+            }) if session_id == &released_session_id
+                && code == "agent_released"
+                && message == "terminal worker was released"
+        )));
+        assert!(!terminal_sessions.contains_key(&released_session_id));
+        assert!(!terminal_snapshot_requests.contains_key("released-snapshot"));
+
+        // MUST NOT FIRE: an unrelated healthy view may be legitimately idle.
+        assert!(terminal_sessions.contains_key(&healthy_session_id));
+        assert!(terminal_snapshot_requests.contains_key("healthy-snapshot"));
+        assert!(
+            !terminal_messages.iter().any(|message| matches!(
+                message,
+                TerminalControlCommand::Send(TerminalToCloud::Closed { session_id, .. })
+                    if session_id == &healthy_session_id
+            )),
+            "healthy idle view must not receive a close"
+        );
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -394,7 +394,8 @@ pub(super) async fn release_worker_locally(
             &name,
             "agent_released",
             "terminal worker was released",
-        );
+        )
+        .await;
     }
     outcome
 }

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -637,7 +637,12 @@ mod tests {
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut ws = accept_async(stream).await.unwrap();
-            ws.next().await
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => continue,
+                    frame => break frame,
+                }
+            }
         });
 
         assert!(matches!(

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -59,6 +59,44 @@ const WRITER_QUEUE_CAPACITY: usize = 64;
 // Small: this queue only ever holds a ping or a shutdown close frame, never
 // bulk terminal output (see `run_terminal_writer`'s priority read).
 const PRIORITY_QUEUE_CAPACITY: usize = 8;
+// Relaycast currently limits a node to 32 live terminal sessions. Final
+// session frames get a distinct lane of that size so a full bulk-output queue
+// cannot shed the only signal that tells a client its target is gone.
+pub(crate) const TERMINAL_CLOSE_RESERVE: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalFrameEnqueue {
+    Queued,
+    Shed,
+    Disconnected,
+}
+
+async fn enqueue_terminal_frame(
+    writer_tx: &mpsc::Sender<Message>,
+    final_tx: &mpsc::Sender<Message>,
+    message: &TerminalToCloud,
+) -> TerminalFrameEnqueue {
+    let Ok(encoded) = serde_json::to_string(message) else {
+        return TerminalFrameEnqueue::Disconnected;
+    };
+    let frame = Message::Text(encoded);
+    if matches!(message, TerminalToCloud::Closed { .. }) {
+        // Unlike bulk output, a final session frame must never be shed just
+        // because the socket writer is draining a burst. Awaiting this bounded
+        // lane is safe: the writer owns a timeout and drops the receiver if the
+        // connection is genuinely wedged.
+        return if final_tx.send(frame).await.is_ok() {
+            TerminalFrameEnqueue::Queued
+        } else {
+            TerminalFrameEnqueue::Disconnected
+        };
+    }
+    match writer_tx.try_send(frame) {
+        Ok(()) => TerminalFrameEnqueue::Queued,
+        Err(mpsc::error::TrySendError::Full(_)) => TerminalFrameEnqueue::Shed,
+        Err(mpsc::error::TrySendError::Closed(_)) => TerminalFrameEnqueue::Disconnected,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -293,6 +331,7 @@ pub(crate) async fn run_terminal_control_client(
         let _ = event_tx.send(TerminalControlEvent::Connected).await;
         let (sink, mut stream) = socket.split();
         let (writer_tx, writer_rx) = mpsc::channel::<Message>(WRITER_QUEUE_CAPACITY);
+        let (final_tx, final_rx) = mpsc::channel::<Message>(TERMINAL_CLOSE_RESERVE);
         // Pings (and the shutdown close frame) get their own small queue,
         // checked ahead of `writer_rx` on every write. Without this, a large
         // legitimate output burst can bury a ping behind everything already
@@ -307,7 +346,7 @@ pub(crate) async fn run_terminal_control_client(
         // never the select loop below, which must keep observing
         // `last_inbound` on schedule regardless of what the write side is
         // doing.
-        let writer = tokio::spawn(run_terminal_writer(sink, writer_rx, priority_rx));
+        let writer = tokio::spawn(run_terminal_writer(sink, writer_rx, final_rx, priority_rx));
         // Shedding is per-connection state, not per-frame. Under sustained
         // backpressure the queue stays full, so warning on every dropped frame
         // would produce a log storm in exactly the situation an operator most
@@ -327,67 +366,40 @@ pub(crate) async fn run_terminal_control_client(
             tokio::select! {
                 command = command_rx.recv() => match command {
                     Some(TerminalControlCommand::Send(message)) => {
-                        match serde_json::to_string(&message) {
-                            Ok(encoded) => {
-                                // A momentarily full queue means the writer
-                                // hasn't caught up to a burst yet — it says
-                                // nothing about whether the connection is
-                                // alive, since this loop can enqueue far
-                                // faster than any real socket write
-                                // completes. Only a closed queue (the writer
-                                // task has exited) means the connection is
-                                // actually dead. Dropping a frame under
-                                // backpressure matches the existing outer
-                                // `terminal_control_tx` channel's philosophy
-                                // (fleet.rs `try_send_terminal`): a wedged
-                                // lane must fail forward, not accumulate.
-                                match writer_tx.try_send(Message::Text(encoded)) {
-                                    Ok(()) => {
-                                        // One accepted frame is not a recovery.
-                                        // While output outruns the writer, each
-                                        // dequeue frees exactly one slot and the
-                                        // next send refills it, so clearing the
-                                        // episode here would flap — emitting a
-                                        // begin/end pair per frame, which is the
-                                        // same log storm in a different shape.
-                                        // Require the queue to be genuinely
-                                        // drained before declaring recovery.
-                                        if shedding
-                                            && writer_tx.capacity() >= WRITER_QUEUE_CAPACITY / 2
-                                        {
-                                            tracing::warn!(
-                                                target = "relay_broker::terminal",
-                                                dropped_frames = shed_frames,
-                                                "fleet terminal writer drained; resuming output"
-                                            );
-                                            shedding = false;
-                                            shed_frames = 0;
-                                        }
-                                    }
-                                    // Shedding is deliberate, but it must not be
-                                    // silent: a viewer quietly missing output is
-                                    // indistinguishable from a wedged session,
-                                    // and an unobservable drop is exactly the
-                                    // failure class that let the fleet dispatch
-                                    // outage run for hours unnoticed. Log the
-                                    // episode, not each frame.
-                                    Err(mpsc::error::TrySendError::Full(_)) => {
-                                        shed_frames = shed_frames.saturating_add(1);
-                                        if !shedding {
-                                            shedding = true;
-                                            tracing::warn!(
-                                                target = "relay_broker::terminal",
-                                                capacity = WRITER_QUEUE_CAPACITY,
-                                                "fleet terminal writer queue full; shedding output frames under backpressure"
-                                            );
-                                        }
-                                    }
-                                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                                        connected = false;
-                                    }
+                        // A momentarily full bulk queue means the writer hasn't
+                        // caught up to a burst yet; final session frames use a
+                        // distinct reliable lane and are never shed with output.
+                        match enqueue_terminal_frame(&writer_tx, &final_tx, &message).await {
+                            TerminalFrameEnqueue::Queued => {
+                                // One accepted frame is not a recovery. While
+                                // output outruns the writer, each dequeue frees
+                                // exactly one slot and the next send refills it,
+                                // so require a genuine drain before clearing the
+                                // episode.
+                                if shedding && writer_tx.capacity() >= WRITER_QUEUE_CAPACITY / 2 {
+                                    tracing::warn!(
+                                        target = "relay_broker::terminal",
+                                        dropped_frames = shed_frames,
+                                        "fleet terminal writer drained; resuming output"
+                                    );
+                                    shedding = false;
+                                    shed_frames = 0;
                                 }
                             }
-                            Err(_) => connected = false,
+                            // Shedding is deliberate, but it must not be silent:
+                            // log the episode, not each frame.
+                            TerminalFrameEnqueue::Shed => {
+                                shed_frames = shed_frames.saturating_add(1);
+                                if !shedding {
+                                    shedding = true;
+                                    tracing::warn!(
+                                        target = "relay_broker::terminal",
+                                        capacity = WRITER_QUEUE_CAPACITY,
+                                        "fleet terminal writer queue full; shedding output frames under backpressure"
+                                    );
+                                }
+                            }
+                            TerminalFrameEnqueue::Disconnected => connected = false,
                         }
                     }
                     Some(TerminalControlCommand::Shutdown) | None => {
@@ -396,6 +408,7 @@ pub(crate) async fn run_terminal_control_client(
                         // even mid-burst.
                         let _ = priority_tx.try_send(Message::Close(None));
                         drop(priority_tx);
+                        drop(final_tx);
                         drop(writer_tx);
                         // Bounded by WRITE_TIMEOUT inside the writer itself,
                         // so this can't hang shutdown indefinitely even if
@@ -448,8 +461,8 @@ pub(crate) async fn run_terminal_control_client(
                                         .is_err()
                                     {
                                         // The consumer is gone, so this client is
-                                        // finished. Dropping `writer_tx`/`priority_tx`
-                                        // on the way out already ends the writer —
+                                        // finished. Dropping `writer_tx`/`final_tx`/
+                                        // `priority_tx` on the way out ends the writer —
                                         // its `recv()` yields `None` — so this is
                                         // not a leak fix. Aborting makes the
                                         // teardown immediate and explicit rather
@@ -498,14 +511,14 @@ pub(crate) async fn run_terminal_control_client(
 /// block forever, and this task simply exits, which closes both queues and
 /// makes the next `try_send` from the select loop fail immediately.
 ///
-/// `priority_rx` (pings, the shutdown close frame) is always read ahead of
-/// `data_rx` (bulk terminal output): a large legitimate output burst must
-/// never be able to bury a time-sensitive liveness ping behind everything
-/// already queued for send, or a peer that is genuinely still draining data
-/// would look silent to `read_idle_timeout` and get disconnected anyway.
+/// `final_rx` (session-final frames) is read ahead of `priority_rx` (pings and
+/// the shutdown close frame), and both are read ahead of `data_rx` (bulk
+/// terminal output). A large legitimate output burst must never bury either a
+/// teardown signal or a time-sensitive liveness ping behind bulk output.
 async fn run_terminal_writer<S>(
     mut sink: S,
     mut data_rx: mpsc::Receiver<Message>,
+    mut final_rx: mpsc::Receiver<Message>,
     mut priority_rx: mpsc::Receiver<Message>,
 ) where
     S: Sink<Message> + Unpin,
@@ -514,6 +527,7 @@ async fn run_terminal_writer<S>(
     loop {
         let message = tokio::select! {
             biased;
+            message = final_rx.recv() => message,
             message = priority_rx.recv() => message,
             message = data_rx.recv() => message,
         };
@@ -553,10 +567,54 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message;
 
     use super::{
-        run_terminal_control_client, InboundDeliveryMode, TerminalControlCommand,
-        TerminalControlConfig, TerminalControlEvent, TerminalFromCloud, TerminalMode,
-        TerminalToCloud,
+        enqueue_terminal_frame, run_terminal_control_client, InboundDeliveryMode,
+        TerminalControlCommand, TerminalControlConfig, TerminalControlEvent, TerminalFrameEnqueue,
+        TerminalFromCloud, TerminalMode, TerminalToCloud,
     };
+
+    #[tokio::test]
+    async fn terminal_close_uses_reserved_writer_lane_when_bulk_output_is_full() {
+        let (writer_tx, mut writer_rx) = mpsc::channel(1);
+        let (final_tx, mut final_rx) = mpsc::channel(1);
+        writer_tx
+            .try_send(Message::Text("already queued output".into()))
+            .unwrap();
+
+        let shed = enqueue_terminal_frame(
+            &writer_tx,
+            &final_tx,
+            &TerminalToCloud::Output {
+                session_id: "session-a".into(),
+                chunk: "new output".into(),
+                offset: None,
+            },
+        )
+        .await;
+        assert_eq!(shed, TerminalFrameEnqueue::Shed);
+
+        let queued = enqueue_terminal_frame(
+            &writer_tx,
+            &final_tx,
+            &TerminalToCloud::Closed {
+                session_id: "session-a".into(),
+                code: Some("agent_released".into()),
+                message: Some("terminal worker was released".into()),
+            },
+        )
+        .await;
+        assert_eq!(queued, TerminalFrameEnqueue::Queued);
+        assert!(matches!(
+            final_rx.try_recv(),
+            Ok(Message::Text(frame))
+                if serde_json::from_str::<serde_json::Value>(&frame)
+                    .is_ok_and(|value| value["type"] == "terminal.closed"
+                        && value["code"] == "agent_released")
+        ));
+        assert!(matches!(
+            writer_rx.try_recv(),
+            Ok(Message::Text(frame)) if frame == "already queued output"
+        ));
+    }
 
     #[test]
     fn terminal_wire_round_trips_without_control_frames() {

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -408,7 +408,6 @@ pub(crate) async fn run_terminal_control_client(
                         // even mid-burst.
                         let _ = priority_tx.try_send(Message::Close(None));
                         drop(priority_tx);
-                        drop(final_tx);
                         drop(writer_tx);
                         // Bounded by WRITE_TIMEOUT inside the writer itself,
                         // so this can't hang shutdown indefinitely even if
@@ -614,6 +613,52 @@ mod tests {
             writer_rx.try_recv(),
             Ok(Message::Text(frame)) if frame == "already queued output"
         ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_sends_websocket_close_with_an_empty_final_lane() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ws_url = format!(
+            "ws://{}/v1/node/terminal/ws",
+            listener.local_addr().unwrap()
+        );
+        let (command_tx, command_rx) = mpsc::channel(8);
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        let session_token = Arc::new(RwLock::new(Some("nt_test".to_string())));
+        let client = tokio::spawn(run_terminal_control_client(
+            TerminalControlConfig {
+                ws_url,
+                session_token,
+                read_idle_timeout: Some(Duration::from_secs(30)),
+            },
+            command_rx,
+            event_tx,
+        ));
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            ws.next().await
+        });
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+                .await
+                .unwrap(),
+            Some(TerminalControlEvent::Connected)
+        ));
+        command_tx
+            .send(TerminalControlCommand::Shutdown)
+            .await
+            .unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("server never observed terminal client shutdown")
+            .unwrap();
+        assert!(matches!(received, Some(Ok(Message::Close(_)))));
+        tokio::time::timeout(Duration::from_secs(5), client)
+            .await
+            .expect("terminal client did not finish shutdown")
+            .unwrap();
     }
 
     #[test]

--- a/packages/cli/src/cli/lib/attach-fleet-node.test.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.test.ts
@@ -7,7 +7,7 @@
  */
 import type { AddressInfo } from 'node:net';
 
-import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
+import { WebSocket as WsClient, WebSocketServer, type WebSocket as WsSocket } from 'ws';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { startFleetNodeAttachProxy, type FleetNodeAttachProxy } from './attach-fleet-node.js';
@@ -96,6 +96,17 @@ async function putDeliveryMode(
   });
   const body = (await response.json()) as Record<string, unknown>;
   return { status: response.status, body };
+}
+
+async function connectLoopbackEvents(proxy: FleetNodeAttachProxy): Promise<WsClient> {
+  const socket = new WsClient(`${proxy.brokerUrl.replace(/^http/, 'ws')}/ws`, {
+    headers: { Authorization: `Bearer ${proxy.apiKey}` },
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', resolve);
+    socket.once('error', reject);
+  });
+  return socket;
 }
 
 describe('startFleetNodeAttachProxy delivery-mode PUT lifecycle', () => {
@@ -326,6 +337,71 @@ describe('startFleetNodeAttachProxy delivery-mode PUT lifecycle', () => {
     expect(result.body).toMatchObject({ error: { code: 'closed' } });
     expect(elapsedMs).toBeLessThan(5_000);
   }, 10_000);
+});
+
+describe('startFleetNodeAttachProxy view target lifecycle', () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      const fn = cleanup.pop()!;
+      await fn().catch(() => undefined);
+    }
+  });
+
+  it('keeps a healthy idle view open, then closes it with code and reason when its target disappears', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'view-target',
+      node: 'view-node',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'wk',
+      fetch: fakeTicketFetch(remote.url),
+    });
+    cleanup.push(proxy.close);
+
+    const remoteSocket = await remote.nextConnection();
+    sendReady(remoteSocket, 'auto_inject');
+    const viewSocket = await connectLoopbackEvents(proxy);
+    const closes: Array<{ code: number; reason: string }> = [];
+    const closed = new Promise<void>((resolve) => {
+      viewSocket.on('close', (code, reason) => {
+        closes.push({ code, reason: reason.toString('utf8') });
+        resolve();
+      });
+    });
+
+    // MUST NOT FIRE: readiness and ordinary output from a healthy target do
+    // not finalize its view. Waiting for the output on the real loopback WS is
+    // the ordering barrier; this is not a fixed-time assertion of silence.
+    const receivedOutput = new Promise<void>((resolve) => viewSocket.once('message', () => resolve()));
+    remoteSocket.send(
+      JSON.stringify({
+        type: 'terminal.output',
+        session_id: SESSION_ID,
+        chunk: 'healthy target output',
+        offset: 1,
+      })
+    );
+    await receivedOutput;
+    expect(viewSocket.readyState).toBe(WsClient.OPEN);
+    expect(closes).toEqual([]);
+
+    // MUST FIRE: the broker's final target-disappearance frame must reach the
+    // actual view client surface as the same actionable close used by drive.
+    remoteSocket.send(
+      JSON.stringify({
+        type: 'terminal.closed',
+        session_id: SESSION_ID,
+        code: 'agent_released',
+        message: 'terminal worker was released',
+      })
+    );
+    await closed;
+    expect(closes).toEqual([{ code: 1011, reason: 'remote terminal session closed' }]);
+  });
 });
 
 describe('startFleetNodeAttachProxy readiness-gate status mapping', () => {


### PR DESCRIPTION
Fixes #1548.

## Findings established before the fix

### Where the asymmetry lives

View and drive already share the CLI transport adapter. On the base commit (`e3217d290`), `packages/cli/src/cli/lib/attach-fleet-node.ts:669-670` handles `terminal.closed` by calling `endTerminal`, and `:563-575` closes every local event WebSocket with code 1011 and reason `remote terminal session closed`.

The observed drive signal does **not** come from delivery-mode machinery or directly from terminal-session release. Drive/passthrough creates terminal input requests; after the target is gone, `crates/broker/src/runtime/maintenance.rs:99-130` expires/fails that request and `:124-130` queues `TerminalToCloud::Closed`. View has no input request while idle, so it never reaches that fallback.

The actual omission was the fleet release path: `crates/broker/src/runtime/fleet.rs:1264-1283` called `release_worker_locally`, cleared resize/observability state, and never finalized terminal sessions. The local HTTP release path already did so at `crates/broker/src/runtime/api.rs:932-952`. Full pre-fix trace: https://github.com/AgentWorkforce/relay/issues/1548#issuecomment-5314426474

### When silence is correct

Silence/reconnect is correct for a transient terminal-lane transport loss. `attach-fleet-node.ts:551-554` constructs a resume URL for the same session, and `:682-711` retries transport disconnects.

It is not correct after successful worker release: the target no longer exists and the same session cannot resume. `terminal.closed` is already final at `:669-670`. This change leaves transport reconnect/resume untouched and emits a final signal only when worker release succeeds.

## Implementation

- Centralize terminal-session finalization for a disappeared worker: remove only that worker's sessions and pending snapshot/input requests, then queue `terminal.closed` with code `agent_released` and reason `terminal worker was released`.
- Keep outer release finalization nonblocking while reserving capacity for all 32 live terminal sessions, then carry final session frames through a dedicated bounded writer lane prioritized ahead of pings and bulk output, so the teardown signal is not shed under output backpressure.
- Invoke that finalization from `release_worker_locally`, covering fleet release and verified-spawn cleanup.
- Reuse the same helper in the existing local HTTP release path to keep release behavior aligned.
- Preserve the existing client-facing mapping to WebSocket close `1011 / remote terminal session closed`, matching drive.

## Paired regression proof

The broker lifecycle test calls the same `release_worker_locally` function as the fleet action with two live view sessions:

- **Must fire:** the released target emits `TerminalToCloud::Closed` with exact code and reason and has its dependent state removed.
- **Must not fire:** an unrelated healthy idle view remains registered, retains its pending snapshot, and receives no close.

The CLI adapter test uses a real loopback WebSocket. It first observes ordinary output as an ordering barrier and proves the healthy view is still open; only after the remote `terminal.closed` frame does it observe exactly `1011 / remote terminal session closed`.

A deterministic writer-lane test fills the bulk queue, proves another output frame is shed, and proves `terminal.closed` still enters the reserved final lane with its code. Release coverage also verifies the released worker's resize lease is removed while the healthy target's lease remains.

### Mutation proof that both halves bite

- Removed release-time finalization: the focused test exited 101 at `relaycast_events.rs:1023`, with the expected target close missing.
- Broke the worker guard by selecting every terminal session: the focused test exited 101 at `relaycast_events.rs:1050`, with the healthy idle session missing.
- Broke the reserved final-frame route by sending close through the already-full bulk queue: the writer-lane test exited 101 (`left: Shed`, `right: Queued`).
- Reintroduced the premature final-lane sender drop during shutdown: the loopback WebSocket test exited 101 because the peer observed no close frame.
- Restored all changes and reran green.

Full commands and transcripts: https://github.com/AgentWorkforce/relay/issues/1548#issuecomment-5314563803

## Live pre-fix reproduction

Using already-open streams to lane-spawned Daytona targets (not #1539's refusal-to-open case):

- View: after direct release exited 0, the attach produced no close/error/code/reason for 40 seconds; timestamped wrapper heartbeats proved the child remained live until manual Ctrl-C.
- Drive control: after direct release exited 0, one input produced `connection closed (code: 1011, reason: remote terminal session closed)` and direct child exit 1.

The requested executable path was used, but it reported 11.6.9 rather than 11.6.10; the evidence records the observed version. Full ISO-ms transcript: https://github.com/AgentWorkforce/relay/issues/1548#issuecomment-5314640251

## Validation

- `cargo test -p agent-relay-broker` — 991 unit tests passed, 4 ignored; 16 integration tests passed
- focused broker regression — passed
- `npx vitest run packages/cli/src/cli/lib/attach-fleet-node.test.ts` — 12 passed
- `npm run typecheck` — passed
- changed TypeScript ESLint and Prettier checks — passed
- `cargo clippy -p agent-relay-broker --lib -- -D warnings` — passed
- `git diff --check` and staged secret-pattern scan — passed

`cargo clippy -p agent-relay-broker --all-targets -- -D warnings` reaches an unrelated pre-existing test lint at `crates/broker/src/terminal_control.rs:1116` (`while_let_loop`). No unrelated source was changed for that warning.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




