### PR TITLE
fix(attach): stop tearing down the input stream when an agent is busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay fleet spawn --node <name>` now uses the active workspace to mint and clean up a short-lived launcher identity when no agent token is present.
+- `agent-relay node agent attach --mode drive` no longer drops and reopens its input stream when the agent is busy. A full PTY write queue now reports `pty_write_queue_full`, which the broker and SDK treat as a refusal of that one keystroke instead of transport death, replacing the repeating `input stream lost … / reconnected after 1 attempt(s)` flap with a single line that says the session is still attached.
+- Attach input streams send a keepalive ping, so an idle input socket can no longer be closed by a network idle timeout while the screen keeps updating.
+- Attach no longer sends `rows: 0, cols: 0` to the broker when the terminal reports no size, removing the spurious `rows and cols must be positive integers` warning.
 
 ### Added
 

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -1761,6 +1761,17 @@ fn classify_error(err: &str) -> (axum::http::StatusCode, &'static str) {
         // `pty_input_error_is_connection_fatal`, which callers on the PTY
         // input path use to avoid treating this code as transport death.
         (axum::http::StatusCode::GATEWAY_TIMEOUT, "worker_timeout")
+    } else if err.starts_with("pty_write_queue_full") {
+        // The worker refused ONE write because its bounded drainer queue is
+        // full — the child is alive but momentarily not draining its stdin
+        // (a TUI harness mid-tool-call, whose terminal-query replies and
+        // injected messages share the same queue). Flow control, not
+        // transport death: 503 with a distinct code so the PTY input path can
+        // keep the connection open (`pty_input_error_is_connection_fatal`).
+        (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "pty_write_queue_full",
+        )
     } else if err.starts_with("internal_error") {
         (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -1785,8 +1796,18 @@ fn classify_error(err: &str) -> (axum::http::StatusCode, &'static str) {
 /// connection-fatal. Closing the connection on a mere timeout manufactures a
 /// transport failure out of a healthy-but-slow worker, which is exactly what
 /// forced the client-side reconnect loop in relay#1544.
+///
+/// `pty_write_queue_full` is exempt for the same reason and is strictly
+/// stronger evidence of liveness: the worker answered, and its answer was "I
+/// refused this one write because my drainer queue is full". Nothing about the
+/// socket is broken. Tearing it down produced the `input stream lost … /
+/// reconnected after 1 attempt(s)` flap operators hit when driving a busy
+/// agent, and reconnecting cannot help — the queue drains when the child
+/// resumes reading, not when a new socket opens. Note the queue is shared with
+/// terminal-query replies, injected messages and auto-responder writes, so the
+/// human whose keystroke is refused is usually not the one who filled it.
 fn pty_input_error_is_connection_fatal(code: &str) -> bool {
-    code != "worker_timeout"
+    !matches!(code, "worker_timeout" | "pty_write_queue_full")
 }
 
 fn internal_error() -> (axum::http::StatusCode, axum::Json<Value>) {
@@ -5415,6 +5436,50 @@ mod auth_tests {
         assert!(!super::pty_input_error_is_connection_fatal(
             "worker_timeout"
         ));
+    }
+
+    #[test]
+    fn queue_full_does_not_close_the_pty_input_connection() {
+        // relay#1597 MUST-FIRE: a worker that answers "my drainer queue is
+        // full" has proved it is alive, and the write it refused is the only
+        // casualty. Closing the socket here produced one
+        // `input stream lost … / reconnected after 1 attempt(s)` flap per
+        // keystroke against any busy agent, and reconnecting cannot help — the
+        // queue drains when the child resumes reading, not when a new socket
+        // opens. Revert to `code != "worker_timeout"` and this fails.
+        assert!(!super::pty_input_error_is_connection_fatal(
+            "pty_write_queue_full"
+        ));
+        // The client is told the stream is still usable.
+        assert!(!super::pty_input_error_is_connection_fatal(
+            "worker_timeout"
+        ));
+    }
+
+    #[test]
+    fn queue_full_is_classified_as_its_own_retryable_code() {
+        // The code must survive classification intact: `classify_error` used to
+        // collapse it into the catch-all `request_failed`, which is fatal, so
+        // the exemption above could never be reached from a real worker error.
+        let (status, code) = super::classify_error(
+            "pty_write_queue_full: pty write queue full (128 writes pending; drainer wedged behind child not reading stdin)",
+        );
+        assert_eq!(code, "pty_write_queue_full");
+        assert_eq!(status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn a_broken_pty_write_is_still_fatal() {
+        // relay#1597 MUST-NOT-FIRE: only the queue-full code is exempt.
+        // `pty_write_failed` covers a confirmed I/O error or an exited drainer
+        // — real loss, which must still close the socket so the client's
+        // reconnect-and-verify recovery runs.
+        assert!(super::pty_input_error_is_connection_fatal(
+            "pty_write_failed"
+        ));
+        let (status, code) = super::classify_error("pty_write_failed: broken pipe");
+        assert_eq!(code, "request_failed");
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/crates/broker/src/pty_worker.rs
+++ b/crates/broker/src/pty_worker.rs
@@ -11,7 +11,7 @@ use futures_util::{stream::FuturesUnordered, StreamExt};
 use crate::{
     ids::{DeliveryId, RequestId},
     protocol::{MessageInjectionMode, ProtocolEnvelope, RelayDelivery},
-    pty::PtySession,
+    pty::{PtySession, PtyWriteSubmitError},
 };
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -990,9 +990,24 @@ pub(crate) async fn run_pty_worker(cmd: PtyCommand) -> Result<()> {
                                                 // Surface the enqueue failure on the correlated
                                                 // response so the client's send() rejects instead
                                                 // of resolving on a write that never happened.
+                                                //
+                                                // A full drainer queue gets its own code. The child
+                                                // is alive and the transport is healthy — it is only
+                                                // momentarily not draining its stdin — so an attach
+                                                // client must be able to tell this apart from a
+                                                // genuinely broken write and keep its input stream
+                                                // open (see `pty_input_error_is_connection_fatal`).
+                                                let code = match e
+                                                    .downcast_ref::<PtyWriteSubmitError>()
+                                                {
+                                                    Some(PtyWriteSubmitError::QueueFull { .. }) => {
+                                                        "pty_write_queue_full"
+                                                    }
+                                                    _ => "pty_write_failed",
+                                                };
                                                 let _ = send_frame(&out_tx, "write_pty_response", frame.request_id, json!({
                                                     "error": {
-                                                        "code": "pty_write_failed",
+                                                        "code": code,
                                                         "message": e.to_string(),
                                                     }
                                                 })).await;

--- a/crates/relay-pty/src/pty.rs
+++ b/crates/relay-pty/src/pty.rs
@@ -30,6 +30,34 @@ use tokio::sync::{mpsc, oneshot};
 /// a time.
 const WRITE_QUEUE_DEPTH: usize = 128;
 
+/// Why [`PtySession::submit_write`] refused to enqueue.
+///
+/// Typed — not a bare string — because the two cases mean opposite things to a
+/// caller serving an interactive attach session. [`QueueFull`] says the child
+/// is alive but momentarily not draining its stdin, so the write is the only
+/// thing that failed and the caller should keep its transport open and retry.
+/// [`DrainerExited`] says the PTY is gone. Callers recover the variant with
+/// `anyhow::Error::downcast_ref::<PtyWriteSubmitError>()`; `submit_write` keeps
+/// returning `anyhow::Result` so existing call sites are unaffected.
+///
+/// [`QueueFull`]: PtyWriteSubmitError::QueueFull
+/// [`DrainerExited`]: PtyWriteSubmitError::DrainerExited
+#[derive(Debug, thiserror::Error)]
+pub enum PtyWriteSubmitError {
+    /// The bounded drainer queue is full. Retryable: the drainer is blocked in
+    /// `write_all` behind a child that has stopped reading its stdin, and drains
+    /// as soon as it resumes.
+    #[error("pty write queue full ({depth} writes pending; drainer wedged behind child not reading stdin)")]
+    QueueFull {
+        /// Queue capacity, which is also the number of writes pending.
+        depth: usize,
+    },
+
+    /// The drainer thread is gone (PTY teardown). Not retryable.
+    #[error("pty write queue is closed (drainer exited)")]
+    DrainerExited,
+}
+
 /// Single FIFO command for the PTY write drainer. Both query-reply
 /// writebacks (from `RelayEventListener`) and user-input/injection
 /// writes (from `PtySession::write_all`) go through the same queue so
@@ -498,13 +526,14 @@ fn enqueue_user_write(
         ack: ack_tx,
     }) {
         Ok(()) => Ok(ack_rx),
-        Err(std_mpsc::TrySendError::Full(_)) => Err(anyhow::anyhow!(
-            "pty write queue full ({} writes pending; drainer wedged behind child not reading stdin)",
-            WRITE_QUEUE_DEPTH
-        )),
-        Err(std_mpsc::TrySendError::Disconnected(_)) => Err(anyhow::anyhow!(
-            "pty write queue is closed (drainer exited)"
-        )),
+        Err(std_mpsc::TrySendError::Full(_)) => {
+            Err(anyhow::Error::new(PtyWriteSubmitError::QueueFull {
+                depth: WRITE_QUEUE_DEPTH,
+            }))
+        }
+        Err(std_mpsc::TrySendError::Disconnected(_)) => {
+            Err(anyhow::Error::new(PtyWriteSubmitError::DrainerExited))
+        }
     }
 }
 
@@ -1048,7 +1077,7 @@ impl PtySession {
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_command_path, resolve_command_path_with, GridSize, PtySession,
+        resolve_command_path, resolve_command_path_with, GridSize, PtySession, PtyWriteSubmitError,
         DEFAULT_NO_PID_EXIT_THRESHOLD,
     };
     use crate::snapshot::Snapshot;
@@ -1613,6 +1642,45 @@ mod tests {
             flooded,
             Ok(true),
             "submit_write must return an error when the queue fills, never block"
+        );
+        let _ = pty.shutdown();
+    }
+
+    /// relay#1597 MUST-FIRE: the full-queue rejection must be recoverable as a
+    /// *typed* variant, not only as prose.
+    ///
+    /// The broker turns this into the wire code an attach client uses to decide
+    /// whether its input stream is dead (`pty_write_queue_full`) or merely
+    /// refused one write. Matching on the message text there would silently
+    /// start closing healthy sessions the first time this wording changed, so
+    /// the type is the contract. Revert `enqueue_user_write` to
+    /// `anyhow::anyhow!("pty write queue full …")` and the downcast goes None.
+    #[tokio::test]
+    async fn full_write_queue_reports_a_typed_queue_full_error() {
+        let (pty, _rx) = PtySession::spawn("sleep", &["30".into()], 24, 80).unwrap();
+
+        let err = timeout(Duration::from_secs(5), async {
+            loop {
+                if let Err(err) = pty.submit_write(vec![b'x'; 8192]) {
+                    return err;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("submit_write must fail promptly, never block");
+
+        match err.downcast_ref::<PtyWriteSubmitError>() {
+            Some(PtyWriteSubmitError::QueueFull { depth }) => {
+                assert_eq!(*depth, WRITE_QUEUE_DEPTH);
+            }
+            other => panic!("expected a typed QueueFull error, got {other:?}"),
+        }
+        // The operator-facing text still has to explain itself.
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("pty write queue full") && rendered.contains("128"),
+            "queue-full error lost its explanation: {rendered}"
         );
         let _ = pty.shutdown();
     }

--- a/packages/cli/src/cli/lib/attach-input-recovery.test.ts
+++ b/packages/cli/src/cli/lib/attach-input-recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createInputStreamRecovery,
   isBackpressureRejection,
+  isWriteRefusedRejection,
   isWriteTimeoutRejection,
   type InputStreamRecoveryOptions,
 } from './attach-input-recovery.js';
@@ -364,5 +365,88 @@ describe('recover', () => {
     expect(verify).toHaveBeenCalledTimes(1);
     expect(h.logs.filter((l) => l.includes('reconnected'))).toHaveLength(1);
     expect(h.first.closed).toBe(true); // the dead handle was released
+  });
+});
+
+describe('isWriteRefusedRejection', () => {
+  it('matches only the queue-full code, and only as a structured code', () => {
+    expect(isWriteRefusedRejection(Object.assign(new Error('x'), { code: 'pty_write_queue_full' }))).toBe(
+      true
+    );
+    // `pty_write_failed` is the *other* worker write error — a confirmed I/O
+    // failure or a dead drainer. It must stay fatal.
+    expect(isWriteRefusedRejection(Object.assign(new Error('x'), { code: 'pty_write_failed' }))).toBe(false);
+    expect(isWriteRefusedRejection(Object.assign(new Error('x'), { code: 'worker_timeout' }))).toBe(false);
+    expect(isWriteRefusedRejection(new Error('pty write queue full (128 writes pending)'))).toBe(false);
+    expect(isWriteRefusedRejection(null)).toBe(false);
+  });
+});
+
+describe('handleSendFailure — refused write (relay#1597)', () => {
+  it('relay#1597 MUST-FIRE: a full PTY write queue does not tear down the input stream', () => {
+    // The worker refusing one write because its drainer queue is full proves
+    // it is ALIVE — it answered. Reconnecting cannot drain that queue (it
+    // empties when the child resumes reading, not when a new socket opens), so
+    // recovering here produced one `input stream lost … / reconnected after 1
+    // attempt(s)` flap per keystroke for as long as the agent stayed busy.
+    // Delete the `isWriteRefusedRejection` branch in `handleSendFailure` and
+    // this goes red on `isRecovering()` and on the `input stream lost` line.
+    const h = harness();
+    const queueFull = Object.assign(
+      new Error('pty write queue full (128 writes pending; drainer wedged behind child not reading stdin)'),
+      { code: 'pty_write_queue_full' }
+    );
+
+    for (let i = 0; i < 50; i++) h.recovery.handleSendFailure(queueFull);
+
+    expect(h.recovery.isRecovering()).toBe(false);
+    expect(h.getCurrent()).toBe(h.first);
+    expect(h.first.closed).toBe(false);
+    expect(h.logs.some((l) => l.includes('input stream lost'))).toBe(false);
+    // One line for the episode, not one per keystroke.
+    expect(h.logs.filter((l) => l.includes('is not reading input right now'))).toHaveLength(1);
+    // The refusal IS confirmed — the byte never reached the child — so unlike
+    // `worker_timeout` every optimistic echo must come back off the screen.
+    expect(h.counts().rollbacks).toBe(50);
+  });
+
+  it('tells the operator the session survived and what to do, without blaming their typing', () => {
+    const h = harness();
+    h.recovery.handleSendFailure(
+      Object.assign(new Error('pty write queue full (128 writes pending)'), {
+        code: 'pty_write_queue_full',
+      })
+    );
+    const line = h.logs.find((l) => l.includes('is not reading input right now'));
+    expect(line).toBeDefined();
+    expect(line).toContain('still attached');
+    // The 128 slots are shared with terminal-query replies, injections and
+    // auto-responder writes, so the operator usually did not fill them.
+    expect(line).not.toContain('faster than');
+  });
+
+  it('reports a second episode after a successful send in between', () => {
+    const h = harness();
+    const queueFull = Object.assign(new Error('full'), { code: 'pty_write_queue_full' });
+    h.recovery.handleSendFailure(queueFull);
+    h.recovery.noteSendSuccess();
+    h.recovery.handleSendFailure(queueFull);
+    expect(h.logs.filter((l) => l.includes('is not reading input right now'))).toHaveLength(2);
+  });
+
+  it('relay#1597 MUST-NOT-FIRE: a confirmed write failure still enters recovery', () => {
+    // The companion guard: only the queue-full code is exempt. `pty_write_failed`
+    // (drainer exited / I/O error) is real transport loss and must still tear
+    // the stream down and reconnect. If a future edit widens the exemption to
+    // every `pty_write_*` code, this goes red — which is the point.
+    const h = harness();
+    h.recovery.handleSendFailure(
+      Object.assign(new Error('pty write queue is closed (drainer exited)'), {
+        code: 'pty_write_failed',
+      })
+    );
+    expect(h.recovery.isRecovering()).toBe(true);
+    expect(h.logs.some((l) => l.includes('input stream lost'))).toBe(true);
+    expect(h.counts().rollbacks).toBe(1);
   });
 });

--- a/packages/cli/src/cli/lib/attach-input-recovery.ts
+++ b/packages/cli/src/cli/lib/attach-input-recovery.ts
@@ -82,6 +82,36 @@ export function isWriteTimeoutRejection(error: unknown): boolean {
   );
 }
 
+/**
+ * `PtyInputStream.send()` rejects with `pty_write_queue_full` when the worker
+ * refused THAT ONE write because relay-pty's bounded drainer queue is full
+ * (`WRITE_QUEUE_DEPTH`, `crates/relay-pty/src/pty.rs`). The child is alive and
+ * the socket is healthy — the drainer is parked in `write_all` behind a child
+ * that has momentarily stopped reading its stdin, which is the normal state of
+ * a TUI harness mid-tool-call.
+ *
+ * This must not enter recovery. Reconnecting cannot drain the queue — it
+ * empties when the child resumes reading, not when a new socket opens — so a
+ * teardown here produced exactly one flap per keystroke for as long as the
+ * agent stayed busy (`input stream lost … / reconnected after 1 attempt(s)`,
+ * relay#1597). The broker keeps the connection open for this code for the same
+ * reason (`pty_input_error_is_connection_fatal`, `listen_api.rs`).
+ *
+ * Unlike {@link isWriteTimeoutRejection} this IS a confirmed refusal: the byte
+ * was never enqueued and will never reach the child, so the optimistic echo has
+ * to come back off the screen. Note the queue is shared with terminal-query
+ * replies, injected messages and auto-responder writes, so the operator whose
+ * keystroke is refused is usually not the one who filled it — the message must
+ * not blame their typing speed.
+ */
+export function isWriteRefusedRejection(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === 'pty_write_queue_full'
+  );
+}
+
 export interface InputStreamRecoveryOptions {
   /** Log prefix tag — `drive` or `passthrough`. */
   label: string;
@@ -150,13 +180,14 @@ export interface InputStreamRecovery {
   /** Begin recovery. No-ops if already recovering or settled. */
   recover(reason: string): void;
   /**
-   * Classify a rejected `send()`. Two codes never enter recovery:
+   * Classify a rejected `send()`. Three codes never enter recovery:
    * `input_backpressure` is flow control on a healthy stream and only costs
-   * the optimistic echo, and `worker_timeout` is a late ack on a write that
-   * may still land, so it costs nothing — no rollback, no recovery. Every
-   * other rejection is treated as transport loss and enters recovery, which
-   * does roll back. Callers route every send rejection here rather than
-   * assuming loss.
+   * the optimistic echo; `pty_write_queue_full` is the worker refusing one
+   * write while its drainer queue is full, which also only costs the echo; and
+   * `worker_timeout` is a late ack on a write that may still land, so it costs
+   * nothing — no rollback, no recovery. Every other rejection is treated as
+   * transport loss and enters recovery, which does roll back. Callers route
+   * every send rejection here rather than assuming loss.
    */
   handleSendFailure(error: unknown): void;
   /** Clears the backpressure latch so a later episode reports again. */
@@ -197,6 +228,8 @@ export function createInputStreamRecovery(options: InputStreamRecoveryOptions): 
   let backpressureReported = false;
   /** True once a write-timeout episode has been reported; reset on the next good send. */
   let writeTimeoutReported = false;
+  /** True once a write-refused episode has been reported; reset on the next good send. */
+  let writeRefusedReported = false;
 
   const cancel = (): void => {
     if (timer) {
@@ -246,6 +279,7 @@ export function createInputStreamRecovery(options: InputStreamRecoveryOptions): 
   const noteSendSuccess = (): void => {
     backpressureReported = false;
     writeTimeoutReported = false;
+    writeRefusedReported = false;
   };
 
   const handleSendFailure = (sendError: unknown): void => {
@@ -260,6 +294,21 @@ export function createInputStreamRecovery(options: InputStreamRecoveryOptions): 
         backpressureReported = true;
         log(
           `[${label}] input is arriving faster than ${name} can accept it; dropping keystrokes until it catches up.`
+        );
+      }
+      return;
+    }
+    if (isWriteRefusedRejection(sendError)) {
+      // Confirmed refusal on a healthy stream: roll the optimistic echo back
+      // (the byte will never reach the child) but keep the socket. Report once
+      // per episode — the cause persists for as long as the agent is busy, so
+      // per-keystroke reporting would rebuild the flood this module removes.
+      onRollback();
+      if (!writeRefusedReported) {
+        writeRefusedReported = true;
+        log(
+          `[${label}] ${name} is not reading input right now (busy); that keystroke was dropped. ` +
+            `The session is still attached — retry once it is idle.`
         );
       }
       return;
@@ -390,7 +439,14 @@ export function createInputStreamRecovery(options: InputStreamRecoveryOptions): 
       }
 
       setStream(replacement);
-      log(`[${label}] input stream reconnected after ${attempt} attempt(s)`);
+      // Say plainly that the session survived. A recovered flap and a fatal
+      // disconnect previously read the same to a human — both were red lines
+      // that named a failure and stopped — so operators read a working session
+      // as a crash (relay#1597).
+      log(
+        `[${label}] input stream reconnected after ${attempt} attempt(s) — ${name} is still attached ` +
+          `and usable. Keystrokes typed during the outage were dropped, not queued; retype them.`
+      );
       return 'opened';
     };
 

--- a/packages/cli/src/cli/lib/attach.test.ts
+++ b/packages/cli/src/cli/lib/attach.test.ts
@@ -37,6 +37,26 @@ describe('reserveStatusLineRow', () => {
     expect(reserveStatusLineRow({ rows: 2, cols: 80 })).toEqual({ rows: 2, cols: 80 });
     expect(reserveStatusLineRow(null)).toBeNull();
   });
+
+  it('relay#1597 MUST-FIRE: a zero-size TTY is treated as no size, not forwarded', () => {
+    // `script(1)` with no winsize, a minimized window, or a size not yet
+    // reported gives `{rows: 0, cols: 0}` while `stdout.isTTY` is still true.
+    // Returning it unchanged made every attach mode POST `{rows: 0, cols: 0}`
+    // and collect `rows and cols must be positive integers` from the broker.
+    // Callers already treat null as "skip the resize", which is the honest
+    // answer. Delete the `< 1` guard and these go red.
+    expect(reserveStatusLineRow({ rows: 0, cols: 0 })).toBeNull();
+    expect(reserveStatusLineRow({ rows: 0, cols: 80 })).toBeNull();
+    expect(reserveStatusLineRow({ rows: 40, cols: 0 })).toBeNull();
+    expect(reserveStatusLineRow({ rows: -1, cols: -1 })).toBeNull();
+  });
+
+  it('relay#1597 MUST-NOT-FIRE: a 1x1 terminal is still a real size', () => {
+    // The guard must reject only non-positive dimensions. A genuinely tiny
+    // terminal is still something the operator is looking at, and skipping its
+    // resize would leave the agent rendering at the wrong width.
+    expect(reserveStatusLineRow({ rows: 1, cols: 1 })).toEqual({ rows: 1, cols: 1 });
+  });
 });
 
 describe('fitStatusLineText', () => {

--- a/packages/cli/src/cli/lib/attach.ts
+++ b/packages/cli/src/cli/lib/attach.ts
@@ -520,6 +520,15 @@ export function reserveStatusLineRow(
   localSize: { rows: number; cols: number } | null
 ): { rows: number; cols: number } | null {
   if (!localSize) return null;
+  // A terminal can report a degenerate size: `script(1)` with no winsize, a
+  // minimized window, a size not yet reported after attach, or a teardown race
+  // all surface as 0 (or worse) rows/cols while `stdout.isTTY` is still true.
+  // Forwarding that verbatim made every attach mode POST `{rows: 0, cols: 0}`
+  // and collect `rows and cols must be positive integers` from the broker —
+  // harmless but alarming noise that has sent more than one investigation down
+  // the wrong path (relay#1597). Treat it the same as "no local size": skip the
+  // resize entirely rather than inventing dimensions the operator never had.
+  if (localSize.rows < 1 || localSize.cols < 1) return null;
   if (localSize.rows < 3 || localSize.cols < 2) return localSize;
   return {
     rows: localSize.rows - 1,

--- a/packages/harness-driver/src/pty-input-stream.test.ts
+++ b/packages/harness-driver/src/pty-input-stream.test.ts
@@ -340,7 +340,6 @@ describe('PtyInputStream keepalive (relay#1597)', () => {
     expect(socket.pings).toBe(1);
     await vi.advanceTimersByTimeAsync(40_000);
     expect(socket.pings).toBe(3);
-    void stream;
   });
 
   it('relay#1597 MUST-NOT-FIRE: stops pinging once the stream is closed', async () => {

--- a/packages/harness-driver/src/pty-input-stream.test.ts
+++ b/packages/harness-driver/src/pty-input-stream.test.ts
@@ -43,6 +43,13 @@ class FakeWebSocket {
     this.sends.push({ data, cb });
   }
 
+  /** Application-level keepalive pings (see INPUT_KEEPALIVE_INTERVAL_MS). */
+  pings = 0;
+
+  ping(): void {
+    this.pings += 1;
+  }
+
   close(): void {
     this.closed = true;
   }
@@ -264,5 +271,92 @@ describe('PtyInputStream after its socket closes', () => {
     // Nothing was put back on the wire, and no replacement socket was opened.
     expect(socket.sends).toHaveLength(0);
     expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});
+
+describe('PtyInputStream refused writes (relay#1597)', () => {
+  it('relay#1597 MUST-FIRE: a full PTY write queue rejects one write and keeps the stream', async () => {
+    // `pty_write_queue_full` means the worker refused THIS write because its
+    // bounded drainer queue is full — it answered, so it is alive, and the
+    // broker deliberately keeps the socket open for this code. Closing here
+    // (as the old `every code except worker_timeout is fatal` rule did) forced
+    // the CLI into a reconnect per keystroke against any busy agent. Remove
+    // `pty_write_queue_full` from the non-fatal list in `handleMessage` and the
+    // `stream.closed` assertion goes red.
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    const p1 = stream.send('x');
+    await Promise.resolve();
+    socket.errorFrame(
+      'pty_write_queue_full',
+      'pty write queue full (128 writes pending; drainer wedged behind child not reading stdin)'
+    );
+
+    await expect(p1).rejects.toMatchObject({ code: 'pty_write_queue_full' });
+    expect(stream.closed).toBe(false);
+
+    // Still usable for the next keystroke once the child drains.
+    const p2 = stream.send('y');
+    await Promise.resolve();
+    socket.ack(1);
+    await expect(p2).resolves.toMatchObject({ bytes_written: 1 });
+  });
+
+  it('relay#1597 MUST-NOT-FIRE: a non-queue write failure still closes the stream', async () => {
+    // `pty_write_failed` is the other worker write error: a confirmed I/O
+    // failure or an exited drainer. It must stay fatal, so the exemption
+    // cannot be widened to "any pty_write_* code" without going red here.
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    const p = stream.send('x');
+    await Promise.resolve();
+    socket.errorFrame('pty_write_failed', 'pty write queue is closed (drainer exited)');
+
+    await expect(p).rejects.toMatchObject({ code: 'pty_write_failed' });
+    expect(stream.closed).toBe(true);
+  });
+});
+
+describe('PtyInputStream keepalive (relay#1597)', () => {
+  it('relay#1597 MUST-FIRE: pings an idle input socket so it cannot die silently', async () => {
+    // The broker pings the events WS every 30s but never the input WS, so an
+    // input socket carrying no keystrokes was invisible to every idle timeout
+    // between client and broker — the screen stayed live while input was dead.
+    // Remove `startKeepalive()` and this goes red.
+    vi.useFakeTimers();
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    expect(socket.pings).toBe(0);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(socket.pings).toBe(1);
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(socket.pings).toBe(3);
+    void stream;
+  });
+
+  it('relay#1597 MUST-NOT-FIRE: stops pinging once the stream is closed', async () => {
+    // A keepalive that outlives its socket would keep a torn-down session
+    // referenced (and, unref aside, keep firing forever).
+    vi.useFakeTimers();
+    const stream = new PtyInputStream({ url: 'ws://x/api/input/agent/stream' });
+    const socket = lastSocket();
+    socket.open();
+    await stream.waitUntilOpen();
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(socket.pings).toBe(1);
+
+    stream.close();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(socket.pings).toBe(1);
   });
 });

--- a/packages/harness-driver/src/transport.ts
+++ b/packages/harness-driver/src/transport.ts
@@ -68,6 +68,23 @@ interface PendingPtyInput {
 
 const DEFAULT_INPUT_HIGH_WATER_MARK_BYTES = 1024 * 1024;
 const DEFAULT_INPUT_OPEN_TIMEOUT_MS = 10_000;
+/**
+ * Keepalive interval for the PTY input WebSocket.
+ *
+ * The broker pings the *events* WebSocket every 30s but has never pinged the
+ * input one, and this client never did either — so an input socket carrying no
+ * keystrokes was completely silent on the wire and died to any idle timeout
+ * between client and broker (a cloud edge on `--node` attaches, NAT, a proxy).
+ * The screen kept updating on the still-pinged events socket, so the seat
+ * looked alive with dead input until the next keystroke reported the loss
+ * (relay#1597).
+ *
+ * Pinging from the client fixes this against every broker version: the broker
+ * has always answered a `Ping` with a `Pong` (`listen_api.rs`), and `ws`
+ * handles pongs internally, so no protocol change is needed. 20s stays under
+ * the common 30s/60s idle windows.
+ */
+const INPUT_KEEPALIVE_INTERVAL_MS = 20_000;
 
 /** Initial delay before retrying a dropped events-WS connection. */
 const INITIAL_RECONNECT_DELAY_MS = 2_000;
@@ -95,6 +112,8 @@ export class PtyInputStream {
   private flushing = false;
   /** EWMA of input→ack round-trip in ms, or null before the first ack. */
   private _srttMs: number | null = null;
+  /** Keepalive timer; see {@link INPUT_KEEPALIVE_INTERVAL_MS}. */
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(options: { url: string; apiKey?: string } & PtyInputStreamOptions) {
     this.highWaterMarkBytes = normalizePositiveIntegerOption(
@@ -133,6 +152,7 @@ export class PtyInputStream {
     this.ws.on('open', () => {
       // The broker sends pty_input_ready after it verifies the agent exists
       // and is PTY-backed. Keep queued writes blocked until that handshake.
+      this.startKeepalive();
     });
 
     this.ws.on('message', (data) => {
@@ -142,6 +162,7 @@ export class PtyInputStream {
     this.ws.on('close', (code, reason) => {
       this._closed = true;
       this.clearOpenTimer();
+      this.stopKeepalive();
       const detail = reason.length > 0 ? `: ${reason.toString()}` : '';
       const error = new HarnessDriverProtocolError({
         code: 'input_stream_closed',
@@ -231,6 +252,7 @@ export class PtyInputStream {
     if (this._closed) return;
     this._closed = true;
     this.clearOpenTimer();
+    this.stopKeepalive();
     if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
       this.ws.close(code, reason);
     }
@@ -241,6 +263,31 @@ export class PtyInputStream {
     });
     this.rejectOpen(error);
     this.failAll(error);
+  }
+
+  /**
+   * Start the application-level keepalive. Failure to ping is not escalated
+   * here: the socket's own `error`/`close` handlers already own transport
+   * death, and throwing out of a timer would take the process down.
+   */
+  private startKeepalive(): void {
+    if (this.keepaliveTimer || this._closed) return;
+    this.keepaliveTimer = setInterval(() => {
+      if (this._closed || this.ws.readyState !== WebSocket.OPEN) return;
+      try {
+        this.ws.ping();
+      } catch {
+        // best effort — close/error handling owns transport death
+      }
+    }, INPUT_KEEPALIVE_INTERVAL_MS);
+    // Never hold the event loop open on a keepalive alone.
+    this.keepaliveTimer.unref?.();
+  }
+
+  private stopKeepalive(): void {
+    if (!this.keepaliveTimer) return;
+    clearInterval(this.keepaliveTimer);
+    this.keepaliveTimer = null;
   }
 
   private async flush(): Promise<void> {
@@ -326,15 +373,24 @@ export class PtyInputStream {
         data: message,
       });
 
-      // `worker_timeout` means the ONE write this error correlates to
-      // didn't get an ack in time — the worker may simply be busy, not
-      // dead (relay#1544). The broker keeps the socket open for exactly
-      // this code (see `pty_input_error_is_connection_fatal` on the
-      // broker side); settle only the write it belongs to and leave the
-      // stream usable for the next one. Every other code means the broker
-      // is closing (or refused to open) the connection, so it's still
-      // fatal to the whole stream.
-      if (error.code === 'worker_timeout') {
+      // Two codes are per-WRITE failures on a stream that stays open, so
+      // they settle only the write they belong to and leave the stream
+      // usable for the next one. Every other code means the broker is
+      // closing (or refused to open) the connection, so it's still fatal to
+      // the whole stream. Both are mirrored by
+      // `pty_input_error_is_connection_fatal` on the broker side; the two
+      // lists must agree, or one side silently tears down a socket the other
+      // is still holding open.
+      //
+      // - `worker_timeout`: the ONE write this error correlates to didn't get
+      //   an ack in time. The worker may simply be busy, not dead
+      //   (relay#1544), and the write may still land.
+      // - `pty_write_queue_full`: the worker refused this ONE write because
+      //   its bounded PTY drainer queue is full — a child that has
+      //   momentarily stopped reading stdin, which is the normal state of a
+      //   TUI harness mid-tool-call. The worker answering at all proves it is
+      //   alive; the write is confirmed not to have landed (relay#1597).
+      if (error.code === 'worker_timeout' || error.code === 'pty_write_queue_full') {
         const current = this.inFlight.shift();
         if (current) this.settle(current, error);
         return;


### PR DESCRIPTION
Closes the top items of the attach-reliability failure-mode map in #1597.

## The reported failure

Driving a busy agent produces this, one cycle per keystroke, for as long as the agent stays busy:

```
[drive] input stream lost (pty write queue full (128 writes pending; drainer wedged behind child not reading stdin)); reconnecting…
[drive] input stream reconnected after 1 attempt(s)
```

It reads like a crash. It is not — the session survives — but it is not benign either, and the wording is the smallest part of the problem.

## Mechanism

The refused write is rejected by relay-pty's bounded drainer queue (`WRITE_QUEUE_DEPTH = 128`) while the child is momentarily not reading its stdin — the normal state of a TUI harness mid-tool-call. The worker *answering at all* proves it is alive. But the refusal was reported as the generic `pty_write_failed`, and **both** the broker's input-WS loop (`pty_input_error_is_connection_fatal`) and the SDK transport treated every code except `worker_timeout` as transport death. So each refusal closed a healthy socket — and reconnecting cannot help, because the queue drains when the child resumes reading, not when a new socket opens.

Two details worth knowing, both established by reproduction (see #1597):

- **A human cannot fill that queue by typing.** Keystrokes are serialized per agent and each waits up to `PTY_INPUT_ACK_TIMEOUT = 5s`, so an operator adds at most ~1 slot per 5 s. The 128 slots are shared with alacritty terminal-query replies, injected messages and auto-responder writes — the operator whose keystroke is refused is usually not the one who filled the queue. The new message says the agent is busy rather than blaming their typing.
- **Reconnecting does not drop the queued input; the broker replays it.** Writes already accepted into the drainer queue are written to the child whenever it resumes reading — verified by `SIGSTOP`ing a throwaway agent's child, typing, then `SIGCONT` and dumping the screen: keystrokes and injected message bodies from minutes earlier executed as shell commands. This PR does not change that behaviour (see *Not in this PR*), but it stops manufacturing extra disconnects on top of it.

## What changed

**Queue-full is a refused write, not a dead stream** — the core fix.

- `relay-pty` returns a typed `PtyWriteSubmitError::QueueFull`, recovered by downcast so the wire code never depends on message wording.
- `pty_worker` maps it to a distinct `pty_write_queue_full`; `classify_error` keeps that code as a 503 instead of collapsing it into the catch-all `request_failed` (which is fatal — without this the exemption below is unreachable from a real worker error).
- `pty_input_error_is_connection_fatal` and the SDK transport both treat it as a per-write failure. **The two lists must agree**, or one side tears down a socket the other is holding open; both carry a comment saying so.
- The CLI rolls the optimistic echo back — the byte is confirmed not to have landed, unlike `worker_timeout` — and reports once per episode without entering recovery.

The code propagates unchanged over the `--node` path too (worker → `TerminalToCloud::Error` → cloud → loopback shim → `pty_input_error`), which is where this was reported.

**Keepalive on the PTY input WebSocket.** The broker pings the events WS every 30 s and has never pinged the input one; the client never pinged either. An input socket carrying no keystrokes was therefore silent on the wire and died to any idle timeout between client and broker, while the screen kept updating on the still-pinged events socket — a seat that looks alive with dead input. Pinging from the client fixes it against every broker version, since the broker has always answered `Ping` with `Pong`.

**A recovered reconnect no longer reads like a fatal one.** It now says the session is still attached and usable, and that keystrokes typed during the outage were dropped rather than queued, so the operator knows to retype them.

**Degenerate terminal sizes.** `reserveStatusLineRow` treated `{rows: 0, cols: 0}` as a usable size and forwarded it, producing `could not sync agent PTY size to local terminal (rows and cols must be positive integers)`. It now returns null — which every caller already handles as "skip the resize" — instead of inventing dimensions the operator never had.

## Tests

Every change ships a **must-fire** test, each verified red by reverting the fix, plus a **must-not-fire** companion proving real disconnects still tear the stream down.

| Test | Guards |
|---|---|
| `full_write_queue_reports_a_typed_queue_full_error` (relay-pty) | the rejection is typed, not prose |
| `queue_full_does_not_close_the_pty_input_connection` (broker) | the socket survives a refused write |
| `queue_full_is_classified_as_its_own_retryable_code` (broker) | the code survives classification |
| `a_broken_pty_write_is_still_fatal` (broker) | **must-not-fire** — `pty_write_failed` still closes |
| `a full PTY write queue rejects one write and keeps the stream` (SDK) | transport agrees with the broker |
| `a non-queue write failure still closes the stream` (SDK) | **must-not-fire** |
| `a full PTY write queue does not tear down the input stream` (CLI) | no recovery, one line, echo rolled back |
| `a confirmed write failure still enters recovery` (CLI) | **must-not-fire** — exemption stays narrow |
| `pings an idle input socket so it cannot die silently` (SDK) | keepalive exists |
| `stops pinging once the stream is closed` (SDK) | **must-not-fire** — no timer outlives its socket |
| `a zero-size TTY is treated as no size` / `a 1x1 terminal is still a real size` (CLI) | the clamp rejects only non-positive sizes |

Verification transcript for the two headline must-fire tests, with the fix reverted:

```
× relay#1597 MUST-FIRE: a full PTY write queue does not tear down the input stream
  AssertionError: expected true to be false
× relay#1597 MUST-FIRE: pings an idle input socket so it cannot die silently
  AssertionError: expected +0 to be 1
test listen_api::auth_tests::queue_full_does_not_close_the_pty_input_connection ... FAILED
```

and green with it in place (326 attach tests, 89 harness-driver tests, broker + relay-pty suites).

## Not in this PR, deliberately

- **The events/screen WebSocket still has no reconnect** (`attach-drive.ts` → `finish(1)` on any error or non-1000 close). This is the largest remaining "stay attached" win and `?sinceSeq=` already exists to resume it, but it is a behaviour change to every attach mode and deserves its own PR. Mapped as item 4 in #1597.
- **No client-side keystroke replay after a reconnect.** Delayed replay is already the hazard described above; adding more would make a live agent execute stale input.
- **No attach-module rewrite.** The failure modes are all local to the lines changed here.
- **A separate backpressure channel before the cap.** The early signal already exists — `worker_timeout` fires at 5 s, long before the queue fills — so this PR improves its wording rather than adding a second mechanism. If operators still want a visible depth indicator, the cheapest version is `queue_depth` on the write ack; called out in #1597 rather than bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

