### PR TITLE
fix(broker): report API send recipient reachability

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283.trace.json
@@ -1,0 +1,654 @@
+{
+  "version": "1.0.0",
+  "id": "edfe4a42-faba-49b6-b9c0-5408d6f11ba1",
+  "timestamp": "2026-09-02T12:08:46.178Z",
+  "trajectory": "traj_7yref3wye283",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/compacted/compact_q6xtouz4s10m_2026-09-02.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 69,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/compacted/compact_q6xtouz4s10m_2026-09-02.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 23,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 16,
+              "end_line": 22,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/relaycast/ws.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 120,
+              "end_line": 138,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 231,
+              "end_line": 237,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 1561,
+              "end_line": 1575,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/runtime/api.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1246,
+              "end_line": 1303,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 1343,
+              "end_line": 1349,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/attach-drive.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2299,
+              "end_line": 2308,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 2310,
+              "end_line": 2316,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 2319,
+              "end_line": 2325,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 2351,
+              "end_line": 2357,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 2365,
+              "end_line": 2371,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 2375,
+              "end_line": 2381,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/attach-drive.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 777,
+              "end_line": 783,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 1011,
+              "end_line": 1019,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 1047,
+              "end_line": 1062,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/attach-input-recovery.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 14,
+              "end_line": 23,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 26,
+              "end_line": 32,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 370,
+              "end_line": 474,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/attach-input-recovery.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 24,
+              "end_line": 31,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 36,
+              "end_line": 47,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 139,
+              "end_line": 146,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 170,
+              "end_line": 177,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 179,
+              "end_line": 194,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 199,
+              "end_line": 206,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 212,
+              "end_line": 219,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 236,
+              "end_line": 245,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 256,
+              "end_line": 316,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 321,
+              "end_line": 333,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 342,
+              "end_line": 348,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 364,
+              "end_line": 440,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 489,
+              "end_line": 507,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 513,
+              "end_line": 525,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 527,
+              "end_line": 540,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 552,
+              "end_line": 571,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 578,
+              "end_line": 591,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 611,
+              "end_line": 667,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 689,
+              "end_line": 697,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 704,
+              "end_line": 710,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/attach-passthrough.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 421,
+              "end_line": 427,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 584,
+              "end_line": 592,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 620,
+              "end_line": 634,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/evals/src/harness.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 12,
+              "end_line": 18,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 30,
+              "end_line": 36,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/harness-driver/src/client.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1124,
+              "end_line": 1130,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 1138,
+              "end_line": 1144,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/harness-driver/src/send-message.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 33,
+              "end_line": 39,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/harness-driver/src/types.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 135,
+              "end_line": 141,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-swift/Sources/AgentRelayBrokerSDK/BrokerTypes.swift",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 549,
+              "end_line": 618,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-swift/Tests/AgentRelayBrokerSDKTests/AgentRelayBrokerSDKTests.swift",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 614,
+              "end_line": 620,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 623,
+              "end_line": 636,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/integration/broker/channel-management.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 13,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 42,
+              "end_line": 48,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/integration/broker/messaging.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 15,
+              "end_line": 22,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 45,
+              "end_line": 51,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/integration/broker/utils/broker-harness.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 14,
+              "end_line": 20,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 196,
+              "end_line": 202,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 3,
+              "end_line": 22,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 43,
+              "end_line": 60,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 68,
+              "end_line": 74,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 77,
+              "end_line": 112,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 123,
+              "end_line": 129,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 11,
+              "end_line": 18,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 46,
+              "end_line": 52,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 66,
+              "end_line": 80,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 102,
+              "end_line": 108,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 166,
+              "end_line": 252,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 255,
+              "end_line": 267,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 271,
+              "end_line": 284,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 309,
+              "end_line": 325,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            },
+            {
+              "start_line": 335,
+              "end_line": 346,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1638-attach-input-replay/case.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 21,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1638-attach-input-replay/run.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 243,
+              "revision": "e85f4ca2338c8ef5f788b231748a847b15b94aa4"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283/summary.md
@@ -1,0 +1,73 @@
+# Trajectory: Add real-agent RelayFlow conformance for API send reachability
+
+> **Status:** ✅ Completed
+> **Task:** relay#1615
+> **Confidence:** 93%
+> **Started:** September 2, 2026 at 12:25 PM
+> **Completed:** September 2, 2026 at 02:08 PM
+
+---
+
+## Summary
+
+Added RelayFlow case 1615 with real broker and child-agent effects, and made /api/send report recipient reachability separately from durable Relaycast publication across Rust, TypeScript, and Swift clients.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Treat Relaycast publication and recipient reachability as separate observations
+- **Chose:** Treat Relaycast publication and recipient reachability as separate observations
+- **Reasoning:** An accepted durable message is not confirmed PTY delivery; the API must preserve publication success while reporting live, offline, or unknown without a delivered boolean.
+
+### Keep the reachability probe outside the publication timeout
+- **Chose:** Keep the reachability probe outside the publication timeout
+- **Reasoning:** A slow best-effort read must not turn an already-accepted DM into an HTTP send failure; the probe has its own five-second bound and the RelayFlow makes it slower than the configured publish deadline.
+
+### Keep the synchronous reachability snapshot bounded at five seconds
+- **Chose:** Keep the synchronous reachability snapshot bounded at five seconds
+- **Reasoning:** Issue 1615 explicitly requires the send response to carry the server-observed recipient state. Waiting for the independently bounded GET is the cost of that contract; it cannot alter publication success and remains below the outer 30-second API reply bound.
+
+### Applied independent review findings without weakening the effect oracle
+- **Chose:** Applied independent review findings without weakening the effect oracle
+- **Reasoning:** Preserved required TypeScript targets via runtime normalization, exposed the response in Swift, classified all live Relaycast activity states, made the timeout control exceed the real 500ms clamp, and added unavailable/non-recipient controls.
+
+### Resolve Relaycast @self before reachability probing
+- **Chose:** Resolve Relaycast @self before reachability probing
+- **Reasoning:** @self names the authenticated sender, not an agent record. Probing publish_from preserves the successful self-DM semantics and reports the actual recipient; the RelayFlow now proves one self-injection.
+
+### Treat legacy away as reachable
+- **Chose:** Treat legacy away as reachable
+- **Reasoning:** Relaycast SDK compatibility still exposes pre-active-status away records; a best-effort reachability snapshot must not downgrade those live-compatible records to unknown.
+
+### Cancel reachability observation when publication fails
+- **Chose:** Cancel reachability observation when publication fails
+- **Reasoning:** The observation is only part of a successful publication response. Awaiting it after an immediate publish failure delays the error and blocks the broker runtime actor for no usable evidence; the RelayFlow now measures this negative path.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Treat Relaycast publication and recipient reachability as separate observations: Treat Relaycast publication and recipient reachability as separate observations
+- Keep the reachability probe outside the publication timeout: Keep the reachability probe outside the publication timeout
+- The first real conformance case now discriminates exact base/head effects and also guards timeout independence; full broker validation is green while independent review is in progress.
+- Keep the synchronous reachability snapshot bounded at five seconds: Keep the synchronous reachability snapshot bounded at five seconds
+- Claude review found stale downstream TypeScript annotations; updated all four consumers to SendMessageResult. Its claimed Rust build blocker was disproved by relaycast 7.0.0 source and the compiled 1040-test suite.
+- Applied independent review findings without weakening the effect oracle: Applied independent review findings without weakening the effect oracle
+- Claude and Codex fresh-eyes reviews are complete; all valid P1/P2 findings are implemented, with exact base/head reruns still required after rebase.
+- Resolve Relaycast @self before reachability probing: Resolve Relaycast @self before reachability probing
+- Treat legacy away as reachable: Treat legacy away as reachable
+- Cancel reachability observation when publication fails: Cancel reachability observation when publication fails
+- Final fresh Codex review found no actionable defects; exact-sha base/head effects discriminate and the final serialized broker suite is fully green.
+
+---
+
+## Artifacts
+
+**Commits:** e85f4ca23, bf66a2e86, 13971aa8f, 1191af9bd, cefc1ab4d, 2559e668a
+**Files changed:** 23

--- a/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_7yref3wye283/trajectory.json
@@ -1,0 +1,245 @@
+{
+  "id": "traj_7yref3wye283",
+  "version": 1,
+  "task": {
+    "title": "Add real-agent RelayFlow conformance for API send reachability",
+    "source": {
+      "system": "plain",
+      "id": "relay#1615"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-02T10:25:41.382Z",
+  "completedAt": "2026-09-02T12:08:45.907Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-02T10:25:50.537Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_4v7khwpjog52",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-02T10:25:50.537Z",
+      "endedAt": "2026-09-02T12:08:45.907Z",
+      "events": [
+        {
+          "ts": 1788344750542,
+          "type": "decision",
+          "content": "Treat Relaycast publication and recipient reachability as separate observations: Treat Relaycast publication and recipient reachability as separate observations",
+          "raw": {
+            "question": "Treat Relaycast publication and recipient reachability as separate observations",
+            "chosen": "Treat Relaycast publication and recipient reachability as separate observations",
+            "alternatives": [],
+            "reasoning": "An accepted durable message is not confirmed PTY delivery; the API must preserve publication success while reporting live, offline, or unknown without a delivered boolean."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788344751161,
+          "type": "decision",
+          "content": "Keep the reachability probe outside the publication timeout: Keep the reachability probe outside the publication timeout",
+          "raw": {
+            "question": "Keep the reachability probe outside the publication timeout",
+            "chosen": "Keep the reachability probe outside the publication timeout",
+            "alternatives": [],
+            "reasoning": "A slow best-effort read must not turn an already-accepted DM into an HTTP send failure; the probe has its own five-second bound and the RelayFlow makes it slower than the configured publish deadline."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788345248904,
+          "type": "reflection",
+          "content": "The first real conformance case now discriminates exact base/head effects and also guards timeout independence; full broker validation is green while independent review is in progress.",
+          "raw": {
+            "focalPoints": [
+              "effect-oracle",
+              "timeout-separation",
+              "review-gate"
+            ],
+            "adjustments": "Changed the negative arm from missing to existing-offline and made the agent read slower than the publication deadline.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:effect-oracle",
+            "focal:timeout-separation",
+            "focal:review-gate",
+            "confidence:0.9"
+          ]
+        },
+        {
+          "ts": 1788347081977,
+          "type": "decision",
+          "content": "Keep the synchronous reachability snapshot bounded at five seconds: Keep the synchronous reachability snapshot bounded at five seconds",
+          "raw": {
+            "question": "Keep the synchronous reachability snapshot bounded at five seconds",
+            "chosen": "Keep the synchronous reachability snapshot bounded at five seconds",
+            "alternatives": [],
+            "reasoning": "Issue 1615 explicitly requires the send response to carry the server-observed recipient state. Waiting for the independently bounded GET is the cost of that contract; it cannot alter publication success and remains below the outer 30-second API reply bound."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788347082582,
+          "type": "reflection",
+          "content": "Claude review found stale downstream TypeScript annotations; updated all four consumers to SendMessageResult. Its claimed Rust build blocker was disproved by relaycast 7.0.0 source and the compiled 1040-test suite.",
+          "raw": {
+            "focalPoints": [
+              "review-findings",
+              "type-compatibility",
+              "evidence"
+            ],
+            "adjustments": "Added SendMessageResult imports and return types across eval and integration harness consumers.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-findings",
+            "focal:type-compatibility",
+            "focal:evidence",
+            "confidence:0.9"
+          ]
+        },
+        {
+          "ts": 1788348354877,
+          "type": "decision",
+          "content": "Applied independent review findings without weakening the effect oracle: Applied independent review findings without weakening the effect oracle",
+          "raw": {
+            "question": "Applied independent review findings without weakening the effect oracle",
+            "chosen": "Applied independent review findings without weakening the effect oracle",
+            "alternatives": [],
+            "reasoning": "Preserved required TypeScript targets via runtime normalization, exposed the response in Swift, classified all live Relaycast activity states, made the timeout control exceed the real 500ms clamp, and added unavailable/non-recipient controls."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788348355482,
+          "type": "reflection",
+          "content": "Claude and Codex fresh-eyes reviews are complete; all valid P1/P2 findings are implemented, with exact base/head reruns still required after rebase.",
+          "raw": {
+            "focalPoints": [
+              "review-contract",
+              "effect-controls",
+              "sdk-compatibility"
+            ],
+            "adjustments": "Rebase current main, then rebuild exact base/head artifacts and run full validation.",
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-contract",
+            "focal:effect-controls",
+            "focal:sdk-compatibility",
+            "confidence:0.86"
+          ]
+        },
+        {
+          "ts": 1788349547425,
+          "type": "decision",
+          "content": "Resolve Relaycast @self before reachability probing: Resolve Relaycast @self before reachability probing",
+          "raw": {
+            "question": "Resolve Relaycast @self before reachability probing",
+            "chosen": "Resolve Relaycast @self before reachability probing",
+            "alternatives": [],
+            "reasoning": "@self names the authenticated sender, not an agent record. Probing publish_from preserves the successful self-DM semantics and reports the actual recipient; the RelayFlow now proves one self-injection."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788349885385,
+          "type": "decision",
+          "content": "Treat legacy away as reachable: Treat legacy away as reachable",
+          "raw": {
+            "question": "Treat legacy away as reachable",
+            "chosen": "Treat legacy away as reachable",
+            "alternatives": [],
+            "reasoning": "Relaycast SDK compatibility still exposes pre-active-status away records; a best-effort reachability snapshot must not downgrade those live-compatible records to unknown."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788350313539,
+          "type": "decision",
+          "content": "Cancel reachability observation when publication fails: Cancel reachability observation when publication fails",
+          "raw": {
+            "question": "Cancel reachability observation when publication fails",
+            "chosen": "Cancel reachability observation when publication fails",
+            "alternatives": [],
+            "reasoning": "The observation is only part of a successful publication response. Awaiting it after an immediate publish failure delays the error and blocks the broker runtime actor for no usable evidence; the RelayFlow now measures this negative path."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788350925404,
+          "type": "reflection",
+          "content": "Final fresh Codex review found no actionable defects; exact-sha base/head effects discriminate and the final serialized broker suite is fully green.",
+          "raw": {
+            "focalPoints": [
+              "review-signoff",
+              "effect-proof",
+              "full-validation"
+            ],
+            "adjustments": "No further code changes required after the publication-failure probe cancellation control.",
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-signoff",
+            "focal:effect-proof",
+            "focal:full-validation",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added RelayFlow case 1615 with real broker and child-agent effects, and made /api/send report recipient reachability separately from durable Relaycast publication across Rust, TypeScript, and Swift clients.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [
+    "e85f4ca23",
+    "bf66a2e86",
+    "13971aa8f",
+    "1191af9bd",
+    "cefc1ab4d",
+    "2559e668a"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/compacted/compact_q6xtouz4s10m_2026-09-02.json",
+    ".agentworkforce/trajectories/compacted/compact_q6xtouz4s10m_2026-09-02.md",
+    "CHANGELOG.md",
+    "crates/broker/src/relaycast/ws.rs",
+    "crates/broker/src/runtime/api.rs",
+    "packages/cli/src/cli/lib/attach-drive.test.ts",
+    "packages/cli/src/cli/lib/attach-drive.ts",
+    "packages/cli/src/cli/lib/attach-input-recovery.test.ts",
+    "packages/cli/src/cli/lib/attach-input-recovery.ts",
+    "packages/cli/src/cli/lib/attach-passthrough.ts",
+    "packages/evals/src/harness.ts",
+    "packages/harness-driver/src/client.ts",
+    "packages/harness-driver/src/send-message.test.ts",
+    "packages/harness-driver/src/types.ts",
+    "packages/sdk-swift/Sources/AgentRelayBrokerSDK/BrokerTypes.swift",
+    "packages/sdk-swift/Tests/AgentRelayBrokerSDKTests/AgentRelayBrokerSDKTests.swift",
+    "tests/integration/broker/channel-management.test.ts",
+    "tests/integration/broker/messaging.test.ts",
+    "tests/integration/broker/utils/broker-harness.ts",
+    "tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs",
+    "tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs",
+    "tests/relayflows/cases/1638-attach-input-replay/case.json",
+    "tests/relayflows/cases/1638-attach-input-replay/run.mjs"
+  ],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "8a96b3917651769844a9020da0dbc5a0a555550d",
+    "endRef": "e85f4ca2338c8ef5f788b231748a847b15b94aa4",
+    "traceId": "edfe4a42-faba-49b6-b9c0-5408d6f11ba1"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Broker `/api/send` responses now distinguish durable Relaycast publication from confirmed delivery and include the server-observed reachability of named recipients.
 - `node agent message flush` and `node agent message auto` now unblock a held queue that could previously never drain, instead of reporting `flushed: 0` forever and leaving the agent unable to receive anything later. A parked message whose Relaycast identity has been retired is dead-lettered with a reason and is visible in `node deadletters`; injection failures and out-of-order sequences are still held for retry.
 
 ### Added

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -124,11 +124,12 @@ fn agent_is_known_offline(agent: &relaycast::Agent) -> bool {
 /// worker. This is intentionally broader than [`agent_is_live`]: that helper
 /// is a fail-closed credential-rotation guard whose historical contract only
 /// recognizes `active` / `online`, while a send-time observation must report
-/// the engine's `idle`, `blocked`, and `waiting` states as reachable too.
+/// the engine's `idle`, `blocked`, and `waiting` states as reachable too, as
+/// well as legacy `away` records from pre-active-status engines.
 fn agent_is_reachable(agent: &relaycast::Agent) -> bool {
     matches!(
         agent.status.as_str(),
-        "active" | "online" | "idle" | "blocked" | "waiting"
+        "active" | "online" | "idle" | "blocked" | "waiting" | "away"
     )
 }
 
@@ -1565,6 +1566,7 @@ mod tests {
             ("idle-worker", "idle", true),
             ("blocked-worker", "blocked", true),
             ("waiting-worker", "waiting", true),
+            ("away-worker", "away", true),
             ("offline-worker", "offline", false),
             ("released-worker", "released", false),
             ("inactive-worker", "inactive", false),

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -120,6 +120,18 @@ fn agent_is_known_offline(agent: &relaycast::Agent) -> bool {
     matches!(agent.status.as_str(), "offline" | "released" | "inactive")
 }
 
+/// Relaycast activity states that still identify a connected, addressable
+/// worker. This is intentionally broader than [`agent_is_live`]: that helper
+/// is a fail-closed credential-rotation guard whose historical contract only
+/// recognizes `active` / `online`, while a send-time observation must report
+/// the engine's `idle`, `blocked`, and `waiting` states as reachable too.
+fn agent_is_reachable(agent: &relaycast::Agent) -> bool {
+    matches!(
+        agent.status.as_str(),
+        "active" | "online" | "idle" | "blocked" | "waiting"
+    )
+}
+
 /// Bound on the `ImpersonateExisting` presence probe (`relay.get_agent`).
 /// Matches the existing `RELAYCAST_HTTP_TIMEOUT` convention for this same
 /// call in `auth.rs`'s legacy-identity reclaim path — not chosen for snappy
@@ -218,7 +230,7 @@ impl RelaycastHttpClient {
         match tokio::time::timeout(SEND_RECIPIENT_PROBE_TIMEOUT, relay.get_agent(agent_name)).await
         {
             Ok(Ok(agent)) => {
-                let live = if agent_is_live(&agent) {
+                let live = if agent_is_reachable(&agent) {
                     Some(true)
                 } else if agent_is_known_offline(&agent) {
                     Some(false)
@@ -1548,8 +1560,14 @@ mod tests {
     #[tokio::test]
     async fn recipient_reachability_reports_effective_live_and_offline_states() {
         for (name, status, expected_live) in [
-            ("live-worker", "active", true),
-            ("queued-worker", "offline", false),
+            ("active-worker", "active", true),
+            ("online-worker", "online", true),
+            ("idle-worker", "idle", true),
+            ("blocked-worker", "blocked", true),
+            ("waiting-worker", "waiting", true),
+            ("offline-worker", "offline", false),
+            ("released-worker", "released", false),
+            ("inactive-worker", "inactive", false),
         ] {
             let server = MockServer::start();
             let probe = server.mock(|when, then| {

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -134,6 +134,33 @@ fn agent_is_known_offline(agent: &relaycast::Agent) -> bool {
 /// `timeout`; this bound is what protects every other call site.
 const PRESENCE_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// A short, best-effort reachability read that accompanies an already-durable
+/// direct-message publication. This probe is deliberately independent from
+/// the send result: Relaycast accepting a message and Relaycast observing a
+/// live recipient are different facts, and an unavailable read must produce
+/// `unknown` rather than turn a successful publication into a failure.
+const SEND_RECIPIENT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Relaycast's server-observed recipient state at send time.
+///
+/// `live` is `None` whenever the engine cannot make the observation or returns
+/// a status the broker does not understand. `status` remains explicit so API
+/// callers can distinguish an unavailable probe from a missing recipient.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecipientReachability {
+    pub live: Option<bool>,
+    pub status: String,
+}
+
+impl RecipientReachability {
+    fn unknown() -> Self {
+        Self {
+            live: None,
+            status: "unknown".to_string(),
+        }
+    }
+}
+
 impl RelaycastHttpClient {
     pub fn new(
         base_url: Option<String>,
@@ -175,6 +202,57 @@ impl RelaycastHttpClient {
             .as_ref()
             .as_ref()
             .and_then(|registration| registration.registration_block_remaining(agent_name))
+    }
+
+    /// Read a named DM recipient's effective Relaycast presence without
+    /// changing whether a message is published.
+    ///
+    /// This is reporting evidence, not a routing guard: offline agents can
+    /// legitimately receive durable messages later, while a transient probe
+    /// failure must not suppress the publication. relay#1615.
+    pub async fn recipient_reachability(&self, agent_name: &str) -> RecipientReachability {
+        let Some(relay) = self.relay.as_ref().as_ref() else {
+            return RecipientReachability::unknown();
+        };
+
+        match tokio::time::timeout(SEND_RECIPIENT_PROBE_TIMEOUT, relay.get_agent(agent_name)).await
+        {
+            Ok(Ok(agent)) => {
+                let live = if agent_is_live(&agent) {
+                    Some(true)
+                } else if agent_is_known_offline(&agent) {
+                    Some(false)
+                } else {
+                    None
+                };
+                RecipientReachability {
+                    live,
+                    status: agent.status,
+                }
+            }
+            Ok(Err(error)) if error.is_not_found() => RecipientReachability {
+                live: Some(false),
+                status: "not_found".to_string(),
+            },
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    target = "relay_broker::relaycast",
+                    agent = %agent_name,
+                    error = %error,
+                    "recipient reachability probe failed; reporting unknown"
+                );
+                RecipientReachability::unknown()
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target = "relay_broker::relaycast",
+                    agent = %agent_name,
+                    timeout_ms = %SEND_RECIPIENT_PROBE_TIMEOUT.as_millis(),
+                    "recipient reachability probe timed out; reporting unknown"
+                );
+                RecipientReachability::unknown()
+            }
+        }
     }
 
     fn invalidate_cached_registration(&self, agent_name: &str) {
@@ -1431,7 +1509,7 @@ mod tests {
     use super::{
         format_worker_preregistration_error, registration_is_retryable,
         registration_retry_after_secs, ImpersonationAwareRegistrationError, MessageInjectionMode,
-        RegisterIntent, RelaycastHttpClient,
+        RecipientReachability, RegisterIntent, RelaycastHttpClient,
     };
 
     fn seeded_http_client(base_url: &str) -> RelaycastHttpClient {
@@ -1465,6 +1543,90 @@ mod tests {
         let message = format_worker_preregistration_error("worker-a", &error);
         assert!(message.contains("worker-a"));
         assert!(message.contains("pre-register"));
+    }
+
+    #[tokio::test]
+    async fn recipient_reachability_reports_effective_live_and_offline_states() {
+        for (name, status, expected_live) in [
+            ("live-worker", "active", true),
+            ("queued-worker", "offline", false),
+        ] {
+            let server = MockServer::start();
+            let probe = server.mock(|when, then| {
+                when.method(GET).path(format!("/v1/agents/{name}"));
+                then.status(200).json_body(json!({
+                    "ok": true,
+                    "data": {
+                        "id": format!("agent_{name}"),
+                        "workspace_id": "ws_test",
+                        "name": name,
+                        "type": "agent",
+                        "status": status,
+                        "persona": null,
+                        "metadata": {},
+                        "channels": []
+                    }
+                }));
+            });
+            let client = seeded_http_client(&server.base_url());
+
+            let reachability = client.recipient_reachability(name).await;
+
+            assert_eq!(
+                reachability,
+                RecipientReachability {
+                    live: Some(expected_live),
+                    status: status.to_string(),
+                }
+            );
+            probe.assert_hits(1);
+        }
+    }
+
+    #[tokio::test]
+    async fn recipient_reachability_distinguishes_missing_from_unavailable() {
+        let missing_server = MockServer::start();
+        let missing_probe = missing_server.mock(|when, then| {
+            when.method(GET).path("/v1/agents/missing-worker");
+            then.status(404).json_body(json!({
+                "ok": false,
+                "error": { "code": "agent_not_found", "message": "Agent not found" }
+            }));
+        });
+        let missing_client = seeded_http_client(&missing_server.base_url());
+        assert_eq!(
+            missing_client
+                .recipient_reachability("missing-worker")
+                .await,
+            RecipientReachability {
+                live: Some(false),
+                status: "not_found".to_string(),
+            }
+        );
+        missing_probe.assert_hits(1);
+
+        let unavailable_server = MockServer::start();
+        let unavailable_probe = unavailable_server.mock(|when, then| {
+            when.method(GET).path("/v1/agents/unknown-worker");
+            then.status(503).json_body(json!({
+                "ok": false,
+                "error": { "code": "unavailable", "message": "try later" }
+            }));
+        });
+        let unavailable_client = seeded_http_client(&unavailable_server.base_url());
+        assert_eq!(
+            unavailable_client
+                .recipient_reachability("unknown-worker")
+                .await,
+            RecipientReachability {
+                live: None,
+                status: "unknown".to_string(),
+            }
+        );
+        assert!(
+            unavailable_probe.hits() >= 1,
+            "the unknown result must come from a real Relaycast probe"
+        );
     }
 
     /// A single PATCH carrying ONLY the declared keys. The engine merges them

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1246,7 +1246,18 @@ impl BrokerRuntime {
                     );
                 }
                 let relaycast_start = Instant::now();
-                match timeout(
+                let recipient_name = match to.kind() {
+                    MessageTargetKind::Worker(name) => Some(name.to_string()),
+                    MessageTargetKind::Channel(_)
+                    | MessageTargetKind::Thread
+                    | MessageTargetKind::DirectMessage(_)
+                    | MessageTargetKind::Conversation(_) => None,
+                };
+                // Keep the publication deadline scoped to publication. The
+                // reachability read has its own short bound; putting both
+                // futures under this timeout would let a slow observation
+                // turn an already-accepted DM into an HTTP send failure.
+                let publish = timeout(
                     relaycast_timeout,
                     selected_workspace.http_client.send_with_mode(
                         &normalized_to,
@@ -1255,9 +1266,21 @@ impl BrokerRuntime {
                         publish_from,
                         reply_thread_id,
                     ),
-                )
-                .await
-                {
+                );
+                let recipient_probe = async {
+                    match recipient_name.as_deref() {
+                        Some(name) => Some(
+                            selected_workspace
+                                .http_client
+                                .recipient_reachability(name)
+                                .await,
+                        ),
+                        None => None,
+                    }
+                };
+                let (publish_result, recipient_reachability) =
+                    tokio::join!(publish, recipient_probe);
+                match publish_result {
                     Ok(Ok(())) => {
                         tracing::info!(
                             target = "relay_broker::http_api",
@@ -1282,17 +1305,20 @@ impl BrokerRuntime {
                             event_emit_timeout,
                         )
                         .await;
-                        if reply
-                            .send(Ok(json!({
-                                "success": true,
-                                "event_id": event_id,
-                                "relaycast_published": true,
-                                "local": false,
-                                "workspace_id": selected_workspace_id,
-                                "workspace_alias": selected_workspace_alias,
-                            })))
-                            .is_err()
-                        {
+                        let mut response = json!({
+                            "success": true,
+                            "event_id": event_id,
+                            "relaycast_published": true,
+                            "delivery_status": "published_unconfirmed",
+                            "local": false,
+                            "workspace_id": selected_workspace_id,
+                            "workspace_alias": selected_workspace_alias,
+                        });
+                        if let Some(reachability) = recipient_reachability {
+                            response["recipient_live"] = json!(reachability.live);
+                            response["recipient_status"] = json!(reachability.status);
+                        }
+                        if reply.send(Ok(response)).is_err() {
                             tracing::warn!(
                                 target = "relay_broker::http_api",
 

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -37,6 +37,24 @@ fn set_model_write_timeout(timeout_ms: Option<u64>) -> Duration {
         .unwrap_or(DEFAULT_SET_MODEL_TIMEOUT)
 }
 
+/// Resolve the named recipient whose presence accompanies an HTTP send.
+/// Normalize at this boundary so direct runtime requests cannot publish to a
+/// trimmed target while observing a whitespace-padded agent name.
+pub(super) fn recipient_name_for_reachability(
+    to: &MessageTarget,
+    publish_from: &str,
+) -> Option<String> {
+    let normalized_target = MessageTarget::new(to.trim());
+    match normalized_target.kind() {
+        MessageTargetKind::Worker("@self") => Some(publish_from.to_string()),
+        MessageTargetKind::Worker(name) => Some(name.to_string()),
+        MessageTargetKind::Channel(_)
+        | MessageTargetKind::Thread
+        | MessageTargetKind::DirectMessage(_)
+        | MessageTargetKind::Conversation(_) => None,
+    }
+}
+
 /// Scopes granted to observer tokens minted via `/api/observer-token`: broad
 /// read access to workspace activity, deliberately excluding anything
 /// write/spawn-capable (unlike the raw `rk_live_...` workspace key this
@@ -1246,15 +1264,7 @@ impl BrokerRuntime {
                     );
                 }
                 let relaycast_start = Instant::now();
-                let normalized_target = MessageTarget::new(&normalized_to);
-                let recipient_name = match normalized_target.kind() {
-                    MessageTargetKind::Worker("@self") => Some(publish_from.to_string()),
-                    MessageTargetKind::Worker(name) => Some(name.to_string()),
-                    MessageTargetKind::Channel(_)
-                    | MessageTargetKind::Thread
-                    | MessageTargetKind::DirectMessage(_)
-                    | MessageTargetKind::Conversation(_) => None,
-                };
+                let recipient_name = recipient_name_for_reachability(&to, publish_from);
                 // Keep the publication deadline scoped to publication. The
                 // reachability read has its own short bound; putting both
                 // futures under this timeout would let a slow observation

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1247,6 +1247,7 @@ impl BrokerRuntime {
                 }
                 let relaycast_start = Instant::now();
                 let recipient_name = match to.kind() {
+                    MessageTargetKind::Worker("@self") => Some(publish_from.to_string()),
                     MessageTargetKind::Worker(name) => Some(name.to_string()),
                     MessageTargetKind::Channel(_)
                     | MessageTargetKind::Thread

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1279,35 +1279,18 @@ impl BrokerRuntime {
                         reply_thread_id,
                     ),
                 );
-                let recipient_probe = async {
-                    match recipient_name.as_deref() {
-                        Some(name) => Some(
-                            selected_workspace
-                                .http_client
-                                .recipient_reachability(name)
-                                .await,
-                        ),
-                        None => None,
-                    }
-                };
-                tokio::pin!(publish);
-                tokio::pin!(recipient_probe);
-                // If publication fails first, drop the now-irrelevant
-                // best-effort probe immediately. Waiting for its full timeout
-                // would delay the error response and stall this runtime actor.
-                // A successful publication still waits for the observation
-                // required by the response contract.
-                let (publish_result, recipient_reachability) = tokio::select! {
-                    result = &mut publish => {
-                        let reachability = if matches!(&result, Ok(Ok(()))) {
-                            recipient_probe.await
-                        } else {
-                            None
-                        };
-                        (result, reachability)
-                    }
-                    reachability = &mut recipient_probe => (publish.await, reachability),
-                };
+                // Start the best-effort observation alongside publication, but
+                // keep its independent deadline off the serialized runtime
+                // actor. On successful publication a detached response task
+                // awaits the observation and fulfils this request; meanwhile
+                // the actor can process unrelated API and runtime events. A
+                // failed publication aborts the now-irrelevant observation and
+                // still replies immediately from this actor.
+                let recipient_probe = recipient_name.map(|name| {
+                    let http_client = selected_workspace.http_client.clone();
+                    tokio::spawn(async move { http_client.recipient_reachability(&name).await })
+                });
+                let publish_result = publish.await;
                 match publish_result {
                     Ok(Ok(())) => {
                         tracing::info!(
@@ -1333,29 +1316,58 @@ impl BrokerRuntime {
                             event_emit_timeout,
                         )
                         .await;
-                        let mut response = json!({
-                            "success": true,
-                            "event_id": event_id,
-                            "relaycast_published": true,
-                            "delivery_status": "published_unconfirmed",
-                            "local": false,
-                            "workspace_id": selected_workspace_id,
-                            "workspace_alias": selected_workspace_alias,
-                        });
-                        if let Some(reachability) = recipient_reachability {
-                            response["recipient_live"] = json!(reachability.live);
-                            response["recipient_status"] = json!(reachability.status);
-                        }
-                        if reply.send(Ok(response)).is_err() {
-                            tracing::warn!(
+                        let response_event_id = event_id.clone();
+                        let response_to = normalized_to.clone();
+                        let response_start = request_start;
+                        let _send_reply_task = tokio::spawn(async move {
+                            let recipient_reachability = match recipient_probe {
+                                Some(probe) => match probe.await {
+                                    Ok(reachability) => Some(reachability),
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            target = "relay_broker::http_api",
+                                            event_id = %response_event_id,
+                                            error = %error,
+                                            "recipient reachability task ended without an observation"
+                                        );
+                                        None
+                                    }
+                                },
+                                None => None,
+                            };
+                            let mut response = json!({
+                                "success": true,
+                                "event_id": response_event_id,
+                                "relaycast_published": true,
+                                "delivery_status": "published_unconfirmed",
+                                "local": false,
+                                "workspace_id": selected_workspace_id,
+                                "workspace_alias": selected_workspace_alias,
+                            });
+                            if let Some(reachability) = recipient_reachability {
+                                response["recipient_live"] = json!(reachability.live);
+                                response["recipient_status"] = json!(reachability.status);
+                            }
+                            if reply.send(Ok(response)).is_err() {
+                                tracing::warn!(
+                                    target = "relay_broker::http_api",
+                                    event_id = %response_event_id,
+                                    "broker HTTP API reply channel closed before relaycast response"
+                                );
+                            }
+                            tracing::info!(
                                 target = "relay_broker::http_api",
-
-                                event_id = %event_id,
-                                "broker HTTP API reply channel closed before relaycast response"
+                                event_id = %response_event_id,
+                                to = %response_to,
+                                total_ms = %response_start.elapsed().as_millis(),
+                                "HTTP API send request handling complete"
                             );
-                        }
+                        });
                     }
                     Ok(Err(error)) => {
+                        if let Some(probe) = recipient_probe {
+                            probe.abort();
+                        }
                         tracing::warn!(
                             target = "relay_broker::http_api",
 
@@ -1378,6 +1390,9 @@ impl BrokerRuntime {
                         }
                     }
                     Err(_) => {
+                        if let Some(probe) = recipient_probe {
+                            probe.abort();
+                        }
                         tracing::warn!(
                             target = "relay_broker::http_api",
 
@@ -1408,8 +1423,8 @@ impl BrokerRuntime {
 
                     event_id = %event_id,
                     to = %normalized_to,
-                    total_ms = %request_start.elapsed().as_millis(),
-                    "HTTP API send request handling complete"
+                    actor_ms = %request_start.elapsed().as_millis(),
+                    "HTTP API send runtime actor released"
                 );
             }
             ListenApiRequest::List { reply } => {

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1279,8 +1279,24 @@ impl BrokerRuntime {
                         None => None,
                     }
                 };
-                let (publish_result, recipient_reachability) =
-                    tokio::join!(publish, recipient_probe);
+                tokio::pin!(publish);
+                tokio::pin!(recipient_probe);
+                // If publication fails first, drop the now-irrelevant
+                // best-effort probe immediately. Waiting for its full timeout
+                // would delay the error response and stall this runtime actor.
+                // A successful publication still waits for the observation
+                // required by the response contract.
+                let (publish_result, recipient_reachability) = tokio::select! {
+                    result = &mut publish => {
+                        let reachability = if matches!(&result, Ok(Ok(()))) {
+                            recipient_probe.await
+                        } else {
+                            None
+                        };
+                        (result, reachability)
+                    }
+                    reachability = &mut recipient_probe => (publish.await, reachability),
+                };
                 match publish_result {
                     Ok(Ok(())) => {
                         tracing::info!(

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1246,7 +1246,8 @@ impl BrokerRuntime {
                     );
                 }
                 let relaycast_start = Instant::now();
-                let recipient_name = match to.kind() {
+                let normalized_target = MessageTarget::new(&normalized_to);
+                let recipient_name = match normalized_target.kind() {
                     MessageTargetKind::Worker("@self") => Some(publish_from.to_string()),
                     MessageTargetKind::Worker(name) => Some(name.to_string()),
                     MessageTargetKind::Channel(_)

--- a/crates/broker/src/runtime/mod.rs
+++ b/crates/broker/src/runtime/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     dedup::DedupCache,
     fleet_wire::InventoryAgent,
     ids::{
-        AgentId, ChannelName, DeliveryId, EventId, MessageTarget, RequestId, ThreadId, WorkerName,
-        WorkspaceAlias, WorkspaceId,
+        AgentId, ChannelName, DeliveryId, EventId, MessageTarget, MessageTargetKind, RequestId,
+        ThreadId, WorkerName, WorkspaceAlias, WorkspaceId,
     },
     node_control::{FleetControlCommand, FleetControlEvent, FleetDeliveryBook, FleetLoadSnapshot},
     protocol::{

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -35,6 +35,7 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use super::api::recipient_name_for_reachability;
 use super::{
     apply_exit_after_task_instruction, build_agent_state_transition_event,
     build_http_api_spawn_spec, build_thread_infos, channels_from_csv,
@@ -3637,6 +3638,22 @@ fn normalize_sender_preserves_worker_names() {
     assert_eq!(
         normalize_sender(Some("WorkerOne".to_string())),
         "WorkerOne".to_string()
+    );
+}
+
+#[test]
+fn recipient_reachability_uses_the_same_trimmed_target_as_publication() {
+    assert_eq!(
+        recipient_name_for_reachability(&MessageTarget::new("  worker-a  "), "sender"),
+        Some("worker-a".to_string())
+    );
+    assert_eq!(
+        recipient_name_for_reachability(&MessageTarget::new("  @self  "), "sender"),
+        Some("sender".to_string())
+    );
+    assert_eq!(
+        recipient_name_for_reachability(&MessageTarget::new("  #general  "), "sender"),
+        None
     );
 }
 

--- a/packages/evals/src/harness.ts
+++ b/packages/evals/src/harness.ts
@@ -12,6 +12,7 @@ import type {
   ListAgent,
   RuntimeSpawnOptions,
   SendMessageInput,
+  SendMessageResult,
 } from '@agent-relay/harness-driver';
 
 export interface EventWaiter {
@@ -29,7 +30,7 @@ export interface BrokerHarness {
 
   releaseAgent(name: string): Promise<{ name: string }>;
 
-  sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets: string[] }>;
+  sendMessage(input: SendMessageInput): Promise<SendMessageResult>;
 
   listAgents(): Promise<ListAgent[]>;
 

--- a/packages/harness-driver/src/client.ts
+++ b/packages/harness-driver/src/client.ts
@@ -44,6 +44,7 @@ import type {
   SpawnHeadlessInput,
   SpawnPtyInput,
   SendMessageInput,
+  SendMessageResult,
   ListAgent,
   FleetInventoryAgent,
 } from './types.js';
@@ -1138,7 +1139,7 @@ export class HarnessDriverClient {
 
   // ── Messaging ──────────────────────────────────────────────────────
 
-  async sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets: string[] }> {
+  async sendMessage(input: SendMessageInput): Promise<SendMessageResult> {
     try {
       return await this.transport.request('/api/send', {
         method: 'POST',

--- a/packages/harness-driver/src/client.ts
+++ b/packages/harness-driver/src/client.ts
@@ -1141,7 +1141,7 @@ export class HarnessDriverClient {
 
   async sendMessage(input: SendMessageInput): Promise<SendMessageResult> {
     try {
-      return await this.transport.request('/api/send', {
+      const result = await this.transport.request<SendMessageResult>('/api/send', {
         method: 'POST',
         body: JSON.stringify({
           to: input.to,
@@ -1155,6 +1155,7 @@ export class HarnessDriverClient {
           mode: input.mode,
         }),
       });
+      return { ...result, targets: result.targets ?? [] };
     } catch (error) {
       if (error instanceof HarnessDriverProtocolError && error.code === 'unsupported_operation') {
         return { event_id: 'unsupported_operation', targets: [] };

--- a/packages/harness-driver/src/send-message.test.ts
+++ b/packages/harness-driver/src/send-message.test.ts
@@ -33,6 +33,7 @@ describe('HarnessDriverClient.sendMessage', () => {
     const result = await client.sendMessage({ to: 'queued-worker', text: 'hello' });
 
     expect(result).toMatchObject({
+      targets: [],
       relaycast_published: true,
       delivery_status: 'published_unconfirmed',
       recipient_live: false,

--- a/packages/harness-driver/src/send-message.test.ts
+++ b/packages/harness-driver/src/send-message.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HarnessDriverClient } from './client.js';
+
+function stubClient(responseBody: unknown) {
+  const fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  ) as unknown as typeof globalThis.fetch;
+  return {
+    client: new HarnessDriverClient({ baseUrl: 'http://broker', apiKey: 'secret', fetch }),
+    fetch,
+  };
+}
+
+describe('HarnessDriverClient.sendMessage', () => {
+  it('preserves the broker reachability observation without promoting publication to delivery', async () => {
+    const { client, fetch } = stubClient({
+      success: true,
+      event_id: 'http_1',
+      relaycast_published: true,
+      delivery_status: 'published_unconfirmed',
+      recipient_live: false,
+      recipient_status: 'offline',
+      local: false,
+      workspace_id: 'ws_1',
+      workspace_alias: null,
+    });
+
+    const result = await client.sendMessage({ to: 'queued-worker', text: 'hello' });
+
+    expect(result).toMatchObject({
+      relaycast_published: true,
+      delivery_status: 'published_unconfirmed',
+      recipient_live: false,
+      recipient_status: 'offline',
+    });
+    expect(result).not.toHaveProperty('delivered');
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the legacy unsupported-operation result representable', async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ code: 'unsupported_operation', error: 'not supported' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        })
+    ) as unknown as typeof globalThis.fetch;
+    const client = new HarnessDriverClient({ baseUrl: 'http://broker', fetch });
+
+    await expect(client.sendMessage({ to: '#general', text: 'hello' })).resolves.toEqual({
+      event_id: 'unsupported_operation',
+      targets: [],
+    });
+  });
+});

--- a/packages/harness-driver/src/types.ts
+++ b/packages/harness-driver/src/types.ts
@@ -135,7 +135,7 @@ export interface SendMessageInput {
  * recipient fields because they do not name one agent. */
 export interface SendMessageResult {
   event_id: string;
-  targets?: string[];
+  targets: string[];
   success?: boolean;
   relaycast_published?: boolean;
   delivery_status?: 'published_unconfirmed';

--- a/packages/harness-driver/src/types.ts
+++ b/packages/harness-driver/src/types.ts
@@ -127,6 +127,25 @@ export interface SendMessageInput {
   mode?: MessageInjectionMode;
 }
 
+/** Result of a broker `/api/send` publication.
+ *
+ * Relaycast publication is durable acceptance, not proof that bytes reached a
+ * recipient. Named direct-message targets therefore include the engine's
+ * best-effort reachability observation; channels and conversation IDs omit the
+ * recipient fields because they do not name one agent. */
+export interface SendMessageResult {
+  event_id: string;
+  targets?: string[];
+  success?: boolean;
+  relaycast_published?: boolean;
+  delivery_status?: 'published_unconfirmed';
+  recipient_live?: boolean | null;
+  recipient_status?: string;
+  local?: boolean;
+  workspace_id?: string;
+  workspace_alias?: string | null;
+}
+
 /**
  * Re-exported from the wire contract: `GET /api/spawned` and the `agents`
  * array of `GET /api/status` are the same broker payload, so they share one

--- a/packages/sdk-swift/Sources/AgentRelayBrokerSDK/BrokerTypes.swift
+++ b/packages/sdk-swift/Sources/AgentRelayBrokerSDK/BrokerTypes.swift
@@ -579,21 +579,70 @@ public struct SendMessageResult: Codable, Sendable {
     /// empty array when absent. It is retained for parity with the TS driver's
     /// `{ event_id, targets }` result shape.
     public var targets: [String]
+    /// Whether the broker accepted the request.
+    public var success: Bool?
+    /// Durable Relaycast publication; this is not recipient delivery proof.
+    public var relaycastPublished: Bool?
+    /// Current broker contract is `published_unconfirmed` after publication.
+    public var deliveryStatus: String?
+    /// Best-effort Relaycast presence for a named recipient. `nil` means the
+    /// observation was unavailable or the target was not a named recipient.
+    public var recipientLive: Bool?
+    /// Effective Relaycast status observed for a named recipient.
+    public var recipientStatus: String?
+    public var local: Bool?
+    public var workspaceId: String?
+    public var workspaceAlias: String?
 
     enum CodingKeys: String, CodingKey {
         case eventId = "event_id"
         case targets
+        case success
+        case relaycastPublished = "relaycast_published"
+        case deliveryStatus = "delivery_status"
+        case recipientLive = "recipient_live"
+        case recipientStatus = "recipient_status"
+        case local
+        case workspaceId = "workspace_id"
+        case workspaceAlias = "workspace_alias"
     }
 
-    public init(eventId: String, targets: [String] = []) {
+    public init(
+        eventId: String,
+        targets: [String] = [],
+        success: Bool? = nil,
+        relaycastPublished: Bool? = nil,
+        deliveryStatus: String? = nil,
+        recipientLive: Bool? = nil,
+        recipientStatus: String? = nil,
+        local: Bool? = nil,
+        workspaceId: String? = nil,
+        workspaceAlias: String? = nil
+    ) {
         self.eventId = eventId
         self.targets = targets
+        self.success = success
+        self.relaycastPublished = relaycastPublished
+        self.deliveryStatus = deliveryStatus
+        self.recipientLive = recipientLive
+        self.recipientStatus = recipientStatus
+        self.local = local
+        self.workspaceId = workspaceId
+        self.workspaceAlias = workspaceAlias
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.eventId = try container.decode(String.self, forKey: .eventId)
         self.targets = try container.decodeIfPresent([String].self, forKey: .targets) ?? []
+        self.success = try container.decodeIfPresent(Bool.self, forKey: .success)
+        self.relaycastPublished = try container.decodeIfPresent(Bool.self, forKey: .relaycastPublished)
+        self.deliveryStatus = try container.decodeIfPresent(String.self, forKey: .deliveryStatus)
+        self.recipientLive = try container.decodeIfPresent(Bool.self, forKey: .recipientLive)
+        self.recipientStatus = try container.decodeIfPresent(String.self, forKey: .recipientStatus)
+        self.local = try container.decodeIfPresent(Bool.self, forKey: .local)
+        self.workspaceId = try container.decodeIfPresent(String.self, forKey: .workspaceId)
+        self.workspaceAlias = try container.decodeIfPresent(String.self, forKey: .workspaceAlias)
     }
 }
 

--- a/packages/sdk-swift/Tests/AgentRelayBrokerSDKTests/AgentRelayBrokerSDKTests.swift
+++ b/packages/sdk-swift/Tests/AgentRelayBrokerSDKTests/AgentRelayBrokerSDKTests.swift
@@ -614,7 +614,7 @@ final class AgentRelayBrokerSDKTests: XCTestCase {
         // (crates/broker/src/runtime/api.rs); decoding must not throw.
         let http = MockRelayHTTP()
         await http.setResponse(
-            #"{ "success": true, "event_id": "http_abc", "relaycast_published": true, "local": false, "workspace_id": "ws_1", "workspace_alias": "default" }"#,
+            #"{ "success": true, "event_id": "http_abc", "relaycast_published": true, "delivery_status": "published_unconfirmed", "recipient_live": false, "recipient_status": "offline", "local": false, "workspace_id": "ws_1", "workspace_alias": "default" }"#,
             for: "/api/send"
         )
         let core = BrokerCore(apiKey: "rk_test", transport: MockRelayTransport(), http: http)
@@ -623,6 +623,14 @@ final class AgentRelayBrokerSDKTests: XCTestCase {
 
         XCTAssertEqual(result.eventId, "http_abc")
         XCTAssertTrue(result.targets.isEmpty)
+        XCTAssertEqual(result.success, true)
+        XCTAssertEqual(result.relaycastPublished, true)
+        XCTAssertEqual(result.deliveryStatus, "published_unconfirmed")
+        XCTAssertEqual(result.recipientLive, false)
+        XCTAssertEqual(result.recipientStatus, "offline")
+        XCTAssertEqual(result.local, false)
+        XCTAssertEqual(result.workspaceId, "ws_1")
+        XCTAssertEqual(result.workspaceAlias, "default")
     }
 
     func testSendMessageSwallowsUnsupportedOperation() async throws {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -242,9 +242,11 @@ log_info "All CLI command tests passed!"
 log_phase "Phase 3: Final Down Check"
 
 log_info "Testing: agent-relay node down (with 15s timeout)"
-if ! run_with_timeout 15 "$CLI_CMD" node down --timeout 10000; then
-  EXIT_CODE=$?
-  if [ $EXIT_CODE -eq 124 ]; then
+DOWN_EXIT=0
+run_with_timeout 15 "$CLI_CMD" node down --timeout 10000 || DOWN_EXIT=$?
+if [ "$DOWN_EXIT" -ne 0 ]; then
+  EXIT_CODE=$DOWN_EXIT
+  if [ "$EXIT_CODE" -eq 124 ]; then
     log_error "down command timed out (hung for >15s)"
     exit 1
   else
@@ -255,10 +257,23 @@ else
   log_info "  down command completed without hanging"
 fi
 
-# Verify broker is actually stopped
-STATUS_OUTPUT=$(run_with_timeout 5 "$CLI_CMD" node status 2>/dev/null || true)
-if echo "$STATUS_OUTPUT" | grep -q "Status: RUNNING"; then
-  log_error "Broker still reported as running after down command"
+# The broker can finish its already-bounded graceful shutdown just after the
+# CLI's own wait expires. Poll the real process effect for a short grace window
+# instead of treating one racing RUNNING snapshot as permanent. A timed-out
+# status probe is not evidence of absence and therefore never counts as stopped.
+BROKER_STOPPED=false
+STATUS_OUTPUT=""
+for _ in 1 2 3 4 5; do
+  STATUS_EXIT=0
+  STATUS_OUTPUT=$(run_with_timeout 3 "$CLI_CMD" node status 2>/dev/null) || STATUS_EXIT=$?
+  if [ $STATUS_EXIT -eq 0 ] && ! echo "$STATUS_OUTPUT" | grep -q "Status: RUNNING"; then
+    BROKER_STOPPED=true
+    break
+  fi
+  sleep 1
+done
+if [ "$BROKER_STOPPED" != true ]; then
+  log_error "Broker stop was not confirmed after down command"
   echo "$STATUS_OUTPUT"
   exit 1
 fi

--- a/tests/integration/broker/channel-management.test.ts
+++ b/tests/integration/broker/channel-management.test.ts
@@ -7,7 +7,7 @@
 import assert from 'node:assert/strict';
 import test, { type TestContext } from 'node:test';
 
-import type { BrokerEvent } from '@agent-relay/harness-driver';
+import type { BrokerEvent, SendMessageResult } from '@agent-relay/harness-driver';
 import { BrokerHarness, checkPrerequisites, uniqueSuffix } from './utils/broker-harness.js';
 import { assertAgentExists, eventsForAgent } from './utils/assert-helpers.js';
 
@@ -42,7 +42,7 @@ async function sendMessageOrSkip(
   t: TestContext,
   harness: BrokerHarness,
   input: { to: string; text: string; from?: string }
-): Promise<{ event_id: string; targets: string[] }> {
+): Promise<SendMessageResult> {
   try {
     const result = await harness.sendMessage(input);
     if (result.event_id === 'unsupported_operation') {

--- a/tests/integration/broker/messaging.test.ts
+++ b/tests/integration/broker/messaging.test.ts
@@ -15,6 +15,8 @@
 import assert from 'node:assert/strict';
 import test, { type TestContext } from 'node:test';
 
+import type { SendMessageResult } from '@agent-relay/harness-driver';
+
 import { BrokerHarness, checkPrerequisites, uniqueSuffix } from './utils/broker-harness.js';
 import {
   assertNoDoubleDelivery,
@@ -43,7 +45,7 @@ async function sendMessageOrSkip(
   t: TestContext,
   harness: BrokerHarness,
   input: SendMessageInput
-): Promise<{ event_id: string; targets: string[] }> {
+): Promise<SendMessageResult> {
   try {
     const result = await harness.sendMessage(input);
     if (result.event_id === 'unsupported_operation') {

--- a/tests/integration/broker/utils/broker-harness.ts
+++ b/tests/integration/broker/utils/broker-harness.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeSpawnOptions,
   type ListAgent,
   type SendMessageInput,
+  type SendMessageResult,
   type BrokerEvent,
 } from '@agent-relay/harness-driver';
 import { RelayCast } from '@relaycast/sdk';
@@ -195,7 +196,7 @@ export class BrokerHarness {
   /**
    * Send a message between agents via the low-level client.
    */
-  async sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets: string[] }> {
+  async sendMessage(input: SendMessageInput): Promise<SendMessageResult> {
     return this.client.sendMessage(input);
   }
 

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/case.json
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1615-api-send-recipient-reachability",
+  "kind": "bugfix",
+  "title": "Distinguish Relaycast publication from recipient delivery",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "api_send_hides_unroutable_recipient"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "api_send_reports_recipient_reachability"
+    }
+  }
+}

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -9,6 +9,7 @@ export async function startFakeRelaycast({
   unknownRecipientName,
   failedRecipientName,
   agentReadDelayMs = 0,
+  firstRecipientAgentReadDelayMs = agentReadDelayMs,
   failedAgentReadDelayMs = 0,
 }) {
   const sockets = new Set();
@@ -17,6 +18,7 @@ export async function startFakeRelaycast({
     brokerRegistrations: 0,
     directMessages: [],
     channelMessages: [],
+    agentReads: [],
     nodeFrames: [],
     nodeSocket: undefined,
   };
@@ -52,7 +54,14 @@ export async function startFakeRelaycast({
 
     if (request.method === 'GET' && pathname.startsWith('/v1/agents/')) {
       const name = decodeURIComponent(pathname.slice('/v1/agents/'.length));
-      const readDelayMs = name === failedRecipientName ? failedAgentReadDelayMs : agentReadDelayMs;
+      const isFirstRecipientRead = name === recipientName && !state.agentReads.includes(recipientName);
+      state.agentReads.push(name);
+      const readDelayMs =
+        name === failedRecipientName
+          ? failedAgentReadDelayMs
+          : isFirstRecipientRead
+            ? firstRecipientAgentReadDelayMs
+            : agentReadDelayMs;
       if (readDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, readDelayMs));
       }

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -1,0 +1,270 @@
+import { createHash } from 'node:crypto';
+import http from 'node:http';
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+export async function startFakeRelaycast({ recipientName, offlineRecipientName, agentReadDelayMs = 0 }) {
+  const sockets = new Set();
+  const state = {
+    agentId: `agent_${recipientName.replaceAll('-', '_')}`,
+    brokerRegistrations: 0,
+    directMessages: [],
+    nodeFrames: [],
+    nodeSocket: undefined,
+  };
+
+  const server = http.createServer(async (request, response) => {
+    const body = await readJson(request);
+    const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
+
+    if (request.method === 'POST' && pathname === '/v1/agents') {
+      state.brokerRegistrations += 1;
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          id: 'agent_relayflow_broker',
+          workspace_id: 'ws_relayflow_1615',
+          name: body?.name ?? 'relayflow-1615-broker',
+          token: 'at_relayflow_broker',
+          status: 'active',
+          created_at: '2026-09-02T00:00:00.000Z',
+        },
+      });
+      return;
+    }
+
+    if (request.method === 'GET' && pathname.startsWith('/v1/agents/')) {
+      if (agentReadDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, agentReadDelayMs));
+      }
+      const name = decodeURIComponent(pathname.slice('/v1/agents/'.length));
+      if (name !== recipientName && name !== offlineRecipientName) {
+        sendJson(response, 404, {
+          ok: false,
+          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
+        });
+        return;
+      }
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          id: name === recipientName ? state.agentId : `agent_${offlineRecipientName.replaceAll('-', '_')}`,
+          workspace_id: 'ws_relayflow_1615',
+          name,
+          type: 'agent',
+          status: name === recipientName ? 'active' : 'offline',
+          persona: null,
+          metadata: {},
+          channels: [],
+        },
+      });
+      return;
+    }
+
+    if (request.method === 'POST' && pathname === '/v1/dm') {
+      state.directMessages.push(body);
+      const messageId = `msg_relayflow_${state.directMessages.length}`;
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          conversation_id: 'dm_relayflow_1615',
+          message: {
+            id: messageId,
+            agent_id: 'agent_relayflow_broker',
+            agent_name: 'relayflow-1615-broker',
+            text: body?.text ?? '',
+            injection_mode: body?.mode ?? 'wait',
+          },
+          created_at: '2026-09-02T00:00:00.000Z',
+        },
+      });
+      if (body?.to === recipientName) {
+        setTimeout(() => {
+          sendText(state.nodeSocket, {
+            type: 'deliver',
+            v: 1,
+            agent: recipientName,
+            agent_id: state.agentId,
+            delivery_id: `delivery_${messageId}`,
+            msg_id: messageId,
+            seq: state.directMessages.length,
+            mode: body?.mode ?? 'wait',
+            payload: {
+              type: 'dm.received',
+              data: {
+                text: body?.text ?? '',
+                agent_name: 'relayflow-1615-broker',
+              },
+            },
+          });
+        }, 25);
+      }
+      return;
+    }
+
+    if (request.method === 'POST' && pathname === '/v1/agents/release') {
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          invocation_id: 'invocation_release_relayflow_1615',
+          action_name: 'release',
+          handler_agent_id: null,
+          handler_node_id: null,
+          dispatched_node_id: null,
+          input: { name: body?.name ?? recipientName },
+          status: 'completed',
+          created_at: '2026-09-02T00:00:00.000Z',
+        },
+      });
+      return;
+    }
+
+    // Metadata publication, channel setup, release, and graceful-shutdown
+    // bookkeeping are outside this case's routing contract. A successful
+    // generic envelope keeps those best-effort paths from obscuring the probe.
+    sendJson(response, 200, { ok: true, data: {} });
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+
+  server.on('upgrade', (request, socket) => {
+    const key = request.headers['sec-websocket-key'];
+    if (typeof key !== 'string') {
+      socket.destroy();
+      return;
+    }
+    const accept = createHash('sha1')
+      .update(key + WS_GUID)
+      .digest('base64');
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+    const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
+    if (pathname === '/v1/node/ws') state.nodeSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.opcode === 0x9) {
+        sendFrame(socket, 0xa, frame.payload);
+        return;
+      }
+      if (frame.opcode !== 0x1) return;
+      const message = JSON.parse(frame.payload.toString('utf8'));
+      state.nodeFrames.push(message);
+      if (message.type === 'agent.register') {
+        sendText(socket, {
+          type: 'reply',
+          v: 1,
+          id: message.id,
+          ok: true,
+          data: {
+            agent_id: state.agentId,
+            token: 'at_relayflow_recipient',
+            name: message.name,
+            delivery_ack_seq: 0,
+          },
+        });
+      }
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected Relaycast TCP address.');
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    state,
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+function sendJson(response, status, value) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  if (chunks.length === 0) return undefined;
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+function attachFrameReader(socket, onFrame) {
+  let buffered = Buffer.alloc(0);
+  socket.on('data', (chunk) => {
+    buffered = Buffer.concat([buffered, chunk]);
+    while (true) {
+      const decoded = decodeFrame(buffered);
+      if (!decoded) return;
+      buffered = buffered.subarray(decoded.consumed);
+      onFrame(decoded);
+    }
+  });
+}
+
+function decodeFrame(buffer) {
+  if (buffer.length < 2) return undefined;
+  const opcode = buffer[0] & 0x0f;
+  const masked = (buffer[1] & 0x80) !== 0;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    if (buffer.length < 4) return undefined;
+    length = buffer.readUInt16BE(2);
+    offset = 4;
+  } else if (length === 127) {
+    if (buffer.length < 10) return undefined;
+    const wideLength = buffer.readBigUInt64BE(2);
+    if (wideLength > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error('WebSocket frame is too large.');
+    length = Number(wideLength);
+    offset = 10;
+  }
+  let mask;
+  if (masked) {
+    if (buffer.length < offset + 4) return undefined;
+    mask = buffer.subarray(offset, offset + 4);
+    offset += 4;
+  }
+  if (buffer.length < offset + length) return undefined;
+  const payload = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask) {
+    for (let index = 0; index < payload.length; index += 1) {
+      payload[index] ^= mask[index % 4];
+    }
+  }
+  return { opcode, payload, consumed: offset + length };
+}
+
+function sendText(socket, value) {
+  if (!socket || socket.destroyed) return false;
+  sendFrame(socket, 0x1, Buffer.from(JSON.stringify(value)));
+  return true;
+}
+
+function sendFrame(socket, opcode, payload) {
+  const length = payload.length;
+  let header;
+  if (length < 126) {
+    header = Buffer.from([0x80 | opcode, length]);
+  } else if (length <= 0xffff) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(length, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(length), 2);
+  }
+  socket.write(Buffer.concat([header, payload]));
+}

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -113,7 +113,7 @@ export async function startFakeRelaycast({
           created_at: '2026-09-02T00:00:00.000Z',
         },
       });
-      if (body?.to === recipientName) {
+      if (body?.to === recipientName || body?.to === '@self') {
         setTimeout(() => {
           sendText(state.nodeSocket, {
             type: 'deliver',

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -25,10 +25,10 @@ export async function startFakeRelaycast({
     let body;
     try {
       body = await readJson(request);
-    } catch (error) {
+    } catch {
       sendJson(response, 400, {
         ok: false,
-        error: { code: 'invalid_json', message: error instanceof Error ? error.message : String(error) },
+        error: { code: 'invalid_json', message: 'Request body must be valid JSON.' },
       });
       return;
     }

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -3,12 +3,18 @@ import http from 'node:http';
 
 const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
-export async function startFakeRelaycast({ recipientName, offlineRecipientName, agentReadDelayMs = 0 }) {
+export async function startFakeRelaycast({
+  recipientName,
+  offlineRecipientName,
+  unknownRecipientName,
+  agentReadDelayMs = 0,
+}) {
   const sockets = new Set();
   const state = {
     agentId: `agent_${recipientName.replaceAll('-', '_')}`,
     brokerRegistrations: 0,
     directMessages: [],
+    channelMessages: [],
     nodeFrames: [],
     nodeSocket: undefined,
   };
@@ -38,6 +44,13 @@ export async function startFakeRelaycast({ recipientName, offlineRecipientName, 
         await new Promise((resolve) => setTimeout(resolve, agentReadDelayMs));
       }
       const name = decodeURIComponent(pathname.slice('/v1/agents/'.length));
+      if (name === unknownRecipientName) {
+        sendJson(response, 503, {
+          ok: false,
+          error: { code: 'unavailable', message: 'deterministic reachability outage' },
+        });
+        return;
+      }
       if (name !== recipientName && name !== offlineRecipientName) {
         sendJson(response, 404, {
           ok: false,
@@ -56,6 +69,28 @@ export async function startFakeRelaycast({ recipientName, offlineRecipientName, 
           persona: null,
           metadata: {},
           channels: [],
+        },
+      });
+      return;
+    }
+
+    if (request.method === 'POST' && pathname === '/v1/channels/general/messages') {
+      state.channelMessages.push(body);
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          id: `msg_channel_${state.channelMessages.length}`,
+          agent_name: 'relayflow-1615-broker',
+          agent_id: 'agent_relayflow_broker',
+          text: body?.text ?? '',
+          blocks: null,
+          metadata: {},
+          attachments: [],
+          created_at: '2026-09-02T00:00:00.000Z',
+          reply_count: 0,
+          reactions: [],
+          read_by_count: 0,
+          injection_mode: body?.mode ?? 'wait',
         },
       });
       return;

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -7,7 +7,9 @@ export async function startFakeRelaycast({
   recipientName,
   offlineRecipientName,
   unknownRecipientName,
+  failedRecipientName,
   agentReadDelayMs = 0,
+  failedAgentReadDelayMs = 0,
 }) {
   const sockets = new Set();
   const state = {
@@ -40,10 +42,11 @@ export async function startFakeRelaycast({
     }
 
     if (request.method === 'GET' && pathname.startsWith('/v1/agents/')) {
-      if (agentReadDelayMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, agentReadDelayMs));
-      }
       const name = decodeURIComponent(pathname.slice('/v1/agents/'.length));
+      const readDelayMs = name === failedRecipientName ? failedAgentReadDelayMs : agentReadDelayMs;
+      if (readDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, readDelayMs));
+      }
       if (name === unknownRecipientName) {
         sendJson(response, 503, {
           ok: false,
@@ -51,7 +54,7 @@ export async function startFakeRelaycast({
         });
         return;
       }
-      if (name !== recipientName && name !== offlineRecipientName) {
+      if (name !== recipientName && name !== offlineRecipientName && name !== failedRecipientName) {
         sendJson(response, 404, {
           ok: false,
           error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
@@ -65,7 +68,7 @@ export async function startFakeRelaycast({
           workspace_id: 'ws_relayflow_1615',
           name,
           type: 'agent',
-          status: name === recipientName ? 'active' : 'offline',
+          status: name === offlineRecipientName ? 'offline' : 'active',
           persona: null,
           metadata: {},
           channels: [],
@@ -97,6 +100,13 @@ export async function startFakeRelaycast({
     }
 
     if (request.method === 'POST' && pathname === '/v1/dm') {
+      if (body?.to === failedRecipientName) {
+        sendJson(response, 503, {
+          ok: false,
+          error: { code: 'unavailable', message: 'deterministic publish failure' },
+        });
+        return;
+      }
       state.directMessages.push(body);
       const messageId = `msg_relayflow_${state.directMessages.length}`;
       sendJson(response, 200, {

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/fake-relaycast.mjs
@@ -22,7 +22,16 @@ export async function startFakeRelaycast({
   };
 
   const server = http.createServer(async (request, response) => {
-    const body = await readJson(request);
+    let body;
+    try {
+      body = await readJson(request);
+    } catch (error) {
+      sendJson(response, 400, {
+        ok: false,
+        error: { code: 'invalid_json', message: error instanceof Error ? error.message : String(error) },
+      });
+      return;
+    }
     const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
 
     if (request.method === 'POST' && pathname === '/v1/agents') {
@@ -174,7 +183,7 @@ export async function startFakeRelaycast({
     socket.once('close', () => sockets.delete(socket));
   });
 
-  server.on('upgrade', (request, socket) => {
+  server.on('upgrade', (request, socket, head) => {
     const key = request.headers['sec-websocket-key'];
     if (typeof key !== 'string') {
       socket.destroy();
@@ -191,29 +200,33 @@ export async function startFakeRelaycast({
     );
     const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
     if (pathname === '/v1/node/ws') state.nodeSocket = socket;
-    attachFrameReader(socket, (frame) => {
-      if (frame.opcode === 0x9) {
-        sendFrame(socket, 0xa, frame.payload);
-        return;
-      }
-      if (frame.opcode !== 0x1) return;
-      const message = JSON.parse(frame.payload.toString('utf8'));
-      state.nodeFrames.push(message);
-      if (message.type === 'agent.register') {
-        sendText(socket, {
-          type: 'reply',
-          v: 1,
-          id: message.id,
-          ok: true,
-          data: {
-            agent_id: state.agentId,
-            token: 'at_relayflow_recipient',
-            name: message.name,
-            delivery_ack_seq: 0,
-          },
-        });
-      }
-    });
+    attachFrameReader(
+      socket,
+      (frame) => {
+        if (frame.opcode === 0x9) {
+          sendFrame(socket, 0xa, frame.payload);
+          return;
+        }
+        if (frame.opcode !== 0x1) return;
+        const message = JSON.parse(frame.payload.toString('utf8'));
+        state.nodeFrames.push(message);
+        if (message.type === 'agent.register') {
+          sendText(socket, {
+            type: 'reply',
+            v: 1,
+            id: message.id,
+            ok: true,
+            data: {
+              agent_id: state.agentId,
+              token: 'at_relayflow_recipient',
+              name: message.name,
+              delivery_ack_seq: 0,
+            },
+          });
+        }
+      },
+      head
+    );
   });
 
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -243,9 +256,9 @@ async function readJson(request) {
   return raw ? JSON.parse(raw) : undefined;
 }
 
-function attachFrameReader(socket, onFrame) {
-  let buffered = Buffer.alloc(0);
-  socket.on('data', (chunk) => {
+function attachFrameReader(socket, onFrame, initialData = Buffer.alloc(0)) {
+  let buffered = Buffer.from(initialData);
+  const consume = (chunk) => {
     buffered = Buffer.concat([buffered, chunk]);
     while (true) {
       const decoded = decodeFrame(buffered);
@@ -253,7 +266,9 @@ function attachFrameReader(socket, onFrame) {
       buffered = buffered.subarray(decoded.consumed);
       onFrame(decoded);
     }
-  });
+  };
+  socket.on('data', consume);
+  if (buffered.length > 0) consume(Buffer.alloc(0));
 }
 
 function decodeFrame(buffer) {

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -12,6 +12,7 @@ const CASE_ID = '1615-api-send-recipient-reachability';
 const RECIPIENT = 'relayflow-live-recipient';
 const OFFLINE_RECIPIENT = 'relayflow-offline-recipient';
 const UNKNOWN_RECIPIENT = 'relayflow-unknown-recipient';
+const FAILED_RECIPIENT = 'relayflow-failed-recipient';
 const API_KEY = 'br_relayflow_1615';
 const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
 const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
@@ -66,10 +67,14 @@ try {
     recipientName: RECIPIENT,
     offlineRecipientName: OFFLINE_RECIPIENT,
     unknownRecipientName: UNKNOWN_RECIPIENT,
+    failedRecipientName: FAILED_RECIPIENT,
     // The publish itself completes immediately. Keeping the independent
     // reachability read slower than the configured publish deadline proves a
     // best-effort probe cannot turn durable acceptance into a send failure.
     agentReadDelayMs: 750,
+    // A failed publication must cancel this now-useless observation instead
+    // of parking the single broker runtime actor until the probe completes.
+    failedAgentReadDelayMs: 1_500,
   });
 
   broker = spawn(
@@ -185,6 +190,20 @@ try {
       })
     );
   }
+  const failedSendStartedAt = performance.now();
+  const failed = await api('/api/send', {
+    method: 'POST',
+    body: JSON.stringify({ to: FAILED_RECIPIENT, text: 'failed-publication-control' }),
+  });
+  const failedSendElapsedMs = performance.now() - failedSendStartedAt;
+  if (failed.status < 400 || failedSendElapsedMs >= 1_000) {
+    throw new Error(
+      `Failed publication waited for its irrelevant reachability probe: ${JSON.stringify({
+        failed,
+        failedSendElapsedMs,
+      })}`
+    );
+  }
   await new Promise((resolve) => setTimeout(resolve, 250));
   const finalSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
   const finalScreen = finalSnapshot.body?.screen ?? '';
@@ -296,6 +315,8 @@ try {
         negative,
         self,
         unknown,
+        failed,
+        failedSendElapsedMs,
         nonRecipientResponses,
         brokerStderr,
       })}`
@@ -319,6 +340,7 @@ try {
         relaycastPublications: relaycast.state.directMessages.length + relaycast.state.channelMessages.length,
         unknownProbeReported: unknown.body?.recipient_status ?? 'omitted',
         nonRecipientFieldsOmitted,
+        failedSendReturnedBeforeProbe: failed.status >= 400 && failedSendElapsedMs < 1_000,
         teardownProved,
       },
     })}\n`,

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -112,9 +112,9 @@ try {
     brokerStderr = `${brokerStderr}${chunk}`.slice(-16_000);
   });
 
-  const connection = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
+  const brokerUrl = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
   const api = async (pathname, { timeoutMs = 15_000, ...options } = {}) => {
-    const response = await fetch(`${connection.url}${pathname}`, {
+    const response = await fetch(`${brokerUrl}${pathname}`, {
       ...options,
       headers: {
         'content-type': 'application/json',
@@ -337,6 +337,8 @@ try {
   }
 
   await mkdir(path.dirname(resultPath), { recursive: true });
+  // The PR-proof runner owns resultPath. Persist only the bounded effect
+  // summary below—never raw broker, PTY, Relaycast, or response content.
   await writeFile(
     resultPath,
     `${JSON.stringify({
@@ -380,7 +382,21 @@ async function waitForConnection(connectionPath, child) {
         throw new Error(`Broker exited during startup (${child.exitCode}): ${brokerStderr}`);
       }
       try {
-        return JSON.parse(await readFile(connectionPath, 'utf8'));
+        const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
+        const url = new URL(connection.url);
+        if (
+          url.protocol !== 'http:' ||
+          url.hostname !== '127.0.0.1' ||
+          url.username !== '' ||
+          url.password !== '' ||
+          url.pathname !== '/' ||
+          url.search !== '' ||
+          url.hash !== '' ||
+          !/^\d+$/.test(url.port)
+        ) {
+          throw new Error(`Broker connection URL is not a plain loopback origin: ${url.origin}`);
+        }
+        return `http://127.0.0.1:${Number(url.port)}`;
       } catch (error) {
         lastError = error;
         return false;

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -153,10 +153,39 @@ try {
   }
   await waitForSnapshot(api, 'RELAYFLOW_RECIPIENT_READY', 20_000);
 
-  const positive = await api('/api/send', {
+  let positiveSettled = false;
+  const positivePromise = api('/api/send', {
     method: 'POST',
     body: JSON.stringify({ to: RECIPIENT, text: positiveNonce, mode: 'steer' }),
+  }).finally(() => {
+    positiveSettled = true;
   });
+  let runtimeResponsiveDuringProbe;
+  if (arm === 'head') {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    let concurrentSnapshot;
+    const snapshotStartedAt = performance.now();
+    try {
+      concurrentSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+        timeoutMs: 400,
+      });
+    } catch {
+      concurrentSnapshot = undefined;
+    }
+    const snapshotElapsedMs = performance.now() - snapshotStartedAt;
+    runtimeResponsiveDuringProbe =
+      !positiveSettled && concurrentSnapshot?.status === 200 && snapshotElapsedMs < 400;
+    if (!runtimeResponsiveDuringProbe) {
+      throw new Error(
+        `Slow reachability probe blocked the serialized runtime actor: ${JSON.stringify({
+          positiveSettled,
+          concurrentSnapshot,
+          snapshotElapsedMs,
+        })}`
+      );
+    }
+  }
+  const positive = await positivePromise;
   let positiveScreen;
   try {
     positiveScreen = await waitForSnapshot(api, positiveNonce, 20_000);
@@ -357,6 +386,7 @@ try {
         unknownProbeReported: unknown.body?.recipient_status ?? 'omitted',
         nonRecipientFieldsOmitted,
         failedSendReturnedBeforeProbe: failed.status >= 400 && failedSendElapsedMs < 1_000,
+        runtimeResponsiveDuringProbe,
         teardownProved,
       },
     })}\n`,

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -72,6 +72,10 @@ try {
     // reachability read slower than the configured publish deadline proves a
     // best-effort probe cannot turn durable acceptance into a send failure.
     agentReadDelayMs: 750,
+    // Hold the first positive read long enough to distinguish a free runtime
+    // actor from the old serialized wait without relying on sub-second runner
+    // scheduling. The fake records the request before starting this delay.
+    firstRecipientAgentReadDelayMs: 4_000,
     // A failed publication must cancel this now-useless observation instead
     // of parking the single broker runtime actor until the probe completes.
     failedAgentReadDelayMs: 1_500,
@@ -160,29 +164,28 @@ try {
   }).finally(() => {
     positiveSettled = true;
   });
-  let runtimeResponsiveDuringProbe;
+  let runtimeActorDuringProbe;
   if (arm === 'head') {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    let concurrentSnapshot;
-    const snapshotStartedAt = performance.now();
+    await waitFor(
+      () => relaycast.state.agentReads.includes(RECIPIENT),
+      5_000,
+      'positive reachability probe to start'
+    );
     try {
-      concurrentSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
-        timeoutMs: 400,
-      });
-    } catch {
-      concurrentSnapshot = undefined;
-    }
-    const snapshotElapsedMs = performance.now() - snapshotStartedAt;
-    runtimeResponsiveDuringProbe =
-      !positiveSettled && concurrentSnapshot?.status === 200 && snapshotElapsedMs < 400;
-    if (!runtimeResponsiveDuringProbe) {
-      throw new Error(
-        `Slow reachability probe blocked the serialized runtime actor: ${JSON.stringify({
-          positiveSettled,
-          concurrentSnapshot,
-          snapshotElapsedMs,
-        })}`
+      const actorObservation = await waitFor(
+        async () => {
+          if (positiveSettled) return { outcome: 'inconclusive_fast_send' };
+          const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+            timeoutMs: 500,
+          });
+          return snapshot.status === 200 ? { outcome: 'responsive' } : undefined;
+        },
+        2_500,
+        'runtime actor to serve a snapshot during the held reachability probe'
       );
+      runtimeActorDuringProbe = actorObservation.outcome;
+    } catch {
+      runtimeActorDuringProbe = positiveSettled ? 'inconclusive_fast_send' : 'blocked';
     }
   }
   const positive = await positivePromise;
@@ -340,7 +343,12 @@ try {
   let outcome;
   let signature;
   let details;
-  if (baseObserved) {
+  if (arm === 'head' && runtimeActorDuringProbe === 'blocked') {
+    outcome = 'bug';
+    signature = 'api_send_blocks_runtime_during_reachability_probe';
+    details =
+      'The published send held the serialized runtime actor while waiting for recipient reachability, so an unrelated worker snapshot could not complete.';
+  } else if (baseObserved) {
     outcome = 'bug';
     signature = 'api_send_hides_unroutable_recipient';
     details =
@@ -386,7 +394,7 @@ try {
         unknownProbeReported: unknown.body?.recipient_status ?? 'omitted',
         nonRecipientFieldsOmitted,
         failedSendReturnedBeforeProbe: failed.status >= 400 && failedSendElapsedMs < 1_000,
-        runtimeResponsiveDuringProbe,
+        runtimeActorDuringProbe,
         teardownProved,
       },
     })}\n`,

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -113,7 +113,7 @@ try {
   });
 
   const connection = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
-  const api = async (pathname, options = {}) => {
+  const api = async (pathname, { timeoutMs = 15_000, ...options } = {}) => {
     const response = await fetch(`${connection.url}${pathname}`, {
       ...options,
       headers: {
@@ -121,7 +121,7 @@ try {
         'x-api-key': API_KEY,
         ...(options.headers ?? {}),
       },
-      signal: AbortSignal.timeout(20_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     const raw = await response.text();
     let body;
@@ -133,7 +133,11 @@ try {
     return { status: response.status, body };
   };
 
-  await waitFor(async () => (await api('/api/session')).status === 200, 30_000, 'broker readiness');
+  await waitFor(
+    async () => (await api('/api/session', { timeoutMs: 2_000 })).status === 200,
+    30_000,
+    'broker readiness'
+  );
   const spawned = await api('/api/spawn', {
     method: 'POST',
     body: JSON.stringify({
@@ -156,7 +160,9 @@ try {
   try {
     positiveScreen = await waitForSnapshot(api, positiveNonce, 20_000);
   } catch (error) {
-    const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+    const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+      timeoutMs: 2_000,
+    });
     throw new Error(
       `${error.message}; positive=${JSON.stringify(positive)}; nodeFrames=${JSON.stringify(
         relaycast.state.nodeFrames
@@ -205,7 +211,9 @@ try {
     );
   }
   await new Promise((resolve) => setTimeout(resolve, 250));
-  const finalSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+  const finalSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+    timeoutMs: 2_000,
+  });
   const finalScreen = finalSnapshot.body?.screen ?? '';
 
   const positiveInjectionCount = occurrences(positiveScreen, positiveNonce);
@@ -288,7 +296,12 @@ try {
     throw new Error(`Recipient release failed during teardown: ${JSON.stringify(released)}`);
   }
   await waitFor(
-    async () => (await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`)).status === 404,
+    async () =>
+      (
+        await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+          timeoutMs: 2_000,
+        })
+      ).status === 404,
     10_000,
     'recipient absence after release'
   );
@@ -381,7 +394,9 @@ async function waitForConnection(connectionPath, child) {
 async function waitForSnapshot(api, marker, timeoutMs) {
   return waitFor(
     async () => {
-      const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+      const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`, {
+        timeoutMs: 2_000,
+      });
       if (snapshot.status !== 200) return false;
       const screen = snapshot.body?.screen ?? '';
       return screen.includes(marker) ? screen : false;

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -1,0 +1,362 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { startFakeRelaycast } from './fake-relaycast.mjs';
+
+const CASE_ID = '1615-api-send-recipient-reachability';
+const RECIPIENT = 'relayflow-live-recipient';
+const OFFLINE_RECIPIENT = 'relayflow-offline-recipient';
+const API_KEY = 'br_relayflow_1615';
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1615-'));
+const stateDir = path.join(probeDir, 'state');
+const binDir = path.join(probeDir, 'bin');
+const fakeClaudePath = path.join(binDir, 'claude');
+// Keep each nonce shorter than the remaining PTY column width after Relay's
+// injected message prefix, so the terminal renderer cannot visually wrap and
+// split the byte marker the effect oracle searches for.
+const positiveNonce = `R${expectedSha.slice(0, 8)}${arm[0]}`;
+const negativeNonce = `U${expectedSha.slice(0, 8)}${arm[0]}`;
+const fakeClaudeSource = String.raw`#!/usr/bin/env node
+process.stdin.setRawMode?.(true);
+process.stdin.resume();
+process.stdout.write('RELAYFLOW_RECIPIENT_READY\r\n❯');
+process.stdin.on('data', (chunk) => process.stdout.write(chunk));
+`;
+
+let broker;
+let relaycast;
+let brokerStderr = '';
+let teardownProved = false;
+try {
+  await mkdir(binDir, { recursive: true });
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(fakeClaudePath, fakeClaudeSource, { encoding: 'utf8', mode: 0o700 });
+  await chmod(fakeClaudePath, 0o700);
+  relaycast = await startFakeRelaycast({
+    recipientName: RECIPIENT,
+    offlineRecipientName: OFFLINE_RECIPIENT,
+    // The publish itself completes immediately. Keeping the independent
+    // reachability read slower than the configured publish deadline proves a
+    // best-effort probe cannot turn durable acceptance into a send failure.
+    agentReadDelayMs: 250,
+  });
+
+  broker = spawn(
+    binaryPath,
+    [
+      'init',
+      '--instance-name',
+      'relayflow-1615-broker',
+      '--workspace-key',
+      'rk_relayflow_1615',
+      '--state-dir',
+      stateDir,
+      '--api-port',
+      '0',
+      '--channels',
+      '',
+    ],
+    {
+      cwd: probeDir,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${path.dirname(process.execPath)}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        RELAYCAST_BASE_URL: relaycast.baseUrl,
+        RELAY_BROKER_API_KEY: API_KEY,
+        RELAY_NODE_ID: 'node_relayflow_1615',
+        RELAY_NODE_TOKEN: 'nt_relayflow_1615',
+        RELAY_INJECT_RATE_MS: '0',
+        AGENT_RELAY_HTTP_API_RELAYCAST_SEND_TIMEOUT_MS: '100',
+        AGENT_RELAY_NO_DEBUG_FILES: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  broker.stderr.on('data', (chunk) => {
+    brokerStderr = `${brokerStderr}${chunk}`.slice(-16_000);
+  });
+
+  const connection = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
+  const api = async (pathname, options = {}) => {
+    const response = await fetch(`${connection.url}${pathname}`, {
+      ...options,
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': API_KEY,
+        ...(options.headers ?? {}),
+      },
+      signal: AbortSignal.timeout(20_000),
+    });
+    const raw = await response.text();
+    let body;
+    try {
+      body = raw ? JSON.parse(raw) : undefined;
+    } catch {
+      body = { raw };
+    }
+    return { status: response.status, body };
+  };
+
+  await waitFor(async () => (await api('/api/session')).status === 200, 30_000, 'broker readiness');
+  const spawned = await api('/api/spawn', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: RECIPIENT,
+      cli: 'claude',
+      channels: [],
+      skip_relay_prompt: true,
+    }),
+  });
+  if (spawned.status !== 200 || spawned.body?.success !== true) {
+    throw new Error(`Real broker could not spawn the recipient: ${JSON.stringify(spawned)}`);
+  }
+  await waitForSnapshot(api, 'RELAYFLOW_RECIPIENT_READY', 20_000);
+
+  const positive = await api('/api/send', {
+    method: 'POST',
+    body: JSON.stringify({ to: RECIPIENT, text: positiveNonce, mode: 'steer' }),
+  });
+  let positiveScreen;
+  try {
+    positiveScreen = await waitForSnapshot(api, positiveNonce, 20_000);
+  } catch (error) {
+    const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+    throw new Error(
+      `${error.message}; positive=${JSON.stringify(positive)}; nodeFrames=${JSON.stringify(
+        relaycast.state.nodeFrames
+      )}; directMessages=${JSON.stringify(relaycast.state.directMessages)}; snapshot=${JSON.stringify(
+        snapshot
+      )}`
+    );
+  }
+
+  const negative = await api('/api/send', {
+    method: 'POST',
+    body: JSON.stringify({ to: OFFLINE_RECIPIENT, text: negativeNonce, mode: 'steer' }),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const finalSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+  const finalScreen = finalSnapshot.body?.screen ?? '';
+
+  const positiveInjectionCount = occurrences(positiveScreen, positiveNonce);
+  const negativeInjectionCount = occurrences(finalScreen, negativeNonce);
+  const deliveryEffectDiscriminates = positiveInjectionCount === 1 && negativeInjectionCount === 0;
+  if (!deliveryEffectDiscriminates) {
+    throw new Error(
+      `The must-fire/must-not-fire PTY control did not discriminate: ${JSON.stringify({
+        positiveInjectionCount,
+        negativeInjectionCount,
+        finalScreen: finalScreen.slice(-2_000),
+      })}`
+    );
+  }
+  if (relaycast.state.directMessages.length !== 2) {
+    throw new Error(
+      `Expected both controls to cross the real broker publish boundary, observed ${relaycast.state.directMessages.length}.`
+    );
+  }
+
+  const baseObserved =
+    positive.status === 200 &&
+    negative.status === 200 &&
+    positive.body?.success === true &&
+    negative.body?.success === true &&
+    positive.body?.relaycast_published === true &&
+    negative.body?.relaycast_published === true &&
+    !('delivery_status' in positive.body) &&
+    !('delivery_status' in negative.body) &&
+    equivalentExceptEventId(positive.body, negative.body);
+  const headObserved =
+    positive.status === 200 &&
+    negative.status === 200 &&
+    positive.body?.success === true &&
+    negative.body?.success === true &&
+    positive.body?.delivery_status === 'published_unconfirmed' &&
+    negative.body?.delivery_status === 'published_unconfirmed' &&
+    positive.body?.recipient_live === true &&
+    positive.body?.recipient_status === 'active' &&
+    negative.body?.recipient_live === false &&
+    negative.body?.recipient_status === 'offline';
+
+  const released = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}`, {
+    method: 'DELETE',
+    body: '{}',
+  });
+  if (released.status !== 200) {
+    throw new Error(`Recipient release failed during teardown: ${JSON.stringify(released)}`);
+  }
+  await waitFor(
+    async () => (await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`)).status === 404,
+    10_000,
+    'recipient absence after release'
+  );
+  teardownProved = true;
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'api_send_hides_unroutable_recipient';
+    details =
+      'The real base broker published both DMs and injected only the routable nonce, yet returned equivalent successful responses after removing the random event id.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'api_send_reports_recipient_reachability';
+    details =
+      'The real head broker published both DMs, injected only the routable nonce, and separately reported live versus offline recipient observations without claiming delivery.';
+  } else {
+    throw new Error(
+      `Unexpected /api/send observation: ${JSON.stringify({ arm, positive, negative, brokerStderr })}`
+    );
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({
+      version: 1,
+      caseId: CASE_ID,
+      arm,
+      outcome,
+      signature,
+      details,
+      evidence: {
+        positiveInjectionCount,
+        negativeInjectionCount,
+        relaycastPublications: relaycast.state.directMessages.length,
+        teardownProved,
+      },
+    })}\n`,
+    'utf8'
+  );
+} finally {
+  if (broker && broker.exitCode === null) {
+    broker.kill('SIGTERM');
+    await Promise.race([
+      new Promise((resolve) => broker.once('exit', resolve)),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+    if (broker.exitCode === null) broker.kill('SIGKILL');
+  }
+  await relaycast?.close();
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+async function waitForConnection(connectionPath, child) {
+  let lastError;
+  return waitFor(
+    async () => {
+      if (child.exitCode !== null) {
+        throw new Error(`Broker exited during startup (${child.exitCode}): ${brokerStderr}`);
+      }
+      try {
+        return JSON.parse(await readFile(connectionPath, 'utf8'));
+      } catch (error) {
+        lastError = error;
+        return false;
+      }
+    },
+    30_000,
+    `connection metadata (${lastError?.message ?? 'not written'})`
+  );
+}
+
+async function waitForSnapshot(api, marker, timeoutMs) {
+  return waitFor(
+    async () => {
+      const snapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
+      if (snapshot.status !== 200) return false;
+      const screen = snapshot.body?.screen ?? '';
+      return screen.includes(marker) ? screen : false;
+    },
+    timeoutMs,
+    `recipient PTY marker ${marker}`
+  );
+}
+
+async function waitFor(check, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const result = await check();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}; broker=${brokerStderr}`
+  );
+}
+
+function equivalentExceptEventId(left, right) {
+  const normalize = (value) => {
+    const copy = { ...value };
+    delete copy.event_id;
+    return JSON.stringify(copy, Object.keys(copy).sort());
+  };
+  return normalize(left) === normalize(right);
+}
+
+function occurrences(value, needle) {
+  return value.split(needle).length - 1;
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+async function requiredExecutable(name) {
+  const candidate = path.resolve(requiredValue(name));
+  try {
+    await access(candidate, fsConstants.R_OK | fsConstants.X_OK);
+  } catch {
+    throw new Error(`${name} must name a readable executable file.`);
+  }
+  return candidate;
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -11,6 +11,7 @@ import { startFakeRelaycast } from './fake-relaycast.mjs';
 const CASE_ID = '1615-api-send-recipient-reachability';
 const RECIPIENT = 'relayflow-live-recipient';
 const OFFLINE_RECIPIENT = 'relayflow-offline-recipient';
+const UNKNOWN_RECIPIENT = 'relayflow-unknown-recipient';
 const API_KEY = 'br_relayflow_1615';
 const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
 const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
@@ -63,10 +64,11 @@ try {
   relaycast = await startFakeRelaycast({
     recipientName: RECIPIENT,
     offlineRecipientName: OFFLINE_RECIPIENT,
+    unknownRecipientName: UNKNOWN_RECIPIENT,
     // The publish itself completes immediately. Keeping the independent
     // reachability read slower than the configured publish deadline proves a
     // best-effort probe cannot turn durable acceptance into a send failure.
-    agentReadDelayMs: 250,
+    agentReadDelayMs: 750,
   });
 
   broker = spawn(
@@ -162,6 +164,20 @@ try {
     method: 'POST',
     body: JSON.stringify({ to: OFFLINE_RECIPIENT, text: negativeNonce, mode: 'steer' }),
   });
+  const unknown = await api('/api/send', {
+    method: 'POST',
+    body: JSON.stringify({ to: UNKNOWN_RECIPIENT, text: 'unknown-probe-control' }),
+  });
+  const nonRecipientTargets = ['#general', 'thread', 'dm_relayflow_existing', 'conv_relayflow_existing'];
+  const nonRecipientResponses = [];
+  for (const target of nonRecipientTargets) {
+    nonRecipientResponses.push(
+      await api('/api/send', {
+        method: 'POST',
+        body: JSON.stringify({ to: target, text: `non-recipient-control:${target}` }),
+      })
+    );
+  }
   await new Promise((resolve) => setTimeout(resolve, 250));
   const finalSnapshot = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}/snapshot`);
   const finalScreen = finalSnapshot.body?.screen ?? '';
@@ -178,13 +194,26 @@ try {
       })}`
     );
   }
-  if (relaycast.state.directMessages.length !== 2) {
+  const controlledPublications = relaycast.state.directMessages.filter(
+    (message) => message?.to === RECIPIENT || message?.to === OFFLINE_RECIPIENT
+  );
+  if (controlledPublications.length !== 2) {
     throw new Error(
-      `Expected both controls to cross the real broker publish boundary, observed ${relaycast.state.directMessages.length}.`
+      `Expected both delivery controls to cross the real broker publish boundary, observed ${controlledPublications.length}.`
     );
   }
 
+  const nonRecipientFieldsOmitted = nonRecipientResponses.every(
+    ({ status, body }) =>
+      status === 200 &&
+      body?.relaycast_published === true &&
+      !('recipient_live' in body) &&
+      !('recipient_status' in body)
+  );
+  const sharedObservationControls =
+    unknown.status === 200 && unknown.body?.relaycast_published === true && nonRecipientFieldsOmitted;
   const baseObserved =
+    sharedObservationControls &&
     positive.status === 200 &&
     negative.status === 200 &&
     positive.body?.success === true &&
@@ -193,8 +222,11 @@ try {
     negative.body?.relaycast_published === true &&
     !('delivery_status' in positive.body) &&
     !('delivery_status' in negative.body) &&
+    !('recipient_live' in unknown.body) &&
+    !('recipient_status' in unknown.body) &&
     equivalentExceptEventId(positive.body, negative.body);
   const headObserved =
+    sharedObservationControls &&
     positive.status === 200 &&
     negative.status === 200 &&
     positive.body?.success === true &&
@@ -204,7 +236,12 @@ try {
     positive.body?.recipient_live === true &&
     positive.body?.recipient_status === 'active' &&
     negative.body?.recipient_live === false &&
-    negative.body?.recipient_status === 'offline';
+    negative.body?.recipient_status === 'offline' &&
+    unknown.status === 200 &&
+    unknown.body?.relaycast_published === true &&
+    unknown.body?.recipient_live === null &&
+    unknown.body?.recipient_status === 'unknown' &&
+    nonRecipientFieldsOmitted;
 
   const released = await api(`/api/spawned/${encodeURIComponent(RECIPIENT)}`, {
     method: 'DELETE',
@@ -235,7 +272,14 @@ try {
       'The real head broker published both DMs, injected only the routable nonce, and separately reported live versus offline recipient observations without claiming delivery.';
   } else {
     throw new Error(
-      `Unexpected /api/send observation: ${JSON.stringify({ arm, positive, negative, brokerStderr })}`
+      `Unexpected /api/send observation: ${JSON.stringify({
+        arm,
+        positive,
+        negative,
+        unknown,
+        nonRecipientResponses,
+        brokerStderr,
+      })}`
     );
   }
 
@@ -252,7 +296,9 @@ try {
       evidence: {
         positiveInjectionCount,
         negativeInjectionCount,
-        relaycastPublications: relaycast.state.directMessages.length,
+        relaycastPublications: relaycast.state.directMessages.length + relaycast.state.channelMessages.length,
+        unknownProbeReported: unknown.body?.recipient_status ?? 'omitted',
+        nonRecipientFieldsOmitted,
         teardownProved,
       },
     })}\n`,

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -116,6 +116,7 @@ try {
   const api = async (pathname, { timeoutMs = 15_000, ...options } = {}) => {
     const response = await fetch(`${brokerUrl}${pathname}`, {
       ...options,
+      redirect: 'error',
       headers: {
         'content-type': 'application/json',
         'x-api-key': API_KEY,

--- a/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
+++ b/tests/relayflows/cases/1615-api-send-recipient-reachability/run.mjs
@@ -45,6 +45,7 @@ const fakeClaudePath = path.join(binDir, 'claude');
 // split the byte marker the effect oracle searches for.
 const positiveNonce = `R${expectedSha.slice(0, 8)}${arm[0]}`;
 const negativeNonce = `U${expectedSha.slice(0, 8)}${arm[0]}`;
+const selfNonce = `S${expectedSha.slice(0, 8)}${arm[0]}`;
 const fakeClaudeSource = String.raw`#!/usr/bin/env node
 process.stdin.setRawMode?.(true);
 process.stdin.resume();
@@ -160,6 +161,12 @@ try {
     );
   }
 
+  const self = await api('/api/send', {
+    method: 'POST',
+    body: JSON.stringify({ to: '@self', from: RECIPIENT, text: selfNonce, mode: 'steer' }),
+  });
+  const selfScreen = await waitForSnapshot(api, selfNonce, 20_000);
+
   const negative = await api('/api/send', {
     method: 'POST',
     body: JSON.stringify({ to: OFFLINE_RECIPIENT, text: negativeNonce, mode: 'steer' }),
@@ -183,12 +190,15 @@ try {
   const finalScreen = finalSnapshot.body?.screen ?? '';
 
   const positiveInjectionCount = occurrences(positiveScreen, positiveNonce);
+  const selfInjectionCount = occurrences(selfScreen, selfNonce);
   const negativeInjectionCount = occurrences(finalScreen, negativeNonce);
-  const deliveryEffectDiscriminates = positiveInjectionCount === 1 && negativeInjectionCount === 0;
+  const deliveryEffectDiscriminates =
+    positiveInjectionCount === 1 && selfInjectionCount === 1 && negativeInjectionCount === 0;
   if (!deliveryEffectDiscriminates) {
     throw new Error(
       `The must-fire/must-not-fire PTY control did not discriminate: ${JSON.stringify({
         positiveInjectionCount,
+        selfInjectionCount,
         negativeInjectionCount,
         finalScreen: finalScreen.slice(-2_000),
       })}`
@@ -211,7 +221,11 @@ try {
       !('recipient_status' in body)
   );
   const sharedObservationControls =
-    unknown.status === 200 && unknown.body?.relaycast_published === true && nonRecipientFieldsOmitted;
+    self.status === 200 &&
+    self.body?.relaycast_published === true &&
+    unknown.status === 200 &&
+    unknown.body?.relaycast_published === true &&
+    nonRecipientFieldsOmitted;
   const baseObserved =
     sharedObservationControls &&
     positive.status === 200 &&
@@ -224,6 +238,8 @@ try {
     !('delivery_status' in negative.body) &&
     !('recipient_live' in unknown.body) &&
     !('recipient_status' in unknown.body) &&
+    !('recipient_live' in self.body) &&
+    !('recipient_status' in self.body) &&
     equivalentExceptEventId(positive.body, negative.body);
   const headObserved =
     sharedObservationControls &&
@@ -237,6 +253,8 @@ try {
     positive.body?.recipient_status === 'active' &&
     negative.body?.recipient_live === false &&
     negative.body?.recipient_status === 'offline' &&
+    self.body?.recipient_live === true &&
+    self.body?.recipient_status === 'active' &&
     unknown.status === 200 &&
     unknown.body?.relaycast_published === true &&
     unknown.body?.recipient_live === null &&
@@ -276,6 +294,7 @@ try {
         arm,
         positive,
         negative,
+        self,
         unknown,
         nonRecipientResponses,
         brokerStderr,
@@ -295,6 +314,7 @@ try {
       details,
       evidence: {
         positiveInjectionCount,
+        selfInjectionCount,
         negativeInjectionCount,
         relaycastPublications: relaycast.state.directMessages.length + relaycast.state.channelMessages.length,
         unknownProbeReported: unknown.body?.recipient_status ?? 'omitted',


### PR DESCRIPTION
## Summary

- add RelayFlow case `1615-api-send-recipient-reachability`, running the exact real base/head broker and a real spawned child PTY against a deterministic Relaycast boundary
- distinguish durable Relaycast publication from the server-observed reachability of named recipients without claiming delivery
- carry the additive response contract through the TypeScript harness driver and Swift SDK

Closes #1615.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing completed
- exact-SHA RelayFlow: base `bug/api_send_hides_unroutable_recipient`, head `fixed/api_send_reports_recipient_reachability`
- effects in both arms: live injection exactly 1, self injection exactly 1, offline injection exactly 0, teardown proved
- runtime regression: exact pre-fix `5768eb071` blocks an unrelated snapshot during the recipient probe; fixed head keeps the runtime actor responsive
- E2E shutdown oracle hardened in `2449a597e` because the required macOS gate on this PR exposed a real one-shot status race after bounded graceful shutdown; the verifier now polls the process effect and never treats a timed-out status request as absence
- `cargo test -p agent-relay-broker -- --test-threads=1`: 1040 passed, 0 failed, 4 ignored; continuity 12/12; fleet fixture 1/1; journal lock 3/3
- harness-driver focused tests 2/2 and TypeScript check passed
- Swift SDK target builds (host XCTest module unavailable, so Swift tests could not execute locally)

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1615-api-send-recipient-reachability` <!-- relay-pr-proof:case -->

## Screenshots

Not applicable.