### PR TITLE
fix(ci): wait for npm package readiness

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_tj6v5g9rfbce/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_tj6v5g9rfbce/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix npm publish readiness race for SDK and root package
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 25, 2026 at 08:55 PM
+> **Completed:** August 25, 2026 at 09:05 PM
+
+---
+
+## Summary
+
+Confirmed npm's asynchronous SDK processing exposed a publish-readiness race, gated each npm package job on exact-version metadata and tarball availability with a 30-minute bound, added unit coverage and a Cloud red/green RelayFlow case, and recovered the partial 11.8.4 release by rerunning failed jobs.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Gate each npm publish job on exact-version metadata and tarball readiness
+- **Chose:** Gate each npm publish job on exact-version metadata and tarball readiness
+- **Reasoning:** npm accepted @agent-relay/sdk@11.8.4 at 18:45:52 but did not expose it until 19:01:05; waiting at the producer preserves dependency ordering for every downstream job and a 30-minute bound covers the observed 15-minute processing delay.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Gate each npm publish job on exact-version metadata and tarball readiness: Gate each npm publish job on exact-version metadata and tarball readiness

--- a/.agentworkforce/trajectories/completed/2026-08/traj_tj6v5g9rfbce/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_tj6v5g9rfbce/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_tj6v5g9rfbce",
+  "version": 1,
+  "task": {
+    "title": "Fix npm publish readiness race for SDK and root package"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-25T18:55:26.569Z",
+  "completedAt": "2026-08-25T19:05:31.356Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-25T19:04:08.269Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_qqcfvjn8u7tc",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-25T19:04:08.269Z",
+      "endedAt": "2026-08-25T19:05:31.356Z",
+      "events": [
+        {
+          "ts": 1787684648270,
+          "type": "decision",
+          "content": "Gate each npm publish job on exact-version metadata and tarball readiness: Gate each npm publish job on exact-version metadata and tarball readiness",
+          "raw": {
+            "question": "Gate each npm publish job on exact-version metadata and tarball readiness",
+            "chosen": "Gate each npm publish job on exact-version metadata and tarball readiness",
+            "alternatives": [],
+            "reasoning": "npm accepted @agent-relay/sdk@11.8.4 at 18:45:52 but did not expose it until 19:01:05; waiting at the producer preserves dependency ordering for every downstream job and a 30-minute bound covers the observed 15-minute processing delay."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Confirmed npm's asynchronous SDK processing exposed a publish-readiness race, gated each npm package job on exact-version metadata and tarball availability with a 30-minute bound, added unit coverage and a Cloud red/green RelayFlow case, and recovered the partial 11.8.4 release by rerunning failed jobs.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "639158c8cb2fd63d5719d3bf21e2dc4cad19f382",
+    "endRef": "639158c8cb2fd63d5719d3bf21e2dc4cad19f382"
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -746,6 +746,13 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
+
   # Publish the per-platform broker packages first. @agent-relay/sdk declares
   # these as exact-version optionalDependencies, so they must exist on the
   # registry at the matching version before the SDK is published — otherwise
@@ -906,6 +913,13 @@ jobs:
           steps.publish_3.outcome == 'failure'
         run: exit 1
 
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.broker_pkg }}
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
+
   # Publish remaining packages in parallel. SDK runtime deps that are pinned by
   # exact version are published by publish-sdk-internal-deps before this matrix
   # can publish @agent-relay/sdk.
@@ -991,6 +1005,15 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+      # npm may acknowledge large packages before their metadata and tarball
+      # are readable. Keep downstream dependency publishers behind this gate.
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
+
   # Publish @agent-relay/harnesses and @agent-relay/evals after the
   # publish-packages matrix, which is where their exact-version workspace deps
   # (@agent-relay/sdk and @agent-relay/harness-driver) land on the registry.
@@ -1048,6 +1071,13 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
+
   # Publish @agent-relay/fleet after @agent-relay/harnesses lands on the
   # registry. fleet pins @agent-relay/{harnesses,harness-driver,sdk} by exact
   # version, so publishing it before harnesses exists would leave a window where
@@ -1096,6 +1126,13 @@ jobs:
             exit 0
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/fleet
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
 
   # package=main publishes only the root `agent-relay` tarball, but that
   # tarball pins several @agent-relay/* runtime dependencies to the freshly
@@ -1169,6 +1206,13 @@ jobs:
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
+
   # Publish brand package only (when selected)
   publish-brand-only:
     name: Publish Brand to NPM
@@ -1206,6 +1250,13 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         working-directory: packages/brand
         run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/brand
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
 
   # Publish SDK only (when selected)
   publish-sdk-only:
@@ -1259,6 +1310,13 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         working-directory: packages/sdk
         run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+      - name: Wait for published package readiness
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: packages/sdk
+        run: |
+          PKG_SPEC=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
+          node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"
 
   # Publish Python SDK to PyPI as per-platform wheels with the broker binary
   # embedded. One wheel per (broker_artifact, plat_tag) — see issue #769.
@@ -1658,6 +1716,7 @@ jobs:
             exit 0
           fi
           npm publish "$NPM_TARBALL" --access public --provenance --tag "${{ github.event.inputs.tag }}"
+          node scripts/wait-for-npm-package.mjs "agent-relay@${PKG_VERSION}"
           echo "published=true" >> "$GITHUB_OUTPUT"
 
   # Create git tag and release

--- a/scripts/wait-for-npm-package.mjs
+++ b/scripts/wait-for-npm-package.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+// The 11.8.4 SDK took just over 15 minutes to become readable after npm
+// accepted the publish. Leave enough room for that asynchronous processing
+// without allowing a stuck release to wait forever.
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_INTERVAL_MS = 10 * 1000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30 * 1000;
+
+export function parseExactPackageSpec(spec) {
+  const separator = spec.lastIndexOf('@');
+  if (separator <= 0 || separator === spec.length - 1) {
+    throw new Error(`Expected an exact package spec such as @scope/name@1.2.3, got: ${spec}`);
+  }
+
+  return {
+    name: spec.slice(0, separator),
+    version: spec.slice(separator + 1),
+  };
+}
+
+function positiveNumber(value, label) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive number, got: ${value}`);
+  }
+  return parsed;
+}
+
+function describeResponse(response) {
+  return `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`;
+}
+
+export async function waitForNpmPackage(
+  spec,
+  {
+    registryUrl = DEFAULT_REGISTRY,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    fetchImpl = globalThis.fetch,
+    sleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+    now = Date.now,
+    log = console.log,
+  } = {}
+) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required');
+  }
+
+  const { name, version } = parseExactPackageSpec(spec);
+  const normalizedRegistry = registryUrl.endsWith('/') ? registryUrl : `${registryUrl}/`;
+  const metadataUrl = new URL(
+    `${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
+    normalizedRegistry
+  );
+  const startedAt = now();
+  let attempt = 0;
+  let lastFailure = 'package metadata was not checked';
+
+  while (true) {
+    attempt += 1;
+    const cacheBuster = String(now());
+    metadataUrl.searchParams.set('_relay_ready', cacheBuster);
+
+    try {
+      const metadataResponse = await fetchImpl(metadataUrl, {
+        headers: { 'cache-control': 'no-cache' },
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
+
+      if (!metadataResponse.ok) {
+        lastFailure = `metadata ${describeResponse(metadataResponse)}`;
+      } else {
+        const metadata = await metadataResponse.json();
+        if (metadata.version !== version) {
+          lastFailure = `metadata returned version ${metadata.version ?? '<missing>'}`;
+        } else if (!metadata.dist?.tarball) {
+          lastFailure = 'metadata did not include dist.tarball';
+        } else {
+          const tarballUrl = new URL(metadata.dist.tarball);
+          tarballUrl.searchParams.set('_relay_ready', cacheBuster);
+          const tarballResponse = await fetchImpl(tarballUrl, {
+            method: 'HEAD',
+            headers: { 'cache-control': 'no-cache' },
+            redirect: 'follow',
+            signal: AbortSignal.timeout(requestTimeoutMs),
+          });
+
+          if (tarballResponse.ok) {
+            const elapsedSeconds = Math.ceil((now() - startedAt) / 1000);
+            log(`npm package ready: ${spec} (attempt ${attempt}, ${elapsedSeconds}s)`);
+            return metadata;
+          }
+          lastFailure = `tarball ${describeResponse(tarballResponse)}`;
+        }
+      }
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+
+    const elapsedMs = now() - startedAt;
+    if (elapsedMs >= timeoutMs) {
+      throw new Error(`Timed out after ${Math.ceil(elapsedMs / 1000)}s waiting for ${spec}: ${lastFailure}`);
+    }
+
+    const delayMs = Math.min(intervalMs, timeoutMs - elapsedMs);
+    log(
+      `npm package not ready: ${spec} (attempt ${attempt}: ${lastFailure}); retrying in ${Math.ceil(delayMs / 1000)}s`
+    );
+    await sleep(delayMs);
+  }
+}
+
+function parseCliArgs(argv) {
+  const [spec, ...args] = argv;
+  if (!spec) {
+    throw new Error(
+      'Usage: node scripts/wait-for-npm-package.mjs <package@version> [--timeout-seconds N] [--interval-seconds N] [--registry URL]'
+    );
+  }
+
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!value) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+
+    switch (flag) {
+      case '--timeout-seconds':
+        options.timeoutMs = positiveNumber(value, flag) * 1000;
+        break;
+      case '--interval-seconds':
+        options.intervalMs = positiveNumber(value, flag) * 1000;
+        break;
+      case '--registry':
+        options.registryUrl = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+
+  return { spec, options };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const { spec, options } = parseCliArgs(process.argv.slice(2));
+    await waitForNpmPackage(spec, options);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/fixtures/npm-package-readiness.test.ts
+++ b/tests/fixtures/npm-package-readiness.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { parseExactPackageSpec, waitForNpmPackage } from '../../scripts/wait-for-npm-package.mjs';
+
+function response(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Not Found',
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('npm package readiness gate', () => {
+  it('parses scoped exact-version package specs', () => {
+    expect(parseExactPackageSpec('@agent-relay/sdk@11.8.4')).toEqual({
+      name: '@agent-relay/sdk',
+      version: '11.8.4',
+    });
+  });
+
+  it('waits until both version metadata and the tarball are available', async () => {
+    let currentTime = 0;
+    const sleep = vi.fn(async (delayMs: number) => {
+      currentTime += delayMs;
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response(404))
+      .mockResolvedValueOnce(
+        response(200, {
+          version: '11.8.4',
+          dist: { tarball: 'https://registry.npmjs.org/@agent-relay/sdk/-/sdk-11.8.4.tgz' },
+        })
+      )
+      .mockResolvedValueOnce(response(200));
+
+    await waitForNpmPackage('@agent-relay/sdk@11.8.4', {
+      fetchImpl,
+      sleep,
+      now: () => currentTime,
+      intervalMs: 1_000,
+      timeoutMs: 5_000,
+      log: vi.fn(),
+    });
+
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls[2]?.[1]).toMatchObject({ method: 'HEAD' });
+  });
+
+  it('fails with the last registry error after the bounded timeout', async () => {
+    let currentTime = 0;
+
+    await expect(
+      waitForNpmPackage('@agent-relay/sdk@11.8.4', {
+        fetchImpl: vi.fn().mockResolvedValue(response(404)),
+        sleep: async (delayMs: number) => {
+          currentTime += delayMs;
+        },
+        now: () => currentTime,
+        intervalMs: 1_000,
+        timeoutMs: 2_000,
+        log: vi.fn(),
+      })
+    ).rejects.toThrow('Timed out after 2s waiting for @agent-relay/sdk@11.8.4: metadata HTTP 404');
+  });
+
+  it('blocks the package publish matrix on registry readiness', () => {
+    const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
+    const publishMatrix = workflow.match(
+      /  publish-packages:\n[\s\S]*?\n  # Publish @agent-relay\/harnesses/
+    )?.[0];
+
+    expect(publishMatrix).toBeDefined();
+    expect(publishMatrix).toContain('npm publish --access public --provenance');
+    expect(publishMatrix).toContain('Wait for published package readiness');
+    expect(publishMatrix).toContain('node ../../scripts/wait-for-npm-package.mjs "$PKG_SPEC"');
+    expect(publishMatrix!.indexOf('Wait for published package readiness')).toBeGreaterThan(
+      publishMatrix!.indexOf('npm publish --access public --provenance')
+    );
+  });
+});

--- a/tests/relayflows/cases/publish-npm-readiness/case.json
+++ b/tests/relayflows/cases/publish-npm-readiness/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "publish-npm-readiness",
+  "kind": "bugfix",
+  "title": "Wait for npm package metadata and tarball readiness before dependent publishes",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/publish-npm-readiness/run.mjs"]
+  },
+  "timeoutSeconds": 120,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "npm_publish_readiness_gate_missing"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "npm_publish_waits_for_registry_tarball"
+    }
+  }
+}

--- a/tests/relayflows/cases/publish-npm-readiness/run.mjs
+++ b/tests/relayflows/cases/publish-npm-readiness/run.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const CASE_ID = 'publish-npm-readiness';
+const READY_SPEC = '@agent-relay/sdk@11.8.4';
+
+function requiredEnvironment(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function publishMatrixBlock(workflow) {
+  const startMarker = '\n  publish-packages:\n';
+  const endMarker = '\n  publish-harnesses:\n';
+  const start = workflow.indexOf(startMarker);
+  const end = workflow.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < 0) {
+    throw new Error('Could not isolate publish-packages in publish.yml');
+  }
+  return workflow.slice(start, end);
+}
+
+async function helperCanReadPublishedTarball(targetDir) {
+  const helper = path.join(targetDir, 'scripts', 'wait-for-npm-package.mjs');
+  try {
+    await execFileAsync(
+      process.execPath,
+      [helper, READY_SPEC, '--timeout-seconds', '30', '--interval-seconds', '1'],
+      {
+        cwd: targetDir,
+        timeout: 45_000,
+      }
+    );
+    return true;
+  } catch (error) {
+    const stderr = error && typeof error === 'object' && 'stderr' in error ? error.stderr : '';
+    console.error(`Readiness helper failed: ${stderr || error}`);
+    return false;
+  }
+}
+
+const arm = requiredEnvironment('RELAY_PR_PROOF_ARM');
+const targetDir = requiredEnvironment('RELAY_PR_PROOF_TARGET_DIR');
+const resultPath = requiredEnvironment('RELAY_PR_PROOF_RESULT_PATH');
+if (arm !== 'base' && arm !== 'head') throw new Error(`Unexpected proof arm: ${arm}`);
+
+const workflow = await readFile(path.join(targetDir, '.github', 'workflows', 'publish.yml'), 'utf8');
+const publishMatrix = publishMatrixBlock(workflow);
+const publishIndex = publishMatrix.indexOf('npm publish --access public --provenance');
+const gateIndex = publishMatrix.indexOf('scripts/wait-for-npm-package.mjs');
+const gateFollowsPublish = publishIndex >= 0 && gateIndex > publishIndex;
+
+let outcome;
+let signature;
+let details;
+
+if (!gateFollowsPublish) {
+  outcome = 'bug';
+  signature = 'npm_publish_readiness_gate_missing';
+  details =
+    'The package publish matrix can finish immediately after npm accepts a package for asynchronous processing; no exact-version metadata and tarball readiness gate follows npm publish.';
+} else if (await helperCanReadPublishedTarball(targetDir)) {
+  outcome = 'fixed';
+  signature = 'npm_publish_waits_for_registry_tarball';
+  details =
+    'The package publish matrix invokes the target checkout readiness helper after npm publish, and that helper confirmed exact-version metadata plus the public SDK tarball.';
+} else {
+  outcome = 'bug';
+  signature = 'npm_publish_readiness_helper_failed';
+  details =
+    'The workflow references a readiness helper, but the target helper could not confirm exact-version metadata and tarball availability.';
+}
+
+await writeFile(
+  resultPath,
+  `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details }, null, 2)}\n`
+);
+console.log(`Observed ${outcome}: ${signature}`);


### PR DESCRIPTION
## Summary

- block each npm publisher until exact-version metadata and its tarball are readable
- use a bounded 30-minute readiness window so npm asynchronous processing cannot race dependent package jobs
- add focused unit coverage plus one isolated Cloud red/green RelayFlow case

## Root cause

In [publish run 32884395089](https://github.com/AgentWorkforce/relay/actions/runs/32884395089), npm accepted `@agent-relay/sdk@11.8.4` at 18:45:52 but did not expose it in registry metadata until 19:01:05. Downstream jobs started on publish-command success and exhausted their 2-4 minute waits before the 15-minute processing delay ended.

## Test Plan

- [x] `npm exec -- vitest run tests/fixtures/npm-package-readiness.test.ts tests/fixtures/pr-proof-contract.test.ts` (49 tests)
- [x] `actionlint -shellcheck "" .github/workflows/publish.yml`
- [x] `prettier --check` on changed workflow, script, tests, and case files
- [x] local RelayFlow observation: base=`bug/npm_publish_readiness_gate_missing`, head=`fixed/npm_publish_waits_for_registry_tarball`
- [x] live helper probe against `@agent-relay/sdk@11.8.4` metadata and tarball

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `publish-npm-readiness` <!-- relay-pr-proof:case -->

## Screenshots

Not applicable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

