### PR TITLE
ci(release): publish complete main runtime chain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ permissions:
 env:
   NPM_CONFIG_FUND: false
   AGENT_RELAY_TELEMETRY_DISABLED: 1
+  NPM_TAG: ${{ github.event.inputs.tag }}
   WITHDRAWN_STABLE_TAG_PATTERN: '^(v6\.3\.6)$'
 
 jobs:
@@ -731,7 +732,7 @@ jobs:
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/${{ matrix.package }}
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
@@ -744,7 +745,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # Publish the per-platform broker packages first. @agent-relay/sdk declares
   # these as exact-version optionalDependencies, so they must exist on the
@@ -841,7 +842,7 @@ jobs:
         working-directory: packages/${{ matrix.broker_pkg }}
         run: |
           echo "Dry run - would publish @agent-relay/${{ matrix.broker_pkg }}"
-          npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       # Retry up to 3 times — npm registry occasionally flakes and we cannot
       # reuse the version on rerun, so transient failures must be absorbed
@@ -859,7 +860,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
       - name: Wait before retry
         if: github.event.inputs.dry_run != 'true' && steps.publish_1.outcome == 'failure'
@@ -878,7 +879,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
       - name: Wait before retry
         if: github.event.inputs.dry_run != 'true' && steps.publish_2.outcome == 'failure'
@@ -896,7 +897,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
       - name: Fail if all publish attempts failed
         if: >-
@@ -976,7 +977,7 @@ jobs:
           else
             echo "Dry run - would publish @agent-relay/${{ matrix.package }}"
           fi
-          npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
@@ -989,7 +990,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # Publish @agent-relay/harnesses and @agent-relay/evals after the
   # publish-packages matrix, which is where their exact-version workspace deps
@@ -1035,7 +1036,7 @@ jobs:
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/${{ env.PUBLISH_PACKAGE }}
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
@@ -1048,7 +1049,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # Publish @agent-relay/fleet after @agent-relay/harnesses lands on the
   # registry. fleet pins @agent-relay/{harnesses,harness-driver,sdk} by exact
@@ -1086,7 +1087,7 @@ jobs:
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/${{ env.PUBLISH_PACKAGE }}
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
@@ -1099,7 +1100,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # package=main publishes only the root `agent-relay` tarball, but that
   # tarball pins several @agent-relay/* runtime dependencies to the freshly
@@ -1159,7 +1160,7 @@ jobs:
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/${{ matrix.package }}
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
@@ -1172,7 +1173,7 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} already exists on npm; skipping publish"
             exit 0
           fi
-          npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # @agent-relay/harnesses pins the SDK and harness driver to the exact release
   # version. Keep it after the main runtime dependency matrix so package=main
@@ -1229,12 +1230,12 @@ jobs:
         working-directory: packages/brand
         run: |
           echo "Dry run - would publish @agent-relay/brand"
-          npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+          npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish Brand to NPM
         if: github.event.inputs.dry_run != 'true'
         working-directory: packages/brand
-        run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # Publish SDK only (when selected)
   publish-sdk-only:
@@ -1282,12 +1283,12 @@ jobs:
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/sdk
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --dry-run --access public --tag "$NPM_TAG" --ignore-scripts
 
       - name: Publish SDK to NPM
         if: github.event.inputs.dry_run != 'true'
         working-directory: packages/sdk
-        run: npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+        run: npm publish --access public --provenance --tag "$NPM_TAG" --ignore-scripts
 
   # Publish Python SDK to PyPI as per-platform wheels with the broker binary
   # embedded. One wheel per (broker_artifact, plat_tag) — see issue #769.
@@ -1569,9 +1570,9 @@ jobs:
       (needs.verify-binaries.result == 'success' || (needs.verify-binaries.result == 'skipped' && github.event.inputs.package == 'cli-prerelease')) &&
       (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') &&
       (needs.publish-fleet.result == 'success' || needs.publish-fleet.result == 'skipped') &&
-      (needs.publish-main-runtime-deps.result == 'success' || needs.publish-main-runtime-deps.result == 'skipped') &&
-      (needs.publish-main-harnesses.result == 'success' || needs.publish-main-harnesses.result == 'skipped') &&
-      (needs.publish-main-fleet.result == 'success' || needs.publish-main-fleet.result == 'skipped')
+      (needs.publish-main-runtime-deps.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-runtime-deps.result == 'skipped')) &&
+      (needs.publish-main-harnesses.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-harnesses.result == 'skipped')) &&
+      (needs.publish-main-fleet.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-fleet.result == 'skipped'))
 
     steps:
       - name: Checkout code
@@ -1689,7 +1690,7 @@ jobs:
         if: github.event.inputs.dry_run == 'true'
         run: |
           echo "Dry run - would publish agent-relay@${{ needs.build.outputs.new_version }}"
