### PR TITLE
fix(cli): remove targeted fleet spawn token friction

### DIFF
--- a/.agents/skills/using-agent-relay/SKILL.md
+++ b/.agents/skills/using-agent-relay/SKILL.md
@@ -235,31 +235,14 @@ agent-relay agent register Worker
 agent-relay agent list
 ```
 
-Local broker lifecycle and debug (lifecycle only — read replies through the
-`message` group above, never `node tail`):
-
-```bash
-agent-relay status                       # workspace + cloud + broker overview
-agent-relay node up --background --verbose
-agent-relay node status --wait-for 10
-agent-relay node agent list
-agent-relay node agent spawn claude --name Worker --task "Use https://agentrelay.com/skill and ACK over Relay."
-agent-relay node agent attach Worker --mode view
-agent-relay node agent release Worker
-agent-relay node tail --agent Worker    # worker output/TTY, not durable messages
-agent-relay node tail                   # broker debug events (unfiltered), not messages
-```
-
-These lifecycle commands live under `agent-relay node …`. The old flat
-`agent-relay local …` group still works as a hidden, deprecated alias (it prints
-a removal warning) — prefer `node`.
+Broker lifecycle, local worker spawning, terminal attachment, and debug tails
+belong to the outside orchestrator. Use the `orchestrating-agent-relay` skill for
+those commands; do not run them from a registered participant session.
 
 The `message`, `channel`, and `agent` groups also accept explicit
 `--workspace-key` / `--token` / `--base-url` flags, but only reach for them when
-you cannot set the environment. The `node` group does **not** take those — it
-talks to the local broker over its own `--broker-url` / `--api-key` /
-`--state-dir` flags (`RELAY_BROKER_URL`, `RELAY_BROKER_API_KEY`), and the
-`--workspace-key` on `node up` is a different flag with a different meaning.
+you cannot set the environment. Broker lifecycle options are documented in the
+orchestrator skill.
 
 ## Common Mistakes
 

--- a/.agentworkforce/trajectories/completed/2026-08/traj_tfkp7ubijvma/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_tfkp7ubijvma/summary.md
@@ -1,0 +1,14 @@
+# Trajectory: Repair agent-facing skill credential safety gate
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 21, 2026 at 12:24 AM
+> **Completed:** August 21, 2026 at 12:27 AM
+
+---
+
+## Summary
+
+Removed orchestrator-only broker lifecycle commands from both mirrored participant skills, restoring the credential-safety gate.
+
+**Approach:** Standard approach

--- a/.agentworkforce/trajectories/completed/2026-08/traj_tfkp7ubijvma/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_tfkp7ubijvma/trajectory.json
@@ -1,0 +1,25 @@
+{
+  "id": "traj_tfkp7ubijvma",
+  "version": 1,
+  "task": {
+    "title": "Repair agent-facing skill credential safety gate"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-20T22:24:58.716Z",
+  "completedAt": "2026-08-20T22:27:25.374Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Removed orchestrator-only broker lifecycle commands from both mirrored participant skills, restoring the credential-safety gate.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "02f3df9d235e5df4bd7e763465392e16d8170b5a",
+    "endRef": "02f3df9d235e5df4bd7e763465392e16d8170b5a"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_w90vbf0p10fh/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_w90vbf0p10fh/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Remove targeted fleet spawn token friction
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** August 20, 2026 at 11:27 PM
+> **Completed:** August 20, 2026 at 11:36 PM
+
+---
+
+## Summary
+
+Targeted fleet spawn now mints and deletes a short-lived workspace launcher when no agent token is present; added CLI coverage and changelog entry.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn
+- **Chose:** Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn
+- **Reasoning:** The Daytona path already proves this authorization model and cleans up the identity in finally; extending it to named physical nodes removes the explicit token requirement without widening placement authority beyond the active workspace.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn: Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn

--- a/.agentworkforce/trajectories/completed/2026-08/traj_w90vbf0p10fh/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_w90vbf0p10fh/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_w90vbf0p10fh",
+  "version": 1,
+  "task": {
+    "title": "Remove targeted fleet spawn token friction"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-20T21:27:23.751Z",
+  "completedAt": "2026-08-20T21:36:44.389Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-20T21:34:24.162Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_r27i856k1tod",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-20T21:34:24.162Z",
+      "endedAt": "2026-08-20T21:36:44.389Z",
+      "events": [
+        {
+          "ts": 1787261664162,
+          "type": "decision",
+          "content": "Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn: Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn",
+          "raw": {
+            "question": "Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn",
+            "chosen": "Reuse workspace-scoped temporary launcher identity for every tokenless targeted spawn",
+            "alternatives": [],
+            "reasoning": "The Daytona path already proves this authorization model and cleans up the identity in finally; extending it to named physical nodes removes the explicit token requirement without widening placement authority beyond the active workspace."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Targeted fleet spawn now mints and deletes a short-lived workspace launcher when no agent token is present; added CLI coverage and changelog entry.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "9c55dbaa1c2673de87b3aa9142dec79ab349fec9",
+    "endRef": "9c55dbaa1c2673de87b3aa9142dec79ab349fec9"
+  }
+}

--- a/.claude/skills/using-agent-relay/SKILL.md
+++ b/.claude/skills/using-agent-relay/SKILL.md
@@ -235,31 +235,14 @@ agent-relay agent register Worker
 agent-relay agent list
 ```
 
