### PR TITLE
fix(mcp): stop send_dm echoing the message body back to the sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay fleet spawn --node <name>` now uses the active workspace to mint and clean up a short-lived launcher identity when no agent token is present.
+- The `send_dm` MCP tool returns a compact, fixed-size delivery receipt instead of echoing the sent message body back twice, cutting the context a sending agent spends per DM by roughly two-thirds. The `agent-relay message dm --json` output is unchanged.
 
 ### Added
 

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -553,10 +553,15 @@ describe('createAgentRelayMcpServer', () => {
     // it's given, but a correct handler resolves the recipient independently
     // (and reports `recipient_unresolved` when it can't). Asserting `to`
     // would encode that passthrough as expected behavior.
+    //
+    // Nor `text`: the receipt deliberately drops the body rather than echoing
+    // it back to the agent that just wrote it. Asserting `text` here would
+    // likewise re-freeze the echo as expected behavior.
     expect(dmResult.structuredContent).toMatchObject({
       id: 'dm_1',
-      text: 'MCP startup check',
+      delivery: { status: 'recipient_unresolved', readConfirmed: false },
     });
+    expect(dmResult.structuredContent).not.toHaveProperty('text');
     const inboxResult = await server.tools.get('check_inbox')?.handler({});
     expect(inboxResult.structuredContent).toEqual({
       unreadChannels: [],

--- a/packages/cli/src/cli/lib/message-delivery-receipts.ts
+++ b/packages/cli/src/cli/lib/message-delivery-receipts.ts
@@ -133,13 +133,18 @@ export function messageReadersReceipt(readers: unknown[]): {
 export function compactDirectMessageReceipt(
   receipt: DirectMessageDeliveryReceipt
 ): DirectMessageDeliveryReceipt {
-  const keepString = (key: 'id' | 'messageId' | 'conversationId') =>
-    typeof receipt[key] === 'string' ? { [key]: receipt[key] } : {};
+  // The upstream response names the identifier `id` or `messageId` depending on
+  // the endpoint — `directMessageDeliveryFailure` already reads both. Collapse
+  // them to the single `id` the tool's output schema advertises, so a caller
+  // told to follow up with `get_message_readers` always finds it under the
+  // documented name rather than under whichever alias the endpoint happened to
+  // use. An existing `id` wins; `messageId` is a fallback, never an extra field.
+  const id = typeof receipt.id === 'string' ? receipt.id : receipt.messageId;
+  const conversationId = receipt.conversationId;
 
   return {
-    ...keepString('id'),
-    ...keepString('messageId'),
-    ...keepString('conversationId'),
+    ...(typeof id === 'string' ? { id } : {}),
+    ...(typeof conversationId === 'string' ? { conversationId } : {}),
     ...(receipt.target ? { target: receipt.target } : {}),
     delivery: receipt.delivery,
   };

--- a/packages/cli/src/cli/lib/message-delivery-receipts.ts
+++ b/packages/cli/src/cli/lib/message-delivery-receipts.ts
@@ -106,3 +106,41 @@ export function messageReadersReceipt(readers: unknown[]): {
     },
   };
 }
+
+/**
+ * Project a direct-message send receipt down to what the caller needs to act on
+ * it, dropping the echoed message body.
+ *
+ * The upstream create-message response carries the body twice — once at `text`
+ * and once at the nested `message.text` — and `directMessageReceipt` spreads
+ * that response wholesale. On the MCP path that puts two further copies of a DM
+ * into the *sender's* own context window, on top of the `tool_use` parameter
+ * that already holds it. The sender wrote the text; echoing it back informs no
+ * decision, and it is charged against the context budget of exactly the
+ * long-lived resident agents that send the most DMs.
+ *
+ * The projection is an allowlist rather than a denylist on purpose: deleting
+ * known body fields would start leaking the body again the first time the
+ * upstream response grows another text-bearing field.
+ *
+ * Everything kept is fixed-size, so the receipt no longer grows with the
+ * message. `delivery` is kept whole because it is the part that stops an agent
+ * reporting an enqueue as a confirmed delivery; `id` because it is how the
+ * caller follows up with `get_message_readers`; and `target` because its
+ * presence — versus its absence on an unresolved recipient — is an existing
+ * signal that the directory independently confirmed who was addressed.
+ */
+export function compactDirectMessageReceipt(
+  receipt: DirectMessageDeliveryReceipt
+): DirectMessageDeliveryReceipt {
+  const keepString = (key: 'id' | 'messageId' | 'conversationId') =>
+    typeof receipt[key] === 'string' ? { [key]: receipt[key] } : {};
+
+  return {
+    ...keepString('id'),
+    ...keepString('messageId'),
+    ...keepString('conversationId'),
+    ...(receipt.target ? { target: receipt.target } : {}),
+    delivery: receipt.delivery,
+  };
+}

--- a/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
@@ -1,11 +1,39 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  compactDirectMessageReceipt,
   directMessageDeliveryFailure,
   directMessageReceipt,
   messageReadersReceipt,
   resolveExactAgentName,
 } from '../lib/message-delivery-receipts.js';
+
+/**
+ * Shape of the upstream create-message response, which carries the body twice:
+ * once at `text` and once at the nested `message.text`.
+ */
+function sentMessageResponse(body: string) {
+  return {
+    conversationId: 'dm_abc123',
+    message: {
+      id: 'msg_1',
+      agentId: 'agent_sender',
+      agentName: 'sender',
+      text: body,
+      injectionMode: 'wait',
+      attachments: [],
+      metadata: { injection_mode: 'wait' },
+    },
+    createdAt: '2026-08-21T18:37:00.000Z',
+    id: 'msg_1',
+    fromAgentId: 'agent_sender',
+    to: 'chief',
+    text: body,
+    injectionMode: 'wait',
+    attachments: [],
+    metadata: { injection_mode: 'wait' },
+  };
+}
 
 describe('exact agent-name resolution', () => {
   it('chooses the full hyphenated name instead of an existing strict prefix', () => {
@@ -136,5 +164,99 @@ describe('direct message delivery receipts', () => {
         signal: 'At least one agent has read this message.',
       },
     });
+  });
+});
+
+describe('compact direct message receipts', () => {
+  const body = 'x'.repeat(4000);
+
+  it('keeps the identifiers and the full delivery verdict', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief')
+    );
+
+    expect(compact).toEqual({
+      id: 'msg_1',
+      conversationId: 'dm_abc123',
+      target: { kind: 'agent', agentName: 'chief' },
+      delivery: {
+        status: 'queued_unconfirmed',
+        mode: 'wait',
+        requestedRecipient: 'chief',
+        resolvedRecipient: 'chief',
+        recipientMatched: true,
+        readConfirmed: false,
+        note: "Queued for injection at the recipient's next safe idle boundary. It can remain unread while the recipient is busy. This receipt does not confirm delivery or reading; call get_message_readers with the message id.",
+      },
+    });
+  });
+
+  it('does not echo the message body anywhere in the serialised receipt', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief')
+    );
+
+    expect(JSON.stringify(compact)).not.toContain(body);
+  });
+
+  it('drops every body-bearing field the upstream response spreads in', () => {
+    const full = directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief');
+    const compact = compactDirectMessageReceipt(full);
+
+    // The defect: the uncompacted receipt carries the body twice.
+    expect(JSON.stringify(full).split(body).length - 1).toBe(2);
+    for (const dropped of ['text', 'message', 'metadata', 'attachments', 'fromAgentId', 'to', 'createdAt']) {
+      expect(compact).not.toHaveProperty(dropped);
+    }
+  });
+
+  it('keeps the receipt bounded no matter how large the message body is', () => {
+    const short = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse('hi'), 'chief', 'wait', 'chief')
+    );
+    const long = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse('y'.repeat(50_000)), 'chief', 'wait', 'chief')
+    );
+
+    expect(JSON.stringify(long).length).toBe(JSON.stringify(short).length);
+    expect(JSON.stringify(long).length).toBeLessThan(500);
+  });
+
+  it('still reports a recipient mismatch, including the message reference', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse(body), 'chief-khaliq', 'wait', 'chief')
+    );
+
+    expect(compact.delivery.status).toBe('recipient_mismatch');
+    const failure = directMessageDeliveryFailure(compact);
+    expect(failure).toContain('recipient_mismatch');
+    expect(failure).toContain('message msg_1 was enqueued');
+    expect(failure).not.toContain(body);
+  });
+
+  it('omits identifiers that the upstream response did not provide', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt({ text: 'no id here' }, 'chief', 'wait', 'chief')
+    );
+
+    expect(compact).toEqual({
+      target: { kind: 'agent', agentName: 'chief' },
+      delivery: expect.objectContaining({ status: 'queued_unconfirmed' }),
+    });
+    expect(directMessageDeliveryFailure(compact)).toBeUndefined();
+  });
+
+  it('preserves the resolved-versus-unresolved recipient signal that target carries', () => {
+    const resolved = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief')
+    );
+    const unresolved = compactDirectMessageReceipt(
+      directMessageReceipt(sentMessageResponse(body), 'chief')
+    );
+
+    expect(resolved.target).toEqual({ kind: 'agent', agentName: 'chief' });
+    expect(unresolved).not.toHaveProperty('target');
+    expect(unresolved.delivery.status).toBe('recipient_unresolved');
+    expect(JSON.stringify(unresolved)).not.toContain(body);
   });
 });

--- a/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
@@ -246,6 +246,38 @@ describe('compact direct message receipts', () => {
     expect(directMessageDeliveryFailure(compact)).toBeUndefined();
   });
 
+  it('surfaces a messageId-only upstream response under the documented id field', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt(
+        { messageId: 'msg_alias', conversationId: 'dm_alias', text: body },
+        'chief',
+        'wait',
+        'chief'
+      )
+    );
+
+    // The output schema advertises `id`; a caller told to follow up with
+    // get_message_readers must find it there whichever alias upstream used.
+    expect(compact.id).toBe('msg_alias');
+    expect(compact).not.toHaveProperty('messageId');
+    expect(JSON.stringify(compact)).not.toContain(body);
+    expect(
+      directMessageDeliveryFailure({
+        ...compact,
+        delivery: { ...compact.delivery, status: 'recipient_unresolved' },
+      })
+    ).toContain('message msg_alias was enqueued');
+  });
+
+  it('prefers a real id over a messageId alias when both are present', () => {
+    const compact = compactDirectMessageReceipt(
+      directMessageReceipt({ id: 'msg_real', messageId: 'msg_alias' }, 'chief', 'wait', 'chief')
+    );
+
+    expect(compact.id).toBe('msg_real');
+    expect(compact).not.toHaveProperty('messageId');
+  });
+
   it('preserves the resolved-versus-unresolved recipient signal that target carries', () => {
     const resolved = compactDirectMessageReceipt(
       directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief')

--- a/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.delivery.test.ts
@@ -250,9 +250,7 @@ describe('compact direct message receipts', () => {
     const resolved = compactDirectMessageReceipt(
       directMessageReceipt(sentMessageResponse(body), 'chief', 'wait', 'chief')
     );
-    const unresolved = compactDirectMessageReceipt(
-      directMessageReceipt(sentMessageResponse(body), 'chief')
-    );
+    const unresolved = compactDirectMessageReceipt(directMessageReceipt(sentMessageResponse(body), 'chief'));
 
     expect(resolved.target).toEqual({ kind: 'agent', agentName: 'chief' });
     expect(unresolved).not.toHaveProperty('target');

--- a/packages/cli/src/cli/mcp/messaging-tools.protocol.test.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.protocol.test.ts
@@ -93,7 +93,11 @@ describe('messaging delivery receipts over MCP', () => {
       message: { id: 'msg_1', text: body },
     }));
     const server = new McpServer({ name: 'messaging-echo-test', version: '1.0.0' });
-    registerMessagingTools(server, () => ({ dm }) as never, async () => [{ name: 'chief' }]);
+    registerMessagingTools(
+      server,
+      () => ({ dm }) as never,
+      async () => [{ name: 'chief' }]
+    );
 
     const client = new Client({ name: 'messaging-echo-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/packages/cli/src/cli/mcp/messaging-tools.protocol.test.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.protocol.test.ts
@@ -83,6 +83,50 @@ describe('messaging delivery receipts over MCP', () => {
     }
   });
 
+  it('does not echo the sent body back across the MCP boundary', async () => {
+    const body = 'CANARY-BODY-'.repeat(400);
+    const dm = vi.fn(async () => ({
+      // The upstream create-message response carries the body twice.
+      conversationId: 'dm_1',
+      id: 'msg_1',
+      text: body,
+      message: { id: 'msg_1', text: body },
+    }));
+    const server = new McpServer({ name: 'messaging-echo-test', version: '1.0.0' });
+    registerMessagingTools(server, () => ({ dm }) as never, async () => [{ name: 'chief' }]);
+
+    const client = new Client({ name: 'messaging-echo-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const sent = await client.callTool({
+        name: 'send_dm',
+        arguments: { to: 'chief', text: body },
+      });
+
+      // Neither the rendered content block nor the structured payload may
+      // carry the body the caller already holds in its tool_use parameter.
+      expect(JSON.stringify(sent.content)).not.toContain('CANARY-BODY');
+      expect(JSON.stringify(sent.structuredContent)).not.toContain('CANARY-BODY');
+
+      // The receipt stays small no matter how large the message was.
+      expect(JSON.stringify(sent.structuredContent).length).toBeLessThan(600);
+
+      // ...and still says everything the caller needs to act on it.
+      expect(sent.structuredContent).toMatchObject({
+        id: 'msg_1',
+        conversationId: 'dm_1',
+        delivery: { status: 'queued_unconfirmed', resolvedRecipient: 'chief' },
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it('stamps the current replay session on channel, thread, direct, and group messages', async () => {
     vi.stubEnv('RELAY_ATTEST_SESSION_ID', '11111111-1111-4111-8111-111111111111');
     const send = vi.fn(async () => ({ id: 'msg_channel', text: 'channel' }));

--- a/packages/cli/src/cli/mcp/messaging-tools.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.ts
@@ -354,9 +354,7 @@ export function registerMessagingTools(
         attachments,
         data: replayMessageMetadata(),
       });
-      const receipt = compactDirectMessageReceipt(
-        directMessageReceipt(message, to, mode, resolvedRecipient)
-      );
+      const receipt = compactDirectMessageReceipt(directMessageReceipt(message, to, mode, resolvedRecipient));
       const result = jsonContent(receipt);
       return directMessageDeliveryFailure(receipt) ? { ...result, isError: true as const } : result;
     }

--- a/packages/cli/src/cli/mcp/messaging-tools.ts
+++ b/packages/cli/src/cli/mcp/messaging-tools.ts
@@ -3,6 +3,7 @@ import { replayMessageMetadata } from '@agent-relay/sdk';
 import { z } from 'zod';
 
 import {
+  compactDirectMessageReceipt,
   directMessageDeliveryFailure,
   directMessageReceipt,
   messageReadersReceipt,
@@ -13,6 +14,8 @@ import { identityOverrideInputShape, messageResult } from './tool-shapes.js';
 import type { AgentClientLike } from './types.js';
 
 const directMessageResult = z.looseObject({
+  id: z.string().optional().describe('Message ID, for "get_message_readers"'),
+  conversationId: z.string().optional().describe('DM conversation ID, addressing relay://dm/{id}'),
   target: z.object({ kind: z.literal('agent'), agentName: z.string() }).optional(),
   delivery: z.object({
     status: z.enum(['queued_unconfirmed', 'recipient_mismatch', 'recipient_unresolved']),
@@ -317,7 +320,8 @@ export function registerMessagingTools(
       title: 'Send Direct Message',
       description:
         'Send a private direct message visible only to the recipient and this agent. ' +
-        'Returns the created message and an explicit queued/unconfirmed delivery receipt. ' +
+        'Returns a compact delivery receipt — the message ID, the conversation ID, and an explicit queued/unconfirmed delivery status. ' +
+        'The receipt deliberately does not echo the message body back; you already have the text you sent. ' +
         'Returns a tool error while preserving that receipt when the recipient cannot be resolved exactly. ' +
         'A message ID confirms enqueue, not injection or reading; use "get_message_readers" to confirm consumption. ' +
         'Mode "wait" (the default) waits for the recipient\'s next safe idle boundary and can remain unread while they are busy. ' +
@@ -350,7 +354,9 @@ export function registerMessagingTools(
         attachments,
         data: replayMessageMetadata(),
       });
-      const receipt = directMessageReceipt(message, to, mode, resolvedRecipient);
+      const receipt = compactDirectMessageReceipt(
+        directMessageReceipt(message, to, mode, resolvedRecipient)
+      );
       const result = jsonContent(receipt);
       return directMessageDeliveryFailure(receipt) ? { ...result, isError: true as const } : result;
     }


### PR DESCRIPTION
## What

`send_dm` returned the message body back to the agent that just sent it — twice.

The upstream create-message response carries the body at both `text` and the nested
`message.text`. `directMessageReceipt()` spreads that response wholesale into the MCP
tool result, so a sending agent pays for **three** copies of every DM: the `tool_use`
parameter it wrote, plus two echoes in the `tool_result`. None of the echo informs a
decision — the sender wrote the text.

This matters because the agents that send the most DMs are the long-lived resident
leads, and they pay for it out of the same context window they use to make decisions.

## Measured

Serialized receipt size against this repo's own receipt shape:

| body chars | context before | context after | multiple before | multiple after |
|---:|---:|---:|---:|---:|
| 1,200 | 4,739 | 1,838 | 3.95× | 1.53× |
| 2,400 | 8,339 | 3,038 | 3.47× | 1.27× |
| 4,000 | 13,139 | 4,638 | 3.28× | 1.16× |

The receipt is now a **fixed 638 characters regardless of body size** — it no longer
scales with the message at all. Previously it grew by 2 bytes per byte sent.

## How

`compactDirectMessageReceipt()` projects the receipt to what a caller can act on
before it crosses the MCP boundary:

- `id` / `conversationId` — following up with `get_message_readers`, addressing `relay://dm/{id}`
- `target` — its presence, versus absence on an unresolved recipient, is the existing
  signal that the directory independently confirmed who was addressed
- `delivery` — kept whole; it is what stops an enqueue being reported as confirmed delivery

Everything kept is fixed-size. The projection is an **allowlist, not a denylist**:
deleting known body fields would leak the body again the first time the upstream
response grows another text-bearing field.

## Scope

- **`agent-relay message dm --json` is deliberately untouched.** Compaction is applied
  only on the MCP path, where the reader is a context window rather than a terminal.
  The CLI's JSON contract is unchanged for scripts that consume it.
- The same body-echo pattern exists in `post_message`, `reply_to_thread`, and
  `send_group_dm`, and `jsonContent()` separately emits every tool result twice
  (`content` *and* `structuredContent`). Both are real and both are out of scope here —
  filed for follow-up rather than folded into this PR.

## Tests

25 passing across the three messaging/MCP suites. Two guards are deliberately
non-vacuous:

- a unit test asserts the **uncompacted** receipt contains the body exactly twice, so
  the fix cannot silently rot into a no-op;
- a protocol test drives a real client/server pair over `InMemoryTransport` and asserts
  a canary body appears in **neither** `content` nor `structuredContent`. Reverting the
  one-line compaction call fails this test — verified.
