### PR TITLE
feat(fleet): add privacy-safe repository registration contract

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_8xylo1e6uc4z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_8xylo1e6uc4z/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Add privacy-safe repository registration contract
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 19, 2026 at 09:04 AM
+> **Completed:** August 19, 2026 at 09:30 AM
+
+---
+
+## Summary
+
+Added validated node-local repoPaths, privacy-safe registration keys/tags, TypeScript and Rust repo_keys wire plumbing, compiled-child local descriptor handoff, compatibility tests, and documentation.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror
+- **Chose:** Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror
+- **Reasoning:** The relay repository consumes @relaycast/sdk 8.0.0, whose strict node.register shape cannot emit a new repo_keys option yet. Existing tags are already accepted and placement reads them, so deriving authoritative tags from the node-local repoPaths map keeps this PR independently landable. The Rust field remains empty until the node-resolution lane supplies keys from its validated local map.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror: Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror
+- Wire contract is complete and green; security review caught that owner/repo shape must reject dot path segments, so both fleet config and compiled-child IPC now enforce exactly two allowlisted non-dot segments and absolute values.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_8xylo1e6uc4z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_8xylo1e6uc4z/trajectory.json
@@ -1,0 +1,73 @@
+{
+  "id": "traj_8xylo1e6uc4z",
+  "version": 1,
+  "task": {
+    "title": "Add privacy-safe repository registration contract"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-19T07:04:08.402Z",
+  "completedAt": "2026-08-19T07:30:42.191Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T07:14:40.829Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ibagoj6gc7rf",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T07:14:40.829Z",
+      "endedAt": "2026-08-19T07:30:42.191Z",
+      "events": [
+        {
+          "ts": 1787123680829,
+          "type": "decision",
+          "content": "Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror: Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror",
+          "raw": {
+            "question": "Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror",
+            "chosen": "Used repo:<owner/repo> tags for JS provider compatibility while adding explicit repo_keys to the TypeScript/Rust broker wire mirror",
+            "alternatives": [],
+            "reasoning": "The relay repository consumes @relaycast/sdk 8.0.0, whose strict node.register shape cannot emit a new repo_keys option yet. Existing tags are already accepted and placement reads them, so deriving authoritative tags from the node-local repoPaths map keeps this PR independently landable. The Rust field remains empty until the node-resolution lane supplies keys from its validated local map."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787124151246,
+          "type": "reflection",
+          "content": "Wire contract is complete and green; security review caught that owner/repo shape must reject dot path segments, so both fleet config and compiled-child IPC now enforce exactly two allowlisted non-dot segments and absolute values.",
+          "raw": {
+            "focalPoints": [
+              "privacy",
+              "validation",
+              "compatibility"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:privacy",
+            "focal:validation",
+            "focal:compatibility",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added validated node-local repoPaths, privacy-safe registration keys/tags, TypeScript and Rust repo_keys wire plumbing, compiled-child local descriptor handoff, compatibility tests, and documentation.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "286467e936bb3efbd415ed233d416e59cd390c05",
+    "endRef": "286467e936bb3efbd415ed233d416e59cd390c05"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Fleet node definitions can declare node-local `repoPaths`; registration advertises only placement-safe repository keys and keeps absolute checkout paths private to the node.
 
 ## [11.7.2] - 2026-08-19
 

--- a/crates/broker/src/fleet_wire.rs
+++ b/crates/broker/src/fleet_wire.rs
@@ -125,8 +125,8 @@ pub struct NodeRegister {
     pub max_agents: u32,
     pub tags: Vec<String>,
     /// Placement-safe repository keys; absolute node-local paths are forbidden.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repo_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_keys: Option<Vec<String>>,
     pub version: String,
     #[serde(
         default,

--- a/crates/broker/src/fleet_wire.rs
+++ b/crates/broker/src/fleet_wire.rs
@@ -124,6 +124,9 @@ pub struct NodeRegister {
     pub capabilities: Vec<FleetCapability>,
     pub max_agents: u32,
     pub tags: Vec<String>,
+    /// Placement-safe repository keys; absolute node-local paths are forbidden.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repo_keys: Vec<String>,
     pub version: String,
     #[serde(
         default,
@@ -1111,6 +1114,40 @@ mod tests {
                 "resume_cursor": null
             })
         );
+        assert_eq!(encoded.get("repo_keys"), None);
+    }
+
+    #[test]
+    fn node_register_accepts_public_repo_keys_and_rejects_private_repo_paths() {
+        let public = json!({
+            "type": "node.register",
+            "v": 1,
+            "name": "builder-1",
+            "node_id": "node_1",
+            "capabilities": [],
+            "max_agents": 1,
+            "tags": [],
+            "repo_keys": ["AgentWorkforce/factory", "AgentWorkforce/relay"],
+            "version": "relay-broker/test",
+            "resume_cursor": null
+        });
+        let decoded: BrokerToRelaycast = serde_json::from_value(public.clone()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), public);
+
+        let private = json!({
+            "type": "node.register",
+            "v": 1,
+            "name": "builder-1",
+            "node_id": "node_1",
+            "capabilities": [],
+            "max_agents": 1,
+            "tags": [],
+            "repo_keys": ["AgentWorkforce/factory"],
+            "repo_paths": {"AgentWorkforce/factory": "/private/node/factory"},
+            "version": "relay-broker/test",
+            "resume_cursor": null
+        });
+        assert!(serde_json::from_value::<BrokerToRelaycast>(private).is_err());
     }
 
     #[test]

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -1145,6 +1145,7 @@ pub(crate) fn build_node_register(
         capabilities,
         max_agents: manifest.max_agents.unwrap_or(0),
         tags: manifest.tags.clone().unwrap_or_default(),
+        repo_keys: manifest.repo_keys.clone().unwrap_or_default(),
         version: manifest
             .version
             .as_deref()
@@ -3135,6 +3136,7 @@ mod tests {
             }],
             max_agents: Some(8),
             tags: Some(vec!["local".to_string()]),
+            repo_keys: Some(vec!["AgentWorkforce/relay".to_string()]),
             version: Some("sidecar/1".to_string()),
         };
 
@@ -3143,6 +3145,7 @@ mod tests {
         assert_eq!(register.name, "builder");
         assert_eq!(register.node_id, "node-manifest");
         assert_eq!(register.max_agents, 8);
+        assert_eq!(register.repo_keys, vec!["AgentWorkforce/relay"]);
         assert_eq!(
             register.capabilities[0].metadata,
             Some(BTreeMap::from([(
@@ -4085,6 +4088,7 @@ mod tests {
             }],
             max_agents: Some(4),
             tags: Some(vec!["test".to_string()]),
+            repo_keys: None,
             version: Some("sidecar/test".to_string()),
         }
     }

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -1145,7 +1145,19 @@ pub(crate) fn build_node_register(
         capabilities,
         max_agents: manifest.max_agents.unwrap_or(0),
         tags: manifest.tags.clone().unwrap_or_default(),
-        repo_keys: manifest.repo_keys.clone().unwrap_or_default(),
+        // Treat the Fleet wire as a privacy boundary: even an unvalidated
+        // manifest must never serialize a path-shaped or malformed value.
+        // Preserve Some([]) so an updated node can authoritatively clear stale
+        // repository advertisements on the control plane.
+        repo_keys: manifest.repo_keys.as_ref().map(|repo_keys| {
+            let mut seen = HashSet::new();
+            repo_keys
+                .iter()
+                .filter(|repo_key| is_placement_repo_key(repo_key))
+                .filter(|repo_key| seen.insert((*repo_key).clone()))
+                .cloned()
+                .collect()
+        }),
         version: manifest
             .version
             .as_deref()
@@ -1155,6 +1167,25 @@ pub(crate) fn build_node_register(
         machine_id: None,
         resume_cursor,
     }
+}
+
+fn is_placement_repo_key(value: &str) -> bool {
+    let mut segments = value.split('/');
+    let Some(owner) = segments.next() else {
+        return false;
+    };
+    let Some(repo) = segments.next() else {
+        return false;
+    };
+    segments.next().is_none()
+        && [owner, repo].into_iter().all(|segment| {
+            !segment.is_empty()
+                && segment != "."
+                && segment != ".."
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        })
 }
 
 /// The broker's stable provider name. The broker attaches to its node as one
@@ -3145,7 +3176,10 @@ mod tests {
         assert_eq!(register.name, "builder");
         assert_eq!(register.node_id, "node-manifest");
         assert_eq!(register.max_agents, 8);
-        assert_eq!(register.repo_keys, vec!["AgentWorkforce/relay"]);
+        assert_eq!(
+            register.repo_keys,
+            Some(vec!["AgentWorkforce/relay".to_string()])
+        );
         assert_eq!(
             register.capabilities[0].metadata,
             Some(BTreeMap::from([(
@@ -3162,6 +3196,34 @@ mod tests {
                 queue: None,
                 metadata: None,
             })
+        );
+    }
+
+    #[test]
+    fn build_node_register_keeps_only_placement_safe_repo_keys() {
+        let mut manifest = test_manifest();
+        manifest.repo_keys = Some(vec![
+            "AgentWorkforce/relay".to_string(),
+            "/private/node/relay".to_string(),
+            "AgentWorkforce/relay/extra".to_string(),
+            "AgentWorkforce/relay".to_string(),
+            "../relay".to_string(),
+        ]);
+
+        let register =
+            build_node_register(&manifest, "node-default", "host-default", "broker/1", None);
+        assert_eq!(
+            register.repo_keys,
+            Some(vec!["AgentWorkforce/relay".to_string()])
+        );
+
+        manifest.repo_keys = Some(Vec::new());
+        let clear =
+            build_node_register(&manifest, "node-default", "host-default", "broker/1", None);
+        assert_eq!(clear.repo_keys, Some(Vec::new()));
+        assert_eq!(
+            serde_json::to_value(clear).unwrap().get("repo_keys"),
+            Some(&json!([]))
         );
     }
 

--- a/crates/broker/src/protocol.rs
+++ b/crates/broker/src/protocol.rs
@@ -287,6 +287,9 @@ pub struct NodeManifest {
     pub max_agents: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    /// Placement-safe repository keys. Absolute checkout paths remain node-local.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_keys: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -880,6 +880,7 @@ fn bootstrap_node_manifest(node_name: &str, node_id: &str, broker_version: &str)
         capabilities,
         max_agents: node_max_agents(),
         tags: None,
+        repo_keys: None,
         version: Some(broker_version.to_string()),
     }
 }

--- a/crates/broker/tests/fixtures/fleet-wire/node.register.json
+++ b/crates/broker/tests/fixtures/fleet-wire/node.register.json
@@ -25,6 +25,7 @@
   ],
   "max_agents": 8,
   "tags": ["darwin", "arm64", "ssd"],
+  "repo_keys": ["AgentWorkforce/factory", "AgentWorkforce/relay"],
   "version": "relay-broker/0.7.0",
   "resume_cursor": null
 }

--- a/packages/cli/src/cli/lib/node-provider-child.test.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.test.ts
@@ -53,6 +53,41 @@ describe('parseNodeDescriptor', () => {
     expect(parseNodeDescriptor(stdout)).toEqual({ name: 'n', capabilities: ['spawn:claude'] });
   });
 
+  it('carries node-private repo paths across the local describe IPC', () => {
+    const repoPath = path.resolve('private-checkouts', 'relay');
+    const stdout = `${MARKER}${JSON.stringify({
+      name: 'n',
+      capabilities: ['spawn:codex'],
+      repoPaths: { 'AgentWorkforce/relay': repoPath },
+    })}\n`;
+
+    expect(parseNodeDescriptor(stdout)).toEqual({
+      name: 'n',
+      capabilities: ['spawn:codex'],
+      repoPaths: { 'AgentWorkforce/relay': repoPath },
+    });
+  });
+
+  it.each(['./repo', '../repo'])('rejects relative repo path %s from local describe IPC', (repoPath) => {
+    const stdout = `${MARKER}${JSON.stringify({
+      name: 'n',
+      capabilities: [],
+      repoPaths: { 'AgentWorkforce/relay': repoPath },
+    })}\n`;
+
+    expect(() => parseNodeDescriptor(stdout)).toThrow(/absolute paths/);
+  });
+
+  it.each(['./repo', '../repo'])('rejects path-shaped repo key %s from local describe IPC', (repoKey) => {
+    const stdout = `${MARKER}${JSON.stringify({
+      name: 'n',
+      capabilities: [],
+      repoPaths: { [repoKey]: path.resolve('private-checkouts', 'relay') },
+    })}\n`;
+
+    expect(() => parseNodeDescriptor(stdout)).toThrow(/owner\/repo keys/);
+  });
+
   it('ignores output the config printed on import', () => {
     const stdout = [
       'booting my node...',

--- a/packages/cli/src/cli/lib/node-provider-child.test.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.test.ts
@@ -75,7 +75,7 @@ describe('parseNodeDescriptor', () => {
       repoPaths: { 'AgentWorkforce/relay': repoPath },
     })}\n`;
 
-    expect(() => parseNodeDescriptor(stdout)).toThrow(/absolute paths/);
+    expect(() => parseNodeDescriptor(stdout)).toThrow(/absolute path/);
   });
 
   it.each(['./repo', '../repo'])('rejects path-shaped repo key %s from local describe IPC', (repoKey) => {
@@ -85,7 +85,29 @@ describe('parseNodeDescriptor', () => {
       repoPaths: { [repoKey]: path.resolve('private-checkouts', 'relay') },
     })}\n`;
 
-    expect(() => parseNodeDescriptor(stdout)).toThrow(/owner\/repo keys/);
+    expect(() => parseNodeDescriptor(stdout)).toThrow(/owner\/repo format/);
+  });
+
+  it('uses the fleet validator for trimmed and duplicate repo keys', () => {
+    const repoPath = path.resolve('private-checkouts', 'relay');
+    const normalized = `${MARKER}${JSON.stringify({
+      name: 'n',
+      capabilities: [],
+      repoPaths: { ' AgentWorkforce/relay ': repoPath },
+    })}\n`;
+    expect(parseNodeDescriptor(normalized)?.repoPaths).toEqual({
+      'AgentWorkforce/relay': repoPath,
+    });
+
+    const duplicate = `${MARKER}${JSON.stringify({
+      name: 'n',
+      capabilities: [],
+      repoPaths: {
+        'AgentWorkforce/relay': repoPath,
+        ' AgentWorkforce/relay ': path.resolve('private-checkouts', 'other'),
+      },
+    })}\n`;
+    expect(() => parseNodeDescriptor(duplicate)).toThrow(/duplicate key/);
   });
 
   it('ignores output the config printed on import', () => {

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -115,6 +115,11 @@ if (describeOnly) {
     name: definition.name,
     capabilities: Object.keys(definition.capabilities || {}),
     ...(typeof definition.maxAgents === 'number' ? { maxAgents: definition.maxAgents } : {}),
+    // Local child -> CLI IPC only. The parent passes these values directly to
+    // its native broker; serveNode registration independently emits keys only.
+    ...(definition.repoPaths && typeof definition.repoPaths === 'object'
+      ? { repoPaths: definition.repoPaths }
+      : {}),
   };
   console.log('__AGENT_RELAY_NODE_DESCRIPTOR__' + JSON.stringify(descriptor));
   return;
@@ -256,6 +261,8 @@ export type NodeDefinitionDescriptor = {
   name: string;
   capabilities: string[];
   maxAgents?: number;
+  /** Node-private map carried only across local child-to-CLI IPC. */
+  repoPaths?: Readonly<Record<string, string>>;
 };
 
 /**
@@ -273,11 +280,34 @@ export function parseNodeDescriptor(stdout: string): NodeDefinitionDescriptor | 
     return undefined;
   }
   const parsed = JSON.parse(last.slice(NODE_DESCRIPTOR_MARKER.length)) as NodeDefinitionDescriptor;
+  const repoPaths = parseDescriptorRepoPaths(parsed.repoPaths);
   return {
     name: parsed.name,
     capabilities: Array.isArray(parsed.capabilities) ? parsed.capabilities : [],
     ...(typeof parsed.maxAgents === 'number' ? { maxAgents: parsed.maxAgents } : {}),
+    ...(repoPaths !== undefined ? { repoPaths } : {}),
   };
+}
+
+function parseDescriptorRepoPaths(value: unknown): Readonly<Record<string, string>> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Fleet node descriptor repoPaths must be an object keyed by owner/repo');
+  }
+  const repoPaths: Record<string, string> = {};
+  for (const [key, repoPath] of Object.entries(value)) {
+    const segments = key.split('/');
+    const placementSafeKey =
+      segments.length === 2 &&
+      segments.every((segment) => segment !== '.' && segment !== '..' && /^[A-Za-z0-9._-]+$/.test(segment));
+    if (!placementSafeKey || typeof repoPath !== 'string' || !path.isAbsolute(repoPath)) {
+      throw new Error('Fleet node descriptor repoPaths must map owner/repo keys to absolute paths');
+    }
+    repoPaths[key] = repoPath;
+  }
+  return repoPaths;
 }
 
 /**

--- a/packages/cli/src/cli/lib/node-provider-child.ts
+++ b/packages/cli/src/cli/lib/node-provider-child.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { normalizeFleetRepoPaths } from '@agent-relay/fleet';
 import { createLogger } from '@agent-relay/utils';
 
 import type { CoreDependencies, SpawnedProcess } from '../commands/core.js';
@@ -290,24 +291,7 @@ export function parseNodeDescriptor(stdout: string): NodeDefinitionDescriptor | 
 }
 
 function parseDescriptorRepoPaths(value: unknown): Readonly<Record<string, string>> | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Fleet node descriptor repoPaths must be an object keyed by owner/repo');
-  }
-  const repoPaths: Record<string, string> = {};
-  for (const [key, repoPath] of Object.entries(value)) {
-    const segments = key.split('/');
-    const placementSafeKey =
-      segments.length === 2 &&
-      segments.every((segment) => segment !== '.' && segment !== '..' && /^[A-Za-z0-9._-]+$/.test(segment));
-    if (!placementSafeKey || typeof repoPath !== 'string' || !path.isAbsolute(repoPath)) {
-      throw new Error('Fleet node descriptor repoPaths must map owner/repo keys to absolute paths');
-    }
-    repoPaths[key] = repoPath;
-  }
-  return repoPaths;
+  return normalizeFleetRepoPaths(value);
 }
 
 /**

--- a/packages/fleet/README.md
+++ b/packages/fleet/README.md
@@ -48,6 +48,27 @@ agent-relay fleet nodes      # list registered nodes
 agent-relay fleet status     # show node + capability health
 ```
 
+### Repository placement
+
+A node can declare the checkouts it can serve with an `owner/repo` keyed map:
+
+```ts
+export default defineNode({
+  name: 'builder',
+  repoPaths: {
+    'AgentWorkforce/factory': '/srv/repos/factory',
+    'AgentWorkforce/relay': '/srv/repos/relay',
+  },
+  capabilities: {
+    /* … */
+  },
+});
+```
+
+Each value must be an absolute path on that node. Registration derives the
+placement-safe `AgentWorkforce/factory` and `AgentWorkforce/relay` keys; the
+absolute values are never sent to Relaycast, exposed in the roster, or logged.
+
 ### Serving a node programmatically
 
 `@agent-relay/fleet` also ships the node runtime, so you can start a node in

--- a/packages/fleet/src/index.test.ts
+++ b/packages/fleet/src/index.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -6,6 +8,8 @@ import {
   defineDefaultLocalNode,
   defineNode,
   invokeNodeHandler,
+  nodeInfo,
+  nodeRegistrationTags,
   onMessage,
   spawn,
   triggerSyncInputs,
@@ -43,6 +47,73 @@ describe('@agent-relay/fleet', () => {
         stubContext(node.name, Object.keys(node.capabilities))
       )
     ).resolves.toEqual({ input: { hello: 'world' } });
+  });
+
+  it('normalizes node-local repo paths and exposes only deterministic placement keys', () => {
+    const factoryPath = resolve('node-private', 'factory');
+    const relayPath = resolve('node-private', 'relay');
+    const configured = {
+      ' AgentWorkforce/relay ': relayPath,
+      'AgentWorkforce/factory': factoryPath,
+    };
+    const node = defineNode({
+      name: 'repo-builder',
+      capabilities: { ping: async () => 'pong' },
+      tags: ['arm64', 'repo:legacy/manual-tag'],
+      repoPaths: configured,
+    });
+
+    configured[' AgentWorkforce/relay '] = resolve('different-private-path');
+
+    expect(node.repoPaths).toEqual({
+      'AgentWorkforce/relay': relayPath,
+      'AgentWorkforce/factory': factoryPath,
+    });
+    expect(Object.isFrozen(node.repoPaths)).toBe(true);
+    expect(nodeInfo(node)).toEqual({
+      name: 'repo-builder',
+      capabilities: ['ping'],
+      repoKeys: ['AgentWorkforce/factory', 'AgentWorkforce/relay'],
+    });
+    expect(nodeRegistrationTags(node)).toEqual([
+      'arm64',
+      'repo:AgentWorkforce/factory',
+      'repo:AgentWorkforce/relay',
+    ]);
+    expect(JSON.stringify(nodeInfo(node))).not.toContain(factoryPath);
+    expect(JSON.stringify(nodeInfo(node))).not.toContain(relayPath);
+  });
+
+  it('preserves legacy repo tags when repoPaths is not configured', () => {
+    const node = defineNode({
+      name: 'legacy-builder',
+      capabilities: { ping: async () => 'pong' },
+      tags: ['arm64', 'repo:legacy'],
+    });
+
+    expect(nodeRegistrationTags(node)).toEqual(['arm64', 'repo:legacy']);
+  });
+
+  it('rejects non-placement keys and relative checkout paths', () => {
+    const absolute = resolve('node-private', 'factory');
+    for (const invalidKey of ['/private/node/factory', './repo', '../repo']) {
+      expect(() =>
+        defineNode({
+          name: 'bad-key',
+          capabilities: { ping: async () => 'pong' },
+          repoPaths: { [invalidKey]: absolute },
+        })
+      ).toThrow(/owner\/repo format/);
+    }
+    for (const relativePath of ['relative/factory', './repo', '../repo']) {
+      expect(() =>
+        defineNode({
+          name: 'bad-path',
+          capabilities: { ping: async () => 'pong' },
+          repoPaths: { 'AgentWorkforce/factory': relativePath },
+        })
+      ).toThrow(/must be an absolute path/);
+    }
   });
 
   it('builds spawn_agent payloads from a PTY harness', async () => {

--- a/packages/fleet/src/index.ts
+++ b/packages/fleet/src/index.ts
@@ -1,3 +1,5 @@
+import { isAbsolute } from 'node:path';
+
 import { z } from 'zod';
 import { claude, codex, definePtyHarness, gemini, type PtyHarness } from '@agent-relay/harnesses';
 import { resolveStaticHarnessConfig, type StaticPtyHarnessDefinition } from '@agent-relay/harness-driver';
@@ -17,7 +19,12 @@ export interface FleetNodeInfo {
   name: string;
   maxAgents?: number;
   capabilities: string[];
+  /** Placement-safe repository keys; local checkout paths are never exposed. */
+  repoKeys?: string[];
 }
+
+/** Node-local checkout map. Values never leave the node registration runtime. */
+export type FleetRepoPaths = Readonly<Record<string, string>>;
 
 export interface FleetRelaySendMessageInput {
   to: string;
@@ -91,6 +98,11 @@ export interface FleetNodeDefinitionInput {
   capabilities: Record<string, FleetCapabilityValue>;
   triggers?: FleetTriggerDescriptor[];
   tags?: string[];
+  /**
+   * Node-local absolute checkout paths keyed by `owner/repo`.
+   * Registration advertises only the keys; path values remain node-private.
+   */
+  repoPaths?: FleetRepoPaths;
   version?: string;
 }
 
@@ -101,6 +113,8 @@ export interface FleetNodeDefinition {
   readonly capabilities: Record<string, FleetCapability>;
   readonly triggers: FleetTriggerDescriptor[];
   readonly tags?: string[];
+  /** Node-private checkout map; only its keys may be serialized for placement. */
+  readonly repoPaths?: FleetRepoPaths;
   readonly version?: string;
 }
 
@@ -177,6 +191,7 @@ export interface SpawnHandlerOptions {
 
 export function defineNode(input: FleetNodeDefinitionInput): FleetNodeDefinition {
   const name = nonEmpty(input.name, 'node name');
+  const repoPaths = normalizeRepoPaths(input.repoPaths);
   const capabilityEntries = Object.entries(input.capabilities ?? {});
   if (capabilityEntries.length === 0) {
     throw new Error('defineNode requires at least one capability');
@@ -217,6 +232,7 @@ export function defineNode(input: FleetNodeDefinitionInput): FleetNodeDefinition
     capabilities,
     triggers: [...triggers],
     ...(input.tags ? { tags: [...input.tags] } : {}),
+    ...(repoPaths !== undefined ? { repoPaths } : {}),
     ...(input.version ? { version: input.version } : {}),
   };
 }
@@ -350,11 +366,39 @@ export function onMessage(input: OnMessageTriggerInput, actionName: string): Fle
 }
 
 export function nodeInfo(definition: FleetNodeDefinition): FleetNodeInfo {
+  const repoKeys = nodeRepoKeys(definition);
   return {
     name: definition.name,
     ...(definition.maxAgents !== undefined ? { maxAgents: definition.maxAgents } : {}),
     capabilities: Object.keys(definition.capabilities),
+    ...(repoKeys.length > 0 ? { repoKeys } : {}),
   };
+}
+
+/** Return deterministic, placement-safe repository keys without exposing paths. */
+export function nodeRepoKeys(definition: Pick<FleetNodeDefinition, 'repoPaths'>): string[] {
+  return Object.keys(definition.repoPaths ?? {}).sort();
+}
+
+/**
+ * Build the public registration tags for a node definition.
+ *
+ * When `repoPaths` is present it is authoritative: legacy manually supplied
+ * `repo:*` tags are replaced by tags derived from the map's keys. Definitions
+ * without `repoPaths` retain their tags unchanged for backward compatibility.
+ */
+export function nodeRegistrationTags(
+  definition: Pick<FleetNodeDefinition, 'repoPaths' | 'tags'>
+): string[] | undefined {
+  if (definition.repoPaths === undefined) {
+    return definition.tags ? [...definition.tags] : undefined;
+  }
+  const tags = (definition.tags ?? []).filter((tag) => !tag.startsWith('repo:'));
+  const seen = new Set(tags);
+  for (const key of nodeRepoKeys(definition)) {
+    seen.add(`repo:${key}`);
+  }
+  return [...seen];
 }
 
 export async function invokeNodeHandler(
@@ -387,6 +431,7 @@ export function defineDefaultLocalNode(input: {
   name: string;
   maxAgents?: number;
   teams?: { agents?: Array<{ cli?: string }> } | null;
+  repoPaths?: FleetRepoPaths;
 }): FleetNodeDefinition {
   const harnesses = new Map<string, StaticPtyHarnessDefinition>([
     ['claude', claude],
@@ -408,6 +453,7 @@ export function defineDefaultLocalNode(input: {
     name: input.name,
     ...(input.maxAgents !== undefined ? { maxAgents: input.maxAgents } : {}),
     capabilities,
+    ...(input.repoPaths !== undefined ? { repoPaths: input.repoPaths } : {}),
   });
 }
 
@@ -458,6 +504,39 @@ function nonEmpty(value: string | undefined, label: string): string {
     throw new Error(`${label} is required`);
   }
   return trimmed;
+}
+
+function normalizeRepoPaths(repoPaths: FleetRepoPaths | undefined): FleetRepoPaths | undefined {
+  if (repoPaths === undefined) {
+    return undefined;
+  }
+  if (!repoPaths || typeof repoPaths !== 'object' || Array.isArray(repoPaths)) {
+    throw new Error('repoPaths must be an object keyed by owner/repo');
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawKey, rawPath] of Object.entries(repoPaths)) {
+    const key = rawKey.trim();
+    if (!isPlacementRepoKey(key)) {
+      throw new Error(`repoPaths key "${rawKey}" must use owner/repo format`);
+    }
+    if (Object.prototype.hasOwnProperty.call(normalized, key)) {
+      throw new Error(`repoPaths contains duplicate key "${key}" after trimming`);
+    }
+    if (typeof rawPath !== 'string' || !isAbsolute(rawPath)) {
+      throw new Error(`repoPaths["${key}"] must be an absolute path`);
+    }
+    normalized[key] = rawPath;
+  }
+  return Object.freeze(normalized);
+}
+
+function isPlacementRepoKey(key: string): boolean {
+  const segments = key.split('/');
+  return (
+    segments.length === 2 &&
+    segments.every((segment) => segment !== '.' && segment !== '..' && /^[A-Za-z0-9._-]+$/.test(segment))
+  );
 }
 
 function parseWithSchema<T>(schema: ZodLikeSchema<T>, input: unknown): T {

--- a/packages/fleet/src/index.ts
+++ b/packages/fleet/src/index.ts
@@ -191,7 +191,7 @@ export interface SpawnHandlerOptions {
 
 export function defineNode(input: FleetNodeDefinitionInput): FleetNodeDefinition {
   const name = nonEmpty(input.name, 'node name');
-  const repoPaths = normalizeRepoPaths(input.repoPaths);
+  const repoPaths = normalizeFleetRepoPaths(input.repoPaths);
   const capabilityEntries = Object.entries(input.capabilities ?? {});
   if (capabilityEntries.length === 0) {
     throw new Error('defineNode requires at least one capability');
@@ -506,7 +506,11 @@ function nonEmpty(value: string | undefined, label: string): string {
   return trimmed;
 }
 
-function normalizeRepoPaths(repoPaths: FleetRepoPaths | undefined): FleetRepoPaths | undefined {
+/**
+ * Validate and normalize the node-private repository map used by both direct
+ * definitions and the compiled child descriptor bridge.
+ */
+export function normalizeFleetRepoPaths(repoPaths: unknown): FleetRepoPaths | undefined {
   if (repoPaths === undefined) {
     return undefined;
   }

--- a/packages/fleet/src/serve-node.test.ts
+++ b/packages/fleet/src/serve-node.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -114,6 +116,35 @@ describe('serveNode', () => {
     expect(register).toMatchObject({ type: 'node.register', name: 'data-pipeline', node_id: 'node_a' });
     expect(register.provider).toMatchObject({ name: 'data-pipeline' });
     expect(register.capabilities).toEqual([{ name: 'run-etl', kind: 'action' }]);
+
+    sock.emit(acceptAll(register));
+    await flush();
+    await running.stop();
+  });
+
+  it('serializes only placement-safe repo keys and never node-local paths', async () => {
+    const factoryPath = resolve('private-checkouts', 'factory');
+    const relayPath = resolve('private-checkouts', 'relay');
+    const node = defineNode({
+      name: 'repo-builder',
+      capabilities: { ping: async () => 'pong' },
+      tags: ['arm64', 'repo:stale/manual-tag'],
+      repoPaths: {
+        'AgentWorkforce/relay': relayPath,
+        'AgentWorkforce/factory': factoryPath,
+      },
+    });
+    const running = startServeNode({ definition: node, connection, reconnect: false });
+
+    const sock = socket();
+    sock.open();
+    const register = sock.lastRegister();
+    expect(register.tags).toEqual(['arm64', 'repo:AgentWorkforce/factory', 'repo:AgentWorkforce/relay']);
+    expect(register).not.toHaveProperty('repoPaths');
+    expect(register).not.toHaveProperty('repo_paths');
+    const serialized = JSON.stringify(register);
+    expect(serialized).not.toContain(factoryPath);
+    expect(serialized).not.toContain(relayPath);
 
     sock.emit(acceptAll(register));
     await flush();

--- a/packages/fleet/src/serve-node.ts
+++ b/packages/fleet/src/serve-node.ts
@@ -3,6 +3,7 @@ import { NodeProviderClient, type NodeCapabilityHandler, type NodeHandlerContext
 import {
   invokeNodeHandler,
   nodeInfo,
+  nodeRegistrationTags,
   triggerSyncInputs,
   type FleetActionContext,
   type FleetNodeDefinition,
@@ -183,6 +184,7 @@ export async function serveNode(options: ServeNodeOptions): Promise<void> {
   const maxAgents = options.maxAgentsOverride ?? options.definition.maxAgents;
   const reconnect = options.reconnect ?? true;
   const logger = resolveLogger(options);
+  const registrationTags = nodeRegistrationTags(options.definition);
 
   const client = new NodeProviderClient({
     ...(options.connection.baseUrl ? { baseUrl: options.connection.baseUrl } : {}),
@@ -191,7 +193,7 @@ export async function serveNode(options: ServeNodeOptions): Promise<void> {
     nodeName,
     provider: { name: providerName },
     ...(maxAgents !== undefined ? { maxAgents } : {}),
-    ...(options.definition.tags ? { tags: [...options.definition.tags] } : {}),
+    ...(registrationTags !== undefined ? { tags: registrationTags } : {}),
     ...(options.definition.version ? { version: options.definition.version } : {}),
     // A drop during shutdown is expected; only surface a real error otherwise.
     ...(reconnect ? {} : { maxReconnectAttempts: 0 }),

--- a/packages/harness-driver/src/protocol.ts
+++ b/packages/harness-driver/src/protocol.ts
@@ -204,6 +204,8 @@ export interface NodeManifest {
   capabilities: NodeCapabilityManifest[];
   max_agents?: number;
   tags?: string[];
+  /** Placement-safe repository keys. Absolute checkout paths never enter this manifest. */
+  repo_keys?: string[];
   version?: string;
 }
 


### PR DESCRIPTION
## What changed

- add validated node-local `repoPaths` to Fleet node definitions
- derive authoritative `repo:<owner/name>` registration tags while preserving non-repo tags and legacy behavior when no map is present
- add placement-safe `repo_keys` to the TypeScript/Rust node manifest and Rust `node.register` wire encoding
- carry raw `repoPaths` only across captured local compiled-child-to-CLI descriptor IPC for the native node lane
- document the configuration and update the root changelog

## Privacy boundary

Absolute checkout paths remain node-local. Fleet registration serializes only derived repository-key tags; tests assert `repoPaths`, `repo_paths`, and both private values are absent from the frame. Rust `node.register` accepts `repo_keys` but rejects unknown `repo_paths`. The compiled-child descriptor is local IPC only and revalidates keys and absolute values before returning the map.

Repository keys require exactly two allowlisted segments, exclude `.` and `..`, and reject path-shaped keys such as `./repo` and `../repo`. Checkout values must be absolute.

## Compatibility

- absent/empty Rust `repo_keys` is defaulted and omitted on serialization
- definitions without `repoPaths` retain existing tags
- when `repoPaths` exists, its keys authoritatively replace manual `repo:*` tags
- JS provider registration uses the existing tag path until the Relaycast schema/package lane lands optional explicit `repo_keys`

## Validation

- `npx vitest run packages/cli/src/cli/lib/node-provider-child.test.ts packages/fleet/src/index.test.ts packages/fleet/src/serve-node.test.ts` — 3 files, 52 tests passed
- `npm run typecheck` — passed
- clean-environment `cargo test -p agent-relay-broker` — 1,031 passed total, 4 ignored
- targeted Rust wire fixture and registration-builder tests — passed
- Prettier, Rustfmt, `git diff --check`, and added-line credential/absolute-user-path scan — passed

## Dependency order

This is the wire-first parent for the native node-resolution lane. Relaycast owns optional `repo_keys` acceptance/persistence; the node lane owns local `repo_paths` ingestion, storage, manifest population, and fail-closed spawn-time resolution.

Coordination note: draft #1580 is a narrower parallel result from an Agent Relay identity collision and omits the Rust wire plus compiled-child descriptor seams included here.