-Local broker lifecycle and debug (lifecycle only — read replies through the
-`message` group above, never `node tail`):
-
-```bash
-agent-relay status                       # workspace + cloud + broker overview
-agent-relay node up --background --verbose
-agent-relay node status --wait-for 10
-agent-relay node agent list
-agent-relay node agent spawn claude --name Worker --task "Use https://agentrelay.com/skill and ACK over Relay."
-agent-relay node agent attach Worker --mode view
-agent-relay node agent release Worker
-agent-relay node tail --agent Worker    # worker output/TTY, not durable messages
-agent-relay node tail                   # broker debug events (unfiltered), not messages
-```
-
-These lifecycle commands live under `agent-relay node …`. The old flat
-`agent-relay local …` group still works as a hidden, deprecated alias (it prints
-a removal warning) — prefer `node`.
+Broker lifecycle, local worker spawning, terminal attachment, and debug tails
+belong to the outside orchestrator. Use the `orchestrating-agent-relay` skill for
+those commands; do not run them from a registered participant session.
 
 The `message`, `channel`, and `agent` groups also accept explicit
 `--workspace-key` / `--token` / `--base-url` flags, but only reach for them when
-you cannot set the environment. The `node` group does **not** take those — it
-talks to the local broker over its own `--broker-url` / `--api-key` /
-`--state-dir` flags (`RELAY_BROKER_URL`, `RELAY_BROKER_API_KEY`), and the
-`--workspace-key` on `node up` is a different flag with a different meaning.
+you cannot set the environment. Broker lifecycle options are documented in the
+orchestrator skill.
 
 ## Common Mistakes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased - Minor]
 
+### Fixed
+
+- `agent-relay fleet spawn --node <name>` now uses the active workspace to mint and clean up a short-lived launcher identity when no agent token is present.
+
 ### Added
 
 - `relay session replay <id>` and `@agent-relay/session`'s `SessionClient.replaySession()` now include the cross-node Relaycast conversation for the session, report the effective retention boundary, and flag incomplete coverage.

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -720,8 +720,8 @@ describe('fleet command support', () => {
     });
     expect(register).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.stringMatching(/^fleet-sandbox-launcher-[a-f0-9]{8}$/),
-        metadata: { purpose: 'fleet-sandbox-launcher' },
+        name: expect.stringMatching(/^fleet-spawn-launcher-[a-f0-9]{8}$/),
+        metadata: { purpose: 'fleet-spawn-launcher' },
       }),
       { strict: true }
     );
@@ -743,7 +743,7 @@ describe('fleet command support', () => {
     );
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.stringMatching(/^fleet-sandbox-launcher-/),
+        name: expect.stringMatching(/^fleet-spawn-launcher-/),
         deleteAgent: true,
       })
     );
@@ -1180,24 +1180,33 @@ describe('fleet command support', () => {
     });
   });
 
