### PR TITLE
fix(ci): remove production handshake from publish gate

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_7jbhva9a1ucf/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_7jbhva9a1ucf/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Fix Relay publish job and reconcile shipped versions
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** August 19, 2026 at 08:04 AM
+> **Completed:** August 19, 2026 at 08:20 AM
+
+---
+
+## Summary
+
+Isolated every blocking Relay publish lifecycle smoke from production with a loopback Relaycast registration stub, retained real artifact install/resolver/spawn/shutdown checks, added regression coverage and a patch changelog entry, and verified the already-completed 11.7.2 reconciliation across repo manifests, internal pins, and npm.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use an isolated local Relaycast handshake stub for blocking publish smokes
+- **Chose:** Use an isolated local Relaycast handshake stub for blocking publish smokes
+- **Reasoning:** The checks must still install, resolve, spawn, and shut down real release artifacts, but production authenticated-write latency must not gate shipping. A local HTTP stub preserves the real broker lifecycle boundary without timeout inflation or live production writes.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use an isolated local Relaycast handshake stub for blocking publish smokes: Use an isolated local Relaycast handshake stub for blocking publish smokes
+- Publish verification now preserves real install, resolver, spawn, lifecycle, and shutdown checks while replacing only the remote registration dependency with a loopback stub. Version state converged independently during the task: origin/main, 20 release manifests, 23 internal pins, and all 18 npm packages are 11.7.2.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_7jbhva9a1ucf/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_7jbhva9a1ucf/trajectory.json
@@ -1,0 +1,74 @@
+{
+  "id": "traj_7jbhva9a1ucf",
+  "version": 1,
+  "task": {
+    "title": "Fix Relay publish job and reconcile shipped versions"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-19T06:04:25.852Z",
+  "completedAt": "2026-08-19T06:20:28.959Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T06:09:23.826Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_8pwje0ufrqzk",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T06:09:23.826Z",
+      "endedAt": "2026-08-19T06:20:28.959Z",
+      "events": [
+        {
+          "ts": 1787119763827,
+          "type": "decision",
+          "content": "Use an isolated local Relaycast handshake stub for blocking publish smokes: Use an isolated local Relaycast handshake stub for blocking publish smokes",
+          "raw": {
+            "question": "Use an isolated local Relaycast handshake stub for blocking publish smokes",
+            "chosen": "Use an isolated local Relaycast handshake stub for blocking publish smokes",
+            "alternatives": [],
+            "reasoning": "The checks must still install, resolve, spawn, and shut down real release artifacts, but production authenticated-write latency must not gate shipping. A local HTTP stub preserves the real broker lifecycle boundary without timeout inflation or live production writes."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787120421461,
+          "type": "reflection",
+          "content": "Publish verification now preserves real install, resolver, spawn, lifecycle, and shutdown checks while replacing only the remote registration dependency with a loopback stub. Version state converged independently during the task: origin/main, 20 release manifests, 23 internal pins, and all 18 npm packages are 11.7.2.",
+          "raw": {
+            "focalPoints": [
+              "release-gate-isolation",
+              "artifact-integrity",
+              "version-reconciliation"
+            ],
+            "adjustments": "Document that the GitHub OS matrix cannot be executed pre-merge; use actionlint, YAML parsing, focused tests, rebuilt local standalone smoke, and rebuilt harness-driver spawn as pre-merge evidence.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:release-gate-isolation",
+            "focal:artifact-integrity",
+            "focal:version-reconciliation",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Isolated every blocking Relay publish lifecycle smoke from production with a loopback Relaycast registration stub, retained real artifact install/resolver/spawn/shutdown checks, added regression coverage and a patch changelog entry, and verified the already-completed 11.7.2 reconciliation across repo manifests, internal pins, and npm.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "286467e936bb3efbd415ed233d416e59cd390c05",
+    "endRef": "286467e936bb3efbd415ed233d416e59cd390c05"
+  }
+}

--- a/.github/actions/start-relaycast-stub/action.yml
+++ b/.github/actions/start-relaycast-stub/action.yml
@@ -1,0 +1,48 @@
+name: Start local Relaycast handshake stub
+description: Route broker lifecycle verification through an isolated local handshake endpoint.
+
+runs:
+  using: composite
+  steps:
+    - name: Start local handshake endpoint
+      shell: bash
+      run: |
+        set -euo pipefail
+        STUB_ID="${GITHUB_JOB}-${RANDOM}"
+        URL_FILE="$RUNNER_TEMP/relay-ci-handshake-${STUB_ID}.url"
+        LOG_FILE="$RUNNER_TEMP/relay-ci-handshake-${STUB_ID}.log"
+        node "$GITHUB_ACTION_PATH/../../../scripts/ci-relaycast-stub.mjs" \
+          --url-file "$URL_FILE" >"$LOG_FILE" 2>&1 &
+        STUB_PID=$!
+
+        for ((attempt = 0; attempt < 100; attempt += 1)); do
+          if [ -s "$URL_FILE" ]; then
+            break
+          fi
+          if ! kill -0 "$STUB_PID" 2>/dev/null; then
+            echo "Relaycast CI handshake stub exited before becoming ready" >&2
+            cat "$LOG_FILE" >&2
+            exit 1
+          fi
+          sleep 0.1
+        done
+
+        if [ ! -s "$URL_FILE" ]; then
+          echo "Relaycast CI handshake stub did not become ready within 10 seconds" >&2
+          cat "$LOG_FILE" >&2
+          kill "$STUB_PID" 2>/dev/null || true
+          exit 1
+        fi
+
+        RELAYCAST_STUB_URL=$(tr -d '\r\n' < "$URL_FILE")
+        curl --fail --silent --show-error "$RELAYCAST_STUB_URL/health" >/dev/null
+
+        {
+          echo "RELAYCAST_STUB_PID=$STUB_PID"
+          echo "RELAY_BASE_URL=$RELAYCAST_STUB_URL"
+          echo "RELAYCAST_BASE_URL=$RELAYCAST_STUB_URL"
+          echo "RELAY_WORKSPACE_KEY=rk_ci_publish_verify"
+          echo "AGENT_RELAY_WORKSPACE_KEY=rk_ci_publish_verify"
+        } >> "$GITHUB_ENV"
+
+        echo "Broker lifecycle verification is using the local Relaycast handshake stub."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -483,8 +483,10 @@ jobs:
           retention-days: 1
 
   # End-to-end smoke test of the optional-dep broker pattern on every target
-  # platform, using locally-packed tarballs — no registry round-trip, no
-  # mocking. Each matrix leg:
+  # platform, using locally-packed tarballs with no registry round-trip. The
+  # driver and broker artifacts are real; their required Relaycast registration
+  # is isolated behind a loopback stub so production write latency cannot gate
+  # the publish. Each matrix leg:
   #   1. Stages the platform's broker binary into its package tree and
   #      injects os/cpu so the package validates like the published one.
   #   2. `npm pack`s the harness driver and SDK (with packages/sdk/bin emptied
@@ -640,6 +642,9 @@ jobs:
             console.log('OK: resolver returned executable binary from optional-dep package');
           "
 
+      - name: Start isolated Relaycast handshake stub
+        uses: ./.github/actions/start-relaycast-stub
+
       - name: Spawn smoke — HarnessDriverClient.spawn()
         shell: bash
         run: |
@@ -656,6 +661,11 @@ jobs:
             await client.shutdown();
             console.log('OK: client.shutdown() completed');
           " || { echo 'SPAWN_FAILED'; exit 1; }
+
+      - name: Stop isolated Relaycast handshake stub
+        if: always()
+        shell: bash
+        run: kill "$RELAYCAST_STUB_PID" 2>/dev/null || true
 
       - name: Negative smoke — optional dep missing (linux-x64 only)
         if: matrix.platform == 'linux-x64'
@@ -1455,6 +1465,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js for isolated handshake stub
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+
       - name: Download macOS binary
         uses: actions/download-artifact@v4
         with:
@@ -1479,9 +1494,10 @@ jobs:
           scripts/verify-macos-binary.sh "bin/${{ matrix.binary_name }}" "${{ matrix.expected_arch }}" -- --version
           echo "✓ Uncompressed binary verified"
 
+      - name: Start isolated Relaycast handshake stub
+        uses: ./.github/actions/start-relaycast-stub
+
       - name: Smoke standalone lifecycle
-        env:
-          RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}
         run: |
           if [ "$(uname -m)" != "${{ matrix.expected_arch }}" ]; then
             echo "Skipping lifecycle smoke for ${{ matrix.expected_arch }} on $(uname -m) host"
@@ -1489,6 +1505,11 @@ jobs:
           fi
           chmod +x "broker/${{ matrix.broker_name }}"
           bash scripts/ci-standalone-smoke.sh "$PWD/bin/${{ matrix.binary_name }}" "$PWD/broker/${{ matrix.broker_name }}"
+
+      - name: Stop isolated Relaycast handshake stub
+        if: always()
+        shell: bash
+        run: kill "$RELAYCAST_STUB_PID" 2>/dev/null || true
 
       - name: Verify compressed binary
         run: |

--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -17,6 +17,10 @@ name: Verify Published Harness Driver (Cross-Platform)
 # which means it can only verify versions that have already shipped. For
 # pre-publish validation of this logic, use the smoke-broker-packages job in
 # publish.yml — it runs the same assertions against locally-packed tarballs.
+# Both workflows spawn the real broker artifact against a loopback-only
+# registration stub. Production availability is operational telemetry, not an
+# artifact-integrity gate, so a slow authenticated write plane cannot block a
+# release needed to repair it.
 
 on:
   workflow_dispatch:
@@ -63,6 +67,9 @@ jobs:
             expected_pkg: '@agent-relay/broker-win32-x64'
 
     steps:
+      - name: Checkout verification helpers
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -228,6 +235,9 @@ jobs:
             console.log('OK: resolver returned executable binary from optional-dep package');
           "
 
+      - name: Start isolated Relaycast handshake stub
+        uses: ./.github/actions/start-relaycast-stub
+
       - name: Spawn smoke — HarnessDriverClient.spawn()
         shell: bash
         run: |
@@ -244,3 +254,8 @@ jobs:
             await client.shutdown();
             console.log('OK: client.shutdown() completed');
           "
+
+      - name: Stop isolated Relaycast handshake stub
+        if: always()
+        shell: bash
+        run: kill "$RELAYCAST_STUB_PID" 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- The publish workflow now verifies broker lifecycle artifacts against an isolated local Relaycast handshake endpoint, so production control-plane latency cannot block releases.
 
 ## [11.7.2] - 2026-08-19
 

--- a/packages/cli/src/cli/ci-relaycast-stub.test.ts
+++ b/packages/cli/src/cli/ci-relaycast-stub.test.ts
@@ -1,0 +1,86 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const stubScript = resolve('scripts/ci-relaycast-stub.mjs');
+const temporaryDirectories: string[] = [];
+const children: ChildProcess[] = [];
+
+async function waitForUrl(path: string, child: ChildProcess, stderr: () => string): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) {
+      const value = readFileSync(path, 'utf8').trim();
+      if (value) return value;
+    }
+    if (child.exitCode !== null) {
+      throw new Error(`stub exited with ${child.exitCode}: ${stderr()}`);
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+  }
+  throw new Error(`stub did not publish its URL: ${stderr()}`);
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null) child.kill('SIGTERM');
+  }
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('CI Relaycast handshake stub', () => {
+  it('requires a workspace key and returns the registration envelope the broker consumes', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relay-ci-relaycast-stub-test-'));
+    temporaryDirectories.push(directory);
+    const urlFile = join(directory, 'url');
+    const child = spawn(process.execPath, [stubScript, '--url-file', urlFile], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    children.push(child);
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const baseUrl = await waitForUrl(urlFile, child, () => stderr);
+    expect(baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:[0-9]+$/);
+
+    const health = await fetch(`${baseUrl}/health`);
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({
+      ok: true,
+      service: 'relay-ci-handshake-stub',
+    });
+
+    const unauthorized = await fetch(`${baseUrl}/v1/agents`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'publish-smoke' }),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const registered = await fetch(`${baseUrl}/v1/agents`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer rk_ci_publish_verify',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'publish-smoke', type: 'agent' }),
+    });
+    expect(registered.status).toBe(200);
+    await expect(registered.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        id: 'agent_ci_1',
+        workspace_id: 'ws_ci_publish_verify',
+        name: 'publish-smoke',
+        token: 'at_ci_publish_verify_1',
+        status: 'online',
+      },
+    });
+  });
+});

