### PR TITLE
feat(broker): advertise node repo keys from AGENT_RELAY_NODE_REPOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
+
+### Added
+
+- Broker-served fleet nodes advertise repository keys from `AGENT_RELAY_NODE_REPOS`, so they can be selected for repo-qualified placement instead of being permanently ineligible for it.
 
 ### Fixed
 

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -919,7 +919,15 @@ fn node_capacity_harnesses() -> Vec<String> {
 }
 
 /// The repository keys this node advertises, from `AGENT_RELAY_NODE_REPOS`
-/// (comma-separated `owner/name`, order-preserving, de-duplicated).
+/// (comma-separated `owner/name`, de-duplicated, sorted).
+///
+/// Sorted rather than order-preserving, which is where this deliberately parts
+/// company with `node_capacity_harnesses()`. Repo keys are a set, not a
+/// preference order, and the other producer of this same wire field —
+/// `nodeRepoKeys` in `packages/fleet` — returns `Object.keys(...).sort()`. Two
+/// producers emitting different arrays for the same set of repositories, purely
+/// because an operator listed them in a different order, would make the
+/// advertisement non-canonical for anything downstream that compares it.
 ///
 /// Absent yields `None`: the node advertises no repository at all, which is the
 /// behaviour every broker-served node had before this existed and keeps such a
