### PR TITLE
fix(sdk): fail closed on unavailable placement nodes

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Fix PR #1619 accepted placement logging exception
+
+> **Status:** ✅ Completed
+> **Task:** relay#1619
+> **Confidence:** 99%
+> **Started:** August 26, 2026 at 08:10 PM
+> **Completed:** August 26, 2026 at 08:12 PM
+
+---
+
+## Summary
+
+Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28 and SDK typecheck.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Isolate placementLog at accepted-placement roster refresh
+- **Chose:** Isolate placementLog at accepted-placement roster refresh
+- **Reasoning:** commands.invoke has already committed the remote spawn; observability exceptions must not convert success into a retryable rejection. Regression ablation failed 1/28 specifically with observability sink down; restored source passed 28/28.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Isolate placementLog at accepted-placement roster refresh: Isolate placementLog at accepted-placement roster refresh

--- a/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/summary.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28 and SDK typecheck.
+Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28. The SDK-only CI command `npm run -w @agent-relay/sdk check` (`tsc -p tsconfig.json --noEmit`) passed; this does not claim the broader root typecheck, SDK build, or `test:types` scopes.
 
 **Approach:** Standard approach
 

--- a/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/trajectory.json
@@ -42,7 +42,7 @@
     }
   ],
   "retrospective": {
-    "summary": "Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28 and SDK typecheck.",
+    "summary": "Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28. The SDK-only CI command npm run -w @agent-relay/sdk check (tsc -p tsconfig.json --noEmit) passed; this does not claim the broader root typecheck, SDK build, or test:types scopes.",
     "approach": "Standard approach",
     "confidence": 0.99
   },

