### PR TITLE
fix(attach): name the node when attaching to a worker on another machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay fleet spawn --node <name>` now uses the active workspace to mint and clean up a short-lived launcher identity when no agent token is present.
+- Attaching to an agent that lives on another fleet node without `--node` now names the node to run the command on, instead of reporting `no agent named '<name>'` for an agent that is running.
 
 ### Added
 

--- a/packages/cli/src/cli/commands/fleet-agent.ts
+++ b/packages/cli/src/cli/commands/fleet-agent.ts
@@ -36,49 +36,10 @@ export interface RosterAgent {
   metadata?: Record<string, unknown> | null;
 }
 
-export interface RemoteLiveAgent {
-  name: string;
-}
+import type { RemoteLiveAgent } from '../lib/fleet-live-agents.js';
 
-export const LIVE_AGENT_CAPABILITY_NAME = 'relay:live-agents:v1';
-
-export interface RemoteLiveAgentRead {
-  supported: boolean;
-  agents: RemoteLiveAgent[];
-  warning?: string;
-}
-
-/** Decode the broker-owned WorkerName set carried by a node heartbeat. */
-export function readRemoteLiveAgents(node: RelayNode): RemoteLiveAgentRead {
-  let supported = false;
-  let malformed = 0;
-  const names = new Set<string>();
-  for (const capability of node.capabilities) {
-    if (capability.name !== LIVE_AGENT_CAPABILITY_NAME) continue;
-    supported = true;
-    const rawNames = capability.metadata?.names;
-    if (!Array.isArray(rawNames)) {
-      malformed += 1;
-      continue;
-    }
-    for (const rawName of rawNames) {
-      if (typeof rawName !== 'string' || !rawName || names.has(rawName)) {
-        malformed += 1;
-        continue;
-      }
-      names.add(rawName);
-    }
-  }
-  return {
-    supported,
-    agents: Array.from(names, (name) => ({ name })).sort((a, b) => a.name.localeCompare(b.name)),
-    ...(malformed > 0
-      ? {
-          warning: `${malformed} malformed or duplicate live-agent heartbeat capabilit${malformed === 1 ? 'y' : 'ies'}`,
-        }
-      : {}),
-  };
-}
+export type { RemoteLiveAgent, RemoteLiveAgentRead } from '../lib/fleet-live-agents.js';
+export { LIVE_AGENT_CAPABILITY_NAME, readRemoteLiveAgents } from '../lib/fleet-live-agents.js';
 
 /** What each fleet node contributed to the render. */
 export interface FleetNodeContribution {

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -21,6 +21,7 @@ import {
   type RosterAgent,
 } from './fleet-agent.js';
 import { readBrokerConnection } from '../lib/broker-lifecycle.js';
+import { isAvailableFleetNode } from '../lib/fleet-live-agents.js';
 import { declaredWorkforceMetadata } from '../lib/registration-metadata.js';
 import { redactSecrets } from '../lib/redact.js';
 import { attributableReleaseReason } from '../lib/release-reason.js';
@@ -491,19 +492,6 @@ export function registerFleetCommands(
       deps.exit(1);
     }
   });
-}
-
-/** Return whether a roster entry can currently accept Fleet work. */
-function isAvailableFleetNode(node: {
-  live?: boolean;
-  status?: string;
-  handlersLive?: boolean;
-  tags?: unknown;
-}): boolean {
-  const tags = Array.isArray(node.tags) ? node.tags : [];
-  const isDirectPseudoNode = tags.includes('direct');
-  const isLive = node.live === undefined ? node.status === 'online' : node.live === true;
-  return isLive && node.handlersLive !== false && !isDirectPseudoNode;
 }
 
 function parseFleetCli(value: string): string {

--- a/packages/cli/src/cli/lib/fleet-hint.test.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.test.ts
@@ -245,3 +245,31 @@ describe('resolveFleetHint — only live nodes can answer', () => {
     expect(result).toBe("on node 'sf-mini'");
   });
 });
+
+describe('resolveFleetHint — identifier and failure-mode edges', () => {
+  it('uses the node id when the node name is an empty string', async () => {
+    // `node.name ?? node.nodeId` selects '' — `??` only falls through on
+    // null/undefined — which stranded a node that had a perfectly good id.
+    const result = await resolveFleetHint(
+      'worker',
+      makeRelayRejectingAgent(new Error('404'), [nodeRunning('', ['worker'])])
+    );
+    expect(result).toBe("on node 'node_live'");
+  });
+
+  it('still lets the roster answer when the registry lookup fails for a non-404 reason', async () => {
+    // Deliberate: the fallback is NOT gated on a confirmed not-found. A node's
+    // heartbeat is independent evidence of where a worker is running, so if
+    // `agents.get` fails transiently (network, auth, a slow registry) and the
+    // roster can still answer, the hint it produces is true — and gating on a
+    // 404 would withhold a correct answer in exactly the case the operator is
+    // already having a bad time. The wrong-hint risk lives in stale roster
+    // data, which the `isAvailableFleetNode` filter above addresses and which
+    // is identical either way.
+    const result = await resolveFleetHint(
+      'worker',
+      makeRelayRejectingAgent(new Error('502 Bad Gateway'), [nodeRunning('sf-mini', ['worker'])])
+    );
+    expect(result).toBe("on node 'sf-mini'");
+  });
+});

--- a/packages/cli/src/cli/lib/fleet-hint.test.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.test.ts
@@ -19,12 +19,22 @@ function makeRelay(agentMetadata: unknown, nodes: unknown[] = []) {
 }
 
 /** Build a stub where agents.get() rejects — simulates 404 or network error. */
-function makeRelayRejectingAgent(err: Error = new Error('not found')) {
+function makeRelayRejectingAgent(err: Error = new Error('not found'), nodes: unknown[] = []) {
   return () =>
     ({
       agents: { get: vi.fn(async () => Promise.reject(err)) },
-      nodes: { list: vi.fn(async () => []) },
+      nodes: { list: vi.fn(async () => nodes) },
     }) as never;
+}
+
+/** A roster node advertising the worker names its broker is running. */
+function nodeRunning(name: string | undefined, workers: string[], extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    nodeId: 'node_live',
+    capabilities: [{ name: 'relay:live-agents:v1', metadata: { names: workers } }],
+    ...extra,
+  };
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -93,5 +103,92 @@ describe('resolveFleetHint', () => {
   it('returns null when metadata is null', async () => {
     const result = await resolveFleetHint('ghost', makeRelay(null));
     expect(result).toBeNull();
+  });
+});
+
+describe('resolveFleetHint — workers that are not workspace-registered (relay#1597)', () => {
+  it('relay#1597 MUST-FIRE: names the node for a live worker the agent registry does not know', async () => {
+    // This is the case the hint exists for and the one it could not answer.
+    // A broker-spawned worker on a fleet node is NOT in the workspace agent
+    // registry, so `agents.get` 404s and the old code returned null — leaving
+    // attach to say "no agent named X" about an agent that is demonstrably
+    // alive on another machine. Nodes advertise their live worker set on the
+    // heartbeat, so the roster call the hint already makes can answer it.
+    // Restore the early `return null` in the agents.get catch and this fails.
+    const result = await resolveFleetHint(
+      'sandbox-lead-claude-0820b',
+      makeRelayRejectingAgent(new Error('404'), [
+        nodeRunning('barry', ['other-agent']),
+        nodeRunning('sf-mini', ['sandbox-lead-claude-0820b', 'wedge-probe']),
+      ])
+    );
+    expect(result).toBe("on node 'sf-mini'");
+  });
+
+  it('relay#1597 MUST-NOT-FIRE: no hint when no node is running that worker', async () => {
+    // The hint must stay silent for a name that genuinely does not exist —
+    // inventing a placement would be worse than the plain "no agent named X".
+    const result = await resolveFleetHint(
+      'ghost',
+      makeRelayRejectingAgent(new Error('404'), [
+        nodeRunning('sf-mini', ['someone-else']),
+        nodeRunning('barry', []),
+      ])
+    );
+    expect(result).toBeNull();
+  });
+
+  it('does not match a different worker on the same node', async () => {
+    const result = await resolveFleetHint(
+      'lead',
+      makeRelayRejectingAgent(new Error('404'), [nodeRunning('sf-mini', ['lead-2', 'sub-lead'])])
+    );
+    expect(result).toBeNull();
+  });
+
+  it('falls back to the node id, and never to an empty label', async () => {
+    // A node with a usable id but no name still produces an actionable hint.
+    expect(
+      await resolveFleetHint(
+        'worker',
+        makeRelayRejectingAgent(new Error('404'), [nodeRunning(undefined, ['worker'])])
+      )
+    ).toBe("on node 'node_live'");
+
+    // A node with no identifier at all must produce no hint rather than
+    // "on node 'undefined'", which reads as a bug to the operator.
+    expect(
+      await resolveFleetHint(
+        'worker',
+        makeRelayRejectingAgent(new Error('404'), [
+          {
+            capabilities: [{ name: 'relay:live-agents:v1', metadata: { names: ['worker'] } }],
+          },
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('still prefers the registry placement when the agent IS registered', async () => {
+    // The roster scan is a fallback, not a replacement: an agent whose
+    // registry metadata names its node must keep using that, so the two
+    // sources cannot disagree about a registered agent.
+    const result = await resolveFleetHint(
+      'my-agent',
+      makeRelay({ fleet: { nodeId: 'node_abc123' } }, [
+        { nodeId: 'node_abc123', name: 'finn-mini' },
+        nodeRunning('sf-mini', ['my-agent']),
+      ])
+    );
+    expect(result).toBe("on node 'finn-mini'");
+  });
+
+  it('survives a roster lookup failure without throwing', async () => {
+    const relay = () =>
+      ({
+        agents: { get: vi.fn(async () => Promise.reject(new Error('404'))) },
+        nodes: { list: vi.fn(async () => Promise.reject(new Error('network'))) },
+      }) as never;
+    await expect(resolveFleetHint('worker', relay)).resolves.toBeNull();
   });
 });

--- a/packages/cli/src/cli/lib/fleet-hint.test.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.test.ts
@@ -27,11 +27,14 @@ function makeRelayRejectingAgent(err: Error = new Error('not found'), nodes: unk
     }) as never;
 }
 
-/** A roster node advertising the worker names its broker is running. */
+/** A roster node advertising the worker names its broker is running.
+ *  Online by default; pass `{ status: 'offline' }` (or `live: false`) for a
+ *  history record, which still carries its last heartbeat's worker names. */
 function nodeRunning(name: string | undefined, workers: string[], extra: Record<string, unknown> = {}) {
   return {
     name,
     nodeId: 'node_live',
+    status: 'online',
     capabilities: [{ name: 'relay:live-agents:v1', metadata: { names: workers } }],
     ...extra,
   };
@@ -190,5 +193,55 @@ describe('resolveFleetHint — workers that are not workspace-registered (relay#
         nodes: { list: vi.fn(async () => Promise.reject(new Error('network'))) },
       }) as never;
     await expect(resolveFleetHint('worker', relay)).resolves.toBeNull();
+  });
+});
+
+describe('resolveFleetHint — only live nodes can answer', () => {
+  it('MUST-NOT-FIRE: ignores an offline node still advertising the worker', () => {
+    // `nodes.list()` returns history too, and an offline record keeps the
+    // live-agent names from its last heartbeat. Naming that machine would tell
+    // the operator to go run a command somewhere the agent is not — a
+    // confidently wrong answer, which is worse than the plain message.
+    return expect(
+      resolveFleetHint(
+        'worker',
+        makeRelayRejectingAgent(new Error('404'), [
+          nodeRunning('dead-node', ['worker'], { status: 'offline' }),
+        ])
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('MUST-NOT-FIRE: ignores a node whose handlers are not live', async () => {
+    expect(
+      await resolveFleetHint(
+        'worker',
+        makeRelayRejectingAgent(new Error('404'), [
+          nodeRunning('half-up', ['worker'], { handlersLive: false }),
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it("MUST-NOT-FIRE: ignores a 'direct' pseudo-node", async () => {
+    expect(
+      await resolveFleetHint(
+        'worker',
+        makeRelayRejectingAgent(new Error('404'), [nodeRunning('pseudo', ['worker'], { tags: ['direct'] })])
+      )
+    ).toBeNull();
+  });
+
+  it('picks the live node when a stale record lists the same worker', async () => {
+    // Ordering must not decide this: a stale record appearing first in the
+    // roster must not win over the machine actually running the agent.
+    const result = await resolveFleetHint(
+      'worker',
+      makeRelayRejectingAgent(new Error('404'), [
+        nodeRunning('stale-node', ['worker'], { status: 'offline', nodeId: 'node_stale' }),
+        nodeRunning('sf-mini', ['worker']),
+      ])
+    );
+    expect(result).toBe("on node 'sf-mini'");
   });
 });

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -30,6 +30,7 @@
 import type { AgentRelay } from '@agent-relay/sdk';
 
 import { createWorkspaceRelay } from './sdk-client.js';
+import { readRemoteLiveAgents } from './fleet-live-agents.js';
 
 /**
  * Injectable factory — lets callers (and tests) substitute a workspace
@@ -63,33 +64,48 @@ export async function resolveFleetHint(
       return null;
     }
 
-    let agent: { metadata?: Record<string, unknown> };
+    let agent: { metadata?: Record<string, unknown> } | null = null;
     try {
       agent = await relay.agents.get(agentName);
     } catch {
-      // 404 from the workspace registry (or any network error) — the agent
-      // truly does not exist anywhere, or we can't tell. Original message.
-      return null;
+      // Not in the workspace agent registry (404), or we could not reach it.
+      // This is the COMMON case for the agents this hint exists to describe:
+      // a broker-spawned worker on a fleet node is not a workspace-registered
+      // agent at all, so this lookup 404s for exactly the names an operator
+      // most often mistypes into a cross-node attach. Fall through to the
+      // roster scan below rather than giving up here (relay#1597).
     }
 
-    const fleet = (agent.metadata as Record<string, unknown> | undefined)?.fleet;
+    const fleet = (agent?.metadata as Record<string, unknown> | undefined)?.fleet;
     const nodeId =
       typeof fleet === 'object' && fleet !== null ? (fleet as Record<string, unknown>).nodeId : undefined;
-    if (typeof nodeId !== 'string' || !nodeId) return null;
 
     // Resolve the node's human-readable name by looking it up in the roster.
-    // A failure here is non-fatal — we still emit a hint with the raw ID.
+    // The same call also answers placement for a worker the agent registry
+    // does not know about: every node advertises the set of workers it is
+    // currently running on its heartbeat, so one `nodes.list()` covers both
+    // paths with no extra round-trip.
     try {
       const nodes = await relay.nodes.list();
-      const node = nodes.find((n) => n.nodeId === nodeId || n.id === nodeId);
-      if (node?.name) {
-        return `on node '${node.name}'`;
+      if (typeof nodeId === 'string' && nodeId) {
+        const node = nodes.find((n) => n.nodeId === nodeId || n.id === nodeId);
+        if (node?.name) return `on node '${node.name}'`;
+        // Registry knew the placement but the roster could not name the node.
+        return `on node '${nodeId}'`;
+      }
+      for (const node of nodes) {
+        if (!readRemoteLiveAgents(node).agents.some((live) => live.name === agentName)) continue;
+        const label = node.name ?? node.nodeId ?? node.id;
+        // A node with no usable identifier is worse than no hint: "on node
+        // 'undefined'" tells the operator nothing and looks like a bug.
+        if (typeof label === 'string' && label) return `on node '${label}'`;
       }
     } catch {
-      // Node lookup failed — fall back to the raw ID hint.
+      // Roster lookup failed — fall back to whatever the registry gave us.
     }
 
-    return `on node '${nodeId}'`;
+    if (typeof nodeId === 'string' && nodeId) return `on node '${nodeId}'`;
+    return null;
   } catch {
     // Unexpected error in the outer try — never propagate.
     return null;

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -101,10 +101,14 @@ export async function resolveFleetHint(
         // running at all, which is worse than no hint.
         if (!isAvailableFleetNode(node)) continue;
         if (!readRemoteLiveAgents(node).agents.some((live) => live.name === agentName)) continue;
-        const label = node.name ?? node.nodeId ?? node.id;
-        // A node with no usable identifier is worse than no hint: "on node
-        // 'undefined'" tells the operator nothing and looks like a bug.
-        if (typeof label === 'string' && label) return `on node '${label}'`;
+        // First NON-EMPTY identifier, not first non-nullish: `??` would select
+        // an empty `name` and strand a node that has a perfectly good id.
+        const label = [node.name, node.nodeId, node.id].find(
+          (candidate): candidate is string => typeof candidate === 'string' && candidate.length > 0
+        );
+        // A node with no usable identifier at all is worse than no hint: "on
+        // node 'undefined'" tells the operator nothing and looks like a bug.
+        if (label) return `on node '${label}'`;
       }
     } catch {
       // Roster lookup failed — fall back to whatever the registry gave us.

--- a/packages/cli/src/cli/lib/fleet-hint.ts
+++ b/packages/cli/src/cli/lib/fleet-hint.ts
@@ -30,7 +30,7 @@
 import type { AgentRelay } from '@agent-relay/sdk';
 
 import { createWorkspaceRelay } from './sdk-client.js';
-import { readRemoteLiveAgents } from './fleet-live-agents.js';
+import { isAvailableFleetNode, readRemoteLiveAgents } from './fleet-live-agents.js';
 
 /**
  * Injectable factory — lets callers (and tests) substitute a workspace
@@ -94,6 +94,12 @@ export async function resolveFleetHint(
         return `on node '${nodeId}'`;
       }
       for (const node of nodes) {
+        // Only nodes that can currently host work. `nodes.list()` also returns
+        // history, and an offline record still carries the live-agent names
+        // from its last heartbeat — scanning those would point the operator at
+        // a machine that stopped running the agent hours ago, or is not
+        // running at all, which is worse than no hint.
+        if (!isAvailableFleetNode(node)) continue;
         if (!readRemoteLiveAgents(node).agents.some((live) => live.name === agentName)) continue;
         const label = node.name ?? node.nodeId ?? node.id;
         // A node with no usable identifier is worse than no hint: "on node

--- a/packages/cli/src/cli/lib/fleet-live-agents.ts
+++ b/packages/cli/src/cli/lib/fleet-live-agents.ts
@@ -1,0 +1,59 @@
+/**
+ * Live-agent placement decoded from a fleet node's heartbeat.
+ *
+ * Each node advertises the broker-owned set of worker names it is currently
+ * running as a `relay:live-agents:v1` capability on its roster record, so
+ * `nodes.list()` alone answers "which node is agent X on?" — no per-node
+ * round-trip. `fleet agent list` renders it; `fleet-hint` uses it to name the
+ * node in a cross-node attach error.
+ *
+ * Lives in `lib/` rather than in the `fleet agent` command because two
+ * different surfaces consume it and an error path must not import a command
+ * module to read it.
+ */
+
+import type { RelayNode } from '@agent-relay/sdk';
+
+export interface RemoteLiveAgent {
+  name: string;
+}
+
+export const LIVE_AGENT_CAPABILITY_NAME = 'relay:live-agents:v1';
+
+export interface RemoteLiveAgentRead {
+  supported: boolean;
+  agents: RemoteLiveAgent[];
+  warning?: string;
+}
+
+/** Decode the broker-owned WorkerName set carried by a node heartbeat. */
+export function readRemoteLiveAgents(node: RelayNode): RemoteLiveAgentRead {
+  let supported = false;
+  let malformed = 0;
+  const names = new Set<string>();
+  for (const capability of node.capabilities) {
+    if (capability.name !== LIVE_AGENT_CAPABILITY_NAME) continue;
+    supported = true;
+    const rawNames = capability.metadata?.names;
+    if (!Array.isArray(rawNames)) {
+      malformed += 1;
+      continue;
+    }
+    for (const rawName of rawNames) {
+      if (typeof rawName !== 'string' || !rawName || names.has(rawName)) {
+        malformed += 1;
+        continue;
+      }
+      names.add(rawName);
+    }
+  }
+  return {
+    supported,
+    agents: Array.from(names, (name) => ({ name })).sort((a, b) => a.name.localeCompare(b.name)),
+    ...(malformed > 0
+      ? {
+          warning: `${malformed} malformed or duplicate live-agent heartbeat capabilit${malformed === 1 ? 'y' : 'ies'}`,
+        }
+      : {}),
+  };
+}

--- a/packages/cli/src/cli/lib/fleet-live-agents.ts
+++ b/packages/cli/src/cli/lib/fleet-live-agents.ts
@@ -57,3 +57,25 @@ export function readRemoteLiveAgents(node: RelayNode): RemoteLiveAgentRead {
       : {}),
   };
 }
+
+/**
+ * Whether a roster entry can currently accept Fleet work.
+ *
+ * `nodes.list()` returns history as well as live nodes, and an offline
+ * record still carries the live-agent capability from its last heartbeat —
+ * so a name that node was running hours ago is still listed there. Callers
+ * that answer "where is agent X *now*" must filter with this first, or they
+ * will confidently point an operator at a machine that is not running the
+ * agent (or is not running at all).
+ */
+export function isAvailableFleetNode(node: {
+  live?: boolean;
+  status?: string;
+  handlersLive?: boolean;
+  tags?: unknown;
+}): boolean {
+  const tags = Array.isArray(node.tags) ? node.tags : [];
+  const isDirectPseudoNode = tags.includes('direct');
+  const isLive = node.live === undefined ? node.status === 'online' : node.live === true;
+  return isLive && node.handlersLive !== false && !isDirectPseudoNode;
+}


### PR DESCRIPTION
Closes item 7 of the attach-reliability map in #1597. Independent of #1598 — different files, no overlap.

## The report

"Attaching to a cross-node agent without `--node` silently returns a near-empty stream instead of an error naming the node."

Half of that turned out to be a measurement artifact, and the other half is a real defect.

**Not silent.** Reproduced against a live agent on `sf-mini`:

```
$ agent-relay node agent attach sandbox-lead-claude-0820b --mode view
Error: no agent named 'sandbox-lead-claude-0820b'     # stderr, 50 bytes
$ echo $?
1
```

stdout is 0 bytes and the exit code is 1. A byte count taken over merged streams reads as ~54 bytes of "stream"; there is no silent success.

**The real defect:** that error does not name the node, even though `fleet-hint.ts` exists precisely to turn it into

> `Error: agent 'X' is registered on node 'sf-mini'; cross-node attach is not yet supported — run `agent-relay node agent attach X` on that machine`

## Why the hint could not fire

It resolves placement with `relay.agents.get(name)` and reads `metadata.fleet.nodeId`. That is the workspace **agent registry**, and a broker-spawned worker on a fleet node is not in it:

```
$ agent-relay agent list | grep -c sandbox-lead-claude-0820b
0
$ agent-relay fleet agent list | grep -c '"node": "sf-mini"'
5
```

The lookup 404s for exactly the names an operator points a cross-node attach at, and every failure path in the hint returns `null` by design (it is best-effort on an error path). So the one case the hint was written for is the one case it could not answer.

## The fix

Fall back to the node roster, which already carries the answer. Every node advertises the worker names its broker is running as a `relay:live-agents:v1` heartbeat capability, and the hint **already calls `nodes.list()`** to resolve the node's display name — so the placement scan reuses a call that was already being made. No extra round-trip on an error path that has to stay fast.

Ordering and guards:

- The registry still wins when it knows the placement, so the two sources cannot disagree about a registered agent.
- A node with no usable identifier produces no hint rather than `on node 'undefined'`, which reads as a bug to the operator.
- A roster failure still resolves to `null`; the hint never rejects.

`readRemoteLiveAgents` moves from the `fleet agent` command module to `lib/fleet-live-agents.ts` so both consumers share one implementation — an error path in `lib/` should not import a command module to read a heartbeat. `fleet-agent.ts` re-exports it, so its callers and tests are untouched.

## Tests

**Must-fire:** a live worker the agent registry does not know is now named with its node. Verified red by restoring the early `return null` in the `agents.get` catch:

```
× relay#1597 MUST-FIRE: names the node for a live worker the agent registry does not know
  AssertionError: expected null to be 'on node 'sf-mini''
```

**Must-not-fire companions**, all guarding against the hint inventing a placement:

- no hint when no node is running that worker (a genuinely missing agent must still get the plain message)
- no match against a different worker on the same node
- no `on node 'undefined'` for a node with no identifier
- registry placement still preferred when the agent *is* registered
- a roster lookup failure resolves rather than throwing

67 tests pass across `fleet-hint`, `fleet-agent` and `fleet`.

## Not in this PR

Cross-node attach still is not *supported* — this only makes the refusal actionable by naming the machine to run it on. Making `--node` inferable is a separate design question, not an error-message fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