-          npm publish "$NPM_TARBALL" --dry-run --access public --tag "${{ github.event.inputs.tag }}"
+          npm publish "$NPM_TARBALL" --dry-run --access public --tag "$NPM_TAG"
 
       - name: Publish to NPM
         id: publish_root
@@ -1702,7 +1703,7 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          npm publish "$NPM_TARBALL" --access public --provenance --tag "${{ github.event.inputs.tag }}"
+          npm publish "$NPM_TARBALL" --access public --provenance --tag "$NPM_TAG"
           echo "published=true" >> "$GITHUB_OUTPUT"
 
   # Create git tag and release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1568,8 +1568,8 @@ jobs:
       (github.event.inputs.package == 'all' || github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease') &&
       needs.build.result == 'success' &&
       (needs.verify-binaries.result == 'success' || (needs.verify-binaries.result == 'skipped' && github.event.inputs.package == 'cli-prerelease')) &&
-      (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') &&
-      (needs.publish-fleet.result == 'success' || needs.publish-fleet.result == 'skipped') &&
+      (needs.publish-packages.result == 'success' || ((github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease') && needs.publish-packages.result == 'skipped')) &&
+      (needs.publish-fleet.result == 'success' || ((github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease') && needs.publish-fleet.result == 'skipped')) &&
       (needs.publish-main-runtime-deps.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-runtime-deps.result == 'skipped')) &&
       (needs.publish-main-harnesses.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-harnesses.result == 'skipped')) &&
       (needs.publish-main-fleet.result == 'success' || (github.event.inputs.package == 'all' && needs.publish-main-fleet.result == 'skipped'))

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1003,6 +1003,8 @@ jobs:
     needs: [build, publish-packages]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'all'
+    env:
+      PUBLISH_PACKAGE: ${{ matrix.package }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -1011,18 +1013,18 @@ jobs:
           - harnesses
           - evals
 
-    steps:
+    steps: &publish-harnesses-steps
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: build-output
           path: .
@@ -1032,12 +1034,12 @@ jobs:
 
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
-        working-directory: packages/${{ matrix.package }}
+        working-directory: packages/${{ env.PUBLISH_PACKAGE }}
         run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
-        working-directory: packages/${{ matrix.package }}
+        working-directory: packages/${{ env.PUBLISH_PACKAGE }}
         run: |
           set -euo pipefail
           PKG_NAME=$(node -p "require('./package.json').name")
@@ -1060,18 +1062,20 @@ jobs:
     needs: [build, publish-harnesses]
     runs-on: ubuntu-latest
     if: github.event.inputs.package == 'all'
-    steps:
+    env:
+      PUBLISH_PACKAGE: fleet
+    steps: &publish-fleet-steps
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: build-output
           path: .
@@ -1081,12 +1085,12 @@ jobs:
 
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
-        working-directory: packages/fleet
+        working-directory: packages/${{ env.PUBLISH_PACKAGE }}
         run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }} --ignore-scripts
 
       - name: Publish to NPM
         if: github.event.inputs.dry_run != 'true'
-        working-directory: packages/fleet
+        working-directory: packages/${{ env.PUBLISH_PACKAGE }}
         run: |
           set -euo pipefail
           PKG_NAME=$(node -p "require('./package.json').name")
@@ -1114,6 +1118,7 @@ jobs:
           - cloud
           - config
           - sdk
+          - session
           - utils
           - harness-driver
 
@@ -1168,6 +1173,30 @@ jobs:
             exit 0
           fi
           npm publish --access public --provenance --tag ${{ github.event.inputs.tag }} --ignore-scripts
+
+  # @agent-relay/harnesses pins the SDK and harness driver to the exact release
+  # version. Keep it after the main runtime dependency matrix so package=main
+  # cannot publish a root CLI whose harness dependency was never released.
+  publish-main-harnesses:
+    name: Publish main runtime dep harnesses
+    needs: [build, publish-main-runtime-deps]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease'
+    env:
+      PUBLISH_PACKAGE: harnesses
+    steps: *publish-harnesses-steps
+
+  # @agent-relay/fleet pins harnesses, the harness driver, and the SDK to the
+  # exact release version. It is the final package=main dependency in the
+  # ordered chain before the root CLI can be published.
+  publish-main-fleet:
+    name: Publish main runtime dep fleet
+    needs: [build, publish-main-harnesses]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease'
+    env:
+      PUBLISH_PACKAGE: fleet
+    steps: *publish-fleet-steps
 
   # Publish brand package only (when selected)
   publish-brand-only:
@@ -1520,7 +1549,16 @@ jobs:
   # Publish main package
   publish-main:
     name: Publish Main Package
-    needs: [build, verify-binaries, publish-packages, publish-fleet, publish-main-runtime-deps]
+    needs:
+      [
+        build,
+        verify-binaries,
+        publish-packages,
+        publish-fleet,
+        publish-main-runtime-deps,
+        publish-main-harnesses,
+        publish-main-fleet,
+      ]
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.publish_root.outputs.published }}
@@ -1531,7 +1569,9 @@ jobs:
       (needs.verify-binaries.result == 'success' || (needs.verify-binaries.result == 'skipped' && github.event.inputs.package == 'cli-prerelease')) &&
       (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') &&
       (needs.publish-fleet.result == 'success' || needs.publish-fleet.result == 'skipped') &&
-      (needs.publish-main-runtime-deps.result == 'success' || needs.publish-main-runtime-deps.result == 'skipped')
+      (needs.publish-main-runtime-deps.result == 'success' || needs.publish-main-runtime-deps.result == 'skipped') &&
+      (needs.publish-main-harnesses.result == 'success' || needs.publish-main-harnesses.result == 'skipped') &&
+      (needs.publish-main-fleet.result == 'success' || needs.publish-main-fleet.result == 'skipped')
 
     steps:
       - name: Checkout code
@@ -1576,7 +1616,10 @@ jobs:
             exit 0
           fi
 
-          for _ in {1..12}; do
+          # npm can accept a provenance publish several minutes before the
+          # version becomes queryable. Give the registry a bounded ten-minute
+          # window instead of failing an otherwise successful release after two.
+          for attempt in {0..60}; do
             missing=()
             for spec in "${INTERNAL_DEPS[@]}"; do
               if npm view "$spec" version >/dev/null 2>&1; then
@@ -1592,7 +1635,9 @@ jobs:
             fi
 
             echo "Waiting for npm registry propagation: ${missing[*]}"
-            sleep 10
+            if [ "$attempt" -lt 60 ]; then
+              sleep 10
+            fi
           done
 
           echo "Timed out waiting for CLI @agent-relay/* dependencies:"

--- a/packages/cli/src/cli/publish-workflow.test.ts
+++ b/packages/cli/src/cli/publish-workflow.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+type WorkflowJob = {
+  if?: string;
+  needs?: string[];
+  strategy?: { matrix?: { package?: string[] } };
+  steps?: Array<{ name?: string; run?: string }>;
+};
+
+type PublishWorkflow = {
+  jobs: Record<string, WorkflowJob>;
+};
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+
+function repoPath(path: string): string {
+  return resolve(repoRoot, path);
+}
+
+function loadPublishWorkflow(): PublishWorkflow {
+  return parse(readFileSync(repoPath('.github/workflows/publish.yml'), 'utf8')) as PublishWorkflow;
+}
+
+describe('package=main publish dependency chain', () => {
+  it('publishes every exact-version Agent Relay dependency before the root CLI', () => {
+    const workflow = loadPublishWorkflow();
+    const cliPackage = JSON.parse(readFileSync(repoPath('packages/cli/package.json'), 'utf8')) as {
+      version: string;
+      dependencies?: Record<string, string>;
+    };
+
+    const directInternalDependencies = Object.entries(cliPackage.dependencies ?? {})
+      .filter(([name]) => name.startsWith('@agent-relay/'))
+      .map(([name, version]) => {
+        expect(version).toBe(cliPackage.version);
+        return name;
+      })
+      .sort();
+    const parallelRuntimePackages =
+      workflow.jobs['publish-main-runtime-deps']?.strategy?.matrix?.package ?? [];
+    const publishedByMainChain = [
+      ...parallelRuntimePackages.map((name) => `@agent-relay/${name}`),
+      '@agent-relay/harnesses',
+      '@agent-relay/fleet',
+    ].sort();
+
+    expect(publishedByMainChain).toEqual(directInternalDependencies);
+  });
+
+  it('orders harnesses and fleet after their exact-version dependencies', () => {
+    const jobs = loadPublishWorkflow().jobs;
+
+    expect(jobs['publish-main-harnesses']?.needs).toContain('publish-main-runtime-deps');
+    expect(jobs['publish-main-fleet']?.needs).toContain('publish-main-harnesses');
+    expect(jobs['publish-main-harnesses']?.steps).toEqual(jobs['publish-harnesses']?.steps);
+    expect(jobs['publish-main-fleet']?.steps).toEqual(jobs['publish-fleet']?.steps);
+    expect(jobs['publish-main']?.needs).toEqual(
+      expect.arrayContaining(['publish-main-runtime-deps', 'publish-main-harnesses', 'publish-main-fleet'])
+    );
+  });
+
+  it('allows enough time for provenance-published versions to become queryable', () => {
+    const waitStep = loadPublishWorkflow().jobs['publish-main']?.steps?.find(
+      (step) => step.name === 'Wait for CLI internal dependencies'
+    );
+
+    expect(waitStep?.run).toContain('for attempt in {0..60}');
+    expect(waitStep?.run).toContain('sleep 10');
+    expect(waitStep?.run).toContain('if [ "$attempt" -lt 60 ]');
+  });
+});

--- a/packages/cli/src/cli/publish-workflow.test.ts
+++ b/packages/cli/src/cli/publish-workflow.test.ts
@@ -65,6 +65,11 @@ describe('package=main publish dependency chain', () => {
     );
 
     const publishMainIf = jobs['publish-main']?.if;
+    for (const job of ['publish-packages', 'publish-fleet']) {
+      expect(publishMainIf).toContain(
+        `(needs.${job}.result == 'success' || ((github.event.inputs.package == 'main' || github.event.inputs.package == 'cli-prerelease') && needs.${job}.result == 'skipped'))`
+      );
+    }
     for (const job of ['publish-main-runtime-deps', 'publish-main-harnesses', 'publish-main-fleet']) {
       expect(publishMainIf).toContain(
         `(needs.${job}.result == 'success' || (github.event.inputs.package == 'all' && needs.${job}.result == 'skipped'))`

--- a/packages/cli/src/cli/publish-workflow.test.ts
+++ b/packages/cli/src/cli/publish-workflow.test.ts
@@ -13,6 +13,7 @@ type WorkflowJob = {
 };
 
 type PublishWorkflow = {
+  env?: Record<string, string>;
   jobs: Record<string, WorkflowJob>;
 };
 
@@ -62,6 +63,33 @@ describe('package=main publish dependency chain', () => {
     expect(jobs['publish-main']?.needs).toEqual(
       expect.arrayContaining(['publish-main-runtime-deps', 'publish-main-harnesses', 'publish-main-fleet'])
     );
+
+    const publishMainIf = jobs['publish-main']?.if;
+    for (const job of [
+      'publish-main-runtime-deps',
+      'publish-main-harnesses',
+      'publish-main-fleet',
+    ]) {
+      expect(publishMainIf).toContain(
+        `(needs.${job}.result == 'success' || (github.event.inputs.package == 'all' && needs.${job}.result == 'skipped'))`
+      );
+    }
+  });
+
+  it('passes the untrusted npm tag to publish commands through a quoted environment variable', () => {
+    const workflow = loadPublishWorkflow();
+    expect(workflow.env?.NPM_TAG).toBe('${{ github.event.inputs.tag }}');
+
+    const publishCommands = Object.values(workflow.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .map((step) => step.run ?? '')
+      .filter((run) => run.includes('npm publish'));
+
+    expect(publishCommands.length).toBeGreaterThan(0);
+    for (const command of publishCommands) {
+      expect(command).toContain('--tag "$NPM_TAG"');
+      expect(command).not.toContain('github.event.inputs.tag');
+    }
   });
 
   it('allows enough time for provenance-published versions to become queryable', () => {

--- a/packages/cli/src/cli/publish-workflow.test.ts
+++ b/packages/cli/src/cli/publish-workflow.test.ts
@@ -65,11 +65,7 @@ describe('package=main publish dependency chain', () => {
     );
 
     const publishMainIf = jobs['publish-main']?.if;
-    for (const job of [
-      'publish-main-runtime-deps',
-      'publish-main-harnesses',
-      'publish-main-fleet',
-    ]) {
+    for (const job of ['publish-main-runtime-deps', 'publish-main-harnesses', 'publish-main-fleet']) {
       expect(publishMainIf).toContain(
         `(needs.${job}.result == 'success' || (github.event.inputs.package == 'all' && needs.${job}.result == 'skipped'))`
       );


### PR DESCRIPTION
## Summary

- publish every exact-version `@agent-relay/*` dependency required by `agent-relay` when `package=main`
- order `harnesses` after the base runtime matrix and `fleet` after `harnesses`
- extend bounded npm registry propagation wait from 2 to 10 minutes
- add a workflow contract test derived from the CLI dependency list

## Incident

The 11.9.0 `package=main` run accepted five internal packages, then failed before publishing the root CLI because `session`, `harnesses`, and `fleet` were never scheduled. npm also kept the accepted SDK version non-queryable longer than the existing two-minute wait.

## Validation

- `npx vitest run packages/cli/src/cli/publish-workflow.test.ts` (3 passed)
- `actionlint -ignore SC2086 -ignore SC2012 -ignore SC2129 .github/workflows/publish.yml`
- `git diff --check`

The live 11.9.0 recovery is running separately with `package=all`, which already has the correct dependency order.

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

This changes release orchestration and its contract tests; it does not alter an installed CLI runtime path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