--- a/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_amvcfpsxslch/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_amvcfpsxslch",
+  "version": 1,
+  "task": {
+    "title": "Fix PR #1619 accepted placement logging exception",
+    "source": {
+      "system": "plain",
+      "id": "relay#1619"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-26T20:10:39.773Z",
+  "completedAt": "2026-08-26T20:12:27.497Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-26T20:12:12.424Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cubki8sa0bgb",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-26T20:12:12.424Z",
+      "endedAt": "2026-08-26T20:12:27.497Z",
+      "events": [
+        {
+          "ts": 1787775132425,
+          "type": "decision",
+          "content": "Isolate placementLog at accepted-placement roster refresh: Isolate placementLog at accepted-placement roster refresh",
+          "raw": {
+            "question": "Isolate placementLog at accepted-placement roster refresh",
+            "chosen": "Isolate placementLog at accepted-placement roster refresh",
+            "alternatives": [],
+            "reasoning": "commands.invoke has already committed the remote spawn; observability exceptions must not convert success into a retryable rejection. Regression ablation failed 1/28 specifically with observability sink down; restored source passed 28/28."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Isolated placementLog failures after an accepted automatic dispatch and added a regression proving roster-refresh plus logger failures cannot reject committed work. Source-revert ablation failed 1/28 for the expected observability exception; restored source passed 28/28 and SDK typecheck.",
+    "approach": "Standard approach",
+    "confidence": 0.99
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "b86e33e23ac3c3d80c7bda7a49b4fb47c6515da5",
+    "endRef": "b86e33e23ac3c3d80c7bda7a49b4fb47c6515da5"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_xcxivcsfpz0a/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_xcxivcsfpz0a/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Fix placement node liveness and sandbox-only policy
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** August 26, 2026 at 09:11 PM
+> **Completed:** August 26, 2026 at 09:22 PM
+
+---
+
+## Summary
+
+Hardened SDK placement with strict online/live/handler readiness, atomic automatic dispatch, named fail-fast errors, configurable Cloud JIT sandbox-only eligibility, documentation, focused regression tests, and independent ablation proofs.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility
+- **Chose:** Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility
+- **Reasoning:** SDK preselection currently retargets automatic requests and creates a liveness TOCTOU; cloud explicitly defines roster tags as stable provenance while names are disposable
+
+### Defaulted sandbox-only placement to false and fail-fast placement to true
+- **Chose:** Defaulted sandbox-only placement to false and fail-fast placement to true
+- **Reasoning:** Sandbox provenance is workload policy and generic Relay clients must retain local-node eligibility unless configured; fail-fast removes the production five-minute silent wait while preserving queueing as an explicit bounded opt-in.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility: Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility
+- Defaulted sandbox-only placement to false and fail-fast placement to true: Defaulted sandbox-only placement to false and fail-fast placement to true
+- Diagnosis showed the SDK already checked the derived live bit, but trusted it without status/handler readiness and converted automatic placement into a targeted TOCTOU request. Strict roster readiness, atomic unconstrained dispatch, explicit sandbox policy, and fail-fast defaults now have independent ablation coverage.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_xcxivcsfpz0a/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_xcxivcsfpz0a/trajectory.json
@@ -1,0 +1,88 @@
+{
+  "id": "traj_xcxivcsfpz0a",
+  "version": 1,
+  "task": {
+    "title": "Fix placement node liveness and sandbox-only policy"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-26T19:11:19.799Z",
+  "completedAt": "2026-08-26T19:22:45.372Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-26T19:11:20.665Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_jea2cb61wfqz",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-26T19:11:20.665Z",
+      "endedAt": "2026-08-26T19:22:45.372Z",
+      "events": [
+        {
+          "ts": 1787771480737,
+          "type": "decision",
+          "content": "Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility: Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility",
+          "raw": {
+            "question": "Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility",
+            "chosen": "Preserve Relaycast atomic automatic placement for unrestricted requests; use the established cloud node-type tag family for sandbox-only eligibility",
+            "alternatives": [],
+            "reasoning": "SDK preselection currently retargets automatic requests and creates a liveness TOCTOU; cloud explicitly defines roster tags as stable provenance while names are disposable"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787772158093,
+          "type": "decision",
+          "content": "Defaulted sandbox-only placement to false and fail-fast placement to true: Defaulted sandbox-only placement to false and fail-fast placement to true",
+          "raw": {
+            "question": "Defaulted sandbox-only placement to false and fail-fast placement to true",
+            "chosen": "Defaulted sandbox-only placement to false and fail-fast placement to true",
+            "alternatives": [],
+            "reasoning": "Sandbox provenance is workload policy and generic Relay clients must retain local-node eligibility unless configured; fail-fast removes the production five-minute silent wait while preserving queueing as an explicit bounded opt-in."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787772158783,
+          "type": "reflection",
+          "content": "Diagnosis showed the SDK already checked the derived live bit, but trusted it without status/handler readiness and converted automatic placement into a targeted TOCTOU request. Strict roster readiness, atomic unconstrained dispatch, explicit sandbox policy, and fail-fast defaults now have independent ablation coverage.",
+          "raw": {
+            "focalPoints": [
+              "liveness",
+              "placement-atomicity",
+              "sandbox-policy",
+              "failure-latency"
+            ],
+            "adjustments": "Kept client targeting only for repo, explicit-node, or sandbox constraints; added named failures before action invocation.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:liveness",
+            "focal:placement-atomicity",
+            "focal:sandbox-policy",
+            "focal:failure-latency",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Hardened SDK placement with strict online/live/handler readiness, atomic automatic dispatch, named fail-fast errors, configurable Cloud JIT sandbox-only eligibility, documentation, focused regression tests, and independent ablation proofs.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "10fc5ce1c4b6f0ac557b8cc0a2d3febc1cc6b2e6",
+    "endRef": "10fc5ce1c4b6f0ac557b8cc0a2d3febc1cc6b2e6"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- Placement queueing is no longer implicit. A request without an eligible live node rejects with `no_eligible_node`, `node_unavailable`, or `sandbox_policy_mismatch` instead of waiting for the placement TTL.
+- Placement queueing is no longer implicit. A request without an eligible live node rejects with `no_eligible_node`, `node_unavailable`, `sandbox_policy_mismatch`, or `unmapped_repo` instead of waiting for the placement TTL.
 
 ### Migration Guidance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - Placement queueing is no longer implicit. A request without an eligible live node rejects with `no_eligible_node`, `node_unavailable`, `sandbox_policy_mismatch`, or `unmapped_repo` instead of waiting for the placement TTL.
+- `RelaySpawnPlacementAck.node` and `placement.node` are now optional for engine-selected dispatches whose successful acknowledgment cannot yet be matched to roster metadata; use `dispatchedNodeId` or `handlerNodeId` when an identifier is required.
 
 ### Migration Guidance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Major]
+
+### Added
+
+- `@agent-relay/sdk` placement accepts `placementSandboxOnly` as a client default and `sandboxOnly` per request to restrict eligible nodes to Cloud-provisioned JIT sandboxes; both default to `false`.
+
+### Changed
+
+- `placement.spawn` now fails fast by default when no placement-ready node exists; callers must pass `failFast: false` to opt into bounded queueing.
+
+### Fixed
+
+- `placement.spawn` excludes offline nodes and nodes without live handlers, preserves Relaycast's atomic automatic selection when no client-only constraints apply, and returns named failures without invoking or persisting a hostless placement.
+
+### Breaking Changes
+
+- Placement queueing is no longer implicit. A request without an eligible live node rejects with `no_eligible_node`, `node_unavailable`, or `sandbox_policy_mismatch` instead of waiting for the placement TTL.
+
+### Migration Guidance
+
+- Pass `failFast: false` on placement requests that intentionally wait for nodes to join, and set a bounded `ttlMs`; set `placementSandboxOnly: true` for clients whose workloads must never run on brokers or developer machines.
 
 ## [11.8.4] - 2026-08-25
 

--- a/packages/cli/src/cli/lib/fleet-spawn-confirmation.test.ts
+++ b/packages/cli/src/cli/lib/fleet-spawn-confirmation.test.ts
@@ -22,6 +22,7 @@ const LIVE_NODE = {
   name: 'node-a',
   status: 'online',
   live: true,
+  handlers_live: true,
   capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
   repo_keys: ['relay'],
 };

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -145,6 +145,11 @@ JIT sandbox provenance a client-wide eligibility requirement, or pass
 default to `false`, so existing local and durable fleet nodes remain eligible
 unless the caller opts in.
 
+For unconstrained automatic placement, resolved `node` metadata is present on
+the result when the engine acknowledgment can be matched to the current
+roster. A successful dispatch remains successful if that optional metadata is
+missing or the roster read lags; the raw acknowledgment IDs remain available.
+
 ## Events
 
 `relay.addListener(selector, handler)` accepts a dotted event name, a `*`/prefix wildcard, or a fluent predicate, and always hands the handler one discriminated event object. It returns an unsubscribe function.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -133,6 +133,18 @@ relay.addListener(relay.action('github.open_pr').completed(), (event) => {
 handle.unregister();
 ```
 
+## Placement
+
+`placement.spawn` requires a live, online node with live action handlers and
+fails fast by default. Queueing is explicit: pass `failFast: false` together
+with a bounded `ttlMs` when waiting for a node to join is intentional.
+
+Set `placementSandboxOnly: true` on `RelaycastMessagingClient` to make Cloud
+JIT sandbox provenance a client-wide eligibility requirement, or pass
+`sandboxOnly: true` on one placement request. Both sandbox-policy switches
+default to `false`, so existing local and durable fleet nodes remain eligible
+unless the caller opts in.
+
 ## Events
 
 `relay.addListener(selector, handler)` accepts a dotted event name, a `*`/prefix wildcard, or a fluent predicate, and always hands the handler one discriminated event object. It returns an unsubscribe function.

--- a/packages/sdk/src/messaging/placement.test.mts
+++ b/packages/sdk/src/messaging/placement.test.mts
@@ -24,6 +24,7 @@ function createClient(
     maxQueuedPlacements?: number;
     placementSandboxOnly?: boolean;
     getInvocation?: (name: string, invocationId: string) => Promise<unknown>;
+    listNodes?: (query?: { capability?: string; name?: string }) => Promise<RawNode[]>;
   } = {}
 ) {
   const invoke = vi.fn(async (name: string, input?: Record<string, unknown>) => ({
@@ -46,16 +47,17 @@ function createClient(
     channels: { list: vi.fn(async () => []), get: vi.fn() },
     messages: { list: vi.fn(async () => []), get: vi.fn(), thread: vi.fn(), reactions: vi.fn() },
     nodes: {
-      list: vi.fn(async (query?: { capability?: string; name?: string }) =>
-        nodes
+      list: vi.fn(async (query?: { capability?: string; name?: string }) => {
+        if (options.listNodes) return options.listNodes(query);
+        return nodes
           .filter(
             (node) =>
               (!query?.name || node.name === query.name) &&
               (!query?.capability ||
                 node.capabilities.some((capability) => capability.name === query.capability))
           )
-          .map((node) => ({ handlers_live: true, ...node }))
-      ),
+          .map((node) => ({ handlers_live: true, ...node }));
+      }),
       get: vi.fn(async (name: string) => {
         const node = nodes.find((candidate) => candidate.name === name);
         return node ? { handlers_live: true, ...node } : null;
@@ -292,6 +294,28 @@ describe('RelaycastMessagingClient placement', () => {
     expect(ack.invocationId).toBe('inv-without-node');
     expect(ack.node).toBeUndefined();
     expect(ack.placement.node).toBeUndefined();
+  });
+
+  it('preserves an accepted automatic dispatch when roster refresh and placement logging fail', async () => {
+    const placementLog = vi.fn(() => {
+      throw new Error('observability sink down');
+    });
+    let rosterReads = 0;
+    const { client, invoke } = createClient([LIVE_NODE_A], {
+      placementLog,
+      listNodes: async () => {
+        rosterReads += 1;
+        if (rosterReads > 1) throw new Error('roster refresh down');
+        return [{ handlers_live: true, ...LIVE_NODE_A }];
+      },
+    });
+
+    await expect(client.placement.spawn({ capability: 'spawn:claude' })).resolves.toMatchObject({
+      invocationId: 'inv-1',
+      placement: { queued: false, attempts: 1 },
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(placementLog).toHaveBeenCalledWith(expect.stringContaining('roster refresh down'));
   });
 
   it('never selects a roster-offline node even when its live bit is stale', async () => {

--- a/packages/sdk/src/messaging/placement.test.mts
+++ b/packages/sdk/src/messaging/placement.test.mts
@@ -265,7 +265,10 @@ describe('RelaycastMessagingClient placement', () => {
   it('leaves unconstrained automatic placement atomic in the engine', async () => {
     const { client, invoke } = createClient([LIVE_NODE_A]);
 
-    const ack = await client.placement.spawn({ capability: 'spawn:claude' });
+    const ack = await client.placement.spawn({
+      capability: 'spawn:claude',
+      input: { node: 'caller-target', target_node: 'caller-target' },
+    });
 
     expect(ack.placement.node).toBe('node-a');
     expect(invoke).toHaveBeenCalledWith('spawn', {

--- a/packages/sdk/src/messaging/placement.test.mts
+++ b/packages/sdk/src/messaging/placement.test.mts
@@ -7,8 +7,10 @@ type RawNode = {
   name: string;
   status: string;
   live?: boolean;
+  handlers_live?: boolean;
   capabilities: Array<{ name: string; kind?: string }>;
   repo_keys?: string[];
+  tags?: string[];
 };
 
 function createClient(
@@ -20,6 +22,7 @@ function createClient(
     placementLog?: (message: string) => void;
     selfNodeName?: string;
     maxQueuedPlacements?: number;
+    placementSandboxOnly?: boolean;
     getInvocation?: (name: string, invocationId: string) => Promise<unknown>;
   } = {}
 ) {
@@ -44,14 +47,19 @@ function createClient(
     messages: { list: vi.fn(async () => []), get: vi.fn(), thread: vi.fn(), reactions: vi.fn() },
     nodes: {
       list: vi.fn(async (query?: { capability?: string; name?: string }) =>
-        nodes.filter(
-          (node) =>
-            (!query?.name || node.name === query.name) &&
-            (!query?.capability ||
-              node.capabilities.some((capability) => capability.name === query.capability))
-        )
+        nodes
+          .filter(
+            (node) =>
+              (!query?.name || node.name === query.name) &&
+              (!query?.capability ||
+                node.capabilities.some((capability) => capability.name === query.capability))
+          )
+          .map((node) => ({ handlers_live: true, ...node }))
       ),
-      get: vi.fn(async (name: string) => nodes.find((node) => node.name === name) ?? null),
+      get: vi.fn(async (name: string) => {
+        const node = nodes.find((candidate) => candidate.name === name);
+        return node ? { handlers_live: true, ...node } : null;
+      }),
     },
   };
   const getInvocation = vi.fn(getInvocationOverride ?? (async () => undefined));
@@ -254,6 +262,67 @@ describe('RelaycastMessagingClient placement', () => {
     expect(ack.placement).toMatchObject({ queued: false, attempts: 1 });
   });
 
+  it('leaves unconstrained automatic placement atomic in the engine', async () => {
+    const { client, invoke } = createClient([LIVE_NODE_A]);
+
+    const ack = await client.placement.spawn({ capability: 'spawn:claude' });
+
+    expect(ack.placement.node).toBe('node-a');
+    expect(invoke).toHaveBeenCalledWith('spawn', {
+      capability: 'spawn:claude',
+      ttl_override_ms: 60,
+      cli: 'claude',
+    });
+  });
+
+  it('never selects a roster-offline node even when its live bit is stale', async () => {
+    const { client, invoke } = createClient([
+      {
+        id: 'node_a',
+        name: 'stale-node',
+        status: 'offline',
+        live: true,
+        capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+        repo_keys: ['relay'],
+      },
+      {
+        id: 'node_b',
+        name: 'ready-node',
+        status: 'online',
+        live: true,
+        capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+        repo_keys: ['relay'],
+      },
+    ]);
+
+    const ack = await client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' });
+
+    expect(ack.placement.node).toBe('ready-node');
+    expect(invoke).toHaveBeenCalledWith(
+      'spawn',
+      expect.objectContaining({ node: 'ready-node', target_node: 'ready-node' })
+    );
+  });
+
+  it('never selects a node whose action handlers are not live', async () => {
+    const { client, invoke } = createClient([
+      {
+        id: 'node_a',
+        name: 'dead-handlers',
+        status: 'online',
+        live: true,
+        handlers_live: false,
+        capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+        repo_keys: ['relay'],
+      },
+    ]);
+
+    await expect(client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' })).rejects.toMatchObject(
+      { name: 'RelayPlacementError', code: 'no_eligible_node', attempts: 1 }
+    );
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
   it('rejects with placement_queue_full and reconciles a failed event when the queue is full', async () => {
     const reconciled: unknown[] = [];
     const logs: string[] = [];
@@ -266,6 +335,7 @@ describe('RelaycastMessagingClient placement', () => {
       client.placement.spawn({
         capability: 'spawn:claude',
         repo: 'relay',
+        failFast: false,
         input: { name: 'worker-overflow' },
         ttlMs: 1_000,
         pollIntervalMs: 25,
@@ -293,19 +363,64 @@ describe('RelaycastMessagingClient placement', () => {
     await expect(
       client.placement.spawn({
         capability: 'workflow:run',
-        failFast: true,
         onReconcile: (event) => {
           reconciled.push(event);
         },
       })
     ).rejects.toMatchObject({
       name: 'RelayPlacementError',
-      code: 'placement_ttl_expired',
+      code: 'no_eligible_node',
       attempts: 1,
     });
 
     expect(invoke).not.toHaveBeenCalled();
     expect(reconciled).toEqual([expect.objectContaining({ action: 'failed', reason: 'no_eligible_node' })]);
+  });
+
+  it('defaults sandbox policy off so ordinary live nodes remain eligible', async () => {
+    const { client, invoke } = createClient([LIVE_NODE_A]);
+
+    await expect(client.placement.spawn({ capability: 'spawn:claude' })).resolves.toMatchObject({
+      placement: { node: 'node-a' },
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('sandbox-only placement excludes non-sandbox nodes and selects Cloud JIT nodes', async () => {
+    const { client, invoke } = createClient(
+      [
+        LIVE_NODE_A,
+        {
+          id: 'node_b',
+          name: 'daytona-jit',
+          status: 'online',
+          live: true,
+          capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+          repo_keys: ['relay'],
+          tags: ['cloud:node-type:daytona-jit'],
+        },
+      ],
+      { placementSandboxOnly: true }
+    );
+
+    const ack = await client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' });
+
+    expect(ack.placement.node).toBe('daytona-jit');
+    expect(invoke).toHaveBeenCalledWith(
+      'spawn',
+      expect.objectContaining({ node: 'daytona-jit', target_node: 'daytona-jit' })
+    );
+  });
+
+  it('sandbox-only placement fails closed when no live Cloud sandbox is eligible', async () => {
+    const { client, invoke } = createClient([LIVE_NODE_A], { placementSandboxOnly: true });
+
+    await expect(client.placement.spawn({ capability: 'spawn:claude' })).rejects.toMatchObject({
+      name: 'RelayPlacementError',
+      code: 'sandbox_policy_mismatch',
+      attempts: 1,
+    });
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it('fails fast with code unmapped_repo when a live capable node never maps the repo', async () => {
@@ -361,6 +476,7 @@ describe('RelaycastMessagingClient placement', () => {
       repo: 'relay',
       input: { name: 'worker-throwing-hook' },
       pollIntervalMs: 25,
+      failFast: false,
       onReconcile: () => {
         throw new Error('observability sink down');
       },
@@ -392,6 +508,7 @@ describe('RelaycastMessagingClient placement', () => {
       repo: 'relay',
       input: { name: 'worker-offline' },
       pollIntervalMs: 25,
+      failFast: false,
       onReconcile: (event) => {
         reconciled.push(event);
       },
@@ -431,6 +548,7 @@ describe('RelaycastMessagingClient placement', () => {
       repo: 'relay',
       input: { name: 'worker-targeted-unmapped' },
       pollIntervalMs: 25,
+      failFast: false,
       onReconcile: (event) => {
         reconciled.push(event);
       },
@@ -470,6 +588,7 @@ describe('RelaycastMessagingClient placement', () => {
       repo: 'relay',
       input: { name: 'worker-2' },
       pollIntervalMs: 25,
+      failFast: false,
       onReconcile: (event) => {
         reconciled.push(event);
       },
@@ -514,6 +633,7 @@ describe('RelaycastMessagingClient placement', () => {
       repo: 'relay',
       input: { name: 'worker-3' },
       pollIntervalMs: 25,
+      failFast: false,
     });
     await new Promise((resolve) => setTimeout(resolve, 35));
     nodes[0] = { ...nodes[0], status: 'online', live: true };
@@ -528,7 +648,12 @@ describe('RelaycastMessagingClient placement', () => {
     const { client, invoke } = createClient([], { placementLog: (line) => logs.push(line) });
 
     await expect(
-      client.placement.spawn({ capability: 'workflow:run', ttlMs: 30, pollIntervalMs: 25 })
+      client.placement.spawn({
+        capability: 'workflow:run',
+        ttlMs: 30,
+        pollIntervalMs: 25,
+        failFast: false,
+      })
     ).rejects.toBeInstanceOf(RelayPlacementError);
 
     expect(invoke).not.toHaveBeenCalled();

--- a/packages/sdk/src/messaging/placement.test.mts
+++ b/packages/sdk/src/messaging/placement.test.mts
@@ -278,6 +278,22 @@ describe('RelaycastMessagingClient placement', () => {
     });
   });
 
+  it('preserves a successful automatic dispatch when ack node metadata is unavailable', async () => {
+    const { client, invoke } = createClient([LIVE_NODE_A]);
+    invoke.mockResolvedValueOnce({
+      invocation_id: 'inv-without-node',
+      action_name: 'spawn',
+      status: 'invoked',
+    });
+
+    const ack = await client.placement.spawn({ capability: 'spawn:claude' });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(ack.invocationId).toBe('inv-without-node');
+    expect(ack.node).toBeUndefined();
+    expect(ack.placement.node).toBeUndefined();
+  });
+
   it('never selects a roster-offline node even when its live bit is stale', async () => {
     const { client, invoke } = createClient([
       {

--- a/packages/sdk/src/messaging/relaycast-client.ts
+++ b/packages/sdk/src/messaging/relaycast-client.ts
@@ -220,6 +220,11 @@ export interface RelaycastMessagingOptions extends RelaycastTelemetryOptions {
   selfNodeName?: string;
   /** Default bounded placement queue TTL. RFC placeholder default is one hour. */
   placementTtlMs?: number;
+  /**
+   * Restrict automatic and targeted placement to Cloud-provisioned sandbox
+   * nodes. Defaults to `false`; sandboxed workloads must opt in explicitly.
+   */
+  placementSandboxOnly?: boolean;
   /** Max in-process placement requests allowed to wait for an eligible node. */
   maxQueuedPlacements?: number;
   /** Receives placement queue/reject/fail log lines. */

--- a/packages/sdk/src/messaging/relaycast-placement.ts
+++ b/packages/sdk/src/messaging/relaycast-placement.ts
@@ -7,7 +7,11 @@
  */
 import type { RelayNode } from './types.js';
 
-export type PlacementReconcileReason = 'no_eligible_node' | 'target_offline' | 'unmapped_repo';
+export type PlacementReconcileReason =
+  | 'no_eligible_node'
+  | 'target_offline'
+  | 'unmapped_repo'
+  | 'sandbox_policy_mismatch';
 
 export type PlacementSelection =
   | { node: RelayNode; message?: never; hardFail?: never; reason?: never; reconcileReason?: never }
@@ -16,7 +20,7 @@ export type PlacementSelection =
       node?: never;
       message: string;
       hardFail: true;
-      reason: 'capability_mismatch';
+      reason: 'capability_mismatch' | 'sandbox_policy_mismatch';
       reconcileReason: PlacementReconcileReason;
     }
   | {
@@ -33,6 +37,9 @@ export class RelayPlacementError extends Error {
     | 'capability_mismatch'
     | 'placement_queue_full'
     | 'placement_ttl_expired'
+    | 'no_eligible_node'
+    | 'node_unavailable'
+    | 'sandbox_policy_mismatch'
     | 'unmapped_repo'
     /** The node ran the action and reported a failure. */
     | 'spawn_failed'
@@ -75,12 +82,14 @@ export function placementActionName(capability: string): string {
 
 export function placementActionInput(
   input: Record<string, unknown> | undefined,
-  placement: { capability: string; node: string; repo?: string; ttlMs: number }
+  placement: { capability: string; node?: string; repo?: string; ttlMs: number }
 ): Record<string, unknown> {
   const payload = { ...(input ?? {}) };
   payload.capability = placement.capability;
-  payload.node = placement.node;
-  payload.target_node = placement.node;
+  if (placement.node) {
+    payload.node = placement.node;
+    payload.target_node = placement.node;
+  }
   if (placement.repo) payload.repo = placement.repo;
   if (placement.ttlMs > 0) {
     payload.ttl_override_ms = placement.ttlMs;

--- a/packages/sdk/src/messaging/relaycast-placement.ts
+++ b/packages/sdk/src/messaging/relaycast-placement.ts
@@ -89,6 +89,11 @@ export function placementActionInput(
   if (placement.node) {
     payload.node = placement.node;
     payload.target_node = placement.node;
+  } else {
+    // Automatic placement belongs to the engine. Do not let untrusted action
+    // input silently convert it back into a targeted request.
+    delete payload.node;
+    delete payload.target_node;
   }
   if (placement.repo) payload.repo = placement.repo;
   if (placement.ttlMs > 0) {

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -188,6 +188,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
   private readonly agentClient?: RelaycastAgentLike;
   private readonly selfNodeName?: string;
   private readonly placementTtlMs: number;
+  private readonly placementSandboxOnly: boolean;
   private readonly maxQueuedPlacements: number;
   private readonly placementLog?: (message: string) => void;
   private readonly sessionRef?: string;
@@ -205,6 +206,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
       (options.agentToken ? this.relaycast.as?.(options.agentToken, options.agentClientOptions) : undefined);
     this.selfNodeName = options.selfNodeName;
     this.placementTtlMs = options.placementTtlMs ?? 60 * 60 * 1000;
+    this.placementSandboxOnly = options.placementSandboxOnly ?? false;
     this.maxQueuedPlacements = options.maxQueuedPlacements ?? 100;
     this.placementLog = options.placementLog;
     this.sessionRef =
@@ -702,6 +704,8 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
       const capability = nonEmptyPlacement(input.capability, 'placement capability');
       const repo = input.repo?.trim() || undefined;
       const targetNode = this.resolvePlacementNode(input.node, input.selfNodeName);
+      const sandboxOnly = input.sandboxOnly ?? this.placementSandboxOnly;
+      const failFast = input.failFast ?? true;
       const ttlMs = Math.max(0, input.ttlMs ?? input.ttlOverrideMs ?? this.placementTtlMs);
       const pollIntervalMs = Math.max(25, input.pollIntervalMs ?? 1_000);
       const startedAt = Date.now();
@@ -711,16 +715,25 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
       try {
         while (true) {
           attempts += 1;
-          const decision = await this.selectPlacementNode({ capability, repo, targetNode });
+          const decision = await this.selectPlacementNode({ capability, repo, targetNode, sandboxOnly });
           if (decision.node) {
             const actionName = input.actionName ?? placementActionName(capability);
+            // Preserve the engine's atomic, least-loaded placement when there
+            // are no client-side repo or sandbox constraints. Retargeting every
+            // automatic request to the SDK's roster snapshot creates a TOCTOU:
+            // a node can die between this read and action invocation, after
+            // which the engine treats it as a targeted queued placement.
+            const clientMustTarget = Boolean(targetNode || repo || sandboxOnly);
             const actionInput = placementActionInput(input.input, {
               capability,
-              node: decision.node.name,
+              ...(clientMustTarget ? { node: decision.node.name } : {}),
               repo,
               ttlMs,
             });
             const ack = await this.commands.invoke(actionName, actionInput);
+            const placedNode = clientMustTarget
+              ? decision.node
+              : await this.resolvePlacementAckNode(ack, capability, attempts);
             // The ack proves only that the engine accepted the dispatch. Unless
             // the caller asks for confirmation, a node that accepted the
             // invocation and launched nothing resolves identically to a real
@@ -728,7 +741,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
             const confirmation = input.confirm
               ? await this.confirmPlacementInvocation(actionName, ack, {
                   capability,
-                  node: decision.node.name,
+                  node: placedNode.name,
                   repo,
                   attempts,
                   // Defaults and validation live in confirmPlacementInvocation
@@ -739,10 +752,10 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
               : undefined;
             return {
               ...ack,
-              node: decision.node,
+              node: placedNode,
               placement: {
                 capability,
-                node: decision.node.name,
+                node: placedNode.name,
                 ...(repo ? { repo } : {}),
                 attempts,
                 queued,
@@ -762,15 +775,26 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
             });
           }
 
-          if (input.failFast || Date.now() - startedAt >= ttlMs) {
+          if (failFast || Date.now() - startedAt >= ttlMs) {
             // A repo that no live, capable node maps will never drain by waiting,
             // so report it as `unmapped_repo` rather than a generic TTL expiry.
-            const code: RelayPlacementError['code'] =
-              decision.reconcileReason === 'unmapped_repo' ? 'unmapped_repo' : 'placement_ttl_expired';
+            const code: RelayPlacementError['code'] = failFast
+              ? decision.reconcileReason === 'unmapped_repo'
+                ? 'unmapped_repo'
+                : decision.reconcileReason === 'target_offline'
+                  ? 'node_unavailable'
+                  : decision.reconcileReason === 'sandbox_policy_mismatch'
+                    ? 'sandbox_policy_mismatch'
+                    : 'no_eligible_node'
+              : decision.reconcileReason === 'unmapped_repo'
+                ? 'unmapped_repo'
+                : 'placement_ttl_expired';
             const message =
               code === 'unmapped_repo'
                 ? `${decision.message}; no node maps the requested repo`
-                : `${decision.message}; placement TTL expired`;
+                : failFast
+                  ? `${decision.message}; placement failed fast`
+                  : `${decision.message}; placement TTL expired`;
             await this.reconcilePlacement(input, {
               action: 'failed',
               reason: decision.reconcileReason,
@@ -974,6 +998,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     capability: string;
     repo?: string;
     targetNode?: string;
+    sandboxOnly: boolean;
   }): Promise<PlacementSelection> {
     if (input.targetNode) {
       const node = await this.nodes.get(input.targetNode);
@@ -991,9 +1016,17 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
           reconcileReason: 'no_eligible_node',
         };
       }
-      if (!node.live) {
+      if (input.sandboxOnly && !this.nodeIsCloudSandbox(node)) {
         return {
-          message: `Placement queued: target node "${node.name}" is offline`,
+          message: `Placement rejected: node "${node.name}" is not a Cloud sandbox`,
+          hardFail: true,
+          reason: 'sandbox_policy_mismatch',
+          reconcileReason: 'sandbox_policy_mismatch',
+        };
+      }
+      if (!this.nodeIsPlacementReady(node)) {
+        return {
+          message: `Placement queued: target node "${node.name}" is not placement-ready`,
           reconcileReason: 'target_offline',
         };
       }
@@ -1008,9 +1041,19 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
 
     const nodes = await this.nodes.list({ capability: input.capability });
     const capable = nodes.filter((node) => this.nodeHasCapability(node, input.capability));
-    const live = capable.filter((node) => node.live);
+    const policyEligible = input.sandboxOnly
+      ? capable.filter((node) => this.nodeIsCloudSandbox(node))
+      : capable;
+    const live = policyEligible.filter((node) => this.nodeIsPlacementReady(node));
     const eligible = live.filter((node) => this.nodeMapsRepo(node, input.repo));
     if (eligible[0]) return { node: eligible[0] };
+
+    if (input.sandboxOnly) {
+      return {
+        message: `Placement queued: no placement-ready Cloud sandbox advertises capability "${input.capability}"`,
+        reconcileReason: 'sandbox_policy_mismatch',
+      };
+    }
 
     if (input.repo && live.length > 0) {
       return {
@@ -1026,6 +1069,34 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
 
   private nodeHasCapability(node: RelayNode, capability: string): boolean {
     return node.capabilities.some((item) => item.name === capability);
+  }
+
+  private nodeIsPlacementReady(node: RelayNode): boolean {
+    return node.status === 'online' && node.live === true && node.handlersLive === true;
+  }
+
+  private nodeIsCloudSandbox(node: RelayNode): boolean {
+    return Boolean(
+      node.tags?.some((tag) => /^cloud:node-type:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-jit$/.test(tag))
+    );
+  }
+
+  private async resolvePlacementAckNode(
+    ack: RelayActionInvocationAck,
+    capability: string,
+    attempts: number
+  ): Promise<RelayNode> {
+    const nodeId = ack.dispatchedNodeId ?? ack.handlerNodeId;
+    if (nodeId) {
+      const nodes = await this.nodes.list({ capability });
+      const node = nodes.find((candidate) => candidate.id === nodeId || candidate.nodeId === nodeId);
+      if (node) return node;
+    }
+    throw new RelayPlacementError(
+      'node_unavailable',
+      'Placement failed: the engine did not acknowledge a named dispatch node',
+      { capability, attempts }
+    );
   }
 
   private nodeMapsRepo(node: RelayNode, repo: string | undefined): boolean {

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -733,7 +733,9 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
             const ack = await this.commands.invoke(actionName, actionInput);
             const placedNode = clientMustTarget
               ? decision.node
-              : await this.resolvePlacementAckNode(ack, capability, attempts);
+              : await this.resolvePlacementAckNode(ack, capability);
+            const placedNodeLabel =
+              placedNode?.name ?? ack.dispatchedNodeId ?? ack.handlerNodeId ?? 'engine-selected node';
             // The ack proves only that the engine accepted the dispatch. Unless
             // the caller asks for confirmation, a node that accepted the
             // invocation and launched nothing resolves identically to a real
@@ -741,7 +743,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
             const confirmation = input.confirm
               ? await this.confirmPlacementInvocation(actionName, ack, {
                   capability,
-                  node: placedNode.name,
+                  node: placedNodeLabel,
                   repo,
                   attempts,
                   // Defaults and validation live in confirmPlacementInvocation
@@ -752,10 +754,10 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
               : undefined;
             return {
               ...ack,
-              node: placedNode,
+              ...(placedNode ? { node: placedNode } : {}),
               placement: {
                 capability,
-                node: placedNode.name,
+                ...(placedNode ? { node: placedNode.name } : {}),
                 ...(repo ? { repo } : {}),
                 attempts,
                 queued,
@@ -1085,20 +1087,23 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
 
   private async resolvePlacementAckNode(
     ack: RelayActionInvocationAck,
-    capability: string,
-    attempts: number
-  ): Promise<RelayNode> {
+    capability: string
+  ): Promise<RelayNode | undefined> {
     const nodeId = ack.dispatchedNodeId ?? ack.handlerNodeId;
     if (nodeId) {
-      const nodes = await this.nodes.list({ capability });
-      const node = nodes.find((candidate) => candidate.id === nodeId || candidate.nodeId === nodeId);
-      if (node) return node;
+      try {
+        const nodes = await this.nodes.list({ capability });
+        return nodes.find((candidate) => candidate.id === nodeId || candidate.nodeId === nodeId);
+      } catch (error) {
+        this.placementLog?.(
+          `[placement] dispatch ${ack.invocationId ?? 'unknown'} accepted by ${nodeId}, but roster metadata could not be refreshed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
-    throw new RelayPlacementError(
-      'node_unavailable',
-      'Placement failed: the engine did not acknowledge a named dispatch node',
-      { capability, attempts }
-    );
+    // The action has already been accepted at this point. Missing or lagging
+    // roster metadata must not turn that success into a retryable error that
+    // could duplicate the placement.
+    return undefined;
   }
 
   private nodeMapsRepo(node: RelayNode, repo: string | undefined): boolean {

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -1095,9 +1095,13 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
         const nodes = await this.nodes.list({ capability });
         return nodes.find((candidate) => candidate.id === nodeId || candidate.nodeId === nodeId);
       } catch (error) {
-        this.placementLog?.(
-          `[placement] dispatch ${ack.invocationId ?? 'unknown'} accepted by ${nodeId}, but roster metadata could not be refreshed: ${error instanceof Error ? error.message : String(error)}`
-        );
+        try {
+          this.placementLog?.(
+            `[placement] dispatch ${ack.invocationId ?? 'unknown'} accepted by ${nodeId}, but roster metadata could not be refreshed: ${error instanceof Error ? error.message : String(error)}`
+          );
+        } catch {
+          // Observability must not change the outcome of an accepted placement.
+        }
       }
     }
     // The action has already been accepted at this point. Missing or lagging

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -1071,10 +1071,12 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
     return node.capabilities.some((item) => item.name === capability);
   }
 
+  /** Return true only when the fresh roster reports a usable action handler. */
   private nodeIsPlacementReady(node: RelayNode): boolean {
     return node.status === 'online' && node.live === true && node.handlersLive === true;
   }
 
+  /** Match the stable Cloud JIT provenance tag without relying on disposable node names. */
   private nodeIsCloudSandbox(node: RelayNode): boolean {
     return Boolean(
       node.tags?.some((tag) => /^cloud:node-type:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-jit$/.test(tag))

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -585,9 +585,16 @@ export type RelayPlacementRejectReason =
   | 'capability_mismatch'
   | 'placement_queue_full'
   | 'placement_ttl_expired'
+  | 'no_eligible_node'
+  | 'node_unavailable'
+  | 'sandbox_policy_mismatch'
   | 'unmapped_repo';
 
-export type RelayPlacementReconcileReason = 'no_eligible_node' | 'target_offline' | 'unmapped_repo';
+export type RelayPlacementReconcileReason =
+  | 'no_eligible_node'
+  | 'target_offline'
+  | 'unmapped_repo'
+  | 'sandbox_policy_mismatch';
 
 export interface RelayPlacementReconcileEvent {
   action: 'queued' | 'failed';
@@ -621,8 +628,16 @@ export interface RelaySpawnPlacementInput {
   ttlOverrideMs?: number;
   /** Poll cadence while a placement is queued. */
   pollIntervalMs?: number;
-  /** Fail immediately instead of queueing when no currently eligible node exists. */
+  /**
+   * Fail immediately instead of queueing when no currently eligible node exists.
+   * Defaults to `true`; pass `false` to opt into bounded queue/reconcile behavior.
+   */
   failFast?: boolean;
+  /**
+   * Restrict eligibility to Cloud-provisioned sandbox nodes. Overrides the
+   * client default; the client default is `false`.
+   */
+  sandboxOnly?: boolean;
   /**
    * Wait for the target node's terminal action result before resolving.
    *

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -663,10 +663,12 @@ export interface RelaySpawnPlacementInput {
 }
 
 export interface RelaySpawnPlacementAck extends RelayActionInvocationAck {
-  node: RelayNode;
+  /** Resolved roster node when the dispatch acknowledgment identifies one. */
+  node?: RelayNode;
   placement: {
     capability: string;
-    node: string;
+    /** Resolved roster node name; absent when acknowledgment metadata is missing or not yet visible. */
+    node?: string;
     repo?: string;
     attempts: number;
     queued: boolean;

--- a/tests/relayflows/cases/1619-placement-liveness/case.json
+++ b/tests/relayflows/cases/1619-placement-liveness/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1619-placement-liveness",
+  "kind": "bugfix",
+  "title": "Fail closed when placement nodes are unavailable or policy-ineligible",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1619-placement-liveness/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "placement_accepts_unready_or_policy_ineligible_nodes"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "placement_fails_closed_and_preserves_atomic_selection"
+    }
+  }
+}

--- a/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
+++ b/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
@@ -104,7 +104,10 @@ describe('placement liveness and policy proof', () => {
     );
 
     const automatic = createClient([READY_NODE]);
-    await automatic.client.placement.spawn({ capability: 'spawn:claude' });
+    await automatic.client.placement.spawn({
+      capability: 'spawn:claude',
+      input: { node: 'caller-target', target_node: 'caller-target' },
+    });
     const automaticInput = automatic.invoke.mock.calls[0]?.[1] as Record<string, unknown>;
 
     if (ARM === 'base') {

--- a/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
+++ b/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The runner copies this probe to <target>/.relay-pr-proof before execution.
+import { RelaycastMessagingClient } from '../packages/sdk/src/messaging/index.js';
+
+type RawNode = {
+  id: string;
+  name: string;
+  status: string;
+  live?: boolean;
+  handlers_live?: boolean;
+  capabilities: Array<{ name: string; kind?: string }>;
+  repo_keys?: string[];
+  tags?: string[];
+};
+
+const ARM = process.env.RELAY_PR_PROOF_ARM;
+
+function createClient(
+  nodes: RawNode[],
+  options: { placementSandboxOnly?: boolean; placementTtlMs?: number } = {}
+) {
+  const invoke = vi.fn(async (name: string, input?: Record<string, unknown>) => ({
+    invocation_id: `inv-${invoke.mock.calls.length}`,
+    action_name: name,
+    handler_node_id: 'node_a',
+    dispatched_node_id: 'node_a',
+    input,
+    status: 'invoked',
+  }));
+  const relaycast = {
+    agents: {
+      list: vi.fn(async () => []),
+      get: vi.fn(),
+      register: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      presence: vi.fn(async () => []),
+    },
+    channels: { list: vi.fn(async () => []), get: vi.fn() },
+    messages: { list: vi.fn(async () => []), get: vi.fn(), thread: vi.fn(), reactions: vi.fn() },
+    nodes: {
+      list: vi.fn(async () => nodes),
+      get: vi.fn(async (name: string) => nodes.find((node) => node.name === name) ?? null),
+    },
+  };
+  const agentClient = {
+    actions: {
+      invoke,
+      getInvocation: vi.fn(async () => undefined),
+      completeInvocation: vi.fn(),
+    },
+  };
+  const client = new RelaycastMessagingClient({
+    relaycast: relaycast as never,
+    agentClient: agentClient as never,
+    placementTtlMs: options.placementTtlMs ?? 30,
+    placementSandboxOnly: options.placementSandboxOnly,
+  });
+  return { client, invoke };
+}
+
+const READY_NODE: RawNode = {
+  id: 'node_a',
+  name: 'node-a',
+  status: 'online',
+  live: true,
+  handlers_live: true,
+  capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+  repo_keys: ['relay'],
+};
+
+async function captureError(run: () => Promise<unknown>): Promise<Record<string, unknown> | undefined> {
+  try {
+    await run();
+    return undefined;
+  } catch (error) {
+    return error as Record<string, unknown>;
+  }
+}
+
+describe('placement liveness and policy proof', () => {
+  it('observes the declared base bug or the complete head fix', async () => {
+    expect(['base', 'head']).toContain(ARM);
+
+    const stale = createClient([{ ...READY_NODE, name: 'stale-node', status: 'offline' }]);
+    const staleError = await captureError(() =>
+      stale.client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' })
+    );
+
+    const deadHandlers = createClient([{ ...READY_NODE, handlers_live: false }]);
+    const handlerError = await captureError(() =>
+      deadHandlers.client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' })
+    );
+
+    const absent = createClient([], { placementTtlMs: 30 });
+    const absentError = await captureError(() =>
+      absent.client.placement.spawn({ capability: 'spawn:claude', pollIntervalMs: 25 })
+    );
+
+    const sandboxed = createClient([READY_NODE], { placementSandboxOnly: true });
+    const sandboxError = await captureError(() =>
+      sandboxed.client.placement.spawn({ capability: 'spawn:claude', repo: 'relay' })
+    );
+
+    const automatic = createClient([READY_NODE]);
+    await automatic.client.placement.spawn({ capability: 'spawn:claude' });
+    const automaticInput = automatic.invoke.mock.calls[0]?.[1] as Record<string, unknown>;
+
+    if (ARM === 'base') {
+      expect(staleError).toBeUndefined();
+      expect(stale.invoke).toHaveBeenCalledTimes(1);
+      expect(handlerError).toBeUndefined();
+      expect(deadHandlers.invoke).toHaveBeenCalledTimes(1);
+      expect(absentError).toMatchObject({ code: 'placement_ttl_expired' });
+      expect(sandboxError).toBeUndefined();
+      expect(sandboxed.invoke).toHaveBeenCalledTimes(1);
+      expect(automaticInput).toMatchObject({ node: 'node-a', target_node: 'node-a' });
+      return;
+    }
+
+    expect(staleError).toMatchObject({ code: 'no_eligible_node', attempts: 1 });
+    expect(stale.invoke).not.toHaveBeenCalled();
+    expect(handlerError).toMatchObject({ code: 'no_eligible_node', attempts: 1 });
+    expect(deadHandlers.invoke).not.toHaveBeenCalled();
+    expect(absentError).toMatchObject({ code: 'no_eligible_node', attempts: 1 });
+    expect(sandboxError).toMatchObject({ code: 'sandbox_policy_mismatch', attempts: 1 });
+    expect(sandboxed.invoke).not.toHaveBeenCalled();
+    expect(automaticInput).not.toHaveProperty('node');
+    expect(automaticInput).not.toHaveProperty('target_node');
+  });
+});

--- a/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
+++ b/tests/relayflows/cases/1619-placement-liveness/probe.test.mts
@@ -129,6 +129,8 @@ describe('placement liveness and policy proof', () => {
     expect(absentError).toMatchObject({ code: 'no_eligible_node', attempts: 1 });
     expect(sandboxError).toMatchObject({ code: 'sandbox_policy_mismatch', attempts: 1 });
     expect(sandboxed.invoke).not.toHaveBeenCalled();
+    expect(automatic.invoke).toHaveBeenCalledTimes(1);
+    expect(automaticInput).toBeDefined();
     expect(automaticInput).not.toHaveProperty('node');
     expect(automaticInput).not.toHaveProperty('target_node');
   });

--- a/tests/relayflows/cases/1619-placement-liveness/run.mjs
+++ b/tests/relayflows/cases/1619-placement-liveness/run.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { access, copyFile, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1619-placement-liveness';
+const arm = process.env.RELAY_PR_PROOF_ARM;
+const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
+const resultPath = process.env.RELAY_PR_PROOF_RESULT_PATH;
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+
+if ((arm !== 'base' && arm !== 'head') || !targetDir || !resultPath) {
+  throw new Error('RelayFlow proof environment is incomplete');
+}
+
+async function pathExists(candidate) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  process.stdout.write(result.stdout ?? '');
+  process.stderr.write(result.stderr ?? '');
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
+  }
+}
+
+const vitestEntry = path.join(targetDir, 'node_modules', 'vitest', 'vitest.mjs');
+if (!(await pathExists(vitestEntry))) {
+  run('npm', ['ci', '--no-audit', '--no-fund'], targetDir);
+}
+
+const proofDir = path.join(targetDir, '.relay-pr-proof');
+const probePath = path.join(proofDir, 'placement-liveness.test.mts');
+const configPath = path.join(proofDir, 'vitest.config.mts');
+await mkdir(proofDir, { recursive: true });
+await copyFile(path.join(caseDir, 'probe.test.mts'), probePath);
+await writeFile(
+  configPath,
+  `import { defineConfig } from 'vitest/config';\n\nexport default defineConfig({ test: { environment: 'node', include: ['.relay-pr-proof/placement-liveness.test.mts'] } });\n`
+);
+
+run(process.execPath, [vitestEntry, 'run', '--config', configPath, '--reporter=verbose'], targetDir);
+
+const observation =
+  arm === 'base'
+    ? {
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'bug',
+        signature: 'placement_accepts_unready_or_policy_ineligible_nodes',
+        details:
+          'The base SDK selected stale-status and dead-handler nodes, ignored sandbox-only policy, queued an empty roster by default, and retargeted automatic placement.',
+      }
+    : {
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'fixed',
+        signature: 'placement_fails_closed_and_preserves_atomic_selection',
+        details:
+          'The head SDK rejected stale-status, dead-handler, empty-roster, and sandbox-policy-ineligible placements without invocation, while leaving unconstrained selection atomic.',
+      };
+
+await writeFile(resultPath, `${JSON.stringify(observation, null, 2)}\n`);


### PR DESCRIPTION
## Summary

Harden SDK placement so unavailable or policy-ineligible nodes fail closed before action invocation, while unconstrained automatic placement remains atomic in Relaycast.

> **Breaking:** placement now fails fast by default instead of implicitly queueing, and engine-selected acknowledgments expose resolved `node` metadata only when it can be matched safely.

## Test Plan

- [x] Tests added/updated
- [x] Manual base/head proof completed

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1619-placement-liveness` <!-- relay-pr-proof:case -->

## Diagnosis

The principal framing is partly correct: placement could reach a dead target and then wait, but the SDK already checked Relaycast's derived `node.live` bit.

Current behavior before this PR:

- named placement: exact node lookup → exact capability match → `node.live` → repo mapping;
- automatic placement: capability-filtered roster → exact capability match → `node.live` → repo mapping → first matching roster node;
- the SDK then rewrote every automatic choice into `node` / `target_node`, turning Relaycast's atomic least-loaded selector into a targeted request;
- `status`, `handlers_live`, and heartbeat-derived `live` are available at selection, but status and handler readiness were not checked;
- absent `failFast`, the SDK queued for its one-hour default TTL, so Factory's 300-second outer timeout fired first;
- Cloud sandbox provenance is the existing stable `cloud:node-type:<provider>-jit` tag family (`cloud:node-type:daytona-jit` today). There is no provider field, and Cloud explicitly treats JIT node names as disposable.

That automatic retargeting is the race: the roster-selected node can die before invocation, after which the engine treats the request as targeted and can persist/queue it. Unconstrained automatic placement now stays atomic in the engine.

## Changes

- Require `status === online`, `live === true`, and `handlersLive === true` before client-side selection.
- Fail fast by default with named `no_eligible_node`, `node_unavailable`, or `sandbox_policy_mismatch` errors. Explicit `failFast: false` retains bounded queueing.
- Do not invoke the placement action when the client finds no eligible node, so no hostless placement record can be persisted.
- Add client-wide `placementSandboxOnly` and per-request `sandboxOnly`; both explicitly default to `false`.
- Restrict sandbox-only eligibility to the existing Cloud JIT node-type tag family.
- Preserve engine-side atomic selection when there is no explicit node, repo, or sandbox-only constraint.
- Document the breaking fail-fast default and migration guidance.

## Focused verification

```text
 Test Files  1 passed (1)
      Tests  27 passed (27)
   Duration  1.88s
```

```text
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  2.74s
```

Prettier:

```text
All matched files use Prettier code style!
```

The RelayFlow case was also executed locally against both exact worktrees with the shared installed dependency tree:

```text
base: Test Files 1 passed (1); Tests 1 passed (1); Duration 1.63s
head: Test Files 1 passed (1); Tests 1 passed (1); Duration 1.65s
```

## Ablation matrix

Each row was applied independently to the implementation, the original 26-test focused placement suite was run, and the change was restored before the next row. A later post-review ack-metadata regression test brings the current focused suite to 27 tests.

| Independent ablation | Offline status | Handlers live | No eligible fast/no invoke | Sandbox selects Cloud | Sandbox fails closed | Default off | Atomic engine selection | Whole suite |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Final implementation | P | P | P | P | P | P | P | 26/26 |
| Revert strict readiness to `node.live` only | F | F | P | P | P | P | P | 24/26 |
| Restore implicit queue default | P | F | F | P | F | P | P | 23/26 |
| Disable sandbox filtering | P | P | P | F | F | P | P | 24/26 |
| Restore SDK automatic retargeting | P | P | P | P | P | P | F | 25/26 |
| Invert sandbox default to on | F | F | F | P | P | F | F | 4/26 |

## Broader-suite baseline

The full SDK suite cannot be made authoritative with the shared installed dependency tree: both this branch and an untouched `origin/main` worktree fail identically in Zod normalization/runtime code outside this diff. Untouched-base output:

```text
 Test Files  4 failed | 10 passed (14)
      Tests  25 failed | 157 passed (182)
     Errors  5 errors
   Duration  9.10s
```

The SDK typecheck likewise reproduces the same Zod v3/v4 duplicate-type errors on untouched `origin/main`; none of the changed files appears in those diagnostics.

## Screenshots

Not applicable; SDK behavior change only.