-  it('fleet spawn rejects targeted placement without an agent token before dispatch', async () => {
+  it('fleet spawn mints and removes a temporary launcher for tokenless targeted placement', async () => {
     const previousToken = process.env.RELAY_AGENT_TOKEN;
     delete process.env.RELAY_AGENT_TOKEN;
-    const createAgentRelay = vi.fn();
+    const placement = {
+      spawn: vi.fn(async () => ({
+        invocationId: 'inv_targeted_tokenless',
+        actionName: 'spawn',
+        node: { name: 'sf-mini' },
+      })),
+    };
+    const createAgentRelay = vi.fn(() => ({ messaging: { placement } }));
+    const register = vi.fn(async () => ({ token: 'at_live_temporary_launcher' }));
+    const release = vi.fn(async () => ({ released: true, deleted: true }));
+    const createWorkspaceRelay = vi.fn(() => ({
+      workspace: { register, release },
+    }));
     const createFleetWorkspaceClient = vi.fn();
-    const errors: string[] = [];
     const program = new Command();
     program.exitOverride();
     registerFleetCommands(program, {
       sdk: {
         createAgentRelay: createAgentRelay as never,
-        createWorkspaceRelay: vi.fn() as never,
+        createWorkspaceRelay: createWorkspaceRelay as never,
         createWorkspace: vi.fn() as never,
         log: vi.fn(),
-        error: (...args: unknown[]) => errors.push(args.join(' ')),
-        exit: (() => {
-          throw new Error('__exit__');
-        }) as never,
+        error: vi.fn(),
+        exit: vi.fn() as never,
       },
       createFleetWorkspaceClient: createFleetWorkspaceClient as never,
       log: () => undefined,
@@ -1206,31 +1215,56 @@ describe('fleet command support', () => {
     });
 
     try {
-      await expect(
-        program.parseAsync(
-          [
-            'fleet',
-            'spawn',
-            'codex',
-            '--name',
-            'api-worker',
-            '--task',
-            'ACK',
-            '--node',
-            'sf-mini',
-            '--workspace-key',
-            'rk_live_test',
-          ],
-          { from: 'user' }
-        )
-      ).rejects.toThrow('__exit__');
+      await program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'codex',
+          '--name',
+          'api-worker',
+          '--task',
+          'ACK',
+          '--node',
+          'sf-mini',
+          '--workspace-key',
+          'rk_live_test',
+        ],
+        { from: 'user' }
+      );
     } finally {
       if (previousToken === undefined) delete process.env.RELAY_AGENT_TOKEN;
       else process.env.RELAY_AGENT_TOKEN = previousToken;
     }
 
-    expect(errors.join('\n')).toMatch(/requires an agent token/);
-    expect(createAgentRelay).not.toHaveBeenCalled();
+    expect(createWorkspaceRelay).toHaveBeenCalledWith({
+      workspaceKey: 'rk_live_test',
+      token: undefined,
+      baseUrl: undefined,
+    });
+    expect(register).toHaveBeenCalledWith(
+      {
+        name: expect.stringMatching(/^fleet-spawn-launcher-[a-f0-9]{8}$/),
+        metadata: { purpose: 'fleet-spawn-launcher' },
+      },
+      { strict: true }
+    );
+    expect(createAgentRelay).toHaveBeenCalledWith({
+      workspaceKey: 'rk_live_test',
+      token: 'at_live_temporary_launcher',
+      baseUrl: undefined,
+    });
+    expect(placement.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability: 'spawn:codex',
+        node: 'sf-mini',
+        confirm: true,
+      })
+    );
+    expect(release).toHaveBeenCalledWith({
+      name: expect.stringMatching(/^fleet-spawn-launcher-[a-f0-9]{8}$/),
+      reason: 'Temporary fleet spawn launcher completed',
+      deleteAgent: true,
+    });
     expect(createFleetWorkspaceClient).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -1268,6 +1268,72 @@ describe('fleet command support', () => {
     expect(createFleetWorkspaceClient).not.toHaveBeenCalled();
   });
 
+  it('fleet spawn does not release an existing agent when temporary launcher registration fails', async () => {
+    const previousToken = process.env.RELAY_AGENT_TOKEN;
+    delete process.env.RELAY_AGENT_TOKEN;
+    const registrationError = new Error('Agent already exists');
+    const register = vi.fn(async () => {
+      throw registrationError;
+    });
+    const release = vi.fn();
+    const createWorkspaceRelay = vi.fn(() => ({
+      workspace: { register, release },
+    }));
+    const createAgentRelay = vi.fn();
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: createAgentRelay as never,
+        createWorkspaceRelay: createWorkspaceRelay as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (() => {
+          throw new Error('__exit__');
+        }) as never,
+      },
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    try {
+      await expect(
+        program.parseAsync(
+          [
+            'fleet',
+            'spawn',
+            'codex',
+            '--name',
+            'api-worker',
+            '--task',
+            'ACK',
+            '--node',
+            'sf-mini',
+            '--workspace-key',
+            'rk_live_test',
+          ],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('__exit__');
+    } finally {
+      if (previousToken === undefined) delete process.env.RELAY_AGENT_TOKEN;
+      else process.env.RELAY_AGENT_TOKEN = previousToken;
+    }
+
+    expect(register).toHaveBeenCalledWith(
+      {
+        name: expect.stringMatching(/^fleet-spawn-launcher-[a-f0-9]{8}$/),
+        metadata: { purpose: 'fleet-spawn-launcher' },
+      },
+      { strict: true }
+    );
+    expect(release).not.toHaveBeenCalled();
+    expect(createAgentRelay).not.toHaveBeenCalled();
+  });
+
   it('fleet release delegates to the workspace lifecycle API with a default reason and actor', async () => {
     const release = vi.fn(async () => ({
       name: 'api-worker',

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -310,14 +310,15 @@ export function registerFleetCommands(
           let agentToken = resolveAgentToken(clientOptions);
           if (!agentToken) {
             workspaceRelay ??= deps.sdk.createWorkspaceRelay(clientOptions);
-            launcherName = `fleet-spawn-launcher-${randomUUID().slice(0, 8)}`;
+            const pendingLauncherName = `fleet-spawn-launcher-${randomUUID().slice(0, 8)}`;
             const launcher = await workspaceRelay.workspace.register(
               {
-                name: launcherName,
+                name: pendingLauncherName,
                 metadata: { purpose: 'fleet-spawn-launcher' },
               },
               { strict: true }
             );
+            launcherName = pendingLauncherName;
             agentToken = launcher.token;
             if (!agentToken) {
               throw new Error('The temporary fleet spawn launcher did not receive an agent token.');

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -305,27 +305,22 @@ export function registerFleetCommands(
       }
 
       if (targetNode) {
-        if (!useSandbox && !resolveAgentToken(clientOptions)) {
-          throw new Error(
-            'Targeted Fleet spawn requires an agent token. Pass --token or set RELAY_AGENT_TOKEN.'
-          );
-        }
         let launcherName: string | undefined;
         try {
           let agentToken = resolveAgentToken(clientOptions);
           if (!agentToken) {
             workspaceRelay ??= deps.sdk.createWorkspaceRelay(clientOptions);
-            launcherName = `fleet-sandbox-launcher-${randomUUID().slice(0, 8)}`;
+            launcherName = `fleet-spawn-launcher-${randomUUID().slice(0, 8)}`;
             const launcher = await workspaceRelay.workspace.register(
               {
                 name: launcherName,
-                metadata: { purpose: 'fleet-sandbox-launcher' },
+                metadata: { purpose: 'fleet-spawn-launcher' },
               },
               { strict: true }
             );
             agentToken = launcher.token;
             if (!agentToken) {
-              throw new Error('The temporary fleet sandbox launcher did not receive an agent token.');
+              throw new Error('The temporary fleet spawn launcher did not receive an agent token.');
             }
           }
 
@@ -384,7 +379,7 @@ export function registerFleetCommands(
             await workspaceRelay.workspace
               .release({
                 name: launcherName,
-                reason: 'Temporary fleet sandbox launcher completed',
+                reason: 'Temporary fleet spawn launcher completed',
                 deleteAgent: true,
               })
               .catch((error) => {


### PR DESCRIPTION
## Summary
- let `agent-relay fleet spawn --node <name>` use the active workspace when no `RELAY_AGENT_TOKEN` is present
- mint a short-lived launcher identity, use it for the targeted placement call, and delete it in `finally`
- never clean up a launcher name unless strict registration actually succeeded
- keep explicit agent-token behavior unchanged and share the same launcher path with Daytona spawns
- keep broker-only lifecycle commands out of mirrored participant skills so the credential-safety gate stays green

## Validation
- `npm exec -- vitest run packages/cli/src/cli/commands/fleet.test.ts` (27/27)
- `npm run typecheck`
- targeted ESLint (0 errors; existing complexity warnings only)
- full `npm test`: 147 files passed, 2 skipped; 2,151 tests passed, 16 skipped
- `git diff --check`
- GitHub CI: all required checks green, including two-node fleet matrix, macOS/Linux tests, install smoke, security, and package validation

## Review feedback
- CodeRabbit and Cubic cleanup-safety finding fixed in `9eced004b`
- both review threads resolved; Cubic reports all findings addressed
