### PR TITLE
chore(ci): preserve RelayFlow proof timeout evidence

### DIFF
--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -718,6 +718,8 @@ describe('trusted dispatcher source contract', () => {
     expect(source).toContain('PR_PROOF_ARM_COMPLETE arm=head');
     expect(source).toContain('--source cloud');
     expect(source).toContain("result.status !== 'completed'");
+    expect(source).toContain('.timeout(2_700_000)');
+    expect(source).not.toContain('.timeout(3_600_000)');
   });
 
   it('records the per-step Cloud sandbox id instead of the orchestrator id', async () => {

--- a/workflows/pr-proof.ts
+++ b/workflows/pr-proof.ts
@@ -27,7 +27,10 @@ const result = await workflow('relay-pr-proof')
   // of RelayFlow's default repair-agent retries so no agent can edit the
   // harness or artifacts after a gate rejects them.
   .onError('fail-fast')
-  .timeout(3_600_000)
+  // Finish inside the dispatcher's 60-minute polling deadline so Cloud can
+  // persist terminal step state and retain its sandbox for diagnostics before
+  // the GitHub runner issues an external cancellation.
+  .timeout(2_700_000)
   .agent('base-prover', {
     cli: 'codex',
     preset: 'worker',


### PR DESCRIPTION
## Summary

- reduce the trusted PR proof workflow timeout from 60 minutes to 45 minutes
- leave the GitHub dispatcher deadline at 60 minutes, creating 15 minutes of teardown/reporting headroom
- pin the timeout separation in the trusted-dispatcher contract test

This changes the proof harness, not Relay runtime behavior. It lets the workflow self-fail and persist terminal step state before the outer dispatcher cancels and reaps its orchestrator sandbox.

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

## Validation

- `git diff --check` passed
- dependency-backed test execution could not run locally because the shared checkout volume is at ENOSPC; CI is the validation authority

No production deploy and no merge performed.