### PR TITLE
fix(ci): reuse standalone smoke workspace

### DIFF
--- a/.agentworkforce/trajectories/active/traj_o3fpaluznbp0/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_o3fpaluznbp0/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_o3fpaluznbp0",
+  "version": 1,
+  "task": {
+    "title": "Stop standalone smoke CI from creating throwaway Relaycast workspaces"
+  },
+  "status": "active",
+  "startedAt": "2026-08-18T09:34:00.831Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T09:39:45.723Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_vrkts5t6qnlp",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T09:39:45.723Z",
+      "events": [
+        {
+          "ts": 1787045985724,
+          "type": "decision",
+          "content": "Reuse one secret-backed CI workspace and give every smoke process a unique broker name: Reuse one secret-backed CI workspace and give every smoke process a unique broker name",
+          "raw": {
+            "question": "Reuse one secret-backed CI workspace and give every smoke process a unique broker name",
+            "chosen": "Reuse one secret-backed CI workspace and give every smoke process a unique broker name",
+            "alternatives": [],
+            "reasoning": "The smoke asserts local status/down/up/readiness behavior; fresh workspace provisioning is incidental. A committed pin would expose a credential and create-and-delete is unavailable (relaycast#336). Temporary HOME/project directories isolate local state, while unique broker names and derived node identities prevent concurrent runs from colliding in the shared workspace. Missing credentials fail closed; fork PRs skip the live-cloud job because GitHub withholds repository secrets."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787046771418,
+          "type": "reflection",
+          "content": "The shared-workspace design is behaving as intended: two concurrent real brokers and a follow-up all completed, with unique broker names preventing collision and temp HOME/project roots isolating state. One initial verification harness used relative binary paths and failed before startup; correcting to absolute paths proved the target behavior without creating another workspace.",
+          "raw": {
+            "focalPoints": [
+              "concurrency",
+              "isolation",
+              "credential-safety",
+              "ci"
+            ],
+            "adjustments": "Cleared ambient RELAY_WORKSPACES_JSON so the dedicated single key cannot be shadowed; added fork/Dependabot skip because GitHub withholds Actions secrets.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:concurrency",
+            "focal:isolation",
+            "focal:credential-safety",
+            "focal:ci",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1",
+    "endRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0.trace.json
@@ -1,0 +1,108 @@
+{
+  "version": "1.0.0",
+  "id": "38d0b7b0-ecf2-459a-bd54-8bd77c7a933d",
+  "timestamp": "2026-08-18T10:03:44.543Z",
+  "trajectory": "traj_o3fpaluznbp0",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_o3fpaluznbp0/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 69,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/package-validation.yml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 235,
+              "end_line": 248,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            },
+            {
+              "start_line": 346,
+              "end_line": 350,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/publish.yml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1480,
+              "end_line": 1487,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/ci-standalone-smoke.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 132,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/ci-standalone-smoke.sh",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 6,
+              "end_line": 25,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            },
+            {
+              "start_line": 132,
+              "end_line": 138,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            },
+            {
+              "start_line": 188,
+              "end_line": 204,
+              "revision": "09d73b0400815333df6a4bf5ff50a06276d67aa4"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0/summary.md
@@ -1,0 +1,39 @@
+# Trajectory: Stop standalone smoke CI from creating throwaway Relaycast workspaces
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** August 18, 2026 at 11:34 AM
+> **Completed:** August 18, 2026 at 12:03 PM
+
+---
+
+## Summary
+
+Reworked standalone smoke CI to reuse one secret-backed workspace, fail closed without the key, clear higher-precedence multi-workspace state, use collision-resistant broker names, and assert/announce workspace reuse. Seeded the GitHub Actions secret without exposing it; validated two concurrent real smokes plus a follow-up, a green Package Validation run, the full 2,068-test suite, shell/format checks, and opened PR #1567 without merging.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Reuse one secret-backed CI workspace and give every smoke process a unique broker name
+- **Chose:** Reuse one secret-backed CI workspace and give every smoke process a unique broker name
+- **Reasoning:** The smoke asserts local status/down/up/readiness behavior; fresh workspace provisioning is incidental. A committed pin would expose a credential and create-and-delete is unavailable (relaycast#336). Temporary HOME/project directories isolate local state, while unique broker names and derived node identities prevent concurrent runs from colliding in the shared workspace. Missing credentials fail closed; fork PRs skip the live-cloud job because GitHub withholds repository secrets.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Reuse one secret-backed CI workspace and give every smoke process a unique broker name: Reuse one secret-backed CI workspace and give every smoke process a unique broker name
+- The shared-workspace design is behaving as intended: two concurrent real brokers and a follow-up all completed, with unique broker names preventing collision and temp HOME/project roots isolating state. One initial verification harness used relative binary paths and failed before startup; correcting to absolute paths proved the target behavior without creating another workspace.
+
+---
+
+## Artifacts
+
+**Commits:** 09d73b040
+**Files changed:** 5

--- a/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_o3fpaluznbp0/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Stop standalone smoke CI from creating throwaway Relaycast workspaces"
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-08-18T09:34:00.831Z",
+  "completedAt": "2026-08-18T10:03:44.381Z",
   "agents": [
     {
       "name": "default",
@@ -19,6 +20,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-08-18T09:39:45.723Z",
+      "endedAt": "2026-08-18T10:03:44.381Z",
       "events": [
         {
           "ts": 1787045985724,
@@ -58,12 +60,26 @@
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Reworked standalone smoke CI to reuse one secret-backed workspace, fail closed without the key, clear higher-precedence multi-workspace state, use collision-resistant broker names, and assert/announce workspace reuse. Seeded the GitHub Actions secret without exposing it; validated two concurrent real smokes plus a follow-up, a green Package Validation run, the full 2,068-test suite, shell/format checks, and opened PR #1567 without merging.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [
+    "09d73b040"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_o3fpaluznbp0/trajectory.json",
+    ".github/workflows/package-validation.yml",
+    ".github/workflows/publish.yml",
+    "packages/cli/src/cli/ci-standalone-smoke.test.ts",
+    "scripts/ci-standalone-smoke.sh"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1",
-    "endRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1"
+    "endRef": "09d73b0400815333df6a4bf5ff50a06276d67aa4",
+    "traceId": "38d0b7b0-ecf2-459a-bd54-8bd77c7a933d"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-08/traj_p2yr67vtyhej/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_p2yr67vtyhej/summary.md
@@ -1,0 +1,36 @@
+# Trajectory: Address final PR #1567 review findings
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 18, 2026 at 01:26 PM
+> **Completed:** August 18, 2026 at 01:30 PM
+
+---
+
+## Summary
+
+Addressed final PR #1567 review findings: removed shell interpretation of TMPDIR-derived invocation log paths by passing INVOCATION_LOG through each fake child environment; constrained readiness rereading to a pre-deadline process-exit race; added a late-readiness must-fire test; redirected the background watchdog descriptors so tests do not remain attached after the smoke exits. The new timeout test failed against the unsafe reread and passed after the guard. Five consecutive focused runs passed 5/5, with bash syntax, shellcheck, Prettier, and diff checks green.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Pass the fake invocation log through the environment
+- **Chose:** Pass the fake invocation log through the environment
+- **Reasoning:** Embedding a TMPDIR-derived path in generated Bash source leaves command substitution and backticks executable. Referencing quoted INVOCATION_LOG in the fake scripts preserves logging without interpreting the path as shell code.
+
+### Accept post-loop readiness only after pre-deadline process exit
+- **Chose:** Accept post-loop readiness only after pre-deadline process exit
+- **Reasoning:** A timeout can race with readiness written during teardown. Tracking the early process-exit branch preserves the short-lived CLI fix while preventing late readiness from converting a real timeout into a passing smoke.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Pass the fake invocation log through the environment: Pass the fake invocation log through the environment
+- Accept post-loop readiness only after pre-deadline process exit: Accept post-loop readiness only after pre-deadline process exit

--- a/.agentworkforce/trajectories/completed/2026-08/traj_p2yr67vtyhej/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_p2yr67vtyhej/trajectory.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_p2yr67vtyhej",
+  "version": 1,
+  "task": {
+    "title": "Address final PR #1567 review findings"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T11:26:58.443Z",
+  "completedAt": "2026-08-18T11:30:29.682Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T11:30:14.403Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_xic9v9ml6jbx",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T11:30:14.403Z",
+      "endedAt": "2026-08-18T11:30:29.682Z",
+      "events": [
+        {
+          "ts": 1787052614403,
+          "type": "decision",
+          "content": "Pass the fake invocation log through the environment: Pass the fake invocation log through the environment",
+          "raw": {
+            "question": "Pass the fake invocation log through the environment",
+            "chosen": "Pass the fake invocation log through the environment",
+            "alternatives": [],
+            "reasoning": "Embedding a TMPDIR-derived path in generated Bash source leaves command substitution and backticks executable. Referencing quoted INVOCATION_LOG in the fake scripts preserves logging without interpreting the path as shell code."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787052622148,
+          "type": "decision",
+          "content": "Accept post-loop readiness only after pre-deadline process exit: Accept post-loop readiness only after pre-deadline process exit",
+          "raw": {
+            "question": "Accept post-loop readiness only after pre-deadline process exit",
+            "chosen": "Accept post-loop readiness only after pre-deadline process exit",
+            "alternatives": [],
+            "reasoning": "A timeout can race with readiness written during teardown. Tracking the early process-exit branch preserves the short-lived CLI fix while preventing late readiness from converting a real timeout into a passing smoke."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed final PR #1567 review findings: removed shell interpretation of TMPDIR-derived invocation log paths by passing INVOCATION_LOG through each fake child environment; constrained readiness rereading to a pre-deadline process-exit race; added a late-readiness must-fire test; redirected the background watchdog descriptors so tests do not remain attached after the smoke exits. The new timeout test failed against the unsafe reread and passed after the guard. Five consecutive focused runs passed 5/5, with bash syntax, shellcheck, Prettier, and diff checks green.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "ed176c480f37a67d96605c730b30578dccf12894",
+    "endRef": "ed176c480f37a67d96605c730b30578dccf12894"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7.trace.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "id": "921448c0-2f4e-470b-8a3d-1d11916af6fd",
+  "timestamp": "2026-08-18T11:19:19.407Z",
+  "trajectory": "traj_vo8x942jy3x7",
+  "files": [
+    {
+      "path": "packages/cli/src/cli/ci-standalone-smoke.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 15,
+              "end_line": 40,
+              "revision": "9117f803cba24230003efa94fddc27b629557dd0"
+            },
+            {
+              "start_line": 75,
+              "end_line": 81,
+              "revision": "9117f803cba24230003efa94fddc27b629557dd0"
+            },
+            {
+              "start_line": 93,
+              "end_line": 126,
+              "revision": "9117f803cba24230003efa94fddc27b629557dd0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/ci-standalone-smoke.sh",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 6,
+              "end_line": 12,
+              "revision": "9117f803cba24230003efa94fddc27b629557dd0"
+            },
+            {
+              "start_line": 173,
+              "end_line": 184,
+              "revision": "9117f803cba24230003efa94fddc27b629557dd0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7/summary.md
@@ -1,0 +1,43 @@
+# Trajectory: Finish relay PR #1567 whitespace guard and review threads
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 18, 2026 at 12:52 PM
+> **Completed:** August 18, 2026 at 01:19 PM
+
+---
+
+## Summary
+
+Finished PR #1567: rejected unset, empty, space-only, and tab-only workspace keys before any binary invocation; strengthened the focused contract with invocation logging; preserved the real-CLI integration boundary; closed the short-lived readiness log/liveness race found by Node 24 CI; replied to and resolved all review threads; updated the PR impact to roughly 1,700 avoided throwaway workspaces per day; verified focused tests, shell checks, Node.js Compatibility, and Package Validation including Standalone macOS Smoke.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Keep the fake CLI as the focused shell-script seam
+- **Chose:** Keep the fake CLI as the focused shell-script seam
+- **Reasoning:** The unit test owns ci-standalone-smoke.sh control flow; Package Validation's Standalone macOS Smoke invokes the real built CLI and broker with RELAY_CI_WORKSPACE_KEY, so live output drift is already covered and a recorded transcript would remain static.
+
+### Re-check readiness after a short-lived node up exits
+- **Chose:** Re-check readiness after a short-lived node up exits
+- **Reasoning:** Two Node 24 CI failures showed the fake CLI log already contained Broker started while the polling loop reported unready: the process exited between the loop's log check and liveness check. Re-reading the completed log closes that race without widening timeouts or weakening output assertions.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Keep the fake CLI as the focused shell-script seam: Keep the fake CLI as the focused shell-script seam
+- Re-check readiness after a short-lived node up exits: Re-check readiness after a short-lived node up exits
+
+---
+
+## Artifacts
+
+**Commits:** 9117f803c, bd5913a6c, dc2b59745
+**Files changed:** 2

--- a/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_vo8x942jy3x7/trajectory.json
@@ -1,0 +1,73 @@
+{
+  "id": "traj_vo8x942jy3x7",
+  "version": 1,
+  "task": {
+    "title": "Finish relay PR #1567 whitespace guard and review threads"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T10:52:05.850Z",
+  "completedAt": "2026-08-18T11:19:19.321Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T10:53:48.666Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_3ldfyjqeklgz",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T10:53:48.666Z",
+      "endedAt": "2026-08-18T11:19:19.321Z",
+      "events": [
+        {
+          "ts": 1787050428666,
+          "type": "decision",
+          "content": "Keep the fake CLI as the focused shell-script seam: Keep the fake CLI as the focused shell-script seam",
+          "raw": {
+            "question": "Keep the fake CLI as the focused shell-script seam",
+            "chosen": "Keep the fake CLI as the focused shell-script seam",
+            "alternatives": [],
+            "reasoning": "The unit test owns ci-standalone-smoke.sh control flow; Package Validation's Standalone macOS Smoke invokes the real built CLI and broker with RELAY_CI_WORKSPACE_KEY, so live output drift is already covered and a recorded transcript would remain static."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787051270336,
+          "type": "decision",
+          "content": "Re-check readiness after a short-lived node up exits: Re-check readiness after a short-lived node up exits",
+          "raw": {
+            "question": "Re-check readiness after a short-lived node up exits",
+            "chosen": "Re-check readiness after a short-lived node up exits",
+            "alternatives": [],
+            "reasoning": "Two Node 24 CI failures showed the fake CLI log already contained Broker started while the polling loop reported unready: the process exited between the loop's log check and liveness check. Re-reading the completed log closes that race without widening timeouts or weakening output assertions."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Finished PR #1567: rejected unset, empty, space-only, and tab-only workspace keys before any binary invocation; strengthened the focused contract with invocation logging; preserved the real-CLI integration boundary; closed the short-lived readiness log/liveness race found by Node 24 CI; replied to and resolved all review threads; updated the PR impact to roughly 1,700 avoided throwaway workspaces per day; verified focused tests, shell checks, Node.js Compatibility, and Package Validation including Standalone macOS Smoke.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [
+    "9117f803c",
+    "bd5913a6c",
+    "dc2b59745"
+  ],
+  "filesChanged": [
+    "packages/cli/src/cli/ci-standalone-smoke.test.ts",
+    "scripts/ci-standalone-smoke.sh"
+  ],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "5cf2326dedf5a84e88b934db3db6d86dc0e29bd8",
+    "endRef": "9117f803cba24230003efa94fddc27b629557dd0",
+    "traceId": "921448c0-2f4e-470b-8a3d-1d11916af6fd"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_z9o14mx56gy9/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_z9o14mx56gy9/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Make standalone timeout regression test ordering-based
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 18, 2026 at 01:41 PM
+> **Completed:** August 18, 2026 at 01:42 PM
+
+---
+
+## Summary
+
+Replaced the late-readiness timeout test's fixed 100ms sleep with a second-node-down handshake, added explicit before/after readiness events, proved the test fails when the production timeout guard is removed, and passed the focused suite five consecutive times plus shell and formatting checks.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Gate fake readiness on the second node-down invocation
+- **Chose:** Gate fake readiness on the second node-down invocation
+- **Reasoning:** The first down is preflight cleanup and the second can only occur after the zero-second startup deadline while node up is still alive, so readiness ordering is deterministic and independent of scheduler timing.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Gate fake readiness on the second node-down invocation: Gate fake readiness on the second node-down invocation

--- a/.agentworkforce/trajectories/completed/2026-08/traj_z9o14mx56gy9/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_z9o14mx56gy9/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_z9o14mx56gy9",
+  "version": 1,
+  "task": {
+    "title": "Make standalone timeout regression test ordering-based"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T11:41:55.268Z",
+  "completedAt": "2026-08-18T11:42:37.800Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T11:42:00.043Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_5rza1i4rc7gj",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T11:42:00.043Z",
+      "endedAt": "2026-08-18T11:42:37.800Z",
+      "events": [
+        {
+          "ts": 1787053320044,
+          "type": "decision",
+          "content": "Gate fake readiness on the second node-down invocation: Gate fake readiness on the second node-down invocation",
+          "raw": {
+            "question": "Gate fake readiness on the second node-down invocation",
+            "chosen": "Gate fake readiness on the second node-down invocation",
+            "alternatives": [],
+            "reasoning": "The first down is preflight cleanup and the second can only occur after the zero-second startup deadline while node up is still alive, so readiness ordering is deterministic and independent of scheduler timing."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Replaced the late-readiness timeout test's fixed 100ms sleep with a second-node-down handshake, added explicit before/after readiness events, proved the test fails when the production timeout guard is removed, and passed the focused suite five consecutive times plus shell and formatting checks.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "ad84354329879e11d83b4e85b1bc3f6b22607acb",
+    "endRef": "ad84354329879e11d83b4e85b1bc3f6b22607acb"
+  }
+}

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -235,7 +235,14 @@ jobs:
   standalone-macos-smoke:
     name: Standalone macOS Smoke
     needs: changes
-    if: needs.changes.outputs.node_changed == 'true'
+    # Fork and Dependabot pull requests cannot receive Actions repository
+    # secrets. Skip this live-cloud smoke there instead of falling back to
+    # provisioning an undeletable workspace; other same-repository PRs and
+    # main pushes must reuse the CI workspace.
+    if: >-
+      needs.changes.outputs.node_changed == 'true' &&
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: macos-latest
     env:
       NPM_CONFIG_FUND: false
@@ -339,4 +346,5 @@ jobs:
       - name: Smoke standalone lifecycle
         env:
           AGENT_RELAY_STARTUP_DEBUG: 1
+          RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}
         run: bash scripts/ci-standalone-smoke.sh "$STANDALONE_CLI" "$STANDALONE_BROKER"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1480,6 +1480,8 @@ jobs:
           echo "✓ Uncompressed binary verified"
 
       - name: Smoke standalone lifecycle
+        env:
+          RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}
         run: |
           if [ "$(uname -m)" != "${{ matrix.expected_arch }}" ]; then
             echo "Skipping lifecycle smoke for ${{ matrix.expected_arch }} on $(uname -m) host"

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -15,16 +15,26 @@ function makeExecutable(directory: string, name: string, contents: string): stri
   return path;
 }
 
-function createFakeBinaries(): { cli: string; broker: string } {
+function createFakeBinaries(): { cli: string; broker: string; invocationLog: string } {
   const directory = mkdtempSync(join(tmpdir(), 'relay-standalone-smoke-test-'));
   temporaryDirectories.push(directory);
 
-  const broker = makeExecutable(directory, 'broker', '#!/usr/bin/env bash\nexit 0\n');
+  const invocationLog = join(directory, 'invocations.log');
+  writeFileSync(invocationLog, '');
+  const broker = makeExecutable(
+    directory,
+    'broker',
+    `#!/usr/bin/env bash
+printf 'broker\\n' >> ${JSON.stringify(invocationLog)}
+exit 0
+`
+  );
   const cli = makeExecutable(
     directory,
     'relay',
     `#!/usr/bin/env bash
 set -euo pipefail
+printf 'cli\\n' >> ${JSON.stringify(invocationLog)}
 
 if [ "\${1:-}" != "node" ]; then
   exit 64
@@ -65,7 +75,7 @@ esac
 `
   );
 
-  return { cli, broker };
+  return { cli, broker, invocationLog };
 }
 
 afterEach(() => {
@@ -92,6 +102,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
     ];
 
     for (const [label, value] of unusableKeys) {
+      const { cli, broker, invocationLog } = createFakeBinaries();
       const env = { ...process.env };
       if (value === undefined) {
         delete env.RELAY_WORKSPACE_KEY;
@@ -99,7 +110,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
         env.RELAY_WORKSPACE_KEY = value;
       }
 
-      const result = spawnSync('bash', [smokeScript, '/missing/cli', '/missing/broker'], {
+      const result = spawnSync('bash', [smokeScript, cli, broker], {
         encoding: 'utf8',
         env,
       });
@@ -108,6 +119,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
       expect(result.stderr, label).toContain('Refusing to start');
       expect(result.stderr, label).toContain('throwaway workspace');
       expect(result.stderr, label).not.toContain('binary not found');
+      expect(readFileSync(invocationLog, 'utf8'), label).toBe('');
     }
   });
 

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -1,0 +1,132 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const smokeScript = resolve('scripts/ci-standalone-smoke.sh');
+const temporaryDirectories: string[] = [];
+
+function makeExecutable(directory: string, name: string, contents: string): string {
+  const path = join(directory, name);
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function createFakeBinaries(): { cli: string; broker: string } {
+  const directory = mkdtempSync(join(tmpdir(), 'relay-standalone-smoke-test-'));
+  temporaryDirectories.push(directory);
+
+  const broker = makeExecutable(directory, 'broker', '#!/usr/bin/env bash\nexit 0\n');
+  const cli = makeExecutable(
+    directory,
+    'relay',
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\${1:-}" != "node" ]; then
+  exit 64
+fi
+
+case "\${2:-}" in
+  status)
+    echo "Status: STOPPED"
+    ;;
+  down)
+    echo "Cleaned up (was not running)"
+    ;;
+  up)
+    if [ -z "\${RELAY_WORKSPACE_KEY:-}" ]; then
+      echo "workspace key missing" >&2
+      exit 65
+    fi
+    if [ -n "\${RELAY_WORKSPACES_JSON:-}" ]; then
+      echo "ambient multi-workspace session was not cleared" >&2
+      exit 68
+    fi
+    if [ "\${3:-}" != "--broker-name" ] || [ -z "\${4:-}" ]; then
+      echo "unique broker name missing" >&2
+      exit 66
+    fi
+    echo 'Workspace source: environment ($RELAY_WORKSPACE_KEY)'
+    if [ "\${FAKE_WORKSPACE_MODE:-joined}" = "created" ]; then
+      echo "Workspace: created new workspace rw_throwaway"
+    else
+      echo "Workspace: joined rw_ci"
+    fi
+    echo "Broker started."
+    ;;
+  *)
+    exit 67
+    ;;
+esac
+`
+  );
+
+  return { cli, broker };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('ci-standalone-smoke workspace reuse', () => {
+  it('injects the same dedicated secret at every workflow call site', () => {
+    for (const workflow of ['.github/workflows/package-validation.yml', '.github/workflows/publish.yml']) {
+      expect(readFileSync(resolve(workflow), 'utf8')).toContain(
+        'RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}'
+      );
+    }
+  });
+
+  it('fails closed before invoking binaries when the dedicated key is missing', () => {
+    const result = spawnSync('bash', [smokeScript, '/missing/cli', '/missing/broker'], {
+      encoding: 'utf8',
+      env: { ...process.env, RELAY_WORKSPACE_KEY: '' },
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Refusing to start');
+    expect(result.stderr).toContain('throwaway workspace');
+    expect(result.stderr).not.toContain('binary not found');
+  });
+
+  it('passes the shared key through the isolated lifecycle and joins its workspace', () => {
+    const { cli, broker } = createFakeBinaries();
+    const result = spawnSync('bash', [smokeScript, cli, broker], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RELAY_WORKSPACE_KEY: 'rk_live_test_only',
+        RELAY_WORKSPACES_JSON: '[{"workspace_id":"rw_wrong","api_key":"rk_wrong"}]',
+        AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-a',
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Standalone smoke passed');
+  });
+
+  it('rejects a lifecycle that reports a newly created workspace', () => {
+    const { cli, broker } = createFakeBinaries();
+    const result = spawnSync('bash', [smokeScript, cli, broker], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RELAY_WORKSPACE_KEY: 'rk_live_test_only',
+        AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-b',
+        FAKE_WORKSPACE_MODE: 'created',
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('created a workspace instead of reusing');
+    expect(result.stderr).toContain('Workspace: created new workspace rw_throwaway');
+  });
+});

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -25,7 +25,7 @@ function createFakeBinaries(): { cli: string; broker: string; invocationLog: str
     directory,
     'broker',
     `#!/usr/bin/env bash
-printf 'broker\\n' >> ${JSON.stringify(invocationLog)}
+printf 'broker\\n' >> "$INVOCATION_LOG"
 exit 0
 `
   );
@@ -34,7 +34,7 @@ exit 0
     'relay',
     `#!/usr/bin/env bash
 set -euo pipefail
-printf 'cli\\n' >> ${JSON.stringify(invocationLog)}
+printf 'cli\\n' >> "$INVOCATION_LOG"
 
 if [ "\${1:-}" != "node" ]; then
   exit 64
@@ -59,6 +59,9 @@ case "\${2:-}" in
     if [ "\${3:-}" != "--broker-name" ] || [ -z "\${4:-}" ]; then
       echo "unique broker name missing" >&2
       exit 66
+    fi
+    if [ -n "\${FAKE_STARTUP_DELAY_SECONDS:-}" ]; then
+      sleep "$FAKE_STARTUP_DELAY_SECONDS"
     fi
     echo 'Workspace source: environment ($RELAY_WORKSPACE_KEY)'
     if [ "\${FAKE_WORKSPACE_MODE:-joined}" = "created" ]; then
@@ -109,6 +112,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
       } else {
         env.RELAY_WORKSPACE_KEY = value;
       }
+      env.INVOCATION_LOG = invocationLog;
 
       const result = spawnSync('bash', [smokeScript, cli, broker], {
         encoding: 'utf8',
@@ -124,7 +128,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
   });
 
   it('passes the shared key through the isolated lifecycle and joins its workspace', () => {
-    const { cli, broker } = createFakeBinaries();
+    const { cli, broker, invocationLog } = createFakeBinaries();
     const result = spawnSync('bash', [smokeScript, cli, broker], {
       encoding: 'utf8',
       env: {
@@ -132,6 +136,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
         RELAY_WORKSPACE_KEY: 'rk_live_test_only',
         RELAY_WORKSPACES_JSON: '[{"workspace_id":"rw_wrong","api_key":"rk_wrong"}]',
         AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-a',
+        INVOCATION_LOG: invocationLog,
       },
       timeout: 10_000,
     });
@@ -142,7 +147,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
   });
 
   it('rejects a lifecycle that reports a newly created workspace', () => {
-    const { cli, broker } = createFakeBinaries();
+    const { cli, broker, invocationLog } = createFakeBinaries();
     const result = spawnSync('bash', [smokeScript, cli, broker], {
       encoding: 'utf8',
       env: {
@@ -150,6 +155,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
         RELAY_WORKSPACE_KEY: 'rk_live_test_only',
         AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-b',
         FAKE_WORKSPACE_MODE: 'created',
+        INVOCATION_LOG: invocationLog,
       },
       timeout: 10_000,
     });
@@ -157,5 +163,26 @@ describe('ci-standalone-smoke workspace reuse', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('created a workspace instead of reusing');
     expect(result.stderr).toContain('Workspace: created new workspace rw_throwaway');
+  });
+
+  it('rejects readiness written after the startup deadline', () => {
+    const { cli, broker, invocationLog } = createFakeBinaries();
+    const result = spawnSync('bash', [smokeScript, cli, broker], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RELAY_WORKSPACE_KEY: 'rk_live_test_only',
+        AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-c',
+        AGENT_RELAY_STANDALONE_STARTUP_TIMEOUT_SECONDS: '0',
+        FAKE_STARTUP_DELAY_SECONDS: '0.1',
+        INVOCATION_LOG: invocationLog,
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('did not become ready');
+    expect(result.stderr).toContain('Broker started.');
+    expect(result.stdout).not.toContain('Standalone smoke passed');
   });
 });

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -34,7 +34,7 @@ exit 0
     'relay',
     `#!/usr/bin/env bash
 set -euo pipefail
-printf 'cli\\n' >> "$INVOCATION_LOG"
+printf 'cli %s %s\\n' "\${1:-}" "\${2:-}" >> "$INVOCATION_LOG"
 
 if [ "\${1:-}" != "node" ]; then
   exit 64
@@ -60,8 +60,12 @@ case "\${2:-}" in
       echo "unique broker name missing" >&2
       exit 66
     fi
-    if [ -n "\${FAKE_STARTUP_DELAY_SECONDS:-}" ]; then
-      sleep "$FAKE_STARTUP_DELAY_SECONDS"
+    if [ "\${FAKE_READY_AFTER_SECOND_DOWN:-}" = "1" ]; then
+      printf 'up-waiting\\n' >> "$INVOCATION_LOG"
+      while [ "$(grep -c '^cli node down$' "$INVOCATION_LOG" || true)" -lt 2 ]; do
+        sleep 0.01
+      done
+      printf 'up-ready\\n' >> "$INVOCATION_LOG"
     fi
     echo 'Workspace source: environment ($RELAY_WORKSPACE_KEY)'
     if [ "\${FAKE_WORKSPACE_MODE:-joined}" = "created" ]; then
@@ -174,7 +178,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
         RELAY_WORKSPACE_KEY: 'rk_live_test_only',
         AGENT_RELAY_STANDALONE_BROKER_NAME: 'relay-ci-test-c',
         AGENT_RELAY_STANDALONE_STARTUP_TIMEOUT_SECONDS: '0',
-        FAKE_STARTUP_DELAY_SECONDS: '0.1',
+        FAKE_READY_AFTER_SECOND_DOWN: '1',
         INVOCATION_LOG: invocationLog,
       },
       timeout: 10_000,
@@ -184,5 +188,13 @@ describe('ci-standalone-smoke workspace reuse', () => {
     expect(result.stderr).toContain('did not become ready');
     expect(result.stderr).toContain('Broker started.');
     expect(result.stdout).not.toContain('Standalone smoke passed');
+
+    const invocations = readFileSync(invocationLog, 'utf8').trim().split('\n');
+    const downIndexes = invocations
+      .map((invocation, index) => (invocation === 'cli node down' ? index : -1))
+      .filter((index) => index >= 0);
+    expect(invocations).toContain('up-waiting');
+    expect(downIndexes).toHaveLength(3);
+    expect(invocations.indexOf('up-ready')).toBeGreaterThan(downIndexes[1]);
   });
 });

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -109,6 +109,7 @@ describe('ci-standalone-smoke workspace reuse', () => {
     });
 
     expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Workspace reuse verified');
     expect(result.stdout).toContain('Standalone smoke passed');
   });
 

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -83,16 +83,32 @@ describe('ci-standalone-smoke workspace reuse', () => {
     }
   });
 
-  it('fails closed before invoking binaries when the dedicated key is missing', () => {
-    const result = spawnSync('bash', [smokeScript, '/missing/cli', '/missing/broker'], {
-      encoding: 'utf8',
-      env: { ...process.env, RELAY_WORKSPACE_KEY: '' },
-    });
+  it('fails closed before invoking binaries when the dedicated key is missing or whitespace-only', () => {
+    const unusableKeys: Array<[label: string, value: string | undefined]> = [
+      ['unset', undefined],
+      ['empty', ''],
+      ['single space', ' '],
+      ['tab', '\t'],
+    ];
 
-    expect(result.status).toBe(2);
-    expect(result.stderr).toContain('Refusing to start');
-    expect(result.stderr).toContain('throwaway workspace');
-    expect(result.stderr).not.toContain('binary not found');
+    for (const [label, value] of unusableKeys) {
+      const env = { ...process.env };
+      if (value === undefined) {
+        delete env.RELAY_WORKSPACE_KEY;
+      } else {
+        env.RELAY_WORKSPACE_KEY = value;
+      }
+
+      const result = spawnSync('bash', [smokeScript, '/missing/cli', '/missing/broker'], {
+        encoding: 'utf8',
+        env,
+      });
+
+      expect(result.status, `${label}: ${result.stderr}`).toBe(2);
+      expect(result.stderr, label).toContain('Refusing to start');
+      expect(result.stderr, label).toContain('throwaway workspace');
+      expect(result.stderr, label).not.toContain('binary not found');
+    }
   });
 
   it('passes the shared key through the isolated lifecycle and joins its workspace', () => {

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -6,7 +6,7 @@ if [ "$#" -ne 2 ]; then
   exit 2
 fi
 
-if [ -z "${RELAY_WORKSPACE_KEY:-}" ]; then
+if [[ -z "${RELAY_WORKSPACE_KEY:-}" || "${RELAY_WORKSPACE_KEY:-}" =~ ^[[:space:]]+$ ]]; then
   echo "ERROR: RELAY_WORKSPACE_KEY must name the dedicated standalone-smoke CI workspace." >&2
   echo "Refusing to start without it because node up would create an undeletable throwaway workspace." >&2
   exit 2

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -173,6 +173,12 @@ else
 fi
 
 UP_OUTPUT="$(cat "$UP_LOG")"
+# A short-lived CLI can write readiness and exit between the polling loop's
+# log check and process-liveness check. Re-read the completed log before
+# reporting a false startup failure.
+if [ "$UP_READY" != true ] && grep -q 'Broker started\.' "$UP_LOG"; then
+  UP_READY=true
+fi
 if [ -n "$UP_EXIT" ] && [ "$UP_EXIT" -ne 0 ]; then
   echo "Standalone broker startup command exited early with status $UP_EXIT" >&2
   echo "AGENT_RELAY_STARTUP_DEBUG=1 was enabled for startup diagnostics." >&2

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -6,8 +6,20 @@ if [ "$#" -ne 2 ]; then
   exit 2
 fi
 
+if [ -z "${RELAY_WORKSPACE_KEY:-}" ]; then
+  echo "ERROR: RELAY_WORKSPACE_KEY must name the dedicated standalone-smoke CI workspace." >&2
+  echo "Refusing to start without it because node up would create an undeletable throwaway workspace." >&2
+  exit 2
+fi
+
+# The broker gives a multi-workspace session higher precedence than the single
+# key. This smoke intentionally exercises one dedicated workspace, so do not
+# let an ambient developer/runner session silently replace the CI credential.
+unset RELAY_WORKSPACES_JSON
+
 CLI_BIN="$1"
 BROKER_BIN="$2"
+BROKER_NAME="${AGENT_RELAY_STANDALONE_BROKER_NAME:-relay-ci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-standalone}-$$}"
 
 validate_binary() {
   local label="$1"
@@ -120,7 +132,7 @@ assert_exact_count "$DOWN_OUTPUT" '^Cleaned up \(was not running\)$' 1 'down cle
 
 echo "=== Smoke: standalone up ==="
 UP_LOG="$TMP_ROOT/up.log"
-run_cli node up >"$UP_LOG" 2>&1 &
+run_cli node up --broker-name "$BROKER_NAME" >"$UP_LOG" 2>&1 &
 UP_PID=$!
 
 UP_EXIT=""
@@ -176,6 +188,17 @@ if [ "$UP_READY" != true ]; then
 fi
 
 assert_exact_count "$UP_OUTPUT" 'Broker started\.' 1 'broker start line'
+# The literal dollar sign proves which environment variable won selection.
+# shellcheck disable=SC2016
+assert_exact_count "$UP_OUTPUT" 'Workspace source: environment \(\$RELAY_WORKSPACE_KEY\)' 1 'workspace source line'
+
+if printf '%s\n' "$UP_OUTPUT" | grep -q 'Workspace: created new workspace'; then
+  echo "Standalone smoke created a workspace instead of reusing the dedicated CI workspace" >&2
+  print_output_excerpt "$UP_OUTPUT"
+  exit 1
+fi
+
+assert_exact_count "$UP_OUTPUT" '^Workspace: joined ' 1 'workspace joined line'
 
 if printf '%s\n' "$UP_OUTPUT" | grep -q 'Broker already running for this project'; then
   echo "Standalone CLI reported a false already-running error" >&2

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -137,6 +137,7 @@ UP_PID=$!
 
 UP_EXIT=""
 UP_READY=false
+UP_EXITED_BEFORE_READY=false
 # Startup can legitimately need to retry a Relaycast handshake on a loaded
 # macOS runner. Do not begin teardown on a fixed timer while that retry is in
 # flight; wait for the CLI's explicit readiness line instead.
@@ -148,6 +149,7 @@ while true; do
     break
   fi
   if ! kill -0 "$UP_PID" 2>/dev/null; then
+    UP_EXITED_BEFORE_READY=true
     break
   fi
   if [ "$SECONDS" -ge "$STARTUP_DEADLINE" ]; then
@@ -160,7 +162,7 @@ done
 if kill -0 "$UP_PID" 2>/dev/null; then
   run_cli node down --force --timeout 5000 >/dev/null 2>&1 || true
   # Hard-kill after 15s if down --force didn't terminate the process (e.g. macOS 26 hang)
-  ( sleep 15 && kill -9 "$UP_PID" 2>/dev/null || true ) &
+  ( sleep 15 && kill -9 "$UP_PID" 2>/dev/null || true ) >/dev/null 2>&1 &
   KILLER_PID=$!
   wait "$UP_PID" || true
   kill "$KILLER_PID" 2>/dev/null || true
@@ -174,9 +176,9 @@ fi
 
 UP_OUTPUT="$(cat "$UP_LOG")"
 # A short-lived CLI can write readiness and exit between the polling loop's
-# log check and process-liveness check. Re-read the completed log before
-# reporting a false startup failure.
-if [ "$UP_READY" != true ] && grep -q 'Broker started\.' "$UP_LOG"; then
+# log check and process-liveness check. Re-read the completed log only for
+# that exit race; never accept readiness written after the startup deadline.
+if [ "$UP_READY" != true ] && [ "$UP_EXITED_BEFORE_READY" = true ] && grep -q 'Broker started\.' "$UP_LOG"; then
   UP_READY=true
 fi
 if [ -n "$UP_EXIT" ] && [ "$UP_EXIT" -ne 0 ]; then

--- a/scripts/ci-standalone-smoke.sh
+++ b/scripts/ci-standalone-smoke.sh
@@ -199,6 +199,7 @@ if printf '%s\n' "$UP_OUTPUT" | grep -q 'Workspace: created new workspace'; then
 fi
 
 assert_exact_count "$UP_OUTPUT" '^Workspace: joined ' 1 'workspace joined line'
+echo "Workspace reuse verified: joined the dedicated CI workspace"
 
 if printf '%s\n' "$UP_OUTPUT" | grep -q 'Broker already running for this project'; then
   echo "Standalone CLI reported a false already-running error" >&2


### PR DESCRIPTION
Closes #1565. Related incident: #1562.

## Why

Package Validation ran the standalone lifecycle with no workspace selection, so each execution created an undeletable Relaycast workspace and abandoned it seconds later. Fresh workspace creation is incidental: this smoke asserts local status/down/up/readiness, not first-run provisioning. A create-and-delete design is unavailable because relaycast#336 has no workspace delete endpoint.

## Change

- Reuse the dedicated `relay-ci-standalone-smoke` workspace through the repository secret `RELAY_CI_WORKSPACE_KEY` in Package Validation and publish verification.
- Fail closed when that key is absent; never fall back to workspace creation.
- Clear higher-precedence `RELAY_WORKSPACES_JSON` and assert the CLI reports the secret-backed environment source plus `Workspace: joined`; reject `Workspace: created new workspace`.
- Give every smoke process a unique broker name so parallel branches cannot collide.
- Skip the live-cloud job for fork and Dependabot PRs, where GitHub does not expose Actions repository secrets.

The workspace key was provisioned directly into GitHub Actions and was never printed, committed, or placed on argv.

## Concurrency and isolation evidence

Using real built CLI/Rust broker artifacts against one existing shared workspace:

- two simultaneous smokes: exit 0 / exit 0;
- one follow-up smoke after both teardowns: exit 0.

Each run already uses a unique temporary HOME and project directory. The smoke creates no agents or channels and makes no inventory assertions, so existing workspace contents do not affect it.

## Reduction

This removes roughly 1,700 throwaway workspaces per day. Production currently holds 41,320 workspaces, 40,742 of which have never carried a message, and workspace creation is timing out under that load.

## Validation

- `npm run build` — exit 0
- focused contract — 5/5 passed across five consecutive runs
- full Vitest suite — 144 files, 2,068 passed, 23 skipped
- `bash -n` + `shellcheck` — exit 0
- Prettier — exit 0
- `git diff --check` — exit 0

No changelog entry: this is CI-only and does not change a user-facing Relay surface.

No merge performed; Khaliq owns the gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



