### PR TITLE
fix(broker): tolerate slow Relaycast startup handshakes

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_5y1dq5g1am4s/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_5y1dq5g1am4s/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix relaycast handshake budget for slow backend
+
+> **Status:** ✅ Completed
+> **Task:** relay#1562
+> **Confidence:** 90%
+> **Started:** August 18, 2026 at 11:59 AM
+> **Completed:** August 18, 2026 at 12:08 PM
+
+---
+
+## Summary
+
+Raised the Relaycast startup handshake default to three 12-second attempts, added an honest unconfirmed-response diagnostic, and added production-latency plus SDK-budget regression coverage. Full broker tests and scoped Clippy pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use three 12-second handshake attempts under the SDK deadline
+- **Chose:** Use three 12-second handshake attempts under the SDK deadline
+- **Reasoning:** Production successes took 7.4-9.5s, so 5s guarantees false timeouts. Three 12s attempts tolerate that slow backend with 2.5s headroom while two backoffs total 750ms, yielding a 36.75s never-response bound inside the harness SDK's verified 45s startupTimeoutMs default. This prioritizes slow-backend survival while retaining two retries; adaptive timing would require observing ambiguous in-flight mutations after timeout.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use three 12-second handshake attempts under the SDK deadline: Use three 12-second handshake attempts under the SDK deadline
+- The original default demonstrably rejected the measured 9.5s success path; the new 12s x 3 budget passes both latency and 45s exhaustion constraints. Full broker tests pass. Strict Clippy is blocked only by an unrelated existing terminal_control while-let lint; the scoped rerun allowing that single baseline lint is clean.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_5y1dq5g1am4s/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_5y1dq5g1am4s/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_5y1dq5g1am4s",
+  "version": 1,
+  "task": {
+    "title": "Fix relaycast handshake budget for slow backend",
+    "source": {
+      "system": "plain",
+      "id": "relay#1562"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T09:59:15.285Z",
+  "completedAt": "2026-08-18T10:08:15.033Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T10:01:37.535Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_s67i94ozoq3p",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T10:01:37.535Z",
+      "endedAt": "2026-08-18T10:08:15.033Z",
+      "events": [
+        {
+          "ts": 1787047297535,
+          "type": "decision",
+          "content": "Use three 12-second handshake attempts under the SDK deadline: Use three 12-second handshake attempts under the SDK deadline",
+          "raw": {
+            "question": "Use three 12-second handshake attempts under the SDK deadline",
+            "chosen": "Use three 12-second handshake attempts under the SDK deadline",
+            "alternatives": [],
+            "reasoning": "Production successes took 7.4-9.5s, so 5s guarantees false timeouts. Three 12s attempts tolerate that slow backend with 2.5s headroom while two backoffs total 750ms, yielding a 36.75s never-response bound inside the harness SDK's verified 45s startupTimeoutMs default. This prioritizes slow-backend survival while retaining two retries; adaptive timing would require observing ambiguous in-flight mutations after timeout."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787047684564,
+          "type": "reflection",
+          "content": "The original default demonstrably rejected the measured 9.5s success path; the new 12s x 3 budget passes both latency and 45s exhaustion constraints. Full broker tests pass. Strict Clippy is blocked only by an unrelated existing terminal_control while-let lint; the scoped rerun allowing that single baseline lint is clean.",
+          "raw": {
+            "focalPoints": [
+              "latency-budget",
+              "diagnostic",
+              "validation"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:latency-budget",
+            "focal:diagnostic",
+            "focal:validation",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Raised the Relaycast startup handshake default to three 12-second attempts, added an honest unconfirmed-response diagnostic, and added production-latency plus SDK-budget regression coverage. Full broker tests and scoped Clippy pass.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1",
+    "endRef": "61da735c1bbb4a23678b91cd6dacd8ab7bafbed1"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_iab5z1pyfwjg/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_iab5z1pyfwjg/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Address multi-membership budget review on PR 1568
+
+> **Status:** ✅ Completed
+> **Task:** relay#1562
+> **Confidence:** 92%
+> **Started:** August 18, 2026 at 12:31 PM
+> **Completed:** August 18, 2026 at 12:36 PM
+
+---
+
+## Summary
+
+Added a 44-second aggregate handshake cap with remaining-budget retries, covered the two-membership 24s plus 19.75s schedule, and split the changelog impacts. Full broker tests and scoped Clippy pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Cap aggregate handshake time at 44 seconds
+- **Chose:** Cap aggregate handshake time at 44 seconds
+- **Reasoning:** Membership scaling can make the default exceed the verified 45s harness deadline. A 44s broker cap preserves the single-membership 3x12s behavior, lets multi-membership retries use the remaining budget instead of disappearing entirely, and leaves 1s for the broker error to reach the SDK. It also bounds large membership counts and oversized env overrides that the outer SDK could never honor.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Cap aggregate handshake time at 44 seconds: Cap aggregate handshake time at 44 seconds

--- a/.agentworkforce/trajectories/completed/2026-08/traj_iab5z1pyfwjg/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_iab5z1pyfwjg/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_iab5z1pyfwjg",
+  "version": 1,
+  "task": {
+    "title": "Address multi-membership budget review on PR 1568",
+    "source": {
+      "system": "plain",
+      "id": "relay#1562"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T10:31:45.794Z",
+  "completedAt": "2026-08-18T10:36:01.628Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T10:31:51.494Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_fkpplcnxx9kk",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T10:31:51.494Z",
+      "endedAt": "2026-08-18T10:36:01.628Z",
+      "events": [
+        {
+          "ts": 1787049111495,
+          "type": "decision",
+          "content": "Cap aggregate handshake time at 44 seconds: Cap aggregate handshake time at 44 seconds",
+          "raw": {
+            "question": "Cap aggregate handshake time at 44 seconds",
+            "chosen": "Cap aggregate handshake time at 44 seconds",
+            "alternatives": [],
+            "reasoning": "Membership scaling can make the default exceed the verified 45s harness deadline. A 44s broker cap preserves the single-membership 3x12s behavior, lets multi-membership retries use the remaining budget instead of disappearing entirely, and leaves 1s for the broker error to reach the SDK. It also bounds large membership counts and oversized env overrides that the outer SDK could never honor."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added a 44-second aggregate handshake cap with remaining-budget retries, covered the two-membership 24s plus 19.75s schedule, and split the changelog impacts. Full broker tests and scoped Clippy pass.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "960919b6aa5365f3c076df2a2327b4d094797fda",
+    "endRef": "960919b6aa5365f3c076df2a2327b4d094797fda"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_yt3d2pcyhu2o/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_yt3d2pcyhu2o/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Reserve SDK startup time before Relaycast handshake
+
+> **Status:** ✅ Completed
+> **Task:** relay#1562 review follow-up
+> **Confidence:** 94%
+> **Started:** August 18, 2026 at 12:44 PM
+> **Completed:** August 18, 2026 at 12:47 PM
+
+---
+
+## Summary
+
+Reduced the aggregate Relaycast handshake cap from 44 seconds to 40 seconds, reserving five seconds for post-port-announcement setup inside the SDK 45-second clock. Added a failing-then-passing reserve regression; 7 scoped tests, 1,014 broker tests, formatting, diff check, and scoped Clippy pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Reserve five seconds between API announcement and handshake exhaustion
+- **Chose:** Reserve five seconds between API announcement and handshake exhaustion
+- **Reasoning:** The SDK starts its 45-second polling clock when the broker prints the bound port, before connection-file and startup-listener setup. A 40-second aggregate handshake cap preserves the one-membership 36.75-second schedule, still accepts measured 9.5-second responses, bounds multi-membership retries, and leaves an explicit five-second preparation and error-propagation reserve without changing the SDK.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Reserve five seconds between API announcement and handshake exhaustion: Reserve five seconds between API announcement and handshake exhaustion

--- a/.agentworkforce/trajectories/completed/2026-08/traj_yt3d2pcyhu2o/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_yt3d2pcyhu2o/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_yt3d2pcyhu2o",
+  "version": 1,
+  "task": {
+    "title": "Reserve SDK startup time before Relaycast handshake",
+    "source": {
+      "system": "plain",
+      "id": "relay#1562 review follow-up"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T10:44:38.244Z",
+  "completedAt": "2026-08-18T10:47:43.395Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T10:46:32.388Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_pmr761zk0oqg",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T10:46:32.388Z",
+      "endedAt": "2026-08-18T10:47:43.395Z",
+      "events": [
+        {
+          "ts": 1787049992389,
+          "type": "decision",
+          "content": "Reserve five seconds between API announcement and handshake exhaustion: Reserve five seconds between API announcement and handshake exhaustion",
+          "raw": {
+            "question": "Reserve five seconds between API announcement and handshake exhaustion",
+            "chosen": "Reserve five seconds between API announcement and handshake exhaustion",
+            "alternatives": [],
+            "reasoning": "The SDK starts its 45-second polling clock when the broker prints the bound port, before connection-file and startup-listener setup. A 40-second aggregate handshake cap preserves the one-membership 36.75-second schedule, still accepts measured 9.5-second responses, bounds multi-membership retries, and leaves an explicit five-second preparation and error-propagation reserve without changing the SDK."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reduced the aggregate Relaycast handshake cap from 44 seconds to 40 seconds, reserving five seconds for post-port-announcement setup inside the SDK 45-second clock. Added a failing-then-passing reserve regression; 7 scoped tests, 1,014 broker tests, formatting, diff check, and scoped Clippy pass.",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "7e0edc4e260fd2f403aaaf48a5b9d4b56799bf71",
+    "endRef": "7e0edc4e260fd2f403aaaf48a5b9d4b56799bf71"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fleet node delivery acknowledgements now wait for worker receipt instead of firing when the message is handed off.
 - Fleet node delivery acknowledgements preserve per-agent sequence order across broker restarts.
+- Broker startup now accepts Relaycast registration responses taking up to 12 seconds per attempt while retaining two retries inside the SDK startup deadline, and reports deadline exhaustion as an unconfirmed response instead of declaring the backend unreachable.
 
 ## [11.7.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fleet node delivery acknowledgements now wait for worker receipt instead of firing when the message is handed off.
 - Fleet node delivery acknowledgements preserve per-agent sequence order across broker restarts.
-- Broker startup now accepts Relaycast registration responses taking up to 12 seconds per attempt while retaining two retries inside the SDK startup deadline, and reports deadline exhaustion as an unconfirmed response instead of declaring the backend unreachable.
+- Broker startup now accepts Relaycast registration responses taking up to 12 seconds per attempt, accommodating slower backends.
+- Broker startup now reports handshake deadline exhaustion as an unconfirmed response that may have completed server-side, instead of declaring the backend unreachable.
 
 ## [11.7.0] - 2026-08-17
 

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -163,10 +163,14 @@ const HANDSHAKE_MAX_ATTEMPTS: u32 = 3;
 const HANDSHAKE_BACKOFF_BASE: Duration = Duration::from_millis(250);
 const HANDSHAKE_BACKOFF_MAX: Duration = Duration::from_secs(2);
 /// Aggregate ceiling for every handshake attempt and backoff. The harness SDK
-/// stops polling after 45s, so keeping the broker one second inside that limit
-/// lets it surface the specific handshake error first. This also bounds
-/// membership-scaled deadlines and oversized environment overrides.
-const HANDSHAKE_TOTAL_TIMEOUT: Duration = Duration::from_secs(44);
+/// starts its 45s polling deadline when the broker announces its bound API port,
+/// before connection-file and startup-listener setup reaches `connect_relay`.
+/// Reserving five seconds for that post-announcement work lets the broker surface
+/// the specific handshake error first. This also bounds membership-scaled
+/// deadlines and oversized environment overrides.
+const HANDSHAKE_TOTAL_TIMEOUT: Duration = Duration::from_secs(40);
+#[cfg(test)]
+const HANDSHAKE_POST_ANNOUNCEMENT_RESERVE: Duration = Duration::from_secs(5);
 
 /// Per-attempt handshake timeout, overridable via
 /// `AGENT_RELAY_HANDSHAKE_TIMEOUT_MS` (must be > 0).
@@ -600,13 +604,27 @@ mod tests {
 
         assert_eq!(
             attempt_deadlines,
-            vec![Duration::from_secs(24), Duration::from_millis(19_750)],
+            vec![Duration::from_secs(24), Duration::from_millis(15_750)],
             "the second attempt uses the aggregate budget remaining after the first timeout and backoff"
         );
         assert_eq!(never_responds_budget, HANDSHAKE_TOTAL_TIMEOUT);
         assert!(
             never_responds_budget < Duration::from_secs(45),
             "membership-scaled retries must still exhaust before the SDK deadline"
+        );
+    }
+
+    #[test]
+    fn aggregate_budget_reserves_post_announcement_setup_time() {
+        // The SDK starts its 45s polling deadline as soon as the broker prints
+        // the bound API port. A small amount of connection-file and startup API
+        // setup happens before connect_relay starts its own clock, so the
+        // handshake cannot consume all but one second of the outer deadline.
+        let sdk_startup_budget = Duration::from_secs(45);
+        assert!(
+            HANDSHAKE_TOTAL_TIMEOUT
+                <= sdk_startup_budget.saturating_sub(HANDSHAKE_POST_ANNOUNCEMENT_RESERVE),
+            "the aggregate handshake limit must leave explicit time for setup after API announcement"
         );
     }
 
@@ -618,7 +636,7 @@ mod tests {
             Duration::from_millis(36_750),
         );
         assert!(message.contains("received no response before its deadlines"));
-        assert!(message.contains("44000ms aggregate limit"));
+        assert!(message.contains("40000ms aggregate limit"));
         assert!(message.contains("may still have completed server-side"));
         assert!(
             !message.contains("was unreachable"),

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -162,6 +162,11 @@ const HANDSHAKE_MAX_ATTEMPTS: u32 = 3;
 /// Base backoff between handshake attempts; doubles each retry, capped.
 const HANDSHAKE_BACKOFF_BASE: Duration = Duration::from_millis(250);
 const HANDSHAKE_BACKOFF_MAX: Duration = Duration::from_secs(2);
+/// Aggregate ceiling for every handshake attempt and backoff. The harness SDK
+/// stops polling after 45s, so keeping the broker one second inside that limit
+/// lets it surface the specific handshake error first. This also bounds
+/// membership-scaled deadlines and oversized environment overrides.
+const HANDSHAKE_TOTAL_TIMEOUT: Duration = Duration::from_secs(44);
 
 /// Per-attempt handshake timeout, overridable via
 /// `AGENT_RELAY_HANDSHAKE_TIMEOUT_MS` (must be > 0).
@@ -211,17 +216,33 @@ fn parse_handshake_attempts(raw: Option<&str>) -> u32 {
         .unwrap_or(HANDSHAKE_MAX_ATTEMPTS)
 }
 
+/// Cap the next attempt to the aggregate handshake time that remains. Returning
+/// `None` means the broker has no time left to start another request.
+fn handshake_attempt_timeout_within_budget(
+    attempt_timeout: Duration,
+    elapsed: Duration,
+) -> Option<Duration> {
+    let remaining = HANDSHAKE_TOTAL_TIMEOUT.saturating_sub(elapsed);
+    (!remaining.is_zero()).then_some(attempt_timeout.min(remaining))
+}
+
+fn handshake_retry_fits_within_budget(elapsed: Duration, backoff: Duration) -> bool {
+    HANDSHAKE_TOTAL_TIMEOUT.saturating_sub(elapsed) > backoff
+}
+
 fn format_handshake_timeout_error(
     attempts: u32,
     attempt_timeout: Duration,
     elapsed: Duration,
 ) -> String {
     format!(
-        "relaycast startup handshake received no response before the per-attempt deadline after \
-         {attempts} attempt(s) of {}ms each ({}ms total elapsed); registration was not confirmed \
-         and may still have completed server-side after the client stopped waiting",
+        "relaycast startup handshake received no response before its deadlines after {attempts} \
+         attempt(s) (up to {}ms per attempt, {}ms total elapsed; {}ms aggregate limit); \
+         registration was not confirmed and may still have completed server-side after the client \
+         stopped waiting",
         attempt_timeout.as_millis(),
-        elapsed.as_millis()
+        elapsed.as_millis(),
+        HANDSHAKE_TOTAL_TIMEOUT.as_millis()
     )
 }
 
@@ -293,11 +314,14 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
     // completed the request AND failed to answer within the deadline); the
     // per-attempt deadline is scaled by the configured workspace count so a
     // healthy multi-workspace startup, which registers each membership serially,
-    // is not cut off mid-flight.
+    // is not cut off mid-flight. The final attempt is shortened to whatever
+    // remains of HANDSHAKE_TOTAL_TIMEOUT so membership scaling and environment
+    // overrides cannot move exhaustion past the SDK startup deadline.
     let membership_count = configured_membership_count();
     let attempt_timeout = handshake_attempt_timeout().saturating_mul(membership_count);
     let max_attempts = handshake_max_attempts();
     let mut backoff = HANDSHAKE_BACKOFF_BASE;
+    let handshake_started = Instant::now();
     // Prove this is the SAME node restarting, not a different one squatting
     // the name: honor an explicit override, else fall back to a value stable
     // across restarts of this node's own persisted state directory. Without
@@ -310,9 +334,19 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
     let sessions = {
         let mut attempt: u32 = 0;
         loop {
+            let Some(current_attempt_timeout) = handshake_attempt_timeout_within_budget(
+                attempt_timeout,
+                handshake_started.elapsed(),
+            ) else {
+                anyhow::bail!(format_handshake_timeout_error(
+                    attempt,
+                    attempt_timeout,
+                    handshake_started.elapsed()
+                ));
+            };
             attempt += 1;
             match timeout(
-                attempt_timeout,
+                current_attempt_timeout,
                 auth.startup_session_set_with_identity(
                     Some(opts.requested_name),
                     opts.strict_name,
@@ -328,17 +362,20 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
                     break result.context("failed to initialize relaycast session")?;
                 }
                 Err(_elapsed) => {
-                    if attempt >= max_attempts {
+                    let handshake_elapsed = handshake_started.elapsed();
+                    if attempt >= max_attempts
+                        || !handshake_retry_fits_within_budget(handshake_elapsed, backoff)
+                    {
                         anyhow::bail!(format_handshake_timeout_error(
                             attempt,
                             attempt_timeout,
-                            connect_started.elapsed()
+                            handshake_elapsed
                         ));
                     }
                     tracing::warn!(
                         attempt,
                         max_attempts,
-                        timeout_ms = attempt_timeout.as_millis() as u64,
+                        timeout_ms = current_attempt_timeout.as_millis() as u64,
                         "relaycast startup handshake received no response before deadline; retrying"
                     );
                     log_startup_phase(
@@ -346,7 +383,7 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
                         connect_started,
                         format!(
                             "handshake attempt {attempt}/{max_attempts} received no response within {}ms; retrying in {}ms",
-                            attempt_timeout.as_millis(),
+                            current_attempt_timeout.as_millis(),
                             backoff.as_millis()
                         ),
                     );
@@ -529,9 +566,47 @@ mod tests {
             backoff = (backoff * 2).min(HANDSHAKE_BACKOFF_MAX);
         }
         let sdk_startup_budget = Duration::from_secs(45);
+        assert!(never_responds_budget < HANDSHAKE_TOTAL_TIMEOUT);
         assert!(
             never_responds_budget < sdk_startup_budget,
             "a backend that never responds must exhaust the default handshake budget before the SDK's 45s deadline"
+        );
+    }
+
+    #[test]
+    fn multi_membership_default_budget_stays_inside_sdk_deadline() {
+        let membership_count = 2;
+        let attempt_timeout = parse_handshake_timeout(None).saturating_mul(membership_count);
+        let max_attempts = parse_handshake_attempts(None);
+        let mut never_responds_budget = Duration::ZERO;
+        let mut backoff = HANDSHAKE_BACKOFF_BASE;
+        let mut attempt_deadlines = Vec::new();
+        for attempt in 0..max_attempts {
+            let Some(current_attempt_timeout) =
+                handshake_attempt_timeout_within_budget(attempt_timeout, never_responds_budget)
+            else {
+                break;
+            };
+            attempt_deadlines.push(current_attempt_timeout);
+            never_responds_budget = never_responds_budget.saturating_add(current_attempt_timeout);
+            if attempt + 1 >= max_attempts
+                || !handshake_retry_fits_within_budget(never_responds_budget, backoff)
+            {
+                break;
+            }
+            never_responds_budget = never_responds_budget.saturating_add(backoff);
+            backoff = (backoff * 2).min(HANDSHAKE_BACKOFF_MAX);
+        }
+
+        assert_eq!(
+            attempt_deadlines,
+            vec![Duration::from_secs(24), Duration::from_millis(19_750)],
+            "the second attempt uses the aggregate budget remaining after the first timeout and backoff"
+        );
+        assert_eq!(never_responds_budget, HANDSHAKE_TOTAL_TIMEOUT);
+        assert!(
+            never_responds_budget < Duration::from_secs(45),
+            "membership-scaled retries must still exhaust before the SDK deadline"
         );
     }
 
@@ -542,7 +617,8 @@ mod tests {
             Duration::from_secs(12),
             Duration::from_millis(36_750),
         );
-        assert!(message.contains("received no response before the per-attempt deadline"));
+        assert!(message.contains("received no response before its deadlines"));
+        assert!(message.contains("44000ms aggregate limit"));
         assert!(message.contains("may still have completed server-side"));
         assert!(
             !message.contains("was unreachable"),

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -149,12 +149,16 @@ pub(crate) struct RelaySessionOptions<'a> {
 /// startup indefinitely — long enough for an external supervisor (the CLI's
 /// `down --force`, a test watchdog) to reap the broker, which surfaces to the
 /// SDK as an opaque "broker exited with code null during initial handshake".
-/// Bounding each attempt turns that hang into a fast, retryable error.
-const HANDSHAKE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Bounding each attempt turns that hang into a retryable error. Production
+/// workspace creation has returned successfully in 7.4-9.5s, so the default
+/// leaves headroom above that measured latency instead of abandoning a request
+/// the backend is about to answer.
+const HANDSHAKE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(12);
 /// Default number of handshake attempts (initial try + retries) before giving
-/// up. Kept well within the SDK's 45s startup budget at the default timeout so
-/// a transient blip recovers in-process instead of failing startup.
-const HANDSHAKE_MAX_ATTEMPTS: u32 = 4;
+/// up. Three 12s attempts plus the default 250ms and 500ms backoffs take at
+/// most 36.75s, inside the harness SDK's 45s startup budget, so a transient
+/// blip can still recover in-process without moving the timeout into the SDK.
+const HANDSHAKE_MAX_ATTEMPTS: u32 = 3;
 /// Base backoff between handshake attempts; doubles each retry, capped.
 const HANDSHAKE_BACKOFF_BASE: Duration = Duration::from_millis(250);
 const HANDSHAKE_BACKOFF_MAX: Duration = Duration::from_secs(2);
@@ -205,6 +209,20 @@ fn parse_handshake_attempts(raw: Option<&str>) -> u32 {
     raw.and_then(|value| value.trim().parse::<u32>().ok())
         .filter(|&attempts| attempts >= 1)
         .unwrap_or(HANDSHAKE_MAX_ATTEMPTS)
+}
+
+fn format_handshake_timeout_error(
+    attempts: u32,
+    attempt_timeout: Duration,
+    elapsed: Duration,
+) -> String {
+    format!(
+        "relaycast startup handshake received no response before the per-attempt deadline after \
+         {attempts} attempt(s) of {}ms each ({}ms total elapsed); registration was not confirmed \
+         and may still have completed server-side after the client stopped waiting",
+        attempt_timeout.as_millis(),
+        elapsed.as_millis()
+    )
 }
 
 /// Parse the number of configured memberships from an optional
@@ -311,23 +329,23 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
                 }
                 Err(_elapsed) => {
                     if attempt >= max_attempts {
-                        anyhow::bail!(
-                            "relaycast startup handshake timed out after {attempt} attempt(s) of {}ms each; \
-                             the relay backend was unreachable or too slow to complete registration",
-                            attempt_timeout.as_millis()
-                        );
+                        anyhow::bail!(format_handshake_timeout_error(
+                            attempt,
+                            attempt_timeout,
+                            connect_started.elapsed()
+                        ));
                     }
                     tracing::warn!(
                         attempt,
                         max_attempts,
                         timeout_ms = attempt_timeout.as_millis() as u64,
-                        "relaycast startup handshake timed out; retrying"
+                        "relaycast startup handshake received no response before deadline; retrying"
                     );
                     log_startup_phase(
                         startup_debug,
                         connect_started,
                         format!(
-                            "handshake attempt {attempt}/{max_attempts} timed out after {}ms; retrying in {}ms",
+                            "handshake attempt {attempt}/{max_attempts} received no response within {}ms; retrying in {}ms",
                             attempt_timeout.as_millis(),
                             backoff.as_millis()
                         ),
@@ -484,6 +502,51 @@ mod tests {
         assert_eq!(
             parse_handshake_timeout(Some("1234")),
             Duration::from_millis(1234)
+        );
+    }
+
+    #[test]
+    fn default_handshake_budget_accepts_measured_latency_and_stays_inside_sdk_deadline() {
+        // Production returned successful workspace creates in as much as 9.5s.
+        // A default below that latency abandons a request the backend is about
+        // to answer, so the first attempt must still be alive at that point.
+        let attempt_timeout = parse_handshake_timeout(None);
+        let measured_success_latency = Duration::from_millis(9_500);
+        assert!(
+            measured_success_latency < attempt_timeout,
+            "a backend responding successfully in 9.5s must beat the default per-attempt deadline"
+        );
+
+        // packages/harness-driver/src/spawn-config.ts defaults
+        // startupTimeoutMs to 45_000, and client.ts uses that as the post-bind
+        // handshake polling budget. Include every retry backoff so a backend
+        // that never responds still fails before the SDK gives up.
+        let max_attempts = parse_handshake_attempts(None);
+        let mut never_responds_budget = attempt_timeout.saturating_mul(max_attempts);
+        let mut backoff = HANDSHAKE_BACKOFF_BASE;
+        for _ in 1..max_attempts {
+            never_responds_budget = never_responds_budget.saturating_add(backoff);
+            backoff = (backoff * 2).min(HANDSHAKE_BACKOFF_MAX);
+        }
+        let sdk_startup_budget = Duration::from_secs(45);
+        assert!(
+            never_responds_budget < sdk_startup_budget,
+            "a backend that never responds must exhaust the default handshake budget before the SDK's 45s deadline"
+        );
+    }
+
+    #[test]
+    fn handshake_timeout_diagnostic_reports_an_unconfirmed_response() {
+        let message = format_handshake_timeout_error(
+            3,
+            Duration::from_secs(12),
+            Duration::from_millis(36_750),
+        );
+        assert!(message.contains("received no response before the per-attempt deadline"));
+        assert!(message.contains("may still have completed server-side"));
+        assert!(
+            !message.contains("was unreachable"),
+            "deadline exhaustion cannot prove that the backend was unreachable"
         );
     }
 


### PR DESCRIPTION
## Summary

- raise the default Relaycast startup handshake from four 5-second attempts to three 12-second attempts
- cap the complete broker handshake at 40 seconds so membership scaling and oversized overrides remain inside the SDK deadline with startup preparation time reserved
- describe deadline exhaustion as an unconfirmed response that may have completed server-side, instead of declaring the backend unreachable
- add regression coverage for measured slow success, multi-membership scaling, post-announcement setup reserve, and never-response bounds

## Budget choice

Production returned successful `POST /v1/workspaces` responses in 7.4s and 9.5s. A 5s per-attempt deadline necessarily abandons both. The 12s default accepts the measured 9.5s success with 2.5s of headroom.

I verified the actual outer budget in the harness SDK rather than relying on the issue summary: `packages/harness-driver/src/spawn-config.ts` defaults `startupTimeoutMs` to 45,000ms, and `packages/harness-driver/src/client.ts` starts that polling deadline when the broker announces its bound API port. For one membership, three 12s attempts plus 250ms and 500ms retry backoffs exhaust in at most 36.75s. For multiple memberships or larger environment overrides, each attempt is shortened to the remaining portion of a 40s broker aggregate budget. This leaves five seconds for connection-file and startup-listener setup after port announcement and for the broker error to surface inside the SDK deadline. The SDK budget itself is unchanged.

This deliberately chooses fewer, longer attempts. A dropped request can now take 12s rather than 5s to recycle, and there are two retries instead of three; in exchange, the broker survives the slow-backend case production is currently exhibiting while retaining recovery from two transient stalls when the aggregate budget permits them.

## Diagnostics and adaptation

Returned HTTP or transport errors still surface immediately with their concrete cause. Only deadline exhaustion takes the new path, which now states that no response arrived before the per-attempt deadline, includes total elapsed time and the aggregate limit, and warns that registration may still have completed after the client stopped waiting. That avoids turning an unknown outcome into a false unreachable diagnosis.

I did not add an adaptive deadline. Learning from an elapsed registration would require keeping an ambiguous, mutating request alive after timeout or adding a separate latency probe; that is not a small or obviously safe change. A fixed, tested budget is clearer here.

## Validation

- regression proof against the original defaults: the new 9.5s success test failed as intended, exit 101
- regression proof against uncapped membership scaling: the new two-membership budget test failed as intended, exit 101
- regression proof against the one-second preparation reserve: the new post-announcement reserve test failed as intended, exit 101
- `mise exec -- cargo fmt --all -- --check`: pass
- `mise exec -- cargo test -p agent-relay-broker runtime::session::tests`: 7 passed
- `mise exec -- cargo test -p agent-relay-broker`: 1,014 passed, 4 ignored; all integration and doc tests passed
- `git diff --check`: pass
- strict all-target Clippy found one pre-existing unrelated `while_let_loop` lint at `crates/broker/src/terminal_control.rs:1224`; allowing only that baseline lint, all-target Clippy passed

## Rollout note

`AGENT_RELAY_HANDSHAKE_TIMEOUT_MS` and `AGENT_RELAY_HANDSHAKE_ATTEMPTS` are per-process environment variables. Applying overrides fleet-wide today requires restarting every node, and restarting a node kills every agent on it. The default therefore matters more than the override: nodes receive the safer budget on their next ordinary restart without an operator remembering an environment variable.

Refs #1562

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