--- a/packages/cli/src/cli/ci-standalone-smoke.test.ts
+++ b/packages/cli/src/cli/ci-standalone-smoke.test.ts
@@ -103,12 +103,15 @@ describe('ci-standalone-smoke workspace reuse', () => {
     expect(cleanupSubshellIndex).toBeGreaterThan(trapDisarmIndex);
   });
 
-  it('injects the same dedicated secret at every workflow call site', () => {
-    for (const workflow of ['.github/workflows/package-validation.yml', '.github/workflows/publish.yml']) {
-      expect(readFileSync(resolve(workflow), 'utf8')).toContain(
-        'RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}'
-      );
-    }
+  it('keeps the package-validation production check while isolating publish lifecycle gates', () => {
+    const packageValidation = readFileSync(resolve('.github/workflows/package-validation.yml'), 'utf8');
+    const publish = readFileSync(resolve('.github/workflows/publish.yml'), 'utf8');
+    const publishedDriverVerify = readFileSync(resolve('.github/workflows/verify-publish-sdk.yml'), 'utf8');
+
+    expect(packageValidation).toContain('RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}');
+    expect(publish).not.toContain('secrets.RELAY_CI_WORKSPACE_KEY');
+    expect(publish.match(/uses: \.\/\.github\/actions\/start-relaycast-stub/g)).toHaveLength(2);
+    expect(publishedDriverVerify).toContain('uses: ./.github/actions/start-relaycast-stub');
   });
 
   it('keeps the outer startup deadline above the broker aggregate handshake budget', () => {

--- a/scripts/ci-relaycast-stub.mjs
+++ b/scripts/ci-relaycast-stub.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { createServer } from 'node:http';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const MAX_BODY_BYTES = 64 * 1024;
+const WORKSPACE_ID = 'ws_ci_publish_verify';
+
+function usage() {
+  return 'Usage: node scripts/ci-relaycast-stub.mjs --url-file <path>';
+}
+
+function parseArgs(argv) {
+  if (argv.length !== 2 || argv[0] !== '--url-file' || !argv[1]?.trim()) {
+    throw new Error(usage());
+  }
+  return { urlFile: resolve(argv[1]) };
+}
+
+function sendJson(response, status, body) {
+  const payload = JSON.stringify(body);
+  response.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+  });
+  response.end(payload);
+}
+
+async function readJson(request) {
+  let body = '';
+  for await (const chunk of request) {
+    body += chunk;
+    if (Buffer.byteLength(body) > MAX_BODY_BYTES) {
+      throw new Error(`request body exceeds ${MAX_BODY_BYTES} bytes`);
+    }
+  }
+  return body ? JSON.parse(body) : {};
+}
+
+function hasWorkspaceAuthorization(request) {
+  return /^Bearer rk_[A-Za-z0-9_-]+$/.test(request.headers.authorization ?? '');
+}
+
+async function start() {
+  const { urlFile } = parseArgs(process.argv.slice(2));
+  let registrationSequence = 0;
+
+  const server = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+
+      if (request.method === 'GET' && url.pathname === '/health') {
+        sendJson(response, 200, { ok: true, service: 'relay-ci-handshake-stub' });
+        return;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/v1/agents') {
+        if (!hasWorkspaceAuthorization(request)) {
+          sendJson(response, 401, {
+            ok: false,
+            error: { code: 'unauthorized', message: 'workspace authorization required' },
+          });
+          return;
+        }
+
+        const body = await readJson(request);
+        const name = typeof body.name === 'string' ? body.name.trim() : '';
+        if (!name) {
+          sendJson(response, 400, {
+            ok: false,
+            error: { code: 'invalid_agent_name', message: 'agent name is required' },
+          });
+          return;
+        }
+
+        registrationSequence += 1;
+        sendJson(response, 200, {
+          ok: true,
+          data: {
+            id: `agent_ci_${registrationSequence}`,
+            workspace_id: WORKSPACE_ID,
+            name,
+            token: `at_ci_publish_verify_${registrationSequence}`,
+            status: 'online',
+            created_at: new Date().toISOString(),
+          },
+        });
+        return;
+      }
+
+      sendJson(response, 404, {
+        ok: false,
+        error: { code: 'not_found', message: `${request.method} ${url.pathname} is not stubbed` },
+      });
+    } catch (error) {
+      sendJson(response, 400, {
+        ok: false,
+        error: {
+          code: 'bad_request',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  });
+
+  server.on('error', (error) => {
+    console.error(`Relaycast CI handshake stub failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+
+  server.listen(0, '127.0.0.1', () => {
+    void (async () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Relaycast CI handshake stub did not receive a TCP address');
+      }
+
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      await mkdir(dirname(urlFile), { recursive: true });
+      await writeFile(urlFile, `${baseUrl}\n`, { mode: 0o600 });
+      console.log(`Relaycast CI handshake stub listening on ${baseUrl}`);
+    })().catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+      server.close();
+    });
+  });
+
+  const shutdown = () => server.close(() => process.exit(0));
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+start().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What changed

- Routes every blocking broker lifecycle smoke in the publish flow through a loopback-only Relaycast registration stub:
  - pre-publish locally packed harness-driver and broker matrix
  - macOS standalone lifecycle verification
  - post-publish harness-driver registry matrix
- Keeps the real artifact assertions intact: clean install/pack, platform optional-dependency selection, executable resolution, HarnessDriverClient.spawn, standalone node up/down, and shutdown must still pass.
- Removes RELAY_CI_WORKSPACE_KEY from the publish workflow. Production registration is no longer verified by this blocking release gate; package-validation retains its dedicated production smoke.
- Adds contract and workflow-wiring tests plus an Unreleased - Patch changelog entry.

This intentionally weakens one aspect of the release gate: it no longer proves the production authenticated write plane is healthy. That availability signal should be operational telemetry, not a prerequisite for shipping a repair. The artifact-integrity and local lifecycle checks remain blocking.

## Why this design

Run 32195442556 attempt 1 failed after successful builds/publishes because five real artifacts all waited on the same live production registration path. Raising the 12-second timeout again would only move the failure threshold and make outages slower to surface. A local ephemeral handshake endpoint makes the gate deterministic while still executing the shipped CLI, harness driver, and broker binaries end to end.

Reference: https://github.com/AgentWorkforce/relay/actions/runs/32195442556

## Version reconciliation

The repository changed while this work was starting: run 32195442556 was rerun successfully as attempt 2 and pushed release commit 286467e93 for v11.7.2. Current state is now reconciled:

- agent-relay: repo 11.7.2, npm 11.7.2
- @agent-relay/harness-driver: repo 11.7.2, npm 11.7.2
- all 18 npm packages touched by the release flow report 11.7.2
- the root plus every packages/* manifest and packages/sdk-py/pyproject.toml are 11.7.2 (20 manifests total)
- all 23 internal @agent-relay dependency pins are 11.7.2

Therefore this PR does not manufacture another version bump: its resulting checked-in version remains 11.7.2, and the next patch publish will calculate 11.7.3 through the workflow's Version all packages step.

## Verification

Passed locally:

- npm ci
- npm run typecheck
- npm run build
- npx vitest run packages/cli/src/cli/ci-relaycast-stub.test.ts packages/cli/src/cli/ci-standalone-smoke.test.ts (9/9)
- Prettier checks for every changed source/workflow file
- actionlint syntax checks for publish.yml and verify-publish-sdk.yml
- YAML parse checks for both workflows and the composite action
- exact composite-action shell body launched the stub and passed its health check
- rebuilt CLI plus rebuilt broker passed scripts/ci-standalone-smoke.sh against the loopback endpoint
- rebuilt HarnessDriverClient.spawn started the rebuilt broker against the loopback endpoint and shut it down successfully

The workflow only runs from main, so the exact GitHub-hosted win32/linux/darwin matrix cannot be executed from this unmerged change. The local proof exercises both lifecycle call paths; GitHub will provide the cross-platform proof on the next publish.

Full npm test is not green on current main-equivalent code for two unrelated failures outside this diff:

- broker-lifecycle.test.ts expects the obsolete text Reflex log format, while the implementation emits structured JSON
- integration-relayfile-contract.test.ts cannot replace a stale daemon because lsof is unavailable on this host

Result: 2,098 passed, 14 skipped, 2 unrelated failures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