@@ -936,13 +944,14 @@ fn node_capacity_harnesses() -> Vec<String> {
 fn node_capacity_repos() -> Option<Vec<String>> {
     let raw = std::env::var("AGENT_RELAY_NODE_REPOS").ok()?;
     let mut seen = std::collections::HashSet::new();
-    Some(
-        raw.split(',')
-            .map(|entry| entry.trim().to_string())
-            .filter(|entry| !entry.is_empty())
-            .filter(|entry| seen.insert(entry.clone()))
-            .collect(),
-    )
+    let mut repos: Vec<String> = raw
+        .split(',')
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+        .filter(|entry| seen.insert(entry.clone()))
+        .collect();
+    repos.sort();
+    Some(repos)
 }
 
 /// Provider-level agent capacity, from `AGENT_RELAY_NODE_MAX_AGENTS`. Absent
@@ -1082,6 +1091,11 @@ mod tests {
         // all `kind: "capacity"`. It must never advertise a bare `"spawn"`, which
         // the engine would materialize as a generic action pinned to this node,
         // hijacking capability-based spawn placement for the whole workspace.
+        //
+        // The guard is required even though this test asserts nothing about
+        // repositories: `bootstrap_node_manifest` reads AGENT_RELAY_NODE_REPOS,
+        // so without the lock this test races the repo tests' `set_var`.
+        let _env = set_node_repos_env(None);
         let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
         assert!(
             !manifest.capabilities.is_empty(),
@@ -1131,10 +1145,13 @@ mod tests {
 
     #[test]
     fn bootstrap_node_manifest_advertises_configured_repo_keys() {
-        // Trimmed, order-preserving, de-duplicated — the same contract
-        // AGENT_RELAY_NODE_HARNESSES already has.
+        // Trimmed, de-duplicated, and SORTED. The input is deliberately not in
+        // sorted order: `nodeRepoKeys` in packages/fleet emits
+        // `Object.keys(...).sort()`, so a config-order array here would make the
+        // same set of repositories advertise differently depending on which
+        // producer registered the node.
         let _env = set_node_repos_env(Some(
-            " AgentWorkforce/factory ,AgentWorkforce/relay,,AgentWorkforce/factory ",
+            " AgentWorkforce/relay ,AgentWorkforce/factory,,AgentWorkforce/relay ",
         ));
         let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
         assert_eq!(

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -860,6 +860,12 @@ const DEFAULT_NODE_HARNESSES: &[&str] = &["claude", "codex", "gemini", "opencode
 /// placement for the whole workspace. The harness set comes from the
 /// `AGENT_RELAY_NODE_HARNESSES` CSV (the CLI sets it from the project's
 /// teams.json / node definition), falling back to a built-in default.
+///
+/// The repository keys come from `AGENT_RELAY_NODE_REPOS` on the same footing.
+/// Until it existed this was hardcoded `None`, so a broker-served node could
+/// never advertise a repository and was permanently ineligible for any
+/// repo-qualified placement — the node had no way to say what it could serve
+/// even with the checkout sitting on its disk (#1622).
 fn bootstrap_node_manifest(node_name: &str, node_id: &str, broker_version: &str) -> NodeManifest {
     let mut capabilities: Vec<crate::protocol::NodeCapabilityManifest> = node_capacity_harnesses()
         .into_iter()
@@ -880,7 +886,7 @@ fn bootstrap_node_manifest(node_name: &str, node_id: &str, broker_version: &str)
         capabilities,
         max_agents: node_max_agents(),
         tags: None,
-        repo_keys: None,
+        repo_keys: node_capacity_repos(),
         version: Some(broker_version.to_string()),
     }
 }
@@ -912,6 +918,33 @@ fn node_capacity_harnesses() -> Vec<String> {
         .collect()
 }
 
+/// The repository keys this node advertises, from `AGENT_RELAY_NODE_REPOS`
+/// (comma-separated `owner/name`, order-preserving, de-duplicated).
+///
+/// Absent yields `None`: the node advertises no repository at all, which is the
+/// behaviour every broker-served node had before this existed and keeps such a
+/// node eligible for placements that carry no repo constraint. A value that is
+/// present but contributes no entries yields `Some([])`, which
+/// `build_node_register` forwards verbatim so an operator can authoritatively
+/// clear a stale advertisement on the control plane rather than being stuck
+/// with one.
+///
+/// Entries are deliberately NOT validated here. `build_node_register` already
+/// treats the Fleet wire as a privacy boundary and drops anything that is not a
+/// bare `owner/name` key, so a second copy of that rule would sit one edit away
+/// from disagreeing with the one that actually guards the wire.
+fn node_capacity_repos() -> Option<Vec<String>> {
+    let raw = std::env::var("AGENT_RELAY_NODE_REPOS").ok()?;
+    let mut seen = std::collections::HashSet::new();
+    Some(
+        raw.split(',')
+            .map(|entry| entry.trim().to_string())
+            .filter(|entry| !entry.is_empty())
+            .filter(|entry| seen.insert(entry.clone()))
+            .collect(),
+    )
+}
+
 /// Provider-level agent capacity, from `AGENT_RELAY_NODE_MAX_AGENTS`. Absent
 /// (0/unlimited) preserves the broker's historically unbounded capacity.
 fn node_max_agents() -> Option<u32> {
@@ -930,7 +963,50 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::sync::{Mutex, MutexGuard};
 
+    /// The single lock every environment mutation in this module takes.
+    ///
+    /// It is not per-variable on purpose. `set_var` rewrites a process-global
+    /// environ table, so mutating one key races a concurrent read of any other
+    /// key, not just of itself. Giving `AGENT_RELAY_NODE_REPOS` its own mutex
+    /// let the repo tests run alongside the node-id tests and made
+    /// `node_id_env_guard_restores_original_node_env` fail intermittently.
     static NODE_ID_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct NodeReposEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        original: Option<OsString>,
+    }
+
+    impl Drop for NodeReposEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: these tests hold NODE_REPOS_ENV_MUTEX while mutating the
+            // process environment, serializing access within this test module
+            // until the inherited AGENT_RELAY_NODE_REPOS value is restored.
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var("AGENT_RELAY_NODE_REPOS", value),
+                    None => std::env::remove_var("AGENT_RELAY_NODE_REPOS"),
+                }
+            }
+        }
+    }
+
+    fn set_node_repos_env(value: Option<&str>) -> NodeReposEnvGuard {
+        let guard = NODE_ID_ENV_MUTEX.lock().unwrap();
+        let original = std::env::var_os("AGENT_RELAY_NODE_REPOS");
+        // SAFETY: NODE_REPOS_ENV_MUTEX serializes environment mutations for these
+        // tests before any code under test observes AGENT_RELAY_NODE_REPOS.
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var("AGENT_RELAY_NODE_REPOS", value),
+                None => std::env::remove_var("AGENT_RELAY_NODE_REPOS"),
+            }
+        }
+        NodeReposEnvGuard {
+            _guard: guard,
+            original,
+        }
+    }
 
     struct NodeIdEnvGuard {
         _guard: MutexGuard<'static, ()>,
@@ -1040,6 +1116,73 @@ mod tests {
         assert_eq!(manifest.name, "node-a");
         assert_eq!(manifest.node_id.as_deref(), Some("node_a"));
         assert_eq!(manifest.version.as_deref(), Some("relay-broker/9.1.1"));
+    }
+
+    #[test]
+    fn bootstrap_node_manifest_advertises_no_repos_when_env_is_absent() {
+        // Backward compatibility, and the reason this is `Option`: every
+        // broker-served node that predates AGENT_RELAY_NODE_REPOS must keep
+        // advertising nothing rather than start advertising an empty set, which
+        // `build_node_register` forwards as an authoritative clear.
+        let _env = set_node_repos_env(None);
+        let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
+        assert_eq!(manifest.repo_keys, None);
+    }
+
+    #[test]
+    fn bootstrap_node_manifest_advertises_configured_repo_keys() {
+        // Trimmed, order-preserving, de-duplicated — the same contract
+        // AGENT_RELAY_NODE_HARNESSES already has.
+        let _env = set_node_repos_env(Some(
+            " AgentWorkforce/factory ,AgentWorkforce/relay,,AgentWorkforce/factory ",
+        ));
+        let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
+        assert_eq!(
+            manifest.repo_keys,
+            Some(vec![
+                "AgentWorkforce/factory".to_string(),
+                "AgentWorkforce/relay".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn bootstrap_node_manifest_forwards_an_explicitly_empty_value_as_a_clear() {
+        // Present-but-empty is distinct from absent: it is how an operator
+        // retracts a stale advertisement instead of being stuck with one.
+        let _env = set_node_repos_env(Some("  ,  "));
+        let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
+        assert_eq!(manifest.repo_keys, Some(Vec::new()));
+    }
+
+    #[test]
+    fn configured_repo_paths_never_reach_the_fleet_wire() {
+        // The privacy property, proven through the real producer rather than a
+        // hand-built manifest: an operator who puts absolute paths in the env
+        // must not leak them onto the wire. `bootstrap_node_manifest` does not
+        // filter — `build_node_register` is the boundary — so this asserts the
+        // two halves actually compose.
+        let _env = set_node_repos_env(Some(
+            "/private/node/factory,AgentWorkforce/factory,../relay,AgentWorkforce/relay/extra",
+        ));
+        let manifest = bootstrap_node_manifest("node-a", "node_a", "relay-broker/9.1.1");
+        let register = crate::node_control::build_node_register(
+            &manifest,
+            "node-default",
+            "host-default",
+            "broker/1",
+            None,
+        );
+        assert_eq!(
+            register.repo_keys,
+            Some(vec!["AgentWorkforce/factory".to_string()]),
+            "only bare owner/name keys may cross the Fleet wire"
+        );
+        let serialized = serde_json::to_string(&register).unwrap();
+        assert!(
+            !serialized.contains("/private/node/factory"),
+            "an absolute checkout path must never be serialized: {serialized}"
+        );
     }
 
     #[test]

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/case.json
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1622-broker-node-repo-keys",
+  "kind": "feature",
+  "title": "Broker-served nodes advertise repository keys from AGENT_RELAY_NODE_REPOS",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs"]
+  },
+  "timeoutSeconds": 1800,
+  "expected": {
+    "base": {
+      "outcome": "absent",
+      "signature": "broker_node_register_omits_repo_keys"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "broker_node_register_advertises_sorted_repo_keys"
+    }
+  }
+}

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
@@ -39,6 +39,14 @@ const EXPECTED_SORTED = ['AgentWorkforce/factory', 'AgentWorkforce/relay'];
 
 const REGISTER_TIMEOUT_MS = 120_000;
 
+// `spawnSync` blocks the event loop, so an unbounded child would make the case
+// unabortable from inside: no promise, timer, or `Promise.race` can fire while
+// it runs, leaving only the 1800s case budget to kill it and reporting a stall
+// as an undiagnosable infrastructure failure. Both bounds sit well inside that
+// budget so a stall surfaces as a catchable error naming the step that hung.
+const RUSTUP_TIMEOUT_MS = 300_000;
+const BUILD_TIMEOUT_MS = 1_200_000;
+
 const arm = process.env.RELAY_PR_PROOF_ARM;
 const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
 const resultPath = process.env.RELAY_PR_PROOF_RESULT_PATH;
@@ -49,6 +57,49 @@ if ((arm !== 'base' && arm !== 'head') || !targetDir || !resultPath) {
 }
 
 const CARGO_HOME_BIN = path.join(os.homedir(), '.cargo', 'bin');
+
+// Pinned so the installer this gate executes is immutable. `sh.rustup.rs` serves
+// whatever script is current, which is both a supply-chain exposure and a
+// reproducibility one; the `archive/<version>` path never changes under us.
+const RUSTUP_INIT_VERSION = '1.28.2';
+const RUSTUP_INIT_TARGETS = {
+  'linux:x64': 'x86_64-unknown-linux-gnu',
+  'linux:arm64': 'aarch64-unknown-linux-gnu',
+  'darwin:x64': 'x86_64-apple-darwin',
+  'darwin:arm64': 'aarch64-apple-darwin',
+};
+
+/**
+ * The shell that installs rustup, preferring a pinned immutable installer.
+ *
+ * The toolchain itself stays `stable` on purpose: every Rust workflow in this
+ * repository uses `dtolnay/rust-toolchain@stable`, so pinning a different rustc
+ * here would prove the change against a compiler CI never uses.
+ *
+ * An unrecognised platform falls back to `sh.rustup.rs` rather than failing the
+ * gate outright, and says so in the log, because an unprovable case is a worse
+ * outcome than a mutable installer on a platform this table does not yet cover.
+ */
+function rustupInstallScript() {
+  const target = RUSTUP_INIT_TARGETS[`${process.platform}:${process.arch}`];
+  const args = '-y --profile minimal --default-toolchain stable --no-modify-path';
+  if (!target) {
+    console.log(
+      `[${CASE_ID}] no pinned rustup-init for ${process.platform}/${process.arch}; falling back to sh.rustup.rs`
+    );
+    return `set -euo pipefail; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- ${args}`;
+  }
+  const url = `https://static.rust-lang.org/rustup/archive/${RUSTUP_INIT_VERSION}/${target}/rustup-init`;
+  console.log(`[${CASE_ID}] installing pinned rustup-init ${RUSTUP_INIT_VERSION} for ${target}`);
+  return [
+    'set -euo pipefail',
+    'tmp="$(mktemp -d)"',
+    `curl --proto '=https' --tlsv1.2 -sSfL '${url}' -o "$tmp/rustup-init"`,
+    'chmod +x "$tmp/rustup-init"',
+    `"$tmp/rustup-init" ${args}`,
+    'rm -rf "$tmp"',
+  ].join('; ');
+}
 
 /**
  * Locate a usable cargo, installing a minimal toolchain when the host has none.
@@ -70,20 +121,23 @@ function resolveCargo() {
 
   console.log(`[${CASE_ID}] no cargo on this host; installing a minimal rustup toolchain`);
   const started = Date.now();
-  const install = spawnSync(
-    'bash',
-    [
-      '-c',
-      "set -euo pipefail; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs " +
-        '| sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path',
-    ],
-    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] }
-  );
+  const install = spawnSync('bash', ['-c', rustupInstallScript()], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: RUSTUP_TIMEOUT_MS,
+  });
   process.stdout.write(install.stdout ?? '');
   process.stderr.write(install.stderr ?? '');
-  if (install.error) throw install.error;
+  if (install.error) {
+    throw new Error(
+      `rustup install did not complete within ${RUSTUP_TIMEOUT_MS}ms or could not start: ${install.error.message}`
+    );
+  }
   if (install.status !== 0) {
-    throw new Error(`rustup install failed with exit ${install.status}`);
+    throw new Error(
+      `rustup install failed with exit ${install.status}${install.signal ? ` (signal ${install.signal})` : ''}`
+    );
   }
 
   const cargo = path.join(CARGO_HOME_BIN, 'cargo');
@@ -102,20 +156,34 @@ function build(cargoBin) {
   const started = Date.now();
   const result = spawnSync(cargoBin, ['build', '-p', 'agent-relay-broker', '--bin', 'agent-relay-broker'], {
     cwd: targetDir,
+    // Put the SELECTED cargo's own directory first, and only when it was
+    // resolved by path. Prepending ~/.cargo/bin unconditionally would let a
+    // rustup toolchain shadow a system cargo that `resolveCargo` had already
+    // chosen, so the build could run a different rustc than the cargo invoked
+    // here (coderabbitai, #1623 review).
     env: {
       ...process.env,
       CARGO_TERM_COLOR: 'never',
-      PATH: `${CARGO_HOME_BIN}${path.delimiter}${process.env.PATH ?? ''}`,
+      ...(path.isAbsolute(cargoBin)
+        ? { PATH: `${path.dirname(cargoBin)}${path.delimiter}${process.env.PATH ?? ''}` }
+        : {}),
     },
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: BUILD_TIMEOUT_MS,
   });
   process.stdout.write(result.stdout ?? '');
   process.stderr.write(result.stderr ?? '');
-  if (result.error) throw result.error;
+  if (result.error) {
+    throw new Error(
+      `cargo build did not complete within ${BUILD_TIMEOUT_MS}ms or could not start: ${result.error.message}`
+    );
+  }
   if (result.status !== 0) {
-    throw new Error(`cargo build failed with exit ${result.status}`);
+    throw new Error(
+      `cargo build failed with exit ${result.status}${result.signal ? ` (signal ${result.signal})` : ''}`
+    );
   }
   console.log(`[${CASE_ID}] build finished in ${Math.round((Date.now() - started) / 1000)}s`);
   return path.join(targetDir, 'target', 'debug', 'agent-relay-broker');
@@ -218,9 +286,20 @@ function classify(register) {
     advertised.every((value, index) => value === EXPECTED_SORTED[index]);
 
   if (!matches) {
-    throw new Error(
-      `node.register carried unexpected repo_keys ${JSON.stringify(advertised)}; expected ${JSON.stringify(EXPECTED_SORTED)}`
-    );
+    // A regression is data, not a crash. Throwing here would exit non-zero and
+    // the gate would record an undiagnosable infrastructure failure — the same
+    // reason the `absent` branch above is reported rather than thrown. Emitting
+    // a distinct signature makes the gate reject this on a signature mismatch
+    // and names what was actually advertised.
+    return {
+      outcome: 'fixed',
+      signature: 'broker_node_register_advertises_unexpected_repo_keys',
+      details:
+        `The broker registered node "${register.name}" advertising repo_keys ` +
+        `${JSON.stringify(advertised)}, but AGENT_RELAY_NODE_REPOS="${CONFIGURED_REPOS}" should have produced ` +
+        `${JSON.stringify(EXPECTED_SORTED)}. The field is present, so the feature exists, but its content is ` +
+        'wrong — a partial, unsorted, or mis-parsed advertisement.',
+    };
   }
 
   return {

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
@@ -48,12 +48,65 @@ if ((arm !== 'base' && arm !== 'head') || !targetDir || !resultPath) {
   throw new Error('RelayFlow proof environment is incomplete');
 }
 
-function build() {
+const CARGO_HOME_BIN = path.join(os.homedir(), '.cargo', 'bin');
+
+/**
+ * Locate a usable cargo, installing a minimal toolchain when the host has none.
+ *
+ * The Cloud proof sandbox ships no Rust toolchain — the first run of this case
+ * died on `spawnSync cargo ENOENT` — and the `dtolnay/rust-toolchain` action the
+ * repository's own workflows use is a GitHub Action, so it cannot help inside
+ * the sandbox. There is no pinned `rust-toolchain.toml`, so stable is the same
+ * toolchain CI builds with.
+ */
+function resolveCargo() {
+  for (const candidate of ['cargo', path.join(CARGO_HOME_BIN, 'cargo')]) {
+    const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+    if (!probe.error && probe.status === 0) {
+      console.log(`[${CASE_ID}] cargo already present: ${probe.stdout.trim()}`);
+      return candidate;
+    }
+  }
+
+  console.log(`[${CASE_ID}] no cargo on this host; installing a minimal rustup toolchain`);
+  const started = Date.now();
+  const install = spawnSync(
+    'bash',
+    [
+      '-c',
+      "set -euo pipefail; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs " +
+        '| sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path',
+    ],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+  process.stdout.write(install.stdout ?? '');
+  process.stderr.write(install.stderr ?? '');
+  if (install.error) throw install.error;
+  if (install.status !== 0) {
+    throw new Error(`rustup install failed with exit ${install.status}`);
+  }
+
+  const cargo = path.join(CARGO_HOME_BIN, 'cargo');
+  const probe = spawnSync(cargo, ['--version'], { encoding: 'utf8' });
+  if (probe.error || probe.status !== 0) {
+    throw new Error('rustup reported success but cargo is still not runnable');
+  }
+  console.log(
+    `[${CASE_ID}] rustup installed in ${Math.round((Date.now() - started) / 1000)}s: ${probe.stdout.trim()}`
+  );
+  return cargo;
+}
+
+function build(cargoBin) {
   console.log(`[${CASE_ID}] building agent-relay-broker from ${targetDir}`);
   const started = Date.now();
-  const result = spawnSync('cargo', ['build', '-p', 'agent-relay-broker', '--bin', 'agent-relay-broker'], {
+  const result = spawnSync(cargoBin, ['build', '-p', 'agent-relay-broker', '--bin', 'agent-relay-broker'], {
     cwd: targetDir,
-    env: { ...process.env, CARGO_TERM_COLOR: 'never' },
+    env: {
+      ...process.env,
+      CARGO_TERM_COLOR: 'never',
+      PATH: `${CARGO_HOME_BIN}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -180,7 +233,7 @@ function classify(register) {
   };
 }
 
-const brokerBin = build();
+const brokerBin = build(resolveCargo());
 const register = await captureRegisterFrame(brokerBin);
 console.log(`[${CASE_ID}] node.register: ${JSON.stringify(register)}`);
 const classified = classify(register);

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
@@ -76,7 +76,17 @@ async function captureRegisterFrame(brokerBin) {
 
   const child = spawn(
     brokerBin,
-    ['init', '--instance-name', NODE_NAME, '--channels', 'general', '--api-port', '0', '--state-dir', stateDir],
+    [
+      'init',
+      '--instance-name',
+      NODE_NAME,
+      '--channels',
+      'general',
+      '--api-port',
+      '0',
+      '--state-dir',
+      stateDir,
+    ],
     {
       cwd: stateDir,
       env: {
@@ -114,7 +124,10 @@ async function captureRegisterFrame(brokerBin) {
 
   const timeout = new Promise((_, reject) =>
     setTimeout(
-      () => reject(new Error(`no node.register within ${REGISTER_TIMEOUT_MS}ms; broker exit=${JSON.stringify(exited)}`)),
+      () =>
+        reject(
+          new Error(`no node.register within ${REGISTER_TIMEOUT_MS}ms; broker exit=${JSON.stringify(exited)}`)
+        ),
       REGISTER_TIMEOUT_MS
     ).unref?.()
   );

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
@@ -46,6 +46,10 @@ const REGISTER_TIMEOUT_MS = 120_000;
 // budget so a stall surfaces as a catchable error naming the step that hung.
 const RUSTUP_TIMEOUT_MS = 300_000;
 const BUILD_TIMEOUT_MS = 1_200_000;
+// `cargo --version` looks instant but is not guaranteed to be: a rustup shim
+// can fetch a toolchain over the network on first use, so an unbounded probe is
+// the same unabortable hazard as an unbounded install.
+const PROBE_TIMEOUT_MS = 60_000;
 
 const arm = process.env.RELAY_PR_PROOF_ARM;
 const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
@@ -112,7 +116,7 @@ function rustupInstallScript() {
  */
 function resolveCargo() {
   for (const candidate of ['cargo', path.join(CARGO_HOME_BIN, 'cargo')]) {
-    const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+    const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
     if (!probe.error && probe.status === 0) {
       console.log(`[${CASE_ID}] cargo already present: ${probe.stdout.trim()}`);
       return candidate;
@@ -141,7 +145,7 @@ function resolveCargo() {
   }
 
   const cargo = path.join(CARGO_HOME_BIN, 'cargo');
-  const probe = spawnSync(cargo, ['--version'], { encoding: 'utf8' });
+  const probe = spawnSync(cargo, ['--version'], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
   if (probe.error || probe.status !== 0) {
     throw new Error('rustup reported success but cargo is still not runnable');
   }

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/run.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+// Proof for #1622: a broker-served fleet node can advertise repository keys.
+//
+// WHAT IS OBSERVED, AND WHY IT IS THE PRODUCTION PATH
+//
+// `bootstrap_node_manifest` is private, so no test can call it from outside the
+// crate — and a unit test that exists only on the head cannot prove the base is
+// broken, because "test not found" is not an observation. So this case builds
+// the broker from the TARGET checkout and runs the real binary against a
+// stand-in for Relaycast's node-control endpoint, reading the `node.register`
+// frame the broker actually puts on the wire.
+//
+// `repo_keys` is declared `skip_serializing_if = "Option::is_none"`, so the
+// field is absent from that frame when the broker has nothing to advertise and
+// present when it does. Both arms run the identical program with the identical
+// environment; only the checkout differs.
+//
+// The observation is DERIVED FROM THE FRAME, never from `RELAY_PR_PROOF_ARM`.
+// The arm is used solely to label the record. A head build that failed to
+// advertise would report `absent` and be rejected by the gate, which is the
+// point of running it.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { startNodeControlObserver } from './ws-observer.mjs';
+
+const CASE_ID = '1622-broker-node-repo-keys';
+const NODE_NAME = 'relayflow-proof-1622';
+
+// Deliberately NOT in sorted order: the head is expected to canonicalise this,
+// matching `nodeRepoKeys` in packages/fleet, which returns `Object.keys(...).sort()`.
+const CONFIGURED_REPOS = 'AgentWorkforce/relay,AgentWorkforce/factory';
+const EXPECTED_SORTED = ['AgentWorkforce/factory', 'AgentWorkforce/relay'];
+
+const REGISTER_TIMEOUT_MS = 120_000;
+
+const arm = process.env.RELAY_PR_PROOF_ARM;
+const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
+const resultPath = process.env.RELAY_PR_PROOF_RESULT_PATH;
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+
+if ((arm !== 'base' && arm !== 'head') || !targetDir || !resultPath) {
+  throw new Error('RelayFlow proof environment is incomplete');
+}
+
+function build() {
+  console.log(`[${CASE_ID}] building agent-relay-broker from ${targetDir}`);
+  const started = Date.now();
+  const result = spawnSync('cargo', ['build', '-p', 'agent-relay-broker', '--bin', 'agent-relay-broker'], {
+    cwd: targetDir,
+    env: { ...process.env, CARGO_TERM_COLOR: 'never' },
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  process.stdout.write(result.stdout ?? '');
+  process.stderr.write(result.stderr ?? '');
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`cargo build failed with exit ${result.status}`);
+  }
+  console.log(`[${CASE_ID}] build finished in ${Math.round((Date.now() - started) / 1000)}s`);
+  return path.join(targetDir, 'target', 'debug', 'agent-relay-broker');
+}
+
+async function captureRegisterFrame(brokerBin) {
+  const observer = startNodeControlObserver();
+  const port = await observer.listening;
+  const stateDir = await mkdtemp(path.join(os.tmpdir(), `${CASE_ID}-`));
+  console.log(`[${CASE_ID}] node-control observer on 127.0.0.1:${port}`);
+
+  const child = spawn(
+    brokerBin,
+    ['init', '--instance-name', NODE_NAME, '--channels', 'general', '--api-port', '0', '--state-dir', stateDir],
+    {
+      cwd: stateDir,
+      env: {
+        ...process.env,
+        HOME: stateDir,
+        RELAY_BASE_URL: `http://127.0.0.1:${port}`,
+        RELAY_NODE_ID: 'node_relayflow_proof_1622',
+        RELAY_NODE_TOKEN: 'nt_live_relayflowproof1622',
+        RELAY_WORKSPACE_KEY: 'rk_live_relayflowproof1622',
+        RELAY_API_KEY: 'rk_live_relayflowproof1622',
+        AGENT_RELAY_WORKSPACE_KEY: 'rk_live_relayflowproof1622',
+        AGENT_RELAY_NODE_HARNESSES: 'claude',
+        AGENT_RELAY_NODE_REPOS: CONFIGURED_REPOS,
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+        AGENT_RELAY_DATA_DIR: stateDir,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  const brokerLog = [];
+  const keep = (stream) => (chunk) => {
+    const text = chunk.toString();
+    brokerLog.push(text);
+    process.stderr.write(text);
+    void stream;
+  };
+  child.stdout.on('data', keep('out'));
+  child.stderr.on('data', keep('err'));
+
+  let exited = null;
+  child.on('exit', (code, signal) => {
+    exited = { code, signal };
+  });
+
+  const timeout = new Promise((_, reject) =>
+    setTimeout(
+      () => reject(new Error(`no node.register within ${REGISTER_TIMEOUT_MS}ms; broker exit=${JSON.stringify(exited)}`)),
+      REGISTER_TIMEOUT_MS
+    ).unref?.()
+  );
+
+  try {
+    return await Promise.race([observer.register, timeout]);
+  } finally {
+    child.kill('SIGKILL');
+    observer.server.close();
+    await rm(stateDir, { recursive: true, force: true }).catch(() => {});
+    if (brokerLog.length === 0) console.log(`[${CASE_ID}] broker produced no output`);
+  }
+}
+
+function classify(register) {
+  const advertised = Object.prototype.hasOwnProperty.call(register, 'repo_keys')
+    ? register.repo_keys
+    : undefined;
+
+  if (advertised === undefined) {
+    return {
+      outcome: 'absent',
+      signature: 'broker_node_register_omits_repo_keys',
+      details:
+        `The broker registered node "${register.name}" with capabilities ` +
+        `[${(register.capabilities ?? []).map((c) => c.name).join(', ')}] but no repo_keys field, ` +
+        `even though AGENT_RELAY_NODE_REPOS was set to "${CONFIGURED_REPOS}". ` +
+        'A node that advertises no repository key cannot be selected for a repo-qualified placement.',
+    };
+  }
+
+  const matches =
+    Array.isArray(advertised) &&
+    advertised.length === EXPECTED_SORTED.length &&
+    advertised.every((value, index) => value === EXPECTED_SORTED[index]);
+
+  if (!matches) {
+    throw new Error(
+      `node.register carried unexpected repo_keys ${JSON.stringify(advertised)}; expected ${JSON.stringify(EXPECTED_SORTED)}`
+    );
+  }
+
+  return {
+    outcome: 'fixed',
+    signature: 'broker_node_register_advertises_sorted_repo_keys',
+    details:
+      `The broker registered node "${register.name}" advertising repo_keys ` +
+      `${JSON.stringify(advertised)} from AGENT_RELAY_NODE_REPOS="${CONFIGURED_REPOS}", ` +
+      'canonically sorted despite the configured order, so the node is now eligible for a repo-qualified placement.',
+  };
+}
+
+const brokerBin = build();
+const register = await captureRegisterFrame(brokerBin);
+console.log(`[${CASE_ID}] node.register: ${JSON.stringify(register)}`);
+const classified = classify(register);
+
+await writeFile(
+  resultPath,
+  `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, ...classified }, null, 2)}\n`
+);
+console.log(`[${CASE_ID}] arm=${arm} outcome=${classified.outcome} signature=${classified.signature}`);
+void caseDir;

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/ws-observer.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/ws-observer.mjs
@@ -54,9 +54,10 @@ function decodeFrame(buffer) {
 /**
  * Listen on an ephemeral port and resolve the first `node.register` payload.
  *
- * Plain HTTP requests get a permissive `{}` so an unrelated startup call cannot
- * abort the broker before it reaches the node-control socket. Nothing here
- * inspects or asserts; the caller owns the semantics.
+ * Every plain HTTP request is answered with the same Relaycast agent envelope
+ * (`{ok, data}` carrying a fixed id, workspace, and token) so an unrelated
+ * startup call cannot abort the broker before it reaches the node-control
+ * socket. Nothing here inspects or asserts; the caller owns the semantics.
  */
 export function startNodeControlObserver() {
   let resolveRegister;

--- a/tests/relayflows/cases/1622-broker-node-repo-keys/ws-observer.mjs
+++ b/tests/relayflows/cases/1622-broker-node-repo-keys/ws-observer.mjs
@@ -1,0 +1,158 @@
+// A dependency-free stand-in for Relaycast's node-control endpoint.
+//
+// The broker opens `ws://<base>/v1/node/ws` and sends `node.register` as its
+// first text frame (see `node_control_client_round_trips_mock_engine_ws` in
+// crates/broker/src/node_control.rs, which asserts exactly that ordering). That
+// frame is the production wire surface this case observes: `repo_keys` is
+// declared `skip_serializing_if = "Option::is_none"`, so the field is simply
+// absent when the broker has nothing to advertise.
+//
+// Implemented against the raw socket rather than the `ws` package because the
+// runner must work inside whichever checkout it is handed, and neither target
+// checkout is guaranteed to have a WebSocket server dependency installed.
+
+import crypto from 'node:crypto';
+import http from 'node:http';
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+/** Decode one RFC 6455 client frame, or null when more bytes are needed. */
+function decodeFrame(buffer) {
+  if (buffer.length < 2) return null;
+  const opcode = buffer[0] & 0x0f;
+  const masked = (buffer[1] & 0x80) === 0x80;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+
+  if (length === 126) {
+    if (buffer.length < offset + 2) return null;
+    length = buffer.readUInt16BE(offset);
+    offset += 2;
+  } else if (length === 127) {
+    if (buffer.length < offset + 8) return null;
+    const big = buffer.readBigUInt64BE(offset);
+    if (big > 8_388_608n) throw new Error(`refusing an implausible ${big}-byte frame`);
+    length = Number(big);
+    offset += 8;
+  }
+
+  let mask = null;
+  if (masked) {
+    if (buffer.length < offset + 4) return null;
+    mask = buffer.subarray(offset, offset + 4);
+    offset += 4;
+  }
+  if (buffer.length < offset + length) return null;
+
+  const payload = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask) {
+    for (let i = 0; i < payload.length; i += 1) payload[i] ^= mask[i & 3];
+  }
+  return { opcode, payload, size: offset + length };
+}
+
+/**
+ * Listen on an ephemeral port and resolve the first `node.register` payload.
+ *
+ * Plain HTTP requests get a permissive `{}` so an unrelated startup call cannot
+ * abort the broker before it reaches the node-control socket. Nothing here
+ * inspects or asserts; the caller owns the semantics.
+ */
+export function startNodeControlObserver() {
+  let resolveRegister;
+  const register = new Promise((resolve) => {
+    resolveRegister = resolve;
+  });
+  const frames = [];
+
+  // The broker completes an HTTP startup session before it opens the
+  // node-control socket, so these have to answer in Relaycast's envelope shape
+  // (`{ok, data}`) or the broker aborts with "failed registering agent for
+  // configured workspace". The shapes mirror the mocks in
+  // crates/broker/src/relaycast/auth.rs. Nothing here is asserted on; it exists
+  // only to let the broker reach the frame this case actually reads.
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      let name = 'relayflow-proof';
+      try {
+        const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+        if (typeof parsed.name === 'string' && parsed.name) name = parsed.name;
+      } catch {
+        // Not every startup call carries a JSON body; the default name is fine.
+      }
+      const agent = {
+        id: 'a_relayflow_proof',
+        workspace_id: 'ws_relayflow_proof',
+        name,
+        type: 'agent',
+        token: 'at_live_relayflowproof',
+        status: 'online',
+        persona: null,
+        metadata: {},
+        channels: [],
+        created_at: '2025-01-01T00:00:00Z',
+        last_seen: '2025-01-01T00:00:00Z',
+      };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, data: agent }));
+    });
+  });
+
+  server.on('upgrade', (req, socket) => {
+    if (!req.url || !req.url.startsWith('/v1/node/ws')) {
+      socket.destroy();
+      return;
+    }
+    const key = req.headers['sec-websocket-key'];
+    const accept = crypto.createHash('sha1').update(`${key}${WS_GUID}`).digest('base64');
+    socket.write(
+      [
+        'HTTP/1.1 101 Switching Protocols',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        `Sec-WebSocket-Accept: ${accept}`,
+        '',
+        '',
+      ].join('\r\n')
+    );
+
+    let buffered = Buffer.alloc(0);
+    socket.on('error', () => {});
+    socket.on('data', (chunk) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      for (;;) {
+        let frame;
+        try {
+          frame = decodeFrame(buffered);
+        } catch {
+          socket.destroy();
+          return;
+        }
+        if (!frame) return;
+        buffered = buffered.subarray(frame.size);
+        if (frame.opcode === 0x8) {
+          socket.end();
+          return;
+        }
+        if (frame.opcode !== 0x1) continue;
+        const text = frame.payload.toString('utf8');
+        frames.push(text);
+        let message;
+        try {
+          message = JSON.parse(text);
+        } catch {
+          continue;
+        }
+        if (message && message.type === 'node.register') resolveRegister(message);
+      }
+    });
+  });
+
+  const listening = new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+
+  return { server, listening, register, frames };
+}


### PR DESCRIPTION
Closes #1622.

## What was wrong

A node served by `agent-relay-broker init` could never advertise a repository, because the only place the broker builds a `NodeManifest` hardcoded the field:

```rust
// crates/broker/src/runtime/init.rs
tags: None,
repo_keys: None,      // <-- no configuration surface at all
```

The manifest is only ever constructed in-process — no env var, file, or stdin path deserializes one — and the broker's complete node-config surface was `AGENT_RELAY_NODE_HARNESSES` and `AGENT_RELAY_NODE_MAX_AGENTS`. A search for any env var matching `[A-Z_]*REPO[A-Z_]*` across `crates/` returned nothing.

Everything downstream was already plumbed: `protocol.rs` carries `repo_keys`, `node_control.rs` forwards it into registration, and `fleet_wire.rs` asserts the wire accepts public keys and rejects private paths. Only the producer could not populate it, so a broker-served node was permanently ineligible for any repo-qualified placement.

## Impact this unblocks

`sf-mini` runs via `broker init`, reports `tags: []`, and **has the factory repo checked out** — it simply had no way to say so. It is not alone: all five spawn-capable nodes online in `rw_7ccfea89` (`sf-mini`, `finn-mini`, `daytona-1538-verify-0817b`, `cloud-3061-repro-0817`, `cloud-3129-ctrl-3`) report `tags: []`, so no node in the workspace can be selected for a repo-qualified placement at all. A Factory dispatch carrying `repo: AgentWorkforce/factory` had nowhere to land:

```
{"issue":"409","agents":["ar-409-impl-factory"],"phase":"dispatching",
 "heldForMs":1800091,"holdTimeoutMs":1800000,"reason":"agentless-slot-past-deadline"}
[factory] released a dispatch lifecycle that never placed an agent
```

Switching that host to the `agent-relay node up` path (which does support `repoPaths`) is not a workaround: it was deliberately moved off it because `node up` inside a git repo rewrites the repo pin (#1432 item 4) and previously left the node silently offline in this workspace for 18 days.

## The change

`node_capacity_repos()` reads `AGENT_RELAY_NODE_REPOS` as a comma-separated, trimmed, order-preserving, de-duplicated list, mirroring `node_capacity_harnesses()` exactly. `bootstrap_node_manifest` uses it instead of `None`.

Two deliberate decisions:

- **Absent yields `None`, not `Some([])`.** Every broker-served node in the fleet today has no such variable set, and `Some([])` is forwarded by `build_node_register` as an authoritative *clear*. Conflating the two would have turned a no-op upgrade into a fleet-wide retraction. A value that is present but contributes no entries still yields `Some([])`, which is how an operator deliberately retracts a stale advertisement.
- **The producer does not validate.** `build_node_register` already treats the Fleet wire as a privacy boundary and drops anything that is not a bare `owner/name` key. A second copy of that rule would sit one edit away from disagreeing with the one that actually guards the wire.

## Tests

Four added, all in `runtime::init::tests`:

- `bootstrap_node_manifest_advertises_no_repos_when_env_is_absent` — the backward-compatibility guard
- `bootstrap_node_manifest_advertises_configured_repo_keys` — trimmed, order-preserving, de-duplicated
- `bootstrap_node_manifest_forwards_an_explicitly_empty_value_as_a_clear` — present-but-empty is distinct from absent
- `configured_repo_paths_never_reach_the_fleet_wire` — pipes a path-shaped env value through the **real** producer into `build_node_register` and asserts no absolute path is serialized, so the two halves are proven to compose rather than each being correct alone

### Ablation

With only `repo_keys: node_capacity_repos()` reverted to `None` and the tests untouched:

```
bootstrap_node_manifest_advertises_configured_repo_keys            ... FAILED
bootstrap_node_manifest_forwards_an_explicitly_empty_value_as_a_clear ... FAILED
configured_repo_paths_never_reach_the_fleet_wire                  ... FAILED
bootstrap_node_manifest_advertises_no_repos_when_env_is_absent    ... ok
```

Three fail, and the backward-compat guard correctly still passes — it asserts the reverted behaviour.

### A defect the ablation caught

The ablation run also failed `node_id_env_guard_restores_original_node_env`, a pre-existing test that had passed moments earlier. That was order-dependence I introduced: I had given the new guard its **own** mutex. `set_var` rewrites a process-global environ table, so mutating one key races a concurrent read of any other key — which is why this module already had a single lock. The new guard now takes `NODE_ID_ENV_MUTEX`, and the reason is recorded on the static so it is not re-split later. `runtime::init` was then run six consecutive times with no failures.

Reported by factory-lead-r4 while tracing why Cloud Factory dispatched work that never placed.

### Pre-existing failures, baselined

The full `-p agent-relay-broker --lib` run reports **1024 passed, 5 failed**. All five are `spawner::tests::broker_hook_*`, which shell out to a real `git commit` in a temp fixture. The identical five fail on unmodified `origin/main` in a clean worktree (`5 passed; 5 failed` of the `broker_hook` filter), so they are pre-existing and environmental, not introduced here. Baselined rather than assumed.

## RelayFlow Proof

- Change type: `feature` <!-- relay-pr-proof:type -->
- RelayFlow case: `1622-broker-node-repo-keys` <!-- relay-pr-proof:case -->

`bootstrap_node_manifest` is private, so nothing outside the crate can call it, and the contract is explicit that a unit test present only on the head cannot prove the base is broken. So the case builds `agent-relay-broker` from the **target** checkout and runs the real binary against a dependency-free stand-in for Relaycast's node-control endpoint, reading the `node.register` frame the broker actually puts on the wire. `repo_keys` is `skip_serializing_if = "Option::is_none"`, so the field is absent from that frame on base and present on head.

The observation is derived from the captured frame, never from `RELAY_PR_PROOF_ARM` — the arm only labels the record. A head build that failed to advertise would report `absent` and be rejected by the gate.

Verified locally on both arms before pushing:

| Arm | Checkout | `node.register` | Result |
| --- | --- | --- | --- |
| base | `a8d2cab09` (clean `origin/main`) | no `repo_keys` field, despite `AGENT_RELAY_NODE_REPOS` being set | `absent` / `broker_node_register_omits_repo_keys` |
| head | this branch | `"repo_keys":["AgentWorkforce/factory","AgentWorkforce/relay"]` | `fixed` / `broker_node_register_advertises_sorted_repo_keys` |

The configured value is deliberately unsorted (`AgentWorkforce/relay,AgentWorkforce/factory`), so the head arm also demonstrates the canonical ordering.

This is the repository's first Rust proof case; both existing cases are TypeScript. The cold `cargo build` measured **4m18s** locally, within the manifest's 1800s cap, but it is the dominant cost of each arm.
