### PR TITLE
fix(mcp): wait for raw spawn readiness

### DIFF
--- a/.agentworkforce/trajectories/active/traj_zq10vbcnjpil/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_zq10vbcnjpil/trajectory.json
@@ -1,0 +1,51 @@
+{
+  "id": "traj_zq10vbcnjpil",
+  "version": 1,
+  "task": {
+    "title": "Harden PR 1606 exact RelayFlow proof runner",
+    "source": {
+      "system": "github",
+      "id": "PR-1606",
+      "url": "https://github.com/AgentWorkforce/relay/pull/1606"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-08-26T00:28:25.971Z",
+  "agents": [
+    {
+      "name": "relay-bug-pr-proof-coordinator-0825",
+      "role": "lead",
+      "joinedAt": "2026-08-26T00:28:26.100Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_p8tazr8pd1c2",
+      "title": "Initial work",
+      "agentName": "relay-bug-pr-proof-coordinator-0825",
+      "startedAt": "2026-08-26T00:28:26.100Z",
+      "events": [
+        {
+          "ts": 1787704108480,
+          "type": "decision",
+          "content": "Install optional platform packages and assert the checked-out target SHA: Install optional platform packages and assert the checked-out target SHA",
+          "raw": {
+            "question": "Install optional platform packages and assert the checked-out target SHA",
+            "chosen": "Install optional platform packages and assert the checked-out target SHA",
+            "alternatives": [],
+            "reasoning": "The external proof runner must build the exact base or head checkout reliably; omitting optional packages removed esbuild's platform binary, and the SHA assertion prevents accidentally proving a stale tree."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "231a4fb2841194548f5209a895a53c93943ef1f4",
+    "endRef": "231a4fb2841194548f5209a895a53c93943ef1f4"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_dqaehk33bc2z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_dqaehk33bc2z/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Require complete verified-spawn success contract
+
+> **Status:** ✅ Completed
+> **Task:** AgentWorkforce/relay#1603
+> **Confidence:** 96%
+> **Started:** August 24, 2026 at 01:44 AM
+> **Completed:** August 24, 2026 at 01:45 AM
+
+---
+
+## Summary
+
+Hardened verified raw spawn completion to require spawned=true and ready=true, with regressions for missing and false spawn confirmation; focused tests and typecheck pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Require both spawned and ready on terminal success
+- **Chose:** Require both spawned and ready on terminal success
+- **Reasoning:** The broker success contract is conjunctive; either flag alone can be malformed or legacy output and must not be reported as a verified spawn.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Require both spawned and ready on terminal success: Require both spawned and ready on terminal success

--- a/.agentworkforce/trajectories/completed/2026-08/traj_dqaehk33bc2z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_dqaehk33bc2z/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_dqaehk33bc2z",
+  "version": 1,
+  "task": {
+    "title": "Require complete verified-spawn success contract",
+    "source": {
+      "system": "plain",
+      "id": "AgentWorkforce/relay#1603"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-23T23:44:36.484Z",
+  "completedAt": "2026-08-23T23:45:40.996Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-23T23:45:39.240Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ffgmv8akchv9",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-23T23:45:39.240Z",
+      "endedAt": "2026-08-23T23:45:40.996Z",
+      "events": [
+        {
+          "ts": 1787528739240,
+          "type": "decision",
+          "content": "Require both spawned and ready on terminal success: Require both spawned and ready on terminal success",
+          "raw": {
+            "question": "Require both spawned and ready on terminal success",
+            "chosen": "Require both spawned and ready on terminal success",
+            "alternatives": [],
+            "reasoning": "The broker success contract is conjunctive; either flag alone can be malformed or legacy output and must not be reported as a verified spawn."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Hardened verified raw spawn completion to require spawned=true and ready=true, with regressions for missing and false spawn confirmation; focused tests and typecheck pass.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "464816f48c2986a55db1097cb9f581966234360e",
+    "endRef": "464816f48c2986a55db1097cb9f581966234360e"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_eav8p9bmksk3/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_eav8p9bmksk3/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Make raw MCP fleet spawns wait for broker readiness
+
+> **Status:** ✅ Completed
+> **Task:** relay#1603
+> **Confidence:** 92%
+> **Started:** August 23, 2026 at 07:44 PM
+> **Completed:** August 23, 2026 at 07:54 PM
+
+---
+
+## Summary
+
+Made raw MCP fleet spawns request broker verification, wait for terminal readiness, reject missing ready proof, and surface early exits; added CLI and broker regressions plus changelog.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use an explicit top-level verify_ready action flag instead of synthesizing a harness config
+- **Chose:** Use an explicit top-level verify_ready action flag instead of synthesizing a harness config
+- **Reasoning:** Readiness is an invocation contract, and injecting a PTY harness config could change CLI command/session semantics; the broker already has the readiness state machine and now accepts the flag alongside existing harness metadata.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use an explicit top-level verify_ready action flag instead of synthesizing a harness config: Use an explicit top-level verify_ready action flag instead of synthesizing a harness config

--- a/.agentworkforce/trajectories/completed/2026-08/traj_eav8p9bmksk3/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_eav8p9bmksk3/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_eav8p9bmksk3",
+  "version": 1,
+  "task": {
+    "title": "Make raw MCP fleet spawns wait for broker readiness",
+    "source": {
+      "system": "plain",
+      "id": "relay#1603"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-23T17:44:18.116Z",
+  "completedAt": "2026-08-23T17:54:24.232Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-23T17:53:20.788Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_742ti6u2e5na",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-23T17:53:20.788Z",
+      "endedAt": "2026-08-23T17:54:24.232Z",
+      "events": [
+        {
+          "ts": 1787507600788,
+          "type": "decision",
+          "content": "Use an explicit top-level verify_ready action flag instead of synthesizing a harness config: Use an explicit top-level verify_ready action flag instead of synthesizing a harness config",
+          "raw": {
+            "question": "Use an explicit top-level verify_ready action flag instead of synthesizing a harness config",
+            "chosen": "Use an explicit top-level verify_ready action flag instead of synthesizing a harness config",
+            "alternatives": [],
+            "reasoning": "Readiness is an invocation contract, and injecting a PTY harness config could change CLI command/session semantics; the broker already has the readiness state machine and now accepts the flag alongside existing harness metadata."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Made raw MCP fleet spawns request broker verification, wait for terminal readiness, reject missing ready proof, and surface early exits; added CLI and broker regressions plus changelog.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "2f24c6af2d1f017425db7ae54433dfedcac59b38",
+    "endRef": "2f24c6af2d1f017425db7ae54433dfedcac59b38"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil.trace.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0.0",
+  "id": "c848af12-7a90-42b2-a8e4-3d169f4e89d0",
+  "timestamp": "2026-08-26T00:28:51.519Z",
+  "trajectory": "traj_zq10vbcnjpil",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_zq10vbcnjpil/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 51,
+              "revision": "3bbe4f9aa796b15db9fed7e24c64005ad49c7e79"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 5,
+              "revision": "3bbe4f9aa796b15db9fed7e24c64005ad49c7e79"
+            },
+            {
+              "start_line": 16,
+              "end_line": 29,
+              "revision": "3bbe4f9aa796b15db9fed7e24c64005ad49c7e79"
+            },
+            {
+              "start_line": 45,
+              "end_line": 51,
+              "revision": "3bbe4f9aa796b15db9fed7e24c64005ad49c7e79"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil/summary.md
@@ -1,0 +1,39 @@
+# Trajectory: Harden PR 1606 exact RelayFlow proof runner
+
+> **Status:** ✅ Completed
+> **Task:** [PR-1606](https://github.com/AgentWorkforce/relay/pull/1606)
+> **Confidence:** 96%
+> **Started:** August 26, 2026 at 02:28 AM
+> **Completed:** August 26, 2026 at 02:28 AM
+
+---
+
+## Summary
+
+Made the PR 1606 external RelayFlow harness install platform-specific optional build packages and fail closed when its checkout does not match RELAY_PR_PROOF_TARGET_SHA.
+
+**Approach:** Reproduced the esbuild platform-binary failure, retained the external public MCP stdio harness, added exact-target verification, and preserved deterministic base-bug/head-fixed signatures.
+
+---
+
+## Key Decisions
+
+### Install optional platform packages and assert the checked-out target SHA
+- **Chose:** Install optional platform packages and assert the checked-out target SHA
+- **Reasoning:** The external proof runner must build the exact base or head checkout reliably; omitting optional packages removed esbuild's platform binary, and the SHA assertion prevents accidentally proving a stale tree.
+
+---
+
+## Chapters
+
+### 1. Initial work
+*Agent: relay-bug-pr-proof-coordinator-0825*
+
+- Install optional platform packages and assert the checked-out target SHA: Install optional platform packages and assert the checked-out target SHA
+
+---
+
+## Artifacts
+
+**Commits:** 3bbe4f9aa
+**Files changed:** 2

--- a/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_zq10vbcnjpil/trajectory.json
@@ -9,8 +9,9 @@
       "url": "https://github.com/AgentWorkforce/relay/pull/1606"
     }
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-08-26T00:28:25.971Z",
+  "completedAt": "2026-08-26T00:28:51.212Z",
   "agents": [
     {
       "name": "relay-bug-pr-proof-coordinator-0825",
@@ -24,6 +25,7 @@
       "title": "Initial work",
       "agentName": "relay-bug-pr-proof-coordinator-0825",
       "startedAt": "2026-08-26T00:28:26.100Z",
+      "endedAt": "2026-08-26T00:28:51.212Z",
       "events": [
         {
           "ts": 1787704108480,
@@ -40,12 +42,23 @@
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Made the PR 1606 external RelayFlow harness install platform-specific optional build packages and fail closed when its checkout does not match RELAY_PR_PROOF_TARGET_SHA.",
+    "approach": "Reproduced the esbuild platform-binary failure, retained the external public MCP stdio harness, added exact-target verification, and preserved deterministic base-bug/head-fixed signatures.",
+    "confidence": 0.96
+  },
+  "commits": [
+    "3bbe4f9aa"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_zq10vbcnjpil/trajectory.json",
+    "tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "231a4fb2841194548f5209a895a53c93943ef1f4",
-    "endRef": "231a4fb2841194548f5209a895a53c93943ef1f4"
+    "endRef": "3bbe4f9aa796b15db9fed7e24c64005ad49c7e79",
+    "traceId": "c848af12-7a90-42b2-a8e4-3d169f4e89d0"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay fleet spawn --sandbox` now waits through the mounted Daytona provisioning deadline instead of abandoning successful long-running requests without a sandbox ID for cleanup.
+- Raw CLI spawns through the Agent Relay MCP now return only after the broker observes worker readiness, and surface early exits or missing readiness proof instead of reporting the placement acknowledgement as success.
 
 ## [11.8.5] - 2026-08-27
 

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -197,11 +197,28 @@ fn harness_metadata_flag(config: &ResolvedHarnessConfig, snake: &str, camel: &st
 }
 
 pub(super) fn relaycast_spawn_verifies_ready(value: &Value) -> bool {
-    relaycast_harness_config(value)
-        .ok()
-        .flatten()
-        .as_ref()
-        .is_some_and(|config| harness_metadata_flag(config, "verify_ready", "verifyReady"))
+    let request_flag = value
+        .get("verify_ready")
+        .or_else(|| value.get("verifyReady"))
+        .or_else(|| {
+            value
+                .get("agent")
+                .and_then(|agent| agent.get("verify_ready"))
+        })
+        .or_else(|| {
+            value
+                .get("agent")
+                .and_then(|agent| agent.get("verifyReady"))
+        })
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    request_flag
+        || relaycast_harness_config(value)
+            .ok()
+            .flatten()
+            .as_ref()
+            .is_some_and(|config| harness_metadata_flag(config, "verify_ready", "verifyReady"))
 }
 
 /// Bind a freshly HTTP-registered agent to this broker's relaycast node so it
@@ -1318,7 +1335,7 @@ mod tests {
     }
 
     #[test]
-    fn verified_spawn_contract_is_read_from_harness_metadata() {
+    fn verified_spawn_contract_is_read_from_request_or_harness_metadata() {
         let verified = json!({
             "harness_config": {
                 "runtime": "pty",
@@ -1337,8 +1354,12 @@ mod tests {
                 "args": []
             }
         });
+        let flattened = json!({ "verify_ready": true });
+        let nested_camel = json!({ "agent": { "verifyReady": true } });
 
         assert!(relaycast_spawn_verifies_ready(&verified));
+        assert!(relaycast_spawn_verifies_ready(&flattened));
+        assert!(relaycast_spawn_verifies_ready(&nested_camel));
         assert!(!relaycast_spawn_verifies_ready(&ordinary));
     }
 

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -594,20 +594,24 @@ describe('createAgentRelayMcpServer', () => {
     expect(spawnResult.structuredContent.invocation).toEqual({
       invocationId: 'inv_1',
       actionName: 'spawn',
-      input: {
-        name: 'FleetWorker',
-        cli: 'codex',
-        task: 'Implement a fix',
-        worker_cwd: '/workspace/relay',
-        target_node: 'node-a',
-        channels: ['general'],
-        organization: 'Agent Workforce',
-        project: 'Relay',
-        workstream: 'fleet-metadata',
-        role: 'implementer',
-        objective: 'Implement a fix',
-      },
+      status: 'completed',
+      output: { spawned: true, ready: true },
     });
+    expect(mocks.agentRelayMessagingCommands.invoke).toHaveBeenCalledWith('spawn', {
+      name: 'FleetWorker',
+      cli: 'codex',
+      verify_ready: true,
+      task: 'Implement a fix',
+      worker_cwd: '/workspace/relay',
+      target_node: 'node-a',
+      channels: ['general'],
+      organization: 'Agent Workforce',
+      project: 'Relay',
+      workstream: 'fleet-metadata',
+      role: 'implementer',
+      objective: 'Implement a fix',
+    });
+    expect(mocks.agentRelayMessagingCommands.getInvocation).toHaveBeenCalledWith('spawn', 'inv_1');
 
     const personaSpawnResult = await server.tools.get('spawn')?.handler({
       name: 'IntegrationExpert',
@@ -947,7 +951,7 @@ describe('createAgentRelayMcpServer', () => {
       await vi.advanceTimersByTimeAsync(130_001);
 
       await expect(outcome).resolves.toBe(
-        'Persona spawn timed out before broker registration and harness readiness.'
+        'Spawn timed out before broker registration and harness readiness.'
       );
     } finally {
       vi.useRealTimers();
@@ -1016,6 +1020,87 @@ describe('createAgentRelayMcpServer', () => {
       target_node: 'node-a',
     });
     expect(mocks.agentRelayMessagingCommands.getInvocation).toHaveBeenNthCalledWith(2, 'spawn', 'inv_nested');
+  });
+
+  it.each([
+    { contract: 'readiness', output: { spawned: true } },
+    { contract: 'spawn confirmation', output: { ready: true } },
+    { contract: 'positive spawn confirmation', output: { spawned: false, ready: true } },
+  ])('does not report a raw CLI spawn without $contract proof', async ({ output }) => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const server = mocks.serverInstances[0];
+    mocks.agentRelayMessagingCommands.getInvocation.mockResolvedValueOnce({
+      invocationId: 'inv_1',
+      actionName: 'spawn',
+      status: 'completed',
+      output,
+    });
+
+    await expect(
+      server.tools.get('spawn')?.handler({
+        name: 'RawWorker',
+        cli: 'codex',
+        target_node: 'node-a',
+      })
+    ).rejects.toThrow('Spawn completed without broker registration and harness readiness proof.');
+    expect(mocks.agentRelayMessagingCommands.invoke).toHaveBeenCalledWith('spawn', {
+      name: 'RawWorker',
+      cli: 'codex',
+      verify_ready: true,
+      target_node: 'node-a',
+    });
+  });
+
+  it('surfaces a raw CLI early-exit failure instead of the invocation acknowledgement', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const server = mocks.serverInstances[0];
+    mocks.agentRelayMessagingCommands.getInvocation.mockResolvedValueOnce({
+      invocationId: 'inv_1',
+      actionName: 'spawn',
+      status: 'failed',
+      error: 'spawn_harness_not_ready',
+    });
+
+    await expect(
+      server.tools.get('spawn')?.handler({
+        name: 'RawWorker',
+        cli: 'codex',
+      })
+    ).rejects.toThrow('spawn_harness_not_ready');
+  });
+
+  it('surfaces a denied raw CLI spawn without waiting for the readiness deadline', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const server = mocks.serverInstances[0];
+    mocks.agentRelayMessagingCommands.getInvocation.mockResolvedValueOnce({
+      invocationId: 'inv_1',
+      actionName: 'spawn',
+      status: 'denied',
+      error: 'spawn_policy_denied',
+    });
+
+    await expect(
+      server.tools.get('spawn')?.handler({
+        name: 'RawWorker',
+        cli: 'codex',
+      })
+    ).rejects.toThrow('spawn_policy_denied');
+    expect(mocks.agentRelayMessagingCommands.getInvocation).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a blank workspace name before provisioning a remote workspace', async () => {

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -73,12 +73,13 @@ function withExitAfterTaskInstruction(task: string): string {
   return `${task}\n\n${EXIT_AFTER_TASK_INSTRUCTION}`;
 }
 
-const PERSONA_SPAWN_TIMEOUT_MS = 130_000;
-const PERSONA_SPAWN_POLL_MS = 250;
-const PERSONA_SPAWN_TIMEOUT_MESSAGE =
-  'Persona spawn timed out before broker registration and harness readiness.';
-const PERSONA_SPAWN_SUCCESS_STATUSES = new Set(['completed', 'succeeded', 'success']);
-const PERSONA_SPAWN_FAILURE_STATUSES = new Set(['failed', 'error', 'cancelled', 'canceled']);
+const VERIFIED_SPAWN_TIMEOUT_MS = 130_000;
+const VERIFIED_SPAWN_POLL_MS = 250;
+const VERIFIED_SPAWN_TIMEOUT_MESSAGE = 'Spawn timed out before broker registration and harness readiness.';
+const VERIFIED_SPAWN_MISSING_READY_MESSAGE =
+  'Spawn completed without broker registration and harness readiness proof.';
+const VERIFIED_SPAWN_SUCCESS_STATUSES = new Set(['completed', 'succeeded', 'success']);
+const VERIFIED_SPAWN_FAILURE_STATUSES = new Set(['failed', 'error', 'cancelled', 'canceled', 'denied']);
 
 type InvocationReader = {
   getInvocation(name: string, invocationId: string): Promise<unknown>;
@@ -126,14 +127,14 @@ async function getInvocationBeforeDeadline(
   deadline: number
 ): Promise<unknown> {
   const remainingMs = deadline - Date.now();
-  if (remainingMs <= 0) throw new Error(PERSONA_SPAWN_TIMEOUT_MESSAGE);
+  if (remainingMs <= 0) throw new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE);
 
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       actions.getInvocation(current.actionName, current.invocationId),
       new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error(PERSONA_SPAWN_TIMEOUT_MESSAGE)), remainingMs);
+        timeout = setTimeout(() => reject(new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE)), remainingMs);
       }),
     ]);
   } finally {
@@ -157,21 +158,21 @@ async function pollInvocation(
     } catch (error) {
       if (isInvocationAuthorizationError(error)) throw error;
       if (Date.now() >= deadline) {
-        throw new Error(PERSONA_SPAWN_TIMEOUT_MESSAGE, { cause: error });
+        throw new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE, { cause: error });
       }
-      await new Promise<void>((resolve) => setTimeout(resolve, PERSONA_SPAWN_POLL_MS));
+      await new Promise<void>((resolve) => setTimeout(resolve, VERIFIED_SPAWN_POLL_MS));
     }
   }
 }
 
-async function waitForPersonaSpawn(
+async function waitForVerifiedSpawn(
   actions: InvocationReader,
   ackValue: unknown,
-  timeoutMs = PERSONA_SPAWN_TIMEOUT_MS
+  timeoutMs = VERIFIED_SPAWN_TIMEOUT_MS
 ): Promise<unknown> {
   const ack = recordValue(ackValue);
   let current = invocationRef(ack);
-  if (!current) throw new Error('Persona spawn did not return an invocation id.');
+  if (!current) throw new Error('Spawn did not return an invocation id.');
 
   const deadline = Date.now() + timeoutMs;
   const followed = new Set([`${current.actionName}\u001f${current.invocationId}`]);
@@ -179,7 +180,7 @@ async function waitForPersonaSpawn(
     const invocation = await pollInvocation(actions, current, deadline);
     const record = recordValue(invocation);
     const status = invocationText(record, 'status')?.toLowerCase();
-    if (status && PERSONA_SPAWN_SUCCESS_STATUSES.has(status)) {
+    if (status && VERIFIED_SPAWN_SUCCESS_STATUSES.has(status)) {
       const nested = nestedPersonaSpawnRef(record);
       if (nested) {
         const key = `${nested.actionName}\u001f${nested.invocationId}`;
@@ -190,15 +191,19 @@ async function waitForPersonaSpawn(
         current = nested;
         continue;
       }
+      const output = recordValue(record.output);
+      if (output.spawned !== true || output.ready !== true) {
+        throw new Error(VERIFIED_SPAWN_MISSING_READY_MESSAGE);
+      }
       return invocation;
     }
-    if (status && PERSONA_SPAWN_FAILURE_STATUSES.has(status)) {
-      throw new Error(invocationText(record, 'error') ?? `Persona spawn ${status}.`);
+    if (status && VERIFIED_SPAWN_FAILURE_STATUSES.has(status)) {
+      throw new Error(invocationText(record, 'error') ?? `Spawn ${status}.`);
     }
     if (Date.now() >= deadline) {
-      throw new Error(PERSONA_SPAWN_TIMEOUT_MESSAGE);
+      throw new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE);
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, PERSONA_SPAWN_POLL_MS));
+    await new Promise<void>((resolve) => setTimeout(resolve, VERIFIED_SPAWN_POLL_MS));
   }
 }
 
@@ -609,13 +614,6 @@ type SpawnToolRequest = {
   targetNode?: string;
 };
 
-function requireSpawnActions(client: AgentClientLike): NonNullable<AgentClientLike['actions']> {
-  if (!client.actions) {
-    throw new Error('spawn requires an agent-scoped Relaycast actions client.');
-  }
-  return client.actions;
-}
-
 function validateSpawnRequest({ cli, persona, model, sessionRef, cwd, personaCwd }: SpawnToolRequest): void {
   if (Boolean(cli) === Boolean(persona)) {
     throw new Error('spawn requires exactly one of `cli` or `persona`.');
@@ -659,7 +657,7 @@ function buildSpawnActionInput({
   const registryCwd = personaCwd ?? cwd;
   return {
     name,
-    ...(cli ? { cli } : { persona, capability: 'spawn:persona' }),
+    ...(cli ? { cli, verify_ready: true } : { persona, capability: 'spawn:persona' }),
     ...(task ? { task } : {}),
     ...(persona && registryCwd ? { cwd: registryCwd } : {}),
     ...(workerCwd ? { worker_cwd: workerCwd } : {}),
@@ -671,7 +669,7 @@ function buildSpawnActionInput({
   };
 }
 
-async function invokeVerifiedPersonaSpawn(
+async function invokeVerifiedSpawn(
   session: SessionState,
   asIdentity: string | undefined,
   baseUrl: string | undefined,
@@ -679,11 +677,11 @@ async function invokeVerifiedPersonaSpawn(
 ): Promise<unknown> {
   const agentToken = asIdentity ? session.agents.get(asIdentity)?.agentToken : session.agentToken;
   if (!agentToken) {
-    throw new Error('Persona spawn requires a registered agent identity.');
+    throw new Error('Spawn requires a registered agent identity.');
   }
   const commands = new AgentRelay({ agentToken, baseUrl }).messaging.commands;
   const invocation = await commands.invoke('spawn', actionInput);
-  return waitForPersonaSpawn(commands, invocation);
+  return waitForVerifiedSpawn(commands, invocation);
 }
 
 /**
@@ -1135,7 +1133,7 @@ function registerAgentRelayTools(
       title: 'Spawn Agent',
       description:
         'Invoke the fleet spawn action with either a raw `cli` or an AgentWorkforce `persona` name/path. ' +
-        'Persona requests route to a node exposing `spawn:persona` (for example, `defineWorkforcePersonaSpawnNode` from `@agentworkforce/local-surface`) and return only after broker registration and harness readiness are verified. Raw CLI requests retain asynchronous acknowledgement behavior.',
+        'Persona requests route to a node exposing `spawn:persona` (for example, `defineWorkforcePersonaSpawnNode` from `@agentworkforce/local-surface`). Both forms return only after broker registration and harness readiness are verified.',
       inputSchema: {
         name: z.string().describe('Agent name'),
         cli: z
@@ -1198,7 +1196,6 @@ function registerAgentRelayTools(
       target_node,
       as,
     }) => {
-      const actions = requireSpawnActions(getAgentClient(as));
       const request = {
         name,
         cli,
@@ -1220,9 +1217,7 @@ function registerAgentRelayTools(
       };
       validateSpawnRequest(request);
       const actionInput = buildSpawnActionInput(request);
-      const invocation = persona
-        ? await invokeVerifiedPersonaSpawn(getSession(), as, baseUrl, actionInput)
-        : await actions.invoke('spawn', actionInput);
+      const invocation = await invokeVerifiedSpawn(getSession(), as, baseUrl, actionInput);
       return jsonContent({ invocation });
     }
   );

--- a/tests/relayflows/cases/1603-raw-spawn-readiness/case.json
+++ b/tests/relayflows/cases/1603-raw-spawn-readiness/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1603-raw-spawn-readiness",
+  "kind": "bugfix",
+  "title": "Wait for raw CLI spawn readiness",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "raw_cli_spawn_returns_dispatch_ack_without_readiness"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "raw_cli_spawn_waits_for_verified_readiness"
+    }
+  }
+}

--- a/tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs
+++ b/tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CASE_ID = '1603-raw-spawn-readiness';
+const arm = process.env.RELAY_PR_PROOF_ARM;
+const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
+const resultPath = process.env.RELAY_PR_PROOF_RESULT_PATH;
+const childEnv = { ...process.env };
+delete childEnv.CODEX_MANAGED_BY_NPM;
+
+assert.ok(arm === 'base' || arm === 'head', 'RELAY_PR_PROOF_ARM must be base or head');
+assert.ok(targetDir, 'RELAY_PR_PROOF_TARGET_DIR is required');
+assert.ok(resultPath, 'RELAY_PR_PROOF_RESULT_PATH is required');
+
+async function run(command, args, env = childEnv) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: targetDir,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    const append = (chunk) => {
+      output = `${output}${chunk}`.slice(-16_000);
+    };
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(' ')} failed (${code ?? signal}):\n${output}`));
+    });
+  });
+}
+
+await run('npm', ['ci', '--ignore-scripts', '--no-audit', '--no-fund', '--omit=optional'], {
+  ...childEnv,
+  NODE_OPTIONS: '--max-old-space-size=256',
+});
+await run('npm', ['run', 'build:core']);
+
+const requests = [];
+let invocationReads = 0;
+const server = http.createServer(async (request, response) => {
+  const bodyChunks = [];
+  for await (const chunk of request) bodyChunks.push(chunk);
+  const bodyText = Buffer.concat(bodyChunks).toString('utf8');
+  const body = bodyText ? JSON.parse(bodyText) : undefined;
+  requests.push({ method: request.method, url: request.url, body });
+
+  let data;
+  if (request.method === 'POST' && request.url === '/v1/actions/spawn/invoke') {
+    data = {
+      invocation_id: 'inv_raw_readiness_proof',
+      action_name: 'spawn',
+      status: 'dispatched',
+      input: body?.input,
+    };
+  } else if (
+    request.method === 'GET' &&
+    request.url === '/v1/actions/spawn/invocations/inv_raw_readiness_proof'
+  ) {
+    invocationReads += 1;
+    data =
+      invocationReads === 1
+        ? {
+            invocation_id: 'inv_raw_readiness_proof',
+            action_name: 'spawn',
+            status: 'running',
+          }
+        : {
+            invocation_id: 'inv_raw_readiness_proof',
+            action_name: 'spawn',
+            status: 'completed',
+            output: { spawned: true, ready: true },
+          };
+  } else {
+    response.writeHead(404, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: false, error: { code: 'not_found', message: request.url } }));
+    return;
+  }
+
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ ok: true, data }));
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+
+let client;
+try {
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const clientModule = await import(
+    pathToFileURL(path.join(targetDir, 'node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js'))
+      .href
+  );
+  const transportModule = await import(
+    pathToFileURL(path.join(targetDir, 'node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js'))
+      .href
+  );
+  client = new clientModule.Client({ name: 'relayflow-raw-spawn-readiness', version: '1.0.0' });
+  const transport = new transportModule.StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(targetDir, 'packages/cli/dist/cli/index.js'), 'mcp'],
+    cwd: targetDir,
+    stderr: 'inherit',
+    env: {
+      ...childEnv,
+      RELAY_BASE_URL: `http://127.0.0.1:${address.port}`,
+      RELAY_WORKSPACE_KEY: 'rk_live_relayflow_proof',
+      RELAY_AGENT_TOKEN: 'at_live_relayflow_proof',
+      RELAY_AGENT_NAME: 'relayflow-orchestrator',
+      RELAY_SKIP_BOOTSTRAP: '1',
+      AGENT_RELAY_TELEMETRY_DISABLED: '1',
+    },
+  });
+  await client.connect(transport);
+  const result = await client.callTool({
+    name: 'spawn',
+    arguments: { name: 'RelayflowRawWorker', cli: 'codex', target_node: 'proof-node' },
+  });
+  assert.equal(result.isError, undefined, `spawn returned an MCP error: ${JSON.stringify(result)}`);
+
+  const invokeRequests = requests.filter(
+    (entry) => entry.method === 'POST' && entry.url === '/v1/actions/spawn/invoke'
+  );
+  const readRequests = requests.filter(
+    (entry) => entry.method === 'GET' && entry.url === '/v1/actions/spawn/invocations/inv_raw_readiness_proof'
+  );
+  assert.equal(invokeRequests.length, 1, 'spawn must invoke the production actions HTTP path exactly once');
+  const actionInput = invokeRequests[0].body?.input;
+  assert.equal(actionInput?.cli, 'codex');
+  assert.equal(actionInput?.name, 'RelayflowRawWorker');
+
+  if (arm === 'base') {
+    assert.equal(actionInput.verify_ready, undefined, 'base unexpectedly requested verified readiness');
+    assert.equal(readRequests.length, 0, 'base unexpectedly read the action invocation');
+    assert.equal(result.structuredContent?.invocation?.status, 'dispatched');
+    await writeFile(
+      resultPath,
+      `${JSON.stringify({
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'bug',
+        signature: 'raw_cli_spawn_returns_dispatch_ack_without_readiness',
+        details:
+          'The public MCP spawn tool returned the dispatch acknowledgement and never read the action invocation for readiness.',
+      })}\n`
+    );
+  } else {
+    assert.equal(actionInput.verify_ready, true, 'head did not request the broker readiness contract');
+    assert.equal(readRequests.length, 2, 'head must poll through running to completed readiness');
+    assert.equal(result.structuredContent?.invocation?.status, 'completed');
+    assert.deepEqual(result.structuredContent?.invocation?.output, { spawned: true, ready: true });
+    await writeFile(
+      resultPath,
+      `${JSON.stringify({
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'fixed',
+        signature: 'raw_cli_spawn_waits_for_verified_readiness',
+        details:
+          'The public MCP spawn tool sent verify_ready, polled the production action invocation path, and returned only the spawned-and-ready completion.',
+      })}\n`
+    );
+  }
+} finally {
+  await client?.close().catch(() => undefined);
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs
+++ b/tests/relayflows/cases/1603-raw-spawn-readiness/run.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
@@ -15,6 +15,14 @@ delete childEnv.CODEX_MANAGED_BY_NPM;
 assert.ok(arm === 'base' || arm === 'head', 'RELAY_PR_PROOF_ARM must be base or head');
 assert.ok(targetDir, 'RELAY_PR_PROOF_TARGET_DIR is required');
 assert.ok(resultPath, 'RELAY_PR_PROOF_RESULT_PATH is required');
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+assert.ok(expectedSha, `missing expected ${arm} SHA`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+assert.equal(targetSha, expectedSha, `target checkout does not match exact ${arm} SHA`);
 
 async function run(command, args, env = childEnv) {
   await new Promise((resolve, reject) => {
@@ -37,7 +45,7 @@ async function run(command, args, env = childEnv) {
   });
 }
 
-await run('npm', ['ci', '--ignore-scripts', '--no-audit', '--no-fund', '--omit=optional'], {
+await run('npm', ['ci', '--ignore-scripts', '--no-audit', '--no-fund', '--include=optional'], {
   ...childEnv,
   NODE_OPTIONS: '--max-old-space-size=256',
 });


### PR DESCRIPTION
## Summary

- make raw CLI MCP spawns request the broker's existing verified-readiness contract
- wait for the terminal action result instead of returning the dispatch acknowledgement
- reject a terminal `spawned: true` result unless it includes `ready: true`
- accept the readiness flag at the broker without synthesizing a harness config

This addresses the arrival-proof half of #1603. It deliberately does not close the issue: a worker can still become ready and die later, and that post-readiness exit still needs a correlated durable death signal.

## Why the flag is top-level

Readiness is a property of the invocation contract. Injecting a PTY `harness_config` solely to carry metadata would also select command/session behavior. The broker therefore accepts `verify_ready` on the action input while retaining the existing harness-metadata form.

## Must-not-report-success coverage

- legacy/unsupported node returns `{ spawned: true }` without `ready: true`
- broker reports `spawn_harness_not_ready` after an early exit
- existing bounded poller continues to cover missing readiness/timeouts

## Verification

- `npx vitest run packages/cli/src/cli/agent-relay-mcp.test.ts packages/cli/src/cli/agent-relay-mcp.startup.test.ts` — 54 passed
- `npm run typecheck` — passed
- `cargo fmt --check` — passed
- `cargo test -p agent-relay-broker` with inherited worker git/attestation config removed — 1,040 passed, 4 ignored (1,024 lib + 16 integration)
- `git diff --check` — passed

The first unfiltered Rust run exposed inherited `GIT_CONFIG_*` / `RELAY_ATTEST_*` values from this agent harness in git-hook fixtures. Removing only those test-contaminating variables made the complete package suite green.
