### PR TITLE
fix(sdk-swift): consume relaycast 8.x

### DIFF
--- a/packages/sdk-swift/Package.resolved
+++ b/packages/sdk-swift/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AgentWorkforce/relaycast.git",
       "state" : {
-        "revision" : "f7e86a3c525abcd2d6fe2f9ea151baedbbe9b744",
-        "version" : "6.0.5"
+        "revision" : "3374966534c408d3656c0a8701dd98d82216576b",
+        "version" : "8.0.4"
       }
     }
   ],

--- a/packages/sdk-swift/Package.swift
+++ b/packages/sdk-swift/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AgentWorkforce/relaycast.git",
-            from: "6.0.5"
+            from: "8.0.4"
         )
     ],
     targets: [


### PR DESCRIPTION
The Swift SDK resolves the relaycast engine at 8.x.

## Why

`from: "6.0.5"` capped the engine below the agent-lifecycle status fix, so `AgentStatus` only knew `online` / `offline` / `away` while the hosted API reports `active`, `idle`, `blocked` and `waiting`.

The failure is invisible on a first connection and permanent afterwards. `registerOrRotate` creates the agent when the name is free — fine. Once the name exists the call takes the 409 → `agents.get(name)` → `rotateToken` path, and `agents.get` decodes an agent whose `status` is `active`:

```
relay: connecting to default host as whiteboard
relay: connect failed: Invalid Relaycast API response
```

So a Swift app connects on its very first launch and never again, with an error naming neither the field nor the call.

## Verification

Observed on a macOS app that registers canvas actions over the participant SDK: reproduced the permanent failure on 6.0.5, then connected, subscribed, and registered all eight of its actions on 8.x against `cast.agentrelay.com`.

Two majors of engine drift, no API breakage for this facade — it compiles unchanged and the 152-test suite passes.

Handling an action invocation additionally needs relaycast [#335](https://github.com/AgentWorkforce/relaycast/pull/335) (invocation records decode by `invocation_id`); `from: "8.0.4"` picks that up automatically once it releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

