### PR TITLE
fix(fleet,broker): forward repoPaths to native-broker node registration

### DIFF
--- a/.agentworkforce/trajectories/active/traj_yk755jcjbnfm/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_yk755jcjbnfm/trajectory.json
@@ -1,0 +1,74 @@
+{
+  "id": "traj_yk755jcjbnfm",
+  "version": 1,
+  "task": {
+    "title": "Fix #1582: repoPaths never reaches native-broker node registration",
+    "source": {
+      "system": "plain",
+      "id": "1582"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-08-19T13:51:50.554Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T13:52:00.064Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_032fxb0984sd",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T13:52:00.064Z",
+      "events": [
+        {
+          "ts": 1787147520065,
+          "type": "decision",
+          "content": "Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field: Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field",
+          "raw": {
+            "question": "Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field",
+            "chosen": "Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field",
+            "alternatives": [],
+            "reasoning": "The broker builds its own registration manifest in Rust; the only existing CLI->broker channel into that manifest is env (AGENT_RELAY_NODE_HARNESSES, AGENT_RELAY_NODE_MAX_AGENTS). Reusing that seam keeps the change symmetric with existing capacity plumbing, works identically for the in-process and compiled-binary (--describe child) serving modes, and needs no @relaycast/sdk or protocol version bump."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787147520573,
+          "type": "decision",
+          "content": "Broker emits BOTH repo_keys and repo:<owner/name> tags: Broker emits BOTH repo_keys and repo:<owner/name> tags",
+          "raw": {
+            "question": "Broker emits BOTH repo_keys and repo:<owner/name> tags",
+            "chosen": "Broker emits BOTH repo_keys and repo:<owner/name> tags",
+            "alternatives": [],
+            "reasoning": "packages/sdk relaycast-translate readRepoKeys reads repoKeys/repo_keys first but falls back to repo: tags because the engine roster row has no dedicated repo field. Emitting only repo_keys would leave placement unable to match on rosters that drop the field."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787147521108,
+          "type": "decision",
+          "content": "Presence of repoPaths is the signal; absent env leaves registration untouched: Presence of repoPaths is the signal; absent env leaves registration untouched",
+          "raw": {
+            "question": "Presence of repoPaths is the signal; absent env leaves registration untouched",
+            "chosen": "Presence of repoPaths is the signal; absent env leaves registration untouched",
+            "alternatives": [],
+            "reasoning": "Mirrors nodeRegistrationTags' documented backward-compat contract. Set-but-empty maps to repo_keys: [] which build_node_register deliberately preserves so a node can clear stale advertisements."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "931bc38d6185c1b1e233f4d32c67e09cd0f9815d",
+    "endRef": "931bc38d6185c1b1e233f4d32c67e09cd0f9815d"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm.trace.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.0.0",
+  "id": "2fac979c-be70-4e49-a0b3-acbd1d739f98",
+  "timestamp": "2026-08-19T14:16:56.322Z",
+  "trajectory": "traj_yk755jcjbnfm",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_yk755jcjbnfm/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 74,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/node_control.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1169,
+              "end_line": 1180,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/runtime/init.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 904,
+              "end_line": 921,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            },
+            {
+              "start_line": 1161,
+              "end_line": 1191,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/broker-lifecycle.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 672,
+              "end_line": 708,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/fleet-sidecar.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 87,
+              "end_line": 104,
+              "revision": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm/summary.md
@@ -1,0 +1,49 @@
+# Trajectory: Fix #1582: repoPaths never reaches native-broker node registration
+
+> **Status:** ✅ Completed
+> **Task:** 1582
+> **Confidence:** 90%
+> **Started:** August 19, 2026 at 03:51 PM
+> **Completed:** August 19, 2026 at 04:16 PM
+
+---
+
+## Summary
+
+Forwarded node definition repoPaths keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS so nodes register repo_keys and repo:<owner/name> tags and repo-based placement can match. Validated placement-safe keys once at the env boundary so neither the repo_keys nor the repo: tag channel can carry a path-shaped value, and honored an explicitly empty operator preset so operators can clear stale advertisements.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field
+- **Chose:** Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field
+- **Reasoning:** The broker builds its own registration manifest in Rust; the only existing CLI->broker channel into that manifest is env (AGENT_RELAY_NODE_HARNESSES, AGENT_RELAY_NODE_MAX_AGENTS). Reusing that seam keeps the change symmetric with existing capacity plumbing, works identically for the in-process and compiled-binary (--describe child) serving modes, and needs no @relaycast/sdk or protocol version bump.
+
+### Broker emits BOTH repo_keys and repo:<owner/name> tags
+- **Chose:** Broker emits BOTH repo_keys and repo:<owner/name> tags
+- **Reasoning:** packages/sdk relaycast-translate readRepoKeys reads repoKeys/repo_keys first but falls back to repo: tags because the engine roster row has no dedicated repo field. Emitting only repo_keys would leave placement unable to match on rosters that drop the field.
+
+### Presence of repoPaths is the signal; absent env leaves registration untouched
+- **Chose:** Presence of repoPaths is the signal; absent env leaves registration untouched
+- **Reasoning:** Mirrors nodeRegistrationTags' documented backward-compat contract. Set-but-empty maps to repo_keys: [] which build_node_register deliberately preserves so a node can clear stale advertisements.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field: Carried repo keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS env, not a new IPC or wire field
+- Broker emits BOTH repo_keys and repo:<owner/name> tags: Broker emits BOTH repo_keys and repo:<owner/name> tags
+- Presence of repoPaths is the signal; absent env leaves registration untouched: Presence of repoPaths is the signal; absent env leaves registration untouched
+
+---
+
+## Artifacts
+
+**Commits:** 11f97cbe4, 525560c8f
+**Files changed:** 5

--- a/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_yk755jcjbnfm/trajectory.json
@@ -8,8 +8,9 @@
       "id": "1582"
     }
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-08-19T13:51:50.554Z",
+  "completedAt": "2026-08-19T14:16:56.237Z",
   "agents": [
     {
       "name": "default",
@@ -23,6 +24,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-08-19T13:52:00.064Z",
+      "endedAt": "2026-08-19T14:16:56.237Z",
       "events": [
         {
           "ts": 1787147520065,
@@ -63,12 +65,27 @@
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Forwarded node definition repoPaths keys to the native broker via AGENT_RELAY_NODE_REPO_KEYS so nodes register repo_keys and repo:<owner/name> tags and repo-based placement can match. Validated placement-safe keys once at the env boundary so neither the repo_keys nor the repo: tag channel can carry a path-shaped value, and honored an explicitly empty operator preset so operators can clear stale advertisements.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "11f97cbe4",
+    "525560c8f"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_yk755jcjbnfm/trajectory.json",
+    "crates/broker/src/node_control.rs",
+    "crates/broker/src/runtime/init.rs",
+    "packages/cli/src/cli/lib/broker-lifecycle.test.ts",
+    "packages/cli/src/cli/lib/fleet-sidecar.ts"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "931bc38d6185c1b1e233f4d32c67e09cd0f9815d",
-    "endRef": "931bc38d6185c1b1e233f4d32c67e09cd0f9815d"
+    "endRef": "11f97cbe4ef9f0df89ed46d0b0cf296664f84697",
+    "traceId": "2fac979c-be70-4e49-a0b3-acbd1d739f98"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay node up` now forwards a node definition's `repoPaths` keys to its native broker, so a node registers with `repo:<owner/name>` tags and `repo_keys` instead of none and repo-based placement can match it. Definitions without `repoPaths` register unchanged.
 
 ## [11.8.0] - 2026-08-19
 

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -1169,7 +1169,12 @@ pub(crate) fn build_node_register(
     }
 }
 
-fn is_placement_repo_key(value: &str) -> bool {
+/// Whether `value` is a placement-safe `owner/name` repository key.
+///
+/// The Fleet wire is a privacy boundary: anything that is path-shaped or
+/// otherwise malformed must never be serialized, on either the `repo_keys`
+/// channel or the `repo:<key>` tag channel that placement falls back to.
+pub(crate) fn is_placement_repo_key(value: &str) -> bool {
     let mut segments = value.split('/');
     let Some(owner) = segments.next() else {
         return false;

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -904,13 +904,18 @@ fn bootstrap_node_manifest(node_name: &str, node_id: &str, broker_version: &str)
 /// for definitions that declare no `repoPaths`. A set-but-empty value yields
 /// `Some([])`, which authoritatively clears stale repository advertisements on
 /// the control plane.
+///
+/// Validation happens HERE rather than only in `build_node_register`, because
+/// the derived `repo:<key>` tags are copied to the wire verbatim. Filtering one
+/// channel and not the other would publish a path-shaped operator typo as a tag
+/// and leave the node's two repository advertisements disagreeing.
 fn node_repo_keys() -> Option<Vec<String>> {
     let raw = std::env::var("AGENT_RELAY_NODE_REPO_KEYS").ok()?;
     let mut seen = std::collections::HashSet::new();
     Some(
         raw.split(',')
             .map(|entry| entry.trim().to_string())
-            .filter(|entry| !entry.is_empty())
+            .filter(|entry| crate::node_control::is_placement_repo_key(entry))
             .filter(|entry| seen.insert(entry.clone()))
             .collect(),
     )
@@ -1153,6 +1158,31 @@ mod tests {
                 "repo:AgentWorkforce/factory".to_string(),
             ],
             "registration must also carry repo:<key> tags, which placement reads when the roster row has no dedicated repo field"
+        );
+    }
+
+    #[test]
+    fn a_path_shaped_repo_key_never_reaches_either_wire_channel() {
+        // `build_node_register` filters `repo_keys` but copies `tags` verbatim,
+        // so validating only there would publish an operator's path-shaped typo
+        // as a `repo:/srv/...` tag -- placement falls back to those tags, and
+        // the node's local checkout layout is exactly what the Fleet wire's
+        // privacy boundary exists to keep off the control plane.
+        let _env = set_repo_keys_env(Some(
+            "AgentWorkforce/relay,/srv/repos/relay,../relay,AgentWorkforce/relay/extra",
+        ));
+
+        let register = bootstrap_node_register();
+
+        assert_eq!(
+            register.repo_keys,
+            Some(vec!["AgentWorkforce/relay".to_string()])
+        );
+        assert_eq!(register.tags, vec!["repo:AgentWorkforce/relay".to_string()]);
+        let encoded = serde_json::to_string(&register).unwrap();
+        assert!(
+            !encoded.contains("/srv/repos/relay"),
+            "a path-shaped key must not be serialized on any channel: {encoded}"
         );
     }
 

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -874,15 +874,46 @@ fn bootstrap_node_manifest(node_name: &str, node_id: &str, broker_version: &str)
         kind: Some("capacity".to_string()),
         metadata: None,
     });
+    // Repository advertisement is what makes a node eligible for repo-based
+    // placement. The CLI reads it from the node definition's `repoPaths` and
+    // hands over the KEYS only (`AGENT_RELAY_NODE_REPO_KEYS`); the checkout
+    // paths stay node-local. Both channels are filled because placement reads
+    // `repo_keys` when the roster row carries it and falls back to `repo:<key>`
+    // tags when it does not.
+    let repo_keys = node_repo_keys();
+    let tags = repo_keys
+        .as_ref()
+        .map(|keys| keys.iter().map(|key| format!("repo:{key}")).collect());
     NodeManifest {
         name: node_name.to_string(),
         node_id: Some(node_id.to_string()),
         capabilities,
         max_agents: node_max_agents(),
-        tags: None,
-        repo_keys: None,
+        tags,
+        repo_keys,
         version: Some(broker_version.to_string()),
     }
+}
+
+/// The placement-safe repository keys this node advertises, from
+/// `AGENT_RELAY_NODE_REPO_KEYS` (comma-separated, order-preserving,
+/// de-duplicated).
+///
+/// Presence is the signal, mirroring the CLI's `nodeRegistrationTags`: an unset
+/// variable yields `None`, leaving registration tags and `repo_keys` untouched
+/// for definitions that declare no `repoPaths`. A set-but-empty value yields
+/// `Some([])`, which authoritatively clears stale repository advertisements on
+/// the control plane.
+fn node_repo_keys() -> Option<Vec<String>> {
+    let raw = std::env::var("AGENT_RELAY_NODE_REPO_KEYS").ok()?;
+    let mut seen = std::collections::HashSet::new();
+    Some(
+        raw.split(',')
+            .map(|entry| entry.trim().to_string())
+            .filter(|entry| !entry.is_empty())
+            .filter(|entry| seen.insert(entry.clone()))
+            .collect(),
+    )
 }
 
 /// The harness names this broker can spawn, from `AGENT_RELAY_NODE_HARNESSES`
@@ -1040,6 +1071,122 @@ mod tests {
         assert_eq!(manifest.name, "node-a");
         assert_eq!(manifest.node_id.as_deref(), Some("node_a"));
         assert_eq!(manifest.version.as_deref(), Some("relay-broker/9.1.1"));
+    }
+
+    /// Serializes `AGENT_RELAY_NODE_REPO_KEYS` mutations and restores the
+    /// inherited value, so these tests cannot leak into the rest of the binary.
+    static REPO_KEYS_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct RepoKeysEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        original: Option<OsString>,
+    }
+
+    impl Drop for RepoKeysEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: this guard holds REPO_KEYS_ENV_MUTEX for its whole
+            // lifetime, so AGENT_RELAY_NODE_REPO_KEYS mutations are serialized.
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var("AGENT_RELAY_NODE_REPO_KEYS", value),
+                    None => std::env::remove_var("AGENT_RELAY_NODE_REPO_KEYS"),
+                }
+            }
+        }
+    }
+
+    fn set_repo_keys_env(value: Option<&str>) -> RepoKeysEnvGuard {
+        let guard = REPO_KEYS_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let original = std::env::var_os("AGENT_RELAY_NODE_REPO_KEYS");
+        // SAFETY: the mutex is held for the returned guard's lifetime.
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var("AGENT_RELAY_NODE_REPO_KEYS", value),
+                None => std::env::remove_var("AGENT_RELAY_NODE_REPO_KEYS"),
+            }
+        }
+        RepoKeysEnvGuard {
+            _guard: guard,
+            original,
+        }
+    }
+
+    /// The registration payload the broker actually puts on the Fleet wire,
+    /// built the same way `runtime::init` does: bootstrap manifest -> register.
+    fn bootstrap_node_register() -> crate::fleet_wire::NodeRegister {
+        let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/test");
+        crate::node_control::build_node_register(
+            &manifest,
+            "node-default",
+            "host-default",
+            "relay-broker/test",
+            None,
+        )
+    }
+
+    #[test]
+    fn registration_carries_repo_keys_and_repo_tags_from_the_node_definition() {
+        // MUST FIRE: a node started from a definition WITH `repoPaths` has to
+        // register the derived `repo:<owner/name>` keys, or repo-based placement
+        // can never match it (#1582). Asserted on the wire payload, not on the
+        // env reader in isolation.
+        let _env = set_repo_keys_env(Some(
+            "AgentWorkforce/relay, AgentWorkforce/factory ,AgentWorkforce/relay",
+        ));
+
+        let register = bootstrap_node_register();
+
+        assert_eq!(
+            register.repo_keys,
+            Some(vec![
+                "AgentWorkforce/relay".to_string(),
+                "AgentWorkforce/factory".to_string(),
+            ]),
+            "registration must advertise the definition's repository keys"
+        );
+        assert_eq!(
+            register.tags,
+            vec![
+                "repo:AgentWorkforce/relay".to_string(),
+                "repo:AgentWorkforce/factory".to_string(),
+            ],
+            "registration must also carry repo:<key> tags, which placement reads when the roster row has no dedicated repo field"
+        );
+    }
+
+    #[test]
+    fn registration_leaves_tags_and_repo_keys_untouched_without_repo_paths() {
+        // MUST NOT FIRE: a definition without `repoPaths` leaves the broker's
+        // registration exactly as it was before #1582 — no repo keys, no tags.
+        let _env = set_repo_keys_env(None);
+
+        let register = bootstrap_node_register();
+
+        assert_eq!(register.repo_keys, None);
+        assert!(
+            register.tags.is_empty(),
+            "a definition without repoPaths must not gain tags, got {:?}",
+            register.tags
+        );
+    }
+
+    #[test]
+    fn an_empty_repo_key_list_clears_stale_repository_advertisements() {
+        // `repoPaths: {}` is an authoritative empty declaration, distinct from
+        // absent: it must serialize as `[]` so the control plane drops keys the
+        // node advertised on a previous start.
+        let _env = set_repo_keys_env(Some(""));
+
+        let register = bootstrap_node_register();
+
+        assert_eq!(register.repo_keys, Some(Vec::new()));
+        assert!(register.tags.is_empty());
+        assert_eq!(
+            serde_json::to_value(&register).unwrap().get("repo_keys"),
+            Some(&serde_json::json!([]))
+        );
     }
 
     #[test]

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -672,6 +672,24 @@ describe('runUpCommand repoPaths registration keys', () => {
     expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('Operator/override');
   });
 
+  it('honors an explicitly empty operator preset over a definition that declares repoPaths', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    // How an operator clears a CONFIGURED node's stale advertisements. Falling
+    // through to the definition here would silently re-publish what they cleared.
+    (deps.env as NodeJS.ProcessEnv).AGENT_RELAY_NODE_REPO_KEYS = '';
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      `export default { __agentRelayFleetNode: true, name: 'from-config', capabilities: {}, triggers: [], repoPaths: ${JSON.stringify(
+        { 'AgentWorkforce/relay': pathReal.join(projectRoot, 'checkouts', 'relay') }
+      )} };\n`
+    );
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('');
+  });
+
   it('clears stale advertisements with an explicit empty repoPaths map', async () => {
     const { deps, projectRoot } = createUpHarness();
     fsReal.writeFileSync(

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -672,6 +672,19 @@ describe('runUpCommand repoPaths registration keys', () => {
     expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('Operator/override');
   });
 
+  it('sets nothing when the project has no node definition at all', async () => {
+    // The common case, and what CI's standalone smoke exercises: plain `up` in a
+    // project with no agent-relay.* file. There is no node plan, so the broker
+    // must inherit exactly the environment it did before repo keys existed.
+    const { deps } = createUpHarness();
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    expect(captured.env).toBeDefined();
+    expect(captured.env).not.toHaveProperty('AGENT_RELAY_NODE_REPO_KEYS');
+  });
+
   it('honors an explicitly empty operator preset over a definition that declares repoPaths', async () => {
     const { deps, projectRoot } = createUpHarness();
     // How an operator clears a CONFIGURED node's stale advertisements. Falling

--- a/packages/cli/src/cli/lib/broker-lifecycle.test.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.test.ts
@@ -575,6 +575,120 @@ describe('runUpCommand node-config gating', () => {
   });
 });
 
+// ── repoPaths -> native-broker registration (#1582) ──────────────────────────
+// The broker, not the served definition, performs node registration on the
+// native path. These assert on what the broker process actually inherits at
+// spawn time -- not on the derivation helper in isolation, which would pass
+// even with the wiring reverted.
+describe('runUpCommand repoPaths registration keys', () => {
+  /** Snapshot `deps.env` at the moment the broker process is created. */
+  function captureBrokerEnv(deps: CoreDependencies): { env?: NodeJS.ProcessEnv } {
+    const captured: { env?: NodeJS.ProcessEnv } = {};
+    const inner = deps.createRelay;
+    deps.createRelay = vi.fn(async (...args: Parameters<CoreDependencies['createRelay']>) => {
+      captured.env = { ...deps.env };
+      return inner(...args);
+    }) as CoreDependencies['createRelay'];
+    return captured;
+  }
+
+  it('hands the derived repo keys to the broker when the definition declares repoPaths', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    const relayPath = pathReal.join(projectRoot, 'checkouts', 'relay');
+    const factoryPath = pathReal.join(projectRoot, 'checkouts', 'factory');
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      `export default { __agentRelayFleetNode: true, name: 'from-config', capabilities: {}, triggers: [], repoPaths: ${JSON.stringify(
+        { 'AgentWorkforce/relay': relayPath, 'AgentWorkforce/factory': factoryPath }
+      )} };\n`
+    );
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    // Sorted keys only: the absolute checkout paths stay node-local.
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('AgentWorkforce/factory,AgentWorkforce/relay');
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).not.toContain(projectRoot);
+  });
+
+  it('hands the descriptor repo keys to the broker on the compiled-binary path', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      "export default { __agentRelayFleetNode: true, name: 'child', capabilities: {}, triggers: [] };\n"
+    );
+    deps.argv = ['bun', '/$bunfs/root/agent-relay', 'node', 'up'];
+    deps.cliScript = '/$bunfs/root/agent-relay';
+    const descriptor = {
+      name: 'child',
+      capabilities: [],
+      repoPaths: { 'AgentWorkforce/relay': pathReal.join(projectRoot, 'checkouts', 'relay') },
+    };
+    deps.execCommand = vi.fn(async (command: string) => ({
+      stdout: command.includes('--describe')
+        ? `__AGENT_RELAY_NODE_DESCRIPTOR__${JSON.stringify(descriptor)}\n`
+        : '',
+      stderr: '',
+    }));
+    const child = Object.assign(new EventEmitter(), { pid: 42, killed: false, kill: vi.fn() });
+    deps.spawnProcess = vi.fn(() => {
+      queueMicrotask(() => child.emit('spawn'));
+      return child;
+    });
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('AgentWorkforce/relay');
+  });
+
+  it('leaves the broker registration untouched when the definition has no repoPaths', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      "export default { __agentRelayFleetNode: true, name: 'from-config', capabilities: {}, triggers: [] };\n"
+    );
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    expect(captured.env).toBeDefined();
+    expect(captured.env).not.toHaveProperty('AGENT_RELAY_NODE_REPO_KEYS');
+  });
+
+  it('keeps a pre-set operator declaration verbatim', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    (deps.env as NodeJS.ProcessEnv).AGENT_RELAY_NODE_REPO_KEYS = 'Operator/override';
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      `export default { __agentRelayFleetNode: true, name: 'from-config', capabilities: {}, triggers: [], repoPaths: ${JSON.stringify(
+        { 'AgentWorkforce/relay': pathReal.join(projectRoot, 'checkouts', 'relay') }
+      )} };\n`
+    );
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('Operator/override');
+  });
+
+  it('clears stale advertisements with an explicit empty repoPaths map', async () => {
+    const { deps, projectRoot } = createUpHarness();
+    fsReal.writeFileSync(
+      pathReal.join(projectRoot, 'agent-relay.mjs'),
+      "export default { __agentRelayFleetNode: true, name: 'from-config', capabilities: {}, triggers: [], repoPaths: {} };\n"
+    );
+    const captured = captureBrokerEnv(deps);
+
+    await runUpCommand({ discoverConfig: true }, deps);
+
+    // Present-but-empty is distinct from absent: it tells the broker to send
+    // `repo_keys: []` and drop what a previous start advertised.
+    expect(captured.env).toHaveProperty('AGENT_RELAY_NODE_REPO_KEYS');
+    expect(captured.env?.AGENT_RELAY_NODE_REPO_KEYS).toBe('');
+  });
+});
+
 describe('runUpCommand workspace precedence', () => {
   const readPin = (dataDir: string): Record<string, string> =>
     JSON.parse(fsReal.readFileSync(pathReal.join(dataDir, 'workspace-key.json'), 'utf-8'));

--- a/packages/cli/src/cli/lib/broker-lifecycle.ts
+++ b/packages/cli/src/cli/lib/broker-lifecycle.ts
@@ -11,7 +11,12 @@ import { track } from '../telemetry/index.js';
 import { buildBundledAgentRelayMcpCommand, isBundledBunEntrypointPath } from './agent-relay-mcp-command.js';
 import { errorClassName } from './telemetry-helpers.js';
 import { runSignalHandler } from './exit.js';
-import { createTriggerSyncClient, resolveNodeCapacityHarnesses } from './fleet-sidecar.js';
+import {
+  createTriggerSyncClient,
+  resolveNodeCapacityHarnesses,
+  resolveNodeRepoKeys,
+  NODE_REPO_KEYS_ENV,
+} from './fleet-sidecar.js';
 import {
   discoverNodeConfigPath,
   discoverPythonNodeConfigPath,
@@ -1541,6 +1546,24 @@ function planCapacitySource(
 }
 
 /**
+ * The repository placement keys a plan contributes to the broker's registration.
+ *
+ * Both serving modes expose the same node-private `repoPaths` map — the
+ * in-process definition directly, the out-of-process descriptor via the
+ * `--describe` child's IPC — so the native broker learns its repo keys on
+ * either path. Only the keys are read; the absolute checkout paths never leave
+ * the node.
+ */
+function planRepoKeySource(
+  plan: NodeDefinitionPlan | undefined
+): { repoPaths?: Readonly<Record<string, string>> } | undefined {
+  if (!plan) {
+    return undefined;
+  }
+  return plan.mode === 'in-process' ? plan.definition : plan.descriptor;
+}
+
+/**
  * Apply the resolved workspace to the environment the broker (and any detached
  * child) inherits, and report which source won. Returns the pinned project
  * session when the repository pin supplied the selection.
@@ -1890,6 +1913,18 @@ export async function runUpCommand(options: UpOptions, deps: CoreDependencies): 
       teamsConfig,
       planCapacitySource(nodePlan)
     );
+
+    // The broker — not the served definition — performs node registration on the
+    // native path, so `repoPaths` has to reach it before it registers or the node
+    // comes up with no `repo:` tags and no `repo_keys`, and repo-based placement
+    // can never match it (#1582). Only the keys travel; the checkout paths stay
+    // node-local. Absence is meaningful: leaving the var unset keeps the broker's
+    // prior registration tags/`repo_keys` untouched for definitions that declare
+    // no `repoPaths`.
+    const nodeRepoKeysCsv = resolveNodeRepoKeys(deps.env[NODE_REPO_KEYS_ENV], planRepoKeySource(nodePlan));
+    if (nodeRepoKeysCsv !== undefined) {
+      deps.env[NODE_REPO_KEYS_ENV] = nodeRepoKeysCsv;
+    }
 
     // Kill any orphaned broker processes for this project that lost their PID
     // files (e.g. user deleted .agentworkforce/relay/ while broker was running).

--- a/packages/cli/src/cli/lib/fleet-sidecar.ts
+++ b/packages/cli/src/cli/lib/fleet-sidecar.ts
@@ -1,5 +1,5 @@
 import { AgentRelay } from '@agent-relay/sdk';
-import type { FleetTriggerSyncClient } from '@agent-relay/fleet';
+import { nodeRepoKeys, type FleetTriggerSyncClient } from '@agent-relay/fleet';
 
 import type { CoreTeamsConfig } from '../commands/core.js';
 
@@ -62,6 +62,46 @@ export function resolveNodeCapacityHarnesses(
     return trimmed;
   }
   return nodeCapacityHarnesses(teamsConfig, definition).join(',');
+}
+
+/** Env var carrying the node's placement-safe repository keys to the broker. */
+export const NODE_REPO_KEYS_ENV = 'AGENT_RELAY_NODE_REPO_KEYS';
+
+/**
+ * The minimum a node config has to expose to advertise repository placement
+ * keys. A full {@link FleetNodeDefinition} satisfies this, and so does the
+ * descriptor reported by a node definition served out-of-process.
+ */
+export type NodeRepoKeySource = { repoPaths?: Readonly<Record<string, string>> };
+
+/**
+ * Resolve the `AGENT_RELAY_NODE_REPO_KEYS` CSV the native broker registers
+ * `repo_keys` (and the matching `repo:<owner/name>` tags) from.
+ *
+ * Only the map's KEYS travel: the absolute checkout paths stay node-local, so
+ * the Fleet wire never carries a filesystem layout.
+ *
+ * Presence is the signal, mirroring `nodeRegistrationTags`:
+ * - no `repoPaths` in the definition -> `undefined`, and the broker leaves its
+ *   registration tags/`repo_keys` exactly as before (backward compatible).
+ * - `repoPaths` present -> the sorted keys, possibly the empty string, which
+ *   authoritatively clears stale repository advertisements on the control plane.
+ *
+ * A pre-set value is the operator's authoritative declaration and wins verbatim,
+ * matching {@link resolveNodeCapacityHarnesses}.
+ */
+export function resolveNodeRepoKeys(
+  preset: string | undefined,
+  definition?: NodeRepoKeySource
+): string | undefined {
+  const trimmed = preset?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  if (!definition || definition.repoPaths === undefined) {
+    return undefined;
+  }
+  return nodeRepoKeys(definition).join(',');
 }
 
 /**

--- a/packages/cli/src/cli/lib/fleet-sidecar.ts
+++ b/packages/cli/src/cli/lib/fleet-sidecar.ts
@@ -87,16 +87,18 @@ export type NodeRepoKeySource = { repoPaths?: Readonly<Record<string, string>> }
  * - `repoPaths` present -> the sorted keys, possibly the empty string, which
  *   authoritatively clears stale repository advertisements on the control plane.
  *
- * A pre-set value is the operator's authoritative declaration and wins verbatim,
- * matching {@link resolveNodeCapacityHarnesses}.
+ * A pre-set value is the operator's authoritative declaration and wins verbatim.
+ * Unlike {@link resolveNodeCapacityHarnesses}, an explicitly EMPTY preset is
+ * honored rather than treated as unset: it is how an operator clears a
+ * configured node's stale advertisements, so falling through to the definition
+ * there would silently re-publish the keys they just cleared.
  */
 export function resolveNodeRepoKeys(
   preset: string | undefined,
   definition?: NodeRepoKeySource
 ): string | undefined {
-  const trimmed = preset?.trim();
-  if (trimmed) {
-    return trimmed;
+  if (preset !== undefined) {
+    return preset.trim();
   }
   if (!definition || definition.repoPaths === undefined) {
     return undefined;

--- a/packages/fleet/README.md
+++ b/packages/fleet/README.md
@@ -69,6 +69,13 @@ Each value must be an absolute path on that node. Registration derives the
 placement-safe `AgentWorkforce/factory` and `AgentWorkforce/relay` keys; the
 absolute values are never sent to Relaycast, exposed in the roster, or logged.
 
+`agent-relay node up` passes those keys to its native broker — which performs
+node registration — through `AGENT_RELAY_NODE_REPO_KEYS`, a comma-separated list
+of keys only. Set it yourself to declare a node's repositories authoritatively
+without a definition; a pre-set value wins over the discovered `repoPaths`. An
+empty value clears what the node advertised on a previous start, and leaving it
+unset (no `repoPaths`) leaves the node's registration tags untouched.
+
 ### Serving a node programmatically
 
 `@agent-relay/fleet` also ships the node runtime, so you can start a node in


### PR DESCRIPTION
Fixes #1582.

## The bug

`defineNode({ repoPaths })` never reached node registration when
`agent-relay node up` runs with a **native broker** — the mode every real fleet
node uses. Measured on the live fleet: 0 of 1045 nodes carried a `repo:` tag or
`repoKeys`, so repo-based placement could never match.

## Which code path I wired

On the native path the **broker** — not the served definition — performs node
registration, and it was never told the repo keys:

- `crates/broker/src/runtime/init.rs` `bootstrap_node_manifest()` hardcoded
  `tags: None, repo_keys: None`.
- `crates/broker/src/node_control.rs` `build_node_register()` turns that manifest
  into the `NodeRegister` wire payload, so every native node registered with
  `tags: []` and `repo_keys` absent.
- `packages/cli/.../node-provider-child.ts` already emitted and parsed
  `repoPaths` into its descriptor, with a comment claiming *"The parent passes
  these values directly to its native broker."* Nothing consumed
  `descriptor.repoPaths`.

The only channel the CLI has into that manifest is env — the same one
`AGENT_RELAY_NODE_HARNESSES` (→ `node_capacity_harnesses()`) and
`AGENT_RELAY_NODE_MAX_AGENTS` (→ `node_max_agents()`) already use. So:

1. **CLI** (`broker-lifecycle.ts`, `fleet-sidecar.ts`) — `planRepoKeySource()`
   reads `repoPaths` off the node plan on **both** serving modes (the in-process
   definition, and the `--describe` child's descriptor on the compiled-binary
   path). `resolveNodeRepoKeys()` derives the sorted keys and exports
   `AGENT_RELAY_NODE_REPO_KEYS` **before** the broker starts.
2. **Broker** (`runtime/init.rs`) — `node_repo_keys()` reads that CSV;
   `bootstrap_node_manifest` sets `repo_keys` **and** the matching
   `repo:<owner/name>` tags.

Both channels are filled deliberately: placement
(`packages/sdk/src/messaging/relaycast-translate.ts` `readRepoKeys`) reads
`repoKeys`/`repo_keys` when the roster row carries it and **falls back to
`repo:` tags** when it does not.

Only the map's **keys** travel. The absolute checkout paths stay node-local, per
the privacy contract landed in #1581.

Presence is the signal, mirroring `nodeRegistrationTags`:

| definition | env | registration |
| --- | --- | --- |
| no `repoPaths` | unset | unchanged — `tags: []`, no `repo_keys` |
| `repoPaths: {…}` | `owner/a,owner/b` | `repo_keys: [...]` + `repo:` tags |
| `repoPaths: {}` | `""` | `repo_keys: []` — clears stale advertisements |
| operator preset | verbatim | operator wins (as with `AGENT_RELAY_NODE_HARNESSES`) |

## Tests

Both suites assert on the **actual registration payload / the env the broker
process inherits at spawn time**, not on a helper called in isolation.

- Rust: `bootstrap_node_register()` builds the manifest exactly as
  `runtime::init` does and runs it through the real
  `node_control::build_node_register`, then asserts on the `NodeRegister` wire
  struct (and its JSON).
- TypeScript: the tests wrap `deps.createRelay` and snapshot `deps.env` at the
  moment the broker process is created, driving the full `runUpCommand` path
  from a real on-disk node definition.

### Before — wiring reverted, tests kept (must-fire FAILS)

Rust, `bootstrap_node_manifest` restored to `tags: None, repo_keys: None`:

```
test runtime::init::tests::an_empty_repo_key_list_clears_stale_repository_advertisements ... FAILED
test runtime::init::tests::registration_carries_repo_keys_and_repo_tags_from_the_node_definition ... FAILED
test runtime::init::tests::registration_leaves_tags_and_repo_keys_untouched_without_repo_paths ... ok

---- registration_carries_repo_keys_and_repo_tags_from_the_node_definition stdout ----
assertion `left == right` failed: registration must advertise the definition's repository keys
  left: None
 right: Some(["AgentWorkforce/relay", "AgentWorkforce/factory"])

---- an_empty_repo_key_list_clears_stale_repository_advertisements stdout ----
assertion `left == right` failed
  left: None
 right: Some([])

test result: FAILED. 7 passed; 2 failed
```

TypeScript, the `deps.env[NODE_REPO_KEYS_ENV] = …` assignment removed:

```
FAIL  runUpCommand repoPaths registration keys > hands the derived repo keys to the broker when the definition declares repoPaths
AssertionError: expected undefined to be 'AgentWorkforce/factory,AgentWorkforce/relay'
- Expected: "AgentWorkforce/factory,AgentWorkforce/relay"
+ Received: undefined

FAIL  runUpCommand repoPaths registration keys > hands the descriptor repo keys to the broker on the compiled-binary path
AssertionError: expected undefined to be 'AgentWorkforce/relay'

FAIL  runUpCommand repoPaths registration keys > clears stale advertisements with an explicit empty repoPaths map
AssertionError: expected { …(5) } to have property "AGENT_RELAY_NODE_REPO_KEYS"

Tests  3 failed | 2 passed | 52 skipped (57)
```

The two that stayed green are exactly the must-not-fire pair — "no `repoPaths`
leaves registration untouched" and "a pre-set operator declaration wins" — which
is the point: they pass with and without the fix.

### After — full fix in place

```
running 9 tests
test runtime::init::tests::registration_carries_repo_keys_and_repo_tags_from_the_node_definition ... ok
test runtime::init::tests::registration_leaves_tags_and_repo_keys_untouched_without_repo_paths ... ok
test runtime::init::tests::an_empty_repo_key_list_clears_stale_repository_advertisements ... ok
test runtime::init::tests::bootstrap_node_manifest_advertises_capacity_not_bare_spawn ... ok
...
test result: ok. 9 passed; 0 failed; 0 ignored; 1014 filtered out
```

```
$ npx vitest run packages/fleet packages/cli/src/cli/lib
Test Files  37 passed | 1 skipped (38)
     Tests  629 passed | 9 skipped (638)
```

Also green: `npm run typecheck`, `npm run lint` (0 errors), `prettier --check`,
`cargo fmt --check`, `cargo clippy -p agent-relay-broker --lib --tests` (the one
warning is pre-existing in `terminal_control.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 — both findings were real (525560c8f)

**1. Derived `repo:` tags bypassed the Fleet wire's privacy filter** (Codex P2 +
Devin bug/security, found independently).

`build_node_register` filters `repo_keys` through `is_placement_repo_key`
specifically so an unvalidated manifest can never serialize a path-shaped value
— but it copies `tags` verbatim. So `AGENT_RELAY_NODE_REPO_KEYS=/srv/repos/relay`
was dropped from `repo_keys` and still published as `repo:/srv/repos/relay`,
leaking the node's checkout layout on the exact channel placement falls back to.

`node_repo_keys()` now filters through that predicate (`pub(crate)` now), so both
channels derive from one validated list and cannot diverge. Verified the new test
bites — with the filter reverted:

```
left:  ["repo:AgentWorkforce/relay", "repo:/srv/repos/relay", "repo:../relay", "repo:AgentWorkforce/relay/extra"]
right: ["repo:AgentWorkforce/relay"]
```

**2. An explicitly empty operator preset was overwritten** (Codex P2).

`resolveNodeRepoKeys` treated `AGENT_RELAY_NODE_REPO_KEYS=""` as unset and fell
through to the definition, silently re-publishing keys an operator had just
cleared — contradicting the empty-clears/preset-wins contract in this PR's own
docs. It now branches on `preset !== undefined`. A deliberate divergence from
`resolveNodeCapacityHarnesses` (empty is meaningless for harnesses, and is the
clear signal for repo keys), noted in the docstring. Verified it bites:
`expected 'AgentWorkforce/relay' to be ''`.

After: Rust 10/10, `vitest run packages/fleet packages/cli/src/cli/lib` 630
passed / 0 failed, typecheck + lint + prettier + `cargo fmt --all --check` +
clippy all clean.

## Note on the macOS E2E check

`E2E Integration Test (macos-latest)` failed on the first push with a broker
graceful-shutdown hang (`Graceful shutdown timed out after 10000ms` →
"Broker still reported as running"). This is pre-existing and unrelated: the
**same job is failing on `main` today** with the same signature (run
[32248576455](https://github.com/AgentWorkforce/relay/actions/runs/32248576455):
`status command timed out (hung for >10s)` / `Graceful shutdown timed out`), and
the ubuntu variant of the same job passed here. Nothing in this PR touches
shutdown — it changes registration-manifest construction and adds one env var.
