### PR TITLE
feat(cli): select E2B for fleet sandbox spawn

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_de4u72fsjyyq/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_de4u72fsjyyq/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Finalize and release E2B fleet provider CLI
+
+> **Status:** ✅ Completed
+> **Task:** relay#1628
+> **Confidence:** 96%
+> **Started:** September 1, 2026 at 11:16 AM
+> **Completed:** September 1, 2026 at 11:18 AM
+
+---
+
+## Summary
+
+Made the E2B provider proof restart-safe and revalidated 51 focused tests, Cloud and CLI builds, and exact-head RelayFlow proof.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Overwrite fixed-name RelayFlow probe files on rerun
+- **Chose:** Overwrite fixed-name RelayFlow probe files on rerun
+- **Reasoning:** A killed proof can leave stale files; deterministic reruns must regenerate them while the finally block still removes normal-run artifacts.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Overwrite fixed-name RelayFlow probe files on rerun: Overwrite fixed-name RelayFlow probe files on rerun

--- a/.agentworkforce/trajectories/completed/2026-09/traj_de4u72fsjyyq/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_de4u72fsjyyq/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_de4u72fsjyyq",
+  "version": 1,
+  "task": {
+    "title": "Finalize and release E2B fleet provider CLI",
+    "source": {
+      "system": "plain",
+      "id": "relay#1628"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-01T09:16:36.054Z",
+  "completedAt": "2026-09-01T09:18:23.432Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-01T09:18:22.564Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_956k15i37bzl",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-01T09:18:22.564Z",
+      "endedAt": "2026-09-01T09:18:23.432Z",
+      "events": [
+        {
+          "ts": 1788254302564,
+          "type": "decision",
+          "content": "Overwrite fixed-name RelayFlow probe files on rerun: Overwrite fixed-name RelayFlow probe files on rerun",
+          "raw": {
+            "question": "Overwrite fixed-name RelayFlow probe files on rerun",
+            "chosen": "Overwrite fixed-name RelayFlow probe files on rerun",
+            "alternatives": [],
+            "reasoning": "A killed proof can leave stale files; deterministic reruns must regenerate them while the finally block still removes normal-run artifacts."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Made the E2B provider proof restart-safe and revalidated 51 focused tests, Cloud and CLI builds, and exact-head RelayFlow proof.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "db5f3afb6f30d1486677e26af7066bee16b60ca0",
+    "endRef": "db5f3afb6f30d1486677e26af7066bee16b60ca0"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- `agent-relay fleet spawn --sandbox-provider <daytona|e2b>` pins fresh Cloud sandbox placement to a provider and preserves that provider through attribution checks and cleanup.
 
 ## [11.8.7] - 2026-08-29
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,11 +147,12 @@ agent-relay fleet spawn codex \
 # Omit --node for automatic eligible-node placement.
 agent-relay fleet spawn codex --name api-worker --task "Review the current diff."
 
-# Provision a fresh Daytona node, require the current Relayfile workspace to
-# mount at /workspace, wait for readiness, then spawn Codex there.
+# Provision a fresh E2B node, require the current Relayfile workspace to mount
+# at /workspace, wait for readiness, then spawn Codex there.
 agent-relay fleet spawn codex \
   --sandbox \
-  --name daytona-worker \
+  --sandbox-provider e2b \
+  --name e2b-worker \
   --task "Review the current workspace and wait for follow-up."
 
 agent-relay message dm send api-worker "Detailed task instructions"
@@ -172,11 +173,13 @@ login (`agent-relay cloud login`) but does not need an agent token: when one is
 absent, it creates and removes a short-lived launcher identity automatically.
 Automatic placement and release need only the workspace key.
 
-The sandbox path provisions a fresh Daytona instance and makes the Relayfile
+The sandbox path provisions a fresh hosted instance and makes the Relayfile
 mount mandatory by default, so the spawned worker starts in `/workspace` and
-sees the same synced Relayfile workspace. Pass `--no-sandbox-relayfile` only
-when a deliberately bare sandbox is desired. If provisioning times out or the
-spawn fails, Relay asks Cloud to delete the newly created sandbox.
+sees the same synced Relayfile workspace. Use `--sandbox-provider daytona` or
+`--sandbox-provider e2b` to require an operator-enabled provider; omit the flag
+to let Cloud's sandbox router choose. Pass `--no-sandbox-relayfile` only when a
+deliberately bare sandbox is desired. If provisioning times out or the spawn
+fails, Relay asks Cloud to delete the newly created sandbox.
 
 `--session-ref` is a real CLI resume, not a logical collaboration label. Pass
 the actual Claude session ID or Codex thread ID and target its origin node.

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -643,12 +643,12 @@ describe('fleet command support', () => {
     });
   });
 
-  it('fleet spawn --sandbox provisions Daytona, mounts Relayfile, and uses a temporary launcher', async () => {
+  it('fleet spawn --sandbox-provider e2b provisions E2B, mounts Relayfile, and uses a temporary launcher', async () => {
     vi.stubEnv('RELAY_AGENT_TOKEN', undefined);
     const placement = {
       spawn: vi.fn(async () => ({
         invocationId: 'inv_sandbox',
-        node: { name: 'daytona-codex' },
+        node: { name: 'e2b-codex' },
       })),
     };
     const register = vi.fn(async () => ({ token: 'at_live_launcher' }));
@@ -663,9 +663,10 @@ describe('fleet command support', () => {
     const createAgentRelay = vi.fn(() => ({ messaging: { placement } }));
     const ensureCloudFleetSandbox = vi.fn(async () => ({
       outcome: 'provisioned' as const,
+      providerId: 'e2b' as const,
       cloudWorkspaceId: 'cloud-workspace',
       nodeId: 'node-1',
-      nodeName: 'daytona-codex',
+      nodeName: 'e2b-codex',
       sandboxId: 'sandbox-1',
       relayWorkspaceId: 'rw_abc',
       relayfileMounted: true,
@@ -698,8 +699,10 @@ describe('fleet command support', () => {
         'spawn',
         'codex',
         '--sandbox',
+        '--sandbox-provider',
+        'e2b',
         '--sandbox-name',
-        'daytona-codex',
+        'e2b-codex',
         '--name',
         'sandbox-worker',
         '--task',
@@ -715,8 +718,9 @@ describe('fleet command support', () => {
       maxAgents: 1,
       mountRelayfile: true,
       forceProvision: true,
+      providerId: 'e2b',
       waitTimeoutMs: 90_000,
-      name: 'daytona-codex',
+      name: 'e2b-codex',
     });
     expect(register).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -733,7 +737,7 @@ describe('fleet command support', () => {
     expect(placement.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         capability: 'spawn:codex',
-        node: 'daytona-codex',
+        node: 'e2b-codex',
         confirm: true,
         input: expect.objectContaining({
           name: 'sandbox-worker',
@@ -749,9 +753,9 @@ describe('fleet command support', () => {
     );
     expect(deleteCloudFleetSandbox).not.toHaveBeenCalled();
     expect(JSON.parse(logs[0]!)).toMatchObject({
-      sandbox: { nodeName: 'daytona-codex', relayfileMountPath: '/workspace' },
+      sandbox: { providerId: 'e2b', nodeName: 'e2b-codex', relayfileMountPath: '/workspace' },
       invocation: { invocationId: 'inv_sandbox' },
-      attachCommand: "agent-relay node agent attach 'sandbox-worker' --node 'daytona-codex' --mode drive",
+      attachCommand: "agent-relay node agent attach 'sandbox-worker' --node 'e2b-codex' --mode drive",
     });
   });
 
@@ -875,6 +879,70 @@ describe('fleet command support', () => {
     expect(deleteCloudFleetSandbox).toHaveBeenCalledWith({
       cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
       sandboxId: 'sandbox-1',
+    });
+  });
+
+  it('pins cleanup to the requested E2B provider when Cloud fails closed after provisioning', async () => {
+    const deleteCloudFleetSandbox = vi.fn(async () => undefined);
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn(() => ({
+          workspace: { info: vi.fn(async () => ({ id: 'rw_abc' })) },
+        })) as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (() => {
+          throw new Error('__exit__');
+        }) as never,
+      },
+      ensureCloudFleetSandbox: vi.fn(async () => {
+        throw new CloudFleetSandboxProvisionError('Cloud did not prove requested provider e2b.', {
+          cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
+          sandboxId: 'sandbox-e2b',
+          nodeName: 'e2b-codex',
+          providerId: 'e2b',
+          outcomeUnknown: true,
+        });
+      }),
+      deleteCloudFleetSandbox,
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await expect(
+      program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'codex',
+          '--sandbox',
+          '--sandbox-provider',
+          'e2b',
+          '--sandbox-name',
+          'e2b-codex',
+          '--name',
+          'sandbox-worker',
+          '--task',
+          'Work',
+          '--workspace-key',
+          'rk_live_test',
+          '--token',
+          'at_live_lead',
+        ],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('__exit__');
+
+    expect(deleteCloudFleetSandbox).toHaveBeenCalledWith({
+      cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
+      sandboxId: 'sandbox-e2b',
+      providerId: 'e2b',
     });
   });
 

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -193,11 +193,12 @@ export function registerFleetCommands(
       const useSandbox = options.sandbox === true;
       const sandboxName = optionalText(options.sandboxName, 'Sandbox name');
       const sandboxProviderText = optionalText(options.sandboxProvider, 'Sandbox provider');
-      const sandboxProvider: CloudFleetSandboxProviderId | undefined = sandboxProviderText === undefined
-        ? undefined
-        : sandboxProviderText === 'daytona' || sandboxProviderText === 'e2b'
-          ? sandboxProviderText
-          : undefined;
+      const sandboxProvider: CloudFleetSandboxProviderId | undefined =
+        sandboxProviderText === undefined
+          ? undefined
+          : sandboxProviderText === 'daytona' || sandboxProviderText === 'e2b'
+            ? sandboxProviderText
+            : undefined;
       if (sandboxProviderText !== undefined && sandboxProvider === undefined) {
         throw new Error('--sandbox-provider must be daytona or e2b.');
       }

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -5,6 +5,7 @@ import {
   CloudFleetSandboxProvisionError,
   deleteCloudFleetSandbox,
   ensureCloudFleetSandbox,
+  type CloudFleetSandboxProviderId,
   type EnsureCloudFleetSandboxResult,
 } from '@agent-relay/cloud';
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
@@ -158,9 +159,10 @@ export function registerFleetCommands(
       .option('--target-node <name>', 'Alias for --node')
       .option(
         '--sandbox',
-        'Provision a fresh Cloud Daytona node, mount this Relayfile workspace, and spawn there'
+        'Provision a fresh Cloud sandbox node, mount this Relayfile workspace, and spawn there'
       )
-      .option('--sandbox-name <name>', 'Name for the provisioned Daytona fleet node')
+      .option('--sandbox-name <name>', 'Name for the provisioned sandbox fleet node')
+      .option('--sandbox-provider <provider>', 'Sandbox provider: daytona or e2b')
       .option('--no-sandbox-relayfile', 'Provision the sandbox without mounting Relayfile')
       .option('--channel <name>', 'Channel for the worker to join')
       .option('--persona <persona>', 'Worker persona (automatic placement)')
@@ -190,12 +192,24 @@ export function registerFleetCommands(
       let targetNode = optionalText(options.targetNode, 'Target node') ?? optionalText(options.node, 'Node');
       const useSandbox = options.sandbox === true;
       const sandboxName = optionalText(options.sandboxName, 'Sandbox name');
+      const sandboxProviderText = optionalText(options.sandboxProvider, 'Sandbox provider');
+      const sandboxProvider: CloudFleetSandboxProviderId | undefined = sandboxProviderText === undefined
+        ? undefined
+        : sandboxProviderText === 'daytona' || sandboxProviderText === 'e2b'
+          ? sandboxProviderText
+          : undefined;
+      if (sandboxProviderText !== undefined && sandboxProvider === undefined) {
+        throw new Error('--sandbox-provider must be daytona or e2b.');
+      }
       const mountSandboxRelayfile = options.sandboxRelayfile !== false;
       if (useSandbox && targetNode) {
         throw new Error('--sandbox cannot be combined with --node or --target-node.');
       }
       if (!useSandbox && sandboxName) {
         throw new Error('--sandbox-name requires --sandbox.');
+      }
+      if (!useSandbox && sandboxProvider) {
+        throw new Error('--sandbox-provider requires --sandbox.');
       }
       if (!useSandbox && options.sandboxRelayfile === false) {
         throw new Error('--no-sandbox-relayfile requires --sandbox.');
@@ -236,6 +250,7 @@ export function registerFleetCommands(
             maxAgents: 1,
             mountRelayfile: mountSandboxRelayfile,
             forceProvision: true,
+            ...(sandboxProvider === undefined ? {} : { providerId: sandboxProvider }),
             waitTimeoutMs: 90_000,
             name: requestedSandboxName,
           });
@@ -245,10 +260,11 @@ export function registerFleetCommands(
               .deleteCloudFleetSandbox({
                 cloudWorkspaceId: error.cloudWorkspaceId,
                 sandboxId: error.sandboxId,
+                ...(error.providerId === undefined ? {} : { providerId: error.providerId }),
               })
               .catch((cleanupError) => {
                 deps.warn(
-                  `Provisioning failed after Daytona created sandbox '${error.sandboxId}', and automatic cleanup failed: ${
+                  `Provisioning failed after Cloud created sandbox '${error.sandboxId}', and automatic cleanup failed: ${
                     cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
                   }`
                 );
@@ -257,7 +273,7 @@ export function registerFleetCommands(
             deps.warn(
               `Cloud did not return a complete provisioning response. The outcome is unknown; check Cloud Fleet for node '${
                 error.nodeName ?? requestedSandboxName
-              }' before retrying so a Daytona sandbox is not left running.`
+              }' before retrying so a sandbox is not left running.`
             );
           }
           throw error;
@@ -267,6 +283,7 @@ export function registerFleetCommands(
             .deleteCloudFleetSandbox({
               cloudWorkspaceId: sandbox.cloudWorkspaceId,
               sandboxId: sandbox.sandboxId,
+              ...(sandbox.providerId === undefined ? {} : { providerId: sandbox.providerId }),
             })
             .catch((error) => {
               deps.warn(
@@ -276,7 +293,7 @@ export function registerFleetCommands(
               );
             });
           throw new Error(
-            `Daytona node '${sandbox.nodeName}' did not become ready within ${sandbox.waitedMs}ms.`
+            `Sandbox node '${sandbox.nodeName}' did not become ready within ${sandbox.waitedMs}ms.`
           );
         }
         if (
@@ -288,6 +305,7 @@ export function registerFleetCommands(
               .deleteCloudFleetSandbox({
                 cloudWorkspaceId: sandbox.cloudWorkspaceId,
                 sandboxId: sandbox.sandboxId,
+                ...(sandbox.providerId === undefined ? {} : { providerId: sandbox.providerId }),
               })
               .catch((error) => {
                 deps.warn(
@@ -297,7 +315,7 @@ export function registerFleetCommands(
                 );
               });
           }
-          throw new Error('Cloud returned a Daytona node without the required Relayfile mount.');
+          throw new Error('Cloud returned a sandbox node without the required Relayfile mount.');
         }
         targetNode = sandbox.nodeName;
         if (!workerCwd && sandbox.outcome === 'provisioned' && sandbox.relayfileMounted) {
@@ -366,6 +384,7 @@ export function registerFleetCommands(
               .deleteCloudFleetSandbox({
                 cloudWorkspaceId: sandbox.cloudWorkspaceId,
                 sandboxId: sandbox.sandboxId,
+                ...(sandbox.providerId === undefined ? {} : { providerId: sandbox.providerId }),
               })
               .catch((cleanupError) => {
                 deps.warn(

--- a/packages/cloud/src/fleet-sandbox.test.ts
+++ b/packages/cloud/src/fleet-sandbox.test.ts
@@ -165,9 +165,11 @@ describe('Cloud fleet sandbox client', () => {
     });
 
     const ensureCall = mocks.authorizedApiFetch.mock.calls[1];
-    expect(JSON.parse(String(ensureCall?.[2]?.body))).toEqual(expect.objectContaining({
-      providerId: 'e2b',
-    }));
+    expect(JSON.parse(String(ensureCall?.[2]?.body))).toEqual(
+      expect.objectContaining({
+        providerId: 'e2b',
+      })
+    );
     expect(result).toEqual(expect.objectContaining({ providerId: 'e2b' }));
   });
 

--- a/packages/cloud/src/fleet-sandbox.test.ts
+++ b/packages/cloud/src/fleet-sandbox.test.ts
@@ -135,6 +135,207 @@ describe('Cloud fleet sandbox client', () => {
     });
   });
 
+  it('requests and verifies an exact E2B provider', async () => {
+    mocks.authorizedApiFetch
+      .mockResolvedValueOnce({
+        response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: Response.json(
+          {
+            outcome: 'provisioned',
+            providerId: 'e2b',
+            nodeId: 'node-e2b',
+            nodeName: 'e2b-reviewer',
+            sandboxId: 'sandbox-e2b',
+            relayWorkspaceId: 'rw_abc',
+            relayfileMounted: true,
+          },
+          { status: 201 }
+        ),
+        auth,
+      });
+
+    const result = await ensureCloudFleetSandbox({
+      workspaceId: 'rw_abc',
+      requiredCapability: 'spawn:codex',
+      forceProvision: true,
+      providerId: 'e2b',
+    });
+
+    const ensureCall = mocks.authorizedApiFetch.mock.calls[1];
+    expect(JSON.parse(String(ensureCall?.[2]?.body))).toEqual(expect.objectContaining({
+      providerId: 'e2b',
+    }));
+    expect(result).toEqual(expect.objectContaining({ providerId: 'e2b' }));
+  });
+
+  it('rejects and preserves cleanup identity when Cloud cannot prove the requested provider', async () => {
+    mocks.authorizedApiFetch
+      .mockResolvedValueOnce({
+        response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: Response.json(
+          {
+            outcome: 'provisioned',
+            providerId: 'daytona',
+            nodeId: 'node-1',
+            nodeName: 'wrong-provider',
+            sandboxId: 'sandbox-1',
+            relayWorkspaceId: 'rw_abc',
+            relayfileMounted: true,
+          },
+          { status: 201 }
+        ),
+        auth,
+      });
+
+    const error = await ensureCloudFleetSandbox({
+      workspaceId: 'rw_abc',
+      requiredCapability: 'spawn:codex',
+      providerId: 'e2b',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(CloudFleetSandboxProvisionError);
+    expect(error).toMatchObject({
+      sandboxId: 'sandbox-1',
+      nodeName: 'wrong-provider',
+      providerId: 'daytona',
+      outcomeUnknown: true,
+    });
+    expect(String(error)).toContain('instead of requested provider e2b');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['invalid', 'modal'],
+  ])(
+    'preserves the requested provider for cleanup when a %s provider proof arrives on a 201 response',
+    async (_case, providerId) => {
+      mocks.authorizedApiFetch
+        .mockResolvedValueOnce({
+          response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+          auth,
+        })
+        .mockResolvedValueOnce({
+          response: Response.json(
+            {
+              outcome: 'provisioned',
+              nodeId: 'node-e2b',
+              nodeName: 'e2b-reviewer',
+              sandboxId: 'sandbox-e2b',
+              relayWorkspaceId: 'rw_abc',
+              relayfileMounted: true,
+              ...(providerId === undefined ? {} : { providerId }),
+            },
+            { status: 201 }
+          ),
+          auth,
+        });
+
+      const error = await ensureCloudFleetSandbox({
+        workspaceId: 'rw_abc',
+        requiredCapability: 'spawn:codex',
+        providerId: 'e2b',
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(CloudFleetSandboxProvisionError);
+      expect(error).toMatchObject({
+        cloudWorkspaceId: CLOUD_WORKSPACE_ID,
+        sandboxId: 'sandbox-e2b',
+        nodeName: 'e2b-reviewer',
+        providerId: 'e2b',
+        outcomeUnknown: true,
+      });
+    }
+  );
+
+  it.each([
+    ['missing', undefined],
+    ['invalid', 'modal'],
+  ])(
+    'preserves the requested provider for cleanup when a %s provider proof arrives on a 202 timeout response',
+    async (_case, providerId) => {
+      mocks.authorizedApiFetch
+        .mockResolvedValueOnce({
+          response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+          auth,
+        })
+        .mockResolvedValueOnce({
+          response: Response.json(
+            {
+              outcome: 'provisioning_timeout',
+              sandboxId: 'sandbox-e2b',
+              relayWorkspaceId: 'rw_abc',
+              nodeName: 'e2b-reviewer',
+              waitedMs: 90_000,
+              ...(providerId === undefined ? {} : { providerId }),
+            },
+            { status: 202 }
+          ),
+          auth,
+        });
+
+      const error = await ensureCloudFleetSandbox({
+        workspaceId: 'rw_abc',
+        requiredCapability: 'spawn:codex',
+        providerId: 'e2b',
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(CloudFleetSandboxProvisionError);
+      expect(error).toMatchObject({
+        cloudWorkspaceId: CLOUD_WORKSPACE_ID,
+        sandboxId: 'sandbox-e2b',
+        nodeName: 'e2b-reviewer',
+        providerId: 'e2b',
+        outcomeUnknown: true,
+      });
+    }
+  );
+
+  it.each([
+    ['missing', undefined],
+    ['invalid', 'modal'],
+  ])(
+    'preserves the requested provider for cleanup when a %s provider proof arrives on a non-OK response',
+    async (_case, providerId) => {
+      mocks.authorizedApiFetch
+        .mockResolvedValueOnce({
+          response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+          auth,
+        })
+        .mockResolvedValueOnce({
+          response: Response.json(
+            {
+              error: 'provider rejected request',
+              nodeName: 'e2b-reviewer',
+              sandboxId: 'sandbox-e2b',
+              ...(providerId === undefined ? {} : { providerId }),
+            },
+            { status: 502 }
+          ),
+          auth,
+        });
+
+      const error = await ensureCloudFleetSandbox({
+        workspaceId: 'rw_abc',
+        requiredCapability: 'spawn:codex',
+        providerId: 'e2b',
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(CloudFleetSandboxProvisionError);
+      expect(error).toMatchObject({
+        cloudWorkspaceId: CLOUD_WORKSPACE_ID,
+        sandboxId: 'sandbox-e2b',
+        nodeName: 'e2b-reviewer',
+        providerId: 'e2b',
+      });
+    }
+  );
+
   it('omits repos from the body when the caller did not opt in', async () => {
     mocks.authorizedApiFetch
       .mockResolvedValueOnce({
@@ -415,6 +616,30 @@ describe('Cloud fleet sandbox client', () => {
         method: 'DELETE',
         signal: expect.any(AbortSignal),
         body: JSON.stringify({ workspaceId: CLOUD_WORKSPACE_ID }),
+      },
+      { interactive: false }
+    );
+  });
+
+  it('passes E2B provider identity through the deletion request', async () => {
+    mocks.authorizedApiFetch.mockResolvedValueOnce({
+      response: Response.json({ sandboxId: 'sandbox-e2b', providerId: 'e2b', deleted: true }),
+      auth,
+    });
+
+    await deleteCloudFleetSandbox({
+      cloudWorkspaceId: CLOUD_WORKSPACE_ID,
+      sandboxId: 'sandbox-e2b',
+      providerId: 'e2b',
+    });
+
+    expect(mocks.authorizedApiFetch).toHaveBeenCalledWith(
+      auth,
+      '/api/v1/fleet/nodes/sandbox/sandbox-e2b',
+      {
+        method: 'DELETE',
+        signal: expect.any(AbortSignal),
+        body: JSON.stringify({ workspaceId: CLOUD_WORKSPACE_ID, providerId: 'e2b' }),
       },
       { interactive: false }
     );

--- a/packages/cloud/src/fleet-sandbox.test.ts
+++ b/packages/cloud/src/fleet-sandbox.test.ts
@@ -173,6 +173,74 @@ describe('Cloud fleet sandbox client', () => {
     expect(result).toEqual(expect.objectContaining({ providerId: 'e2b' }));
   });
 
+  it('preserves provider attribution on a reused sandbox response', async () => {
+    mocks.authorizedApiFetch
+      .mockResolvedValueOnce({
+        response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: Response.json({
+          outcome: 'reused',
+          providerId: 'e2b',
+          nodeId: 'node-e2b',
+          nodeName: 'e2b-reviewer',
+          status: 'online',
+          activeAgents: 0,
+          maxAgents: 1,
+        }),
+        auth,
+      });
+
+    await expect(
+      ensureCloudFleetSandbox({
+        workspaceId: 'rw_abc',
+        requiredCapability: 'spawn:codex',
+        providerId: 'e2b',
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        outcome: 'reused',
+        providerId: 'e2b',
+      })
+    );
+  });
+
+  it('keeps router-selected responses forward compatible when no exact provider was requested', async () => {
+    mocks.authorizedApiFetch
+      .mockResolvedValueOnce({
+        response: Response.json({ cloudWorkspaceId: CLOUD_WORKSPACE_ID }),
+        auth,
+      })
+      .mockResolvedValueOnce({
+        response: Response.json(
+          {
+            outcome: 'provisioned',
+            providerId: 'future-provider',
+            nodeId: 'node-future',
+            nodeName: 'future-reviewer',
+            sandboxId: 'sandbox-future',
+            relayWorkspaceId: 'rw_abc',
+            relayfileMounted: true,
+          },
+          { status: 201 }
+        ),
+        auth,
+      });
+
+    await expect(
+      ensureCloudFleetSandbox({
+        workspaceId: 'rw_abc',
+        requiredCapability: 'spawn:codex',
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        outcome: 'provisioned',
+        sandboxId: 'sandbox-future',
+      })
+    );
+  });
+
   it('rejects and preserves cleanup identity when Cloud cannot prove the requested provider', async () => {
     mocks.authorizedApiFetch
       .mockResolvedValueOnce({

--- a/packages/cloud/src/fleet-sandbox.ts
+++ b/packages/cloud/src/fleet-sandbox.ts
@@ -111,7 +111,9 @@ export type CloudFleetSandboxProvisioningTimeout = {
 };
 
 export type EnsureCloudFleetSandboxResult =
-  CloudFleetSandboxReady | CloudFleetSandboxReused | CloudFleetSandboxProvisioningTimeout;
+  | CloudFleetSandboxReady
+  | CloudFleetSandboxReused
+  | CloudFleetSandboxProvisioningTimeout;
 
 export type DeleteCloudFleetSandboxInput = {
   cloudWorkspaceId: string;

--- a/packages/cloud/src/fleet-sandbox.ts
+++ b/packages/cloud/src/fleet-sandbox.ts
@@ -222,7 +222,7 @@ function readProviderId(payload: JsonRecord): CloudFleetSandboxProviderId | unde
 
 function cleanupProviderId(
   payload: JsonRecord,
-  requestedProviderId?: CloudFleetSandboxProviderId,
+  requestedProviderId?: CloudFleetSandboxProviderId
 ): CloudFleetSandboxProviderId | undefined {
   const payloadProviderId = readString(payload, 'providerId');
   return payloadProviderId === 'daytona' || payloadProviderId === 'e2b'
@@ -233,7 +233,7 @@ function cleanupProviderId(
 function normalizeEnsureResult(
   payload: unknown,
   cloudWorkspaceId: string,
-  requestedProviderId?: CloudFleetSandboxProviderId,
+  requestedProviderId?: CloudFleetSandboxProviderId
 ): EnsureCloudFleetSandboxResult {
   if (!isObject(payload)) throw new Error('Cloud fleet sandbox response was not valid JSON.');
   const outcome = readString(payload, 'outcome');
@@ -243,7 +243,7 @@ function normalizeEnsureResult(
     throw new Error(
       providerId === undefined
         ? `Cloud did not prove requested provider ${requestedProviderId}.`
-        : `Cloud returned provider ${providerId} instead of requested provider ${requestedProviderId}.`,
+        : `Cloud returned provider ${providerId} instead of requested provider ${requestedProviderId}.`
     );
   }
 
@@ -366,9 +366,7 @@ export async function ensureCloudFleetSandbox(
   try {
     return normalizeEnsureResult(payload, resolved.cloudWorkspaceId, input.providerId);
   } catch (error) {
-    const providerId = isObject(payload)
-      ? cleanupProviderId(payload, input.providerId)
-      : input.providerId;
+    const providerId = isObject(payload) ? cleanupProviderId(payload, input.providerId) : input.providerId;
     throw new CloudFleetSandboxProvisionError(
       error instanceof Error ? error.message : 'Cloud fleet sandbox response was invalid.',
       {

--- a/packages/cloud/src/fleet-sandbox.ts
+++ b/packages/cloud/src/fleet-sandbox.ts
@@ -20,6 +20,8 @@ export type CloudFleetSandboxRequestOptions = {
   timeoutMs?: number;
 };
 
+export type CloudFleetSandboxProviderId = 'daytona' | 'e2b';
+
 /**
  * Carries every safe identifier Cloud returned when provisioning failed after
  * the request may have created a billable sandbox.
@@ -28,6 +30,7 @@ export class CloudFleetSandboxProvisionError extends Error {
   readonly cloudWorkspaceId?: string;
   readonly sandboxId?: string;
   readonly nodeName?: string;
+  readonly providerId?: CloudFleetSandboxProviderId;
   readonly outcomeUnknown: boolean;
 
   constructor(
@@ -36,6 +39,7 @@ export class CloudFleetSandboxProvisionError extends Error {
       cloudWorkspaceId?: string;
       sandboxId?: string;
       nodeName?: string;
+      providerId?: CloudFleetSandboxProviderId;
       outcomeUnknown?: boolean;
       cause?: unknown;
     } = {}
@@ -45,6 +49,7 @@ export class CloudFleetSandboxProvisionError extends Error {
     this.cloudWorkspaceId = identity.cloudWorkspaceId;
     this.sandboxId = identity.sandboxId;
     this.nodeName = identity.nodeName;
+    this.providerId = identity.providerId;
     this.outcomeUnknown = identity.outcomeUnknown === true;
   }
 }
@@ -57,6 +62,8 @@ export type EnsureCloudFleetSandboxInput = {
   maxAgents?: number;
   mountRelayfile?: boolean;
   forceProvision?: boolean;
+  /** Constrain provisioning to a provider that Cloud has enabled for routing. */
+  providerId?: CloudFleetSandboxProviderId;
   waitTimeoutMs?: number;
   /**
    * Repositories to clone into `/srv/agent-workforce/<name>` inside the
@@ -79,6 +86,7 @@ export type CloudFleetSandboxReady = {
   relayWorkspaceId: string;
   relayfileMounted: boolean;
   relayfileMountPath?: string;
+  providerId?: CloudFleetSandboxProviderId;
 };
 
 export type CloudFleetSandboxReused = {
@@ -98,6 +106,7 @@ export type CloudFleetSandboxProvisioningTimeout = {
   relayWorkspaceId: string;
   nodeName: string;
   waitedMs: number;
+  providerId?: CloudFleetSandboxProviderId;
 };
 
 export type EnsureCloudFleetSandboxResult =
@@ -108,6 +117,7 @@ export type EnsureCloudFleetSandboxResult =
 export type DeleteCloudFleetSandboxInput = {
   cloudWorkspaceId: string;
   sandboxId: string;
+  providerId?: CloudFleetSandboxProviderId;
 };
 
 function isObject(value: unknown): value is JsonRecord {
@@ -203,10 +213,39 @@ async function resolveCloudWorkspaceId(
   };
 }
 
-function normalizeEnsureResult(payload: unknown, cloudWorkspaceId: string): EnsureCloudFleetSandboxResult {
+function readProviderId(payload: JsonRecord): CloudFleetSandboxProviderId | undefined {
+  const value = readString(payload, 'providerId');
+  if (value === undefined) return undefined;
+  if (value === 'daytona' || value === 'e2b') return value;
+  throw new Error('Cloud fleet sandbox response has an unknown providerId.');
+}
+
+function cleanupProviderId(
+  payload: JsonRecord,
+  requestedProviderId?: CloudFleetSandboxProviderId,
+): CloudFleetSandboxProviderId | undefined {
+  const payloadProviderId = readString(payload, 'providerId');
+  return payloadProviderId === 'daytona' || payloadProviderId === 'e2b'
+    ? payloadProviderId
+    : requestedProviderId;
+}
+
+function normalizeEnsureResult(
+  payload: unknown,
+  cloudWorkspaceId: string,
+  requestedProviderId?: CloudFleetSandboxProviderId,
+): EnsureCloudFleetSandboxResult {
   if (!isObject(payload)) throw new Error('Cloud fleet sandbox response was not valid JSON.');
   const outcome = readString(payload, 'outcome');
   const nodeName = requiredString(payload, 'nodeName', 'Cloud fleet sandbox');
+  const providerId = readProviderId(payload);
+  if (requestedProviderId !== undefined && providerId !== requestedProviderId) {
+    throw new Error(
+      providerId === undefined
+        ? `Cloud did not prove requested provider ${requestedProviderId}.`
+        : `Cloud returned provider ${providerId} instead of requested provider ${requestedProviderId}.`,
+    );
+  }
 
   if (outcome === 'provisioned') {
     if (typeof payload.relayfileMounted !== 'boolean') {
@@ -220,6 +259,7 @@ function normalizeEnsureResult(payload: unknown, cloudWorkspaceId: string): Ensu
       sandboxId: requiredString(payload, 'sandboxId', 'Cloud fleet sandbox'),
       relayWorkspaceId: requiredString(payload, 'relayWorkspaceId', 'Cloud fleet sandbox'),
       relayfileMounted: payload.relayfileMounted,
+      ...(providerId === undefined ? {} : { providerId }),
       ...(readString(payload, 'relayfileMountPath')
         ? { relayfileMountPath: readString(payload, 'relayfileMountPath') }
         : {}),
@@ -246,6 +286,7 @@ function normalizeEnsureResult(payload: unknown, cloudWorkspaceId: string): Ensu
       relayWorkspaceId: requiredString(payload, 'relayWorkspaceId', 'Cloud fleet sandbox'),
       nodeName,
       waitedMs: requiredNumber(payload, 'waitedMs', 'Cloud fleet sandbox'),
+      ...(providerId === undefined ? {} : { providerId }),
     };
   }
 
@@ -284,6 +325,7 @@ export async function ensureCloudFleetSandbox(
           ...(input.maxAgents !== undefined ? { maxAgents: input.maxAgents } : {}),
           ...(input.mountRelayfile !== undefined ? { mountRelayfile: input.mountRelayfile } : {}),
           ...(input.forceProvision !== undefined ? { forceProvision: input.forceProvision } : {}),
+          ...(input.providerId !== undefined ? { providerId: input.providerId } : {}),
           ...(input.waitTimeoutMs !== undefined ? { waitTimeoutMs: input.waitTimeoutMs } : {}),
           ...(input.repos !== undefined && input.repos.length > 0 ? { repos: [...input.repos] } : {}),
         }),
@@ -300,6 +342,7 @@ export async function ensureCloudFleetSandbox(
       {
         cloudWorkspaceId: resolved.cloudWorkspaceId,
         ...(input.name ? { nodeName: input.name } : {}),
+        ...(input.providerId ? { providerId: input.providerId } : {}),
         outcomeUnknown: true,
         cause: error,
       }
@@ -309,18 +352,23 @@ export async function ensureCloudFleetSandbox(
   if (!response.ok) {
     const error = endpointError('provision the fleet sandbox', response, payload);
     if (isObject(payload) && readString(payload, 'sandboxId')) {
+      const providerId = cleanupProviderId(payload, input.providerId);
       throw new CloudFleetSandboxProvisionError(error.message, {
         cloudWorkspaceId: resolved.cloudWorkspaceId,
         sandboxId: readString(payload, 'sandboxId'),
         nodeName: readString(payload, 'nodeName') ?? input.name,
+        ...(providerId === undefined ? {} : { providerId }),
         cause: error,
       });
     }
     throw error;
   }
   try {
-    return normalizeEnsureResult(payload, resolved.cloudWorkspaceId);
+    return normalizeEnsureResult(payload, resolved.cloudWorkspaceId, input.providerId);
   } catch (error) {
+    const providerId = isObject(payload)
+      ? cleanupProviderId(payload, input.providerId)
+      : input.providerId;
     throw new CloudFleetSandboxProvisionError(
       error instanceof Error ? error.message : 'Cloud fleet sandbox response was invalid.',
       {
@@ -331,6 +379,7 @@ export async function ensureCloudFleetSandbox(
         ...(isObject(payload) && (readString(payload, 'nodeName') ?? input.name)
           ? { nodeName: readString(payload, 'nodeName') ?? input.name }
           : {}),
+        ...(providerId === undefined ? {} : { providerId }),
         outcomeUnknown: true,
         cause: error,
       }
@@ -338,7 +387,7 @@ export async function ensureCloudFleetSandbox(
   }
 }
 
-/** Best-effort-safe deletion for a Cloud-owned Daytona fleet sandbox. */
+/** Best-effort-safe deletion for a Cloud-owned fleet sandbox. */
 export async function deleteCloudFleetSandbox(
   input: DeleteCloudFleetSandboxInput,
   options: CloudFleetSandboxRequestOptions = {}
@@ -358,7 +407,10 @@ export async function deleteCloudFleetSandbox(
     {
       method: 'DELETE',
       signal,
-      body: JSON.stringify({ workspaceId: cloudWorkspaceId }),
+      body: JSON.stringify({
+        workspaceId: cloudWorkspaceId,
+        ...(input.providerId === undefined ? {} : { providerId: input.providerId }),
+      }),
     },
     { interactive: false }
   );

--- a/packages/cloud/src/fleet-sandbox.ts
+++ b/packages/cloud/src/fleet-sandbox.ts
@@ -97,6 +97,7 @@ export type CloudFleetSandboxReused = {
   status: string;
   activeAgents: number | null;
   maxAgents: number | null;
+  providerId?: CloudFleetSandboxProviderId;
 };
 
 export type CloudFleetSandboxProvisioningTimeout = {
@@ -110,9 +111,7 @@ export type CloudFleetSandboxProvisioningTimeout = {
 };
 
 export type EnsureCloudFleetSandboxResult =
-  | CloudFleetSandboxReady
-  | CloudFleetSandboxReused
-  | CloudFleetSandboxProvisioningTimeout;
+  CloudFleetSandboxReady | CloudFleetSandboxReused | CloudFleetSandboxProvisioningTimeout;
 
 export type DeleteCloudFleetSandboxInput = {
   cloudWorkspaceId: string;
@@ -213,11 +212,17 @@ async function resolveCloudWorkspaceId(
   };
 }
 
-function readProviderId(payload: JsonRecord): CloudFleetSandboxProviderId | undefined {
+function readProviderId(
+  payload: JsonRecord,
+  exactProviderRequested: boolean
+): CloudFleetSandboxProviderId | undefined {
   const value = readString(payload, 'providerId');
   if (value === undefined) return undefined;
   if (value === 'daytona' || value === 'e2b') return value;
-  throw new Error('Cloud fleet sandbox response has an unknown providerId.');
+  if (exactProviderRequested) {
+    throw new Error('Cloud fleet sandbox response has an unknown providerId.');
+  }
+  return undefined;
 }
 
 function cleanupProviderId(
@@ -238,7 +243,7 @@ function normalizeEnsureResult(
   if (!isObject(payload)) throw new Error('Cloud fleet sandbox response was not valid JSON.');
   const outcome = readString(payload, 'outcome');
   const nodeName = requiredString(payload, 'nodeName', 'Cloud fleet sandbox');
-  const providerId = readProviderId(payload);
+  const providerId = readProviderId(payload, requestedProviderId !== undefined);
   if (requestedProviderId !== undefined && providerId !== requestedProviderId) {
     throw new Error(
       providerId === undefined
@@ -275,6 +280,7 @@ function normalizeEnsureResult(
       status: requiredString(payload, 'status', 'Cloud fleet sandbox'),
       activeAgents: readNumber(payload, 'activeAgents') ?? null,
       maxAgents: readNumber(payload, 'maxAgents') ?? null,
+      ...(providerId === undefined ? {} : { providerId }),
     };
   }
 

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -88,6 +88,7 @@ export {
   type CloudFleetSandboxProvisioningTimeout,
   type DeleteCloudFleetSandboxInput,
   type CloudFleetSandboxRequestOptions,
+  type CloudFleetSandboxProviderId,
 } from './fleet-sandbox.js';
 
 export {

--- a/tests/relayflows/cases/1628-e2b-provider-selection/case.json
+++ b/tests/relayflows/cases/1628-e2b-provider-selection/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1628-e2b-provider-selection",
+  "kind": "feature",
+  "title": "Pin fleet sandbox provisioning and cleanup to E2B",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1628-e2b-provider-selection/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "absent",
+      "signature": "sandbox_provider_selection_not_forwarded"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "e2b_provider_selection_forwarded_and_attributed"
+    }
+  }
+}

--- a/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
+++ b/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 const CASE_ID = '1628-e2b-provider-selection';
+const COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
 const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
 const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
 const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
@@ -216,6 +217,7 @@ function run(command, args, cwd, label, extraEnv = {}) {
     cwd,
     env: { ...process.env, ...extraEnv },
     stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: COMMAND_TIMEOUT_MS,
   });
   if (completed.error) throw new Error(`${label} could not start: ${completed.error.message}`);
   if (completed.status !== 0) {

--- a/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
+++ b/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
@@ -1,0 +1,228 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1628-e2b-provider-selection';
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probePath = path.join(targetDir, 'packages/cloud/src/.relayflow-1628-e2b-provider-selection.test.ts');
+const probeObservationPath = path.join(targetDir, '.relayflow-1628-e2b-provider-selection-observation.json');
+const probeConfigPath = path.join(targetDir, '.relayflow-1628-e2b-provider-selection.vitest.config.mjs');
+
+const probeSource = String.raw`import { afterEach, expect, test, vi } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+
+const mocks = vi.hoisted(() => ({
+  ensureCloudSession: vi.fn(),
+  authorizedApiFetch: vi.fn(),
+}));
+
+vi.mock('./auth.js', () => ({
+  ensureCloudSession: mocks.ensureCloudSession,
+  authorizedApiFetch: mocks.authorizedApiFetch,
+}));
+
+import { deleteCloudFleetSandbox, ensureCloudFleetSandbox } from './fleet-sandbox.js';
+
+const auth = {
+  accessToken: 'relayflow-probe-access',
+  refreshToken: 'relayflow-probe-refresh',
+  accessTokenExpiresAt: '2099-01-01T00:00:00Z',
+  apiUrl: 'https://relayflow.invalid',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('observes exact provider forwarding, attribution, and cleanup', async () => {
+  const observationPath = process.env.RELAY_PR1628_OBSERVATION_PATH;
+  if (!observationPath) throw new Error('Missing RELAY_PR1628_OBSERVATION_PATH.');
+
+  mocks.ensureCloudSession.mockResolvedValue({ auth, client: {} });
+  mocks.authorizedApiFetch
+    .mockResolvedValueOnce({
+      response: Response.json({ cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99' }),
+      auth,
+    })
+    .mockResolvedValueOnce({
+      response: Response.json(
+        {
+          outcome: 'provisioned',
+          nodeId: 'node-relayflow',
+          nodeName: 'e2b-relayflow',
+          sandboxId: 'sandbox-relayflow',
+          relayWorkspaceId: 'rw_relayflow',
+          relayfileMounted: true,
+          providerId: 'e2b',
+        },
+        { status: 201 }
+      ),
+      auth,
+    })
+    .mockResolvedValueOnce({
+      response: Response.json({ sandboxId: 'sandbox-relayflow', providerId: 'e2b', deleted: true }),
+      auth,
+    });
+
+  const ready = await ensureCloudFleetSandbox({
+    workspaceId: 'rw_relayflow',
+    requiredCapability: 'spawn:codex',
+    mountRelayfile: true,
+    providerId: 'e2b',
+  });
+  await deleteCloudFleetSandbox({
+    cloudWorkspaceId: '50587328-441d-4acb-b8f3-dbe1b3c5de99',
+    sandboxId: 'sandbox-relayflow',
+    providerId: 'e2b',
+  });
+
+  const ensureRequest = mocks.authorizedApiFetch.mock.calls[1]?.[2];
+  const deleteRequest = mocks.authorizedApiFetch.mock.calls[2]?.[2];
+  expect(ensureRequest?.body).toEqual(expect.any(String));
+  expect(deleteRequest?.body).toEqual(expect.any(String));
+  const ensureBody = JSON.parse(ensureRequest.body);
+  const deleteBody = JSON.parse(deleteRequest.body);
+
+  await writeFile(
+    observationPath,
+    JSON.stringify({
+      ensureProviderId: ensureBody.providerId ?? null,
+      resultProviderId: ready.providerId ?? null,
+      deleteProviderId: deleteBody.providerId ?? null,
+    }),
+    'utf8'
+  );
+});
+`;
+
+const probeConfigSource = `export default {
+  test: {
+    environment: 'node',
+    include: ['packages/cloud/src/.relayflow-1628-e2b-provider-selection.test.ts'],
+    setupFiles: [],
+  },
+};\n`;
+
+try {
+  run(
+    'npm',
+    ['ci', '--ignore-scripts', '--workspace', 'packages/cloud', '--include-workspace-root=false'],
+    targetDir,
+    'Cloud workspace dependency installation'
+  );
+  run('npm', ['run', 'build:config'], targetDir, 'configuration package build');
+  run('npm', ['run', 'build:cloud'], targetDir, 'Cloud package build');
+
+  await writeFile(probePath, probeSource, { encoding: 'utf8', flag: 'wx' });
+  await writeFile(probeConfigPath, probeConfigSource, { encoding: 'utf8', flag: 'wx' });
+  run(
+    'npm',
+    ['exec', '--', 'vitest', 'run', '--config', path.relative(targetDir, probeConfigPath)],
+    targetDir,
+    'provider selection probe',
+    { RELAY_PR1628_OBSERVATION_PATH: probeObservationPath }
+  );
+
+  const observation = JSON.parse(await readFile(probeObservationPath, 'utf8'));
+  const cliSource = await readFile(path.join(targetDir, 'packages/cli/src/cli/commands/fleet.ts'), 'utf8');
+  const cliHasProviderFlag = cliSource.includes("'--sandbox-provider <provider>'");
+  const baseObserved =
+    observation.ensureProviderId === null &&
+    observation.resultProviderId === null &&
+    observation.deleteProviderId === null &&
+    !cliHasProviderFlag;
+  const headObserved =
+    observation.ensureProviderId === 'e2b' &&
+    observation.resultProviderId === 'e2b' &&
+    observation.deleteProviderId === 'e2b' &&
+    cliHasProviderFlag;
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'absent';
+    signature = 'sandbox_provider_selection_not_forwarded';
+    details =
+      'The base client omitted providerId from provisioning and deletion, dropped provider attribution, and exposed no provider selector.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'e2b_provider_selection_forwarded_and_attributed';
+    details =
+      'The head client pinned E2B through provisioning, response attribution, exact deletion, and the fleet spawn CLI surface.';
+  } else {
+    throw new Error(
+      `Unexpected provider selection observation: ${JSON.stringify({ ...observation, cliHasProviderFlag })}.`
+    );
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+} finally {
+  await rm(probePath, { force: true });
+  await rm(probeConfigPath, { force: true });
+  await rm(probeObservationPath, { force: true });
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+function run(command, args, cwd, label, extraEnv = {}) {
+  const completed = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...extraEnv },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  if (completed.error) throw new Error(`${label} could not start: ${completed.error.message}`);
+  if (completed.status !== 0) {
+    throw new Error(
+      `${label} failed with ${
+        completed.signal ? `signal ${completed.signal}` : `exit code ${completed.status ?? 'unknown'}`
+      }.`
+    );
+  }
+}

--- a/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
+++ b/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -139,8 +140,8 @@ try {
   run('npm', ['run', 'build:config'], targetDir, 'configuration package build');
   run('npm', ['run', 'build:cloud'], targetDir, 'Cloud package build');
 
-  await writeFile(probePath, probeSource, { encoding: 'utf8' });
-  await writeFile(probeConfigPath, probeConfigSource, { encoding: 'utf8' });
+  await writeGeneratedFile(probePath, probeSource);
+  await writeGeneratedFile(probeConfigPath, probeConfigSource);
   run(
     'npm',
     ['exec', '--', 'vitest', 'run', '--config', path.relative(targetDir, probeConfigPath)],
@@ -210,6 +211,32 @@ function isWithin(directory, candidate) {
     relative === '' ||
     (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
   );
+}
+
+async function writeGeneratedFile(targetPath, source) {
+  try {
+    const existing = await lstat(targetPath);
+    if (!existing.isFile()) {
+      throw new Error(`Refusing to replace non-regular generated file ${targetPath}.`);
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+
+  const temporaryPath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    const handle = await open(temporaryPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(source, 'utf8');
+    } finally {
+      await handle.close();
+    }
+    // Same-directory rename replaces a regular destination or a raced symlink
+    // itself; it never follows that destination outside the proof checkout.
+    await rename(temporaryPath, targetPath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
 }
 
 function run(command, args, cwd, label, extraEnv = {}) {

--- a/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
+++ b/tests/relayflows/cases/1628-e2b-provider-selection/run.mjs
@@ -139,8 +139,8 @@ try {
   run('npm', ['run', 'build:config'], targetDir, 'configuration package build');
   run('npm', ['run', 'build:cloud'], targetDir, 'Cloud package build');
 
-  await writeFile(probePath, probeSource, { encoding: 'utf8', flag: 'wx' });
-  await writeFile(probeConfigPath, probeConfigSource, { encoding: 'utf8', flag: 'wx' });
+  await writeFile(probePath, probeSource, { encoding: 'utf8' });
+  await writeFile(probeConfigPath, probeConfigSource, { encoding: 'utf8' });
   run(
     'npm',
     ['exec', '--', 'vitest', 'run', '--config', path.relative(targetDir, probeConfigPath)],


### PR DESCRIPTION
## Summary

- Add `agent-relay fleet spawn --sandbox-provider <daytona|e2b>`.
- Carry the selected provider through Cloud provisioning, response attribution, and every cleanup path.
- Fail closed when an exact provider request is not proven by Cloud.
- Keep existing router-selected behavior compatible when the flag is omitted.

## Why

Cloud can route fleet sandboxes to E2B, but users had no way to request or prove that provider from the CLI. A partial or malformed response could also lose provider identity during cleanup. This makes the provider choice explicit and keeps teardown pinned to the backend that created the sandbox.

Cross-repo Cloud lifecycle support is in AgentWorkforce/cloud#3233. Substrate follow-ups are AgentWorkforce/sandbox#44 and AgentWorkforce/sandbox-router#34.

## Test plan

- [x] 51 focused Cloud-client and fleet-CLI tests pass.
- [x] `npm run build:core` passes.
- [x] Unknown providers and `--sandbox-provider` without `--sandbox` fail locally.
- [x] Malformed 201, timeout, and non-OK responses retain the requested E2B cleanup identity.
- [x] Base-vs-head RelayFlow case proves provisioning, attribution, exact deletion, and CLI exposure.

## RelayFlow Proof

- Change type: `feature` <!-- relay-pr-proof:type -->
- RelayFlow case: `1628-e2b-provider-selection` <!-- relay-pr-proof:case -->

## Rollout boundary

This PR does not claim E2B is live in production. After Cloud #3233 merges and deploys to dev, the live gate must prove exact `e2b` attribution, a mounted Relayfile workspace, an online node, a confirmed agent, a round-trip file, exact release/delete, and a gone check.
