### PR TITLE
fix(cli): let message flush/hold/auto target an agent on another node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `node agent message flush` and `node agent message auto` now unblock a held queue that could previously never drain, instead of reporting `flushed: 0` forever and leaving the agent unable to receive anything later. A parked message whose Relaycast identity has been retired is dead-lettered with a reason and is visible in `node deadletters`; injection failures and out-of-order sequences are still held for retry.
+- `node agent message flush`, `hold`, and `auto` now accept `--node`, so an agent on another machine can be flushed or woken from anywhere. Previously they consulted only the local broker and returned `agent_not_found` for a name that `node agent list` and `node agent attach --node` both resolved.
 
 ### Added
 

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -569,6 +569,60 @@ impl BrokerRuntime {
                     message: None,
                 });
             }
+            TerminalControlEvent::Message(TerminalFromCloud::FlushPending {
+                session_id,
+                request_id,
+            }) => {
+                let Some(session) = self.terminal_sessions.get(&session_id).cloned() else {
+                    self.send_terminal(TerminalToCloud::Error {
+                        session_id,
+                        code: "session_not_found".into(),
+                        message: "terminal session is not active".into(),
+                        request_id,
+                    });
+                    return;
+                };
+                // Deliberately no `TerminalMode::View` guard here — see the
+                // frame's doc comment. A flush drains an already-held queue and
+                // does not touch delivery mode, so it cannot corrupt a
+                // concurrent driver, and gating it on `drive` would force an
+                // operator to seize the single drive slot just to wake an agent.
+                let (tx, rx) =
+                    tokio::sync::oneshot::channel::<Result<FlushPendingOk, DeliveryRouteError>>();
+                self.handle_api_request(ListenApiRequest::FlushPending {
+                    name: session.agent.clone(),
+                    reply: tx,
+                })
+                .await;
+                match rx.await {
+                    Ok(Ok(ok)) => {
+                        self.send_terminal(TerminalToCloud::FlushPending {
+                            session_id,
+                            request_id,
+                            flushed: ok.flushed,
+                            dead_lettered: ok.dead_lettered,
+                            held: ok.held,
+                            blocked_reason: ok.blocked_reason,
+                        });
+                    }
+                    Ok(Err(DeliveryRouteError::WorkerNotFound(name))) => {
+                        self.send_terminal(TerminalToCloud::Error {
+                            session_id,
+                            code: "agent_not_found".into(),
+                            message: format!("agent '{name}' is not running on this node"),
+                            request_id,
+                        });
+                    }
+                    Err(_) => {
+                        self.send_terminal(TerminalToCloud::Error {
+                            session_id,
+                            code: "flush_failed".into(),
+                            message: "broker dropped the flush reply".into(),
+                            request_id,
+                        });
+                    }
+                }
+            }
             TerminalControlEvent::Message(TerminalFromCloud::SetDeliveryMode {
                 session_id,
                 mode,
@@ -692,7 +746,8 @@ impl BrokerRuntime {
             | TerminalToCloud::InputAck { session_id, .. }
             | TerminalToCloud::Error { session_id, .. }
             | TerminalToCloud::Closed { session_id, .. }
-            | TerminalToCloud::DeliveryMode { session_id, .. } => session_id.clone(),
+            | TerminalToCloud::DeliveryMode { session_id, .. }
+            | TerminalToCloud::FlushPending { session_id, .. } => session_id.clone(),
         };
         let is_close = matches!(&message, TerminalToCloud::Closed { .. });
         if !try_send_terminal(&self.terminal_control_tx, message) {

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -136,9 +136,6 @@ pub(crate) enum TerminalFromCloud {
     },
     #[serde(rename = "terminal.close")]
     Close { session_id: String },
-    /// Request the broker flip the inbound delivery mode for the session's
-    /// agent. The broker replies with `TerminalToCloud::DeliveryMode` on
-    /// success or `TerminalToCloud::Error` on failure.
     /// Request the broker flush the session agent's parked queue. The broker
     /// replies with `TerminalToCloud::FlushPending` on success or
     /// `TerminalToCloud::Error` on failure.
@@ -157,6 +154,9 @@ pub(crate) enum TerminalFromCloud {
         #[serde(skip_serializing_if = "Option::is_none")]
         request_id: Option<String>,
     },
+    /// Request the broker flip the inbound delivery mode for the session's
+    /// agent. The broker replies with `TerminalToCloud::DeliveryMode` on
+    /// success or `TerminalToCloud::Error` on failure.
     #[serde(rename = "terminal.set_delivery_mode")]
     SetDeliveryMode {
         session_id: String,

--- a/crates/broker/src/terminal_control.rs
+++ b/crates/broker/src/terminal_control.rs
@@ -139,6 +139,24 @@ pub(crate) enum TerminalFromCloud {
     /// Request the broker flip the inbound delivery mode for the session's
     /// agent. The broker replies with `TerminalToCloud::DeliveryMode` on
     /// success or `TerminalToCloud::Error` on failure.
+    /// Request the broker flush the session agent's parked queue. The broker
+    /// replies with `TerminalToCloud::FlushPending` on success or
+    /// `TerminalToCloud::Error` on failure.
+    ///
+    /// Unlike `SetDeliveryMode` this is permitted from a `view` session. A
+    /// flush drains an already-held queue; it does not change the agent's
+    /// delivery mode, so it cannot corrupt a concurrent driver's mode
+    /// bookkeeping. Requiring `drive` here would mean an operator running
+    /// `node agent message flush --node` had to claim the single drive slot
+    /// and lock out whoever was actually attached.
+    #[serde(rename = "terminal.flush_pending")]
+    FlushPending {
+        session_id: String,
+        /// Caller-assigned correlation token echoed in the reply so a delayed
+        /// response cannot be mis-applied to a later request.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
     #[serde(rename = "terminal.set_delivery_mode")]
     SetDeliveryMode {
         session_id: String,
@@ -233,6 +251,20 @@ pub(crate) enum TerminalToCloud {
         flushed: usize,
         matched: bool,
         revision: String,
+    },
+    /// Reply to `TerminalFromCloud::FlushPending`. Carries the same four
+    /// fields as `POST /api/spawned/{name}/flush` so the CLI renders an
+    /// identical result whether it went local or over a node.
+    #[serde(rename = "terminal.flush_pending")]
+    FlushPending {
+        session_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        flushed: usize,
+        dead_lettered: usize,
+        held: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        blocked_reason: Option<String>,
     },
 }
 

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -625,15 +625,22 @@ async function withDeliveryModeClient<T>(
   // hold/auto must claim drive. That is honest — they take control of the
   // agent's inbound delivery — but it means they contend with an attached
   // driver, which a flush does not.
-  const proxy = await startFleetNodeAttachProxy({
-    agent: name,
-    node,
-    mode: sessionMode,
-    env: deps.env,
-    fetch: deps.fetch,
-    ...(workspaceKey ? { workspaceKey } : {}),
-  });
+  // `startFleetNodeAttachProxy` throws `FleetNodeAttachError` for
+  // node_not_found / node_unreachable / control_plane_timeout. Creating it
+  // outside the try meant those rejected the Commander action directly and
+  // bypassed the very error contract this block exists to honour — only
+  // `agent_not_found`, raised inside `run`, was actually covered. It is now
+  // created inside, and closed in `finally` only if it was created.
+  let proxy: Awaited<ReturnType<typeof startFleetNodeAttachProxy>> | undefined;
   try {
+    proxy = await startFleetNodeAttachProxy({
+      agent: name,
+      node,
+      mode: sessionMode,
+      env: deps.env,
+      fetch: deps.fetch,
+      ...(workspaceKey ? { workspaceKey } : {}),
+    });
     return await run(
       createBrokerClient(
         {
@@ -659,7 +666,7 @@ async function withDeliveryModeClient<T>(
     deps.exit(1);
     return undefined;
   } finally {
-    await proxy.close();
+    if (proxy) await proxy.close();
   }
 }
 

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -585,6 +585,61 @@ function validateNativeOptions(
  * Register the `local agent …` subtree (and `runtime tail`) onto the driver
  * group. List/spawn/release/kill talk to a running local broker.
  */
+
+/**
+ * Run a delivery-mode command against an agent that may live on another node.
+ *
+ * `attach` has always accepted `--node` and reaches remote agents through the
+ * fleet-node proxy; `message flush|hold|auto` did not, so they only ever saw
+ * the *local* broker's worker registry. The result was that a name `node agent
+ * list` and `attach` both resolved returned `agent_not_found` from `flush` —
+ * two disjoint registries behind one CLI, and no way to wake a parked agent on
+ * another machine without hand-driving its PTY (relay#1593 row 10).
+ *
+ * With `--node` the command is issued through the same authenticated fleet
+ * proxy `attach --node` uses, so both surfaces resolve names the same way.
+ * Without it the behaviour is unchanged: the local broker, as before.
+ */
+async function withDeliveryModeClient<T>(
+  deps: LocalAgentDependencies,
+  name: string,
+  opts: Record<string, unknown>,
+  sessionMode: AttachMode,
+  run: (client: ReturnType<typeof createBrokerClient>) => Promise<T>
+): Promise<T | undefined> {
+  const node = typeof opts.node === 'string' && opts.node.trim() ? opts.node.trim() : undefined;
+  if (!node) {
+    let captured: T | undefined;
+    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
+      captured = await run(client);
+    });
+    return captured;
+  }
+
+  const workspaceKey =
+    typeof opts.workspaceKey === 'string' && opts.workspaceKey.trim() ? opts.workspaceKey.trim() : undefined;
+  // A flush only drains an already-held queue, so it runs from the
+  // least-privileged session that still establishes the tunnel. Changing
+  // delivery mode is different: the broker refuses `terminal.set_delivery_mode`
+  // from a view session ("view sessions cannot change delivery mode"), so
+  // hold/auto must claim drive. That is honest — they take control of the
+  // agent's inbound delivery — but it means they contend with an attached
+  // driver, which a flush does not.
+  const proxy = await startFleetNodeAttachProxy({
+    agent: name,
+    node,
+    mode: sessionMode,
+    env: deps.env,
+    fetch: deps.fetch,
+    ...(workspaceKey ? { workspaceKey } : {}),
+  });
+  try {
+    return await run(createBrokerClient({ url: proxy.brokerUrl, apiKey: proxy.apiKey }, deps.fetch));
+  } finally {
+    await proxy.close();
+  }
+}
+
 export function registerLocalAgentCommands(
   group: Command,
   overrides: Partial<LocalAgentDependencies> = {}
@@ -880,38 +935,43 @@ export function registerLocalAgentCommands(
   addBrokerOptions(
     message
       .command('flush')
-      .description('Flush queued relay messages into a held local agent')
+      .description('Flush queued relay messages into a held agent')
       .argument('<name>', 'Agent name')
+      .option('--node <node>', 'Target an agent on a fleet node instead of the local broker')
+      .option('--workspace-key <key>', 'Workspace key for the fleet node (requires --node)')
   ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      deps.log(JSON.stringify({ name, ...(await client.flushPending(name)) }, null, 2));
-    });
+    const result = await withDeliveryModeClient(deps, name, opts, 'view', (client) =>
+      client.flushPending(name)
+    );
+    if (result !== undefined) deps.log(JSON.stringify({ name, ...result }, null, 2));
   });
 
   addBrokerOptions(
     message
       .command('hold')
-      .description('Hold new relay messages for a local agent until flushed')
+      .description('Hold new relay messages for an agent until flushed')
       .argument('<name>', 'Agent name')
+      .option('--node <node>', 'Target an agent on a fleet node instead of the local broker')
+      .option('--workspace-key <key>', 'Workspace key for the fleet node (requires --node)')
   ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      deps.log(
-        JSON.stringify({ name, ...(await client.setInboundDeliveryMode(name, 'manual_flush')) }, null, 2)
-      );
-    });
+    const result = await withDeliveryModeClient(deps, name, opts, 'drive', (client) =>
+      client.setInboundDeliveryMode(name, 'manual_flush')
+    );
+    if (result !== undefined) deps.log(JSON.stringify({ name, ...result }, null, 2));
   });
 
   addBrokerOptions(
     message
       .command('auto')
-      .description('Resume automatic relay message injection for a local agent')
+      .description('Resume automatic relay message injection for an agent')
       .argument('<name>', 'Agent name')
+      .option('--node <node>', 'Target an agent on a fleet node instead of the local broker')
+      .option('--workspace-key <key>', 'Workspace key for the fleet node (requires --node)')
   ).action(async (name: string, opts: Record<string, unknown>) => {
-    await runLocalBroker(deps, brokerOptionsFromOpts(opts), async (client) => {
-      deps.log(
-        JSON.stringify({ name, ...(await client.setInboundDeliveryMode(name, 'auto_inject')) }, null, 2)
-      );
-    });
+    const result = await withDeliveryModeClient(deps, name, opts, 'drive', (client) =>
+      client.setInboundDeliveryMode(name, 'auto_inject')
+    );
+    if (result !== undefined) deps.log(JSON.stringify({ name, ...result }, null, 2));
   });
 
   group

--- a/packages/cli/src/cli/commands/local-agent.ts
+++ b/packages/cli/src/cli/commands/local-agent.ts
@@ -634,7 +634,30 @@ async function withDeliveryModeClient<T>(
     ...(workspaceKey ? { workspaceKey } : {}),
   });
   try {
-    return await run(createBrokerClient({ url: proxy.brokerUrl, apiKey: proxy.apiKey }, deps.fetch));
+    return await run(
+      createBrokerClient(
+        {
+          url: proxy.brokerUrl,
+          apiKey: proxy.apiKey,
+          // The proxy can legitimately spend its full reconnect/readiness
+          // budget (162.5s) before a request reaches the loopback handler.
+          // Without this the client used the harness driver's 30s default and
+          // could report a timeout while the proxy went on to apply the
+          // mutation — leaving the operator unsure whether the flush or mode
+          // change actually happened.
+          requestTimeoutMs: proxy.requestTimeoutMs,
+        },
+        deps.fetch
+      )
+    );
+  } catch (error) {
+    // The local path reports failures through deps.error/deps.exit inside
+    // runLocalBroker. Without this the remote path rejected the Commander
+    // action instead, so a remote `agent_not_found` or terminal-session
+    // failure surfaced differently from the identical local failure.
+    deps.error(`Error: ${describeError(error)}`);
+    deps.exit(1);
+    return undefined;
   } finally {
     await proxy.close();
   }

--- a/packages/cli/src/cli/lib/attach-fleet-node.test.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.test.ts
@@ -1177,3 +1177,172 @@ describe('startFleetNodeAttachProxy workspace-key precedence', () => {
     expect(ticket.authorization()).toBe('Bearer rk_live_ambient');
   });
 });
+
+describe('startFleetNodeAttachProxy flush route', () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      const fn = cleanup.pop()!;
+      await fn().catch(() => undefined);
+    }
+  });
+
+  const postFlush = async (proxy: { brokerUrl: string; apiKey: string }, agent: string) => {
+    const response = await fetch(`${proxy.brokerUrl}/api/spawned/${encodeURIComponent(agent)}/flush`, {
+      method: 'POST',
+      headers: { 'x-api-key': proxy.apiKey },
+    });
+    return { status: response.status, body: await response.json().catch(() => ({})) };
+  };
+
+  /**
+   * The point of the whole change: `node agent message flush --node` has to
+   * reach the agent's OWN node. Before this route existed the command only ever
+   * queried the local broker's worker registry and answered `agent_not_found`
+   * for a name that `node agent list` and `attach` both resolve.
+   */
+  it('forwards the flush to the remote node and returns its real result', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-remote',
+      node: 'node-remote',
+      // `view` on purpose: a flush drains an already-held queue without
+      // changing delivery mode, so it must not have to seize the single drive
+      // slot from whoever is attached.
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'wk',
+      fetch: fakeTicketFetch(remote.url),
+    });
+    cleanup.push(proxy.close);
+
+    const socket = await remote.nextConnection();
+    sendReady(socket, 'manual_flush');
+    const forwarded: Array<Record<string, unknown>> = [];
+    socket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8')) as Record<string, unknown>;
+      if (frame.type === 'terminal.flush_pending') {
+        forwarded.push(frame);
+        socket.send(
+          JSON.stringify({
+            type: 'terminal.flush_pending',
+            session_id: SESSION_ID,
+            request_id: frame.request_id,
+            flushed: 2,
+            dead_lettered: 1,
+            held: 0,
+            blocked_reason: null,
+          })
+        );
+      }
+    });
+
+    const result = await postFlush(proxy, 'agent-remote');
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      flushed: 2,
+      dead_lettered: 1,
+      held: 0,
+      blocked_reason: null,
+    });
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]?.session_id).toBe(SESSION_ID);
+  });
+
+  /**
+   * A remote `agent_not_found` must surface as a 404, not a generic failure —
+   * that status is what tells an operator the agent is on a different machine
+   * rather than that the flush itself broke.
+   */
+  it('maps a remote agent_not_found to 404 rather than a generic failure', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-missing',
+      node: 'node-remote',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'wk',
+      fetch: fakeTicketFetch(remote.url),
+    });
+    cleanup.push(proxy.close);
+
+    const socket = await remote.nextConnection();
+    sendReady(socket, 'manual_flush');
+    socket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8')) as Record<string, unknown>;
+      if (frame.type === 'terminal.flush_pending') {
+        socket.send(
+          JSON.stringify({
+            type: 'terminal.error',
+            session_id: SESSION_ID,
+            request_id: frame.request_id,
+            code: 'agent_not_found',
+            message: "agent 'agent-missing' is not running on this node",
+          })
+        );
+      }
+    });
+
+    const result = await postFlush(proxy, 'agent-missing');
+    expect(result.status).toBe(404);
+    expect(result.body).toMatchObject({ error: { code: 'agent_not_found' } });
+  });
+
+  /**
+   * A session-level error carrying no request_id must NOT resolve a pending
+   * flush. Flush is a new frame with no older-broker compatibility to preserve,
+   * so an unrelated failure resolving it would be a false result — the exact
+   * shape of bug this change exists to remove.
+   */
+  it('does not let an unrelated session error resolve a pending flush', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-cross',
+      node: 'node-remote',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'wk',
+      fetch: fakeTicketFetch(remote.url),
+    });
+    cleanup.push(proxy.close);
+
+    const socket = await remote.nextConnection();
+    sendReady(socket, 'manual_flush');
+    socket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8')) as Record<string, unknown>;
+      if (frame.type === 'terminal.flush_pending') {
+        // No request_id: a session-scoped error, not a reply to this flush.
+        socket.send(
+          JSON.stringify({
+            type: 'terminal.error',
+            session_id: SESSION_ID,
+            code: 'pty_write_failed',
+            message: 'unrelated session failure',
+          })
+        );
+        // The real reply arrives after it and must be the one that wins.
+        setTimeout(() => {
+          socket.send(
+            JSON.stringify({
+              type: 'terminal.flush_pending',
+              session_id: SESSION_ID,
+              request_id: frame.request_id,
+              flushed: 1,
+              dead_lettered: 0,
+              held: 0,
+              blocked_reason: null,
+            })
+          );
+        }, 20);
+      }
+    });
+
+    const result = await postFlush(proxy, 'agent-cross');
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ flushed: 1 });
+  });
+});

--- a/packages/cli/src/cli/lib/attach-fleet-node.test.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.test.ts
@@ -1292,6 +1292,63 @@ describe('startFleetNodeAttachProxy flush route', () => {
   });
 
   /**
+   * Requested in review on #1643: the terminal protocol permits a reply with no
+   * request_id, and the proxy always sends one. A no-id `terminal.flush_pending`
+   * frame is therefore never ours, and accepting it would resolve the caller's
+   * flush with an unrelated node's result — a fabricated success.
+   */
+  it('ignores a flush reply that carries no request_id and waits for the real one', async () => {
+    const remote = await startFakeRemote();
+    cleanup.push(remote.close);
+    const proxy = await startFleetNodeAttachProxy({
+      agent: 'agent-noid',
+      node: 'node-remote',
+      mode: 'view',
+      baseUrl: 'https://fake.example',
+      workspaceKey: 'wk',
+      fetch: fakeTicketFetch(remote.url),
+    });
+    cleanup.push(proxy.close);
+
+    const socket = await remote.nextConnection();
+    sendReady(socket, 'manual_flush');
+    socket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8')) as Record<string, unknown>;
+      if (frame.type === 'terminal.flush_pending') {
+        // Decoy: correct type, no request_id, wrong numbers.
+        socket.send(
+          JSON.stringify({
+            type: 'terminal.flush_pending',
+            session_id: SESSION_ID,
+            flushed: 99,
+            dead_lettered: 99,
+            held: 99,
+            blocked_reason: 'decoy',
+          })
+        );
+        setTimeout(() => {
+          socket.send(
+            JSON.stringify({
+              type: 'terminal.flush_pending',
+              session_id: SESSION_ID,
+              request_id: frame.request_id,
+              flushed: 3,
+              dead_lettered: 0,
+              held: 0,
+              blocked_reason: null,
+            })
+          );
+        }, 20);
+      }
+    });
+
+    const result = await postFlush(proxy, 'agent-noid');
+    expect(result.status).toBe(200);
+    // The decoy must not have won.
+    expect(result.body).toMatchObject({ flushed: 3, dead_lettered: 0, blocked_reason: null });
+  });
+
+  /**
    * A session-level error carrying no request_id must NOT resolve a pending
    * flush. Flush is a new frame with no older-broker compatibility to preserve,
    * so an unrelated failure resolving it would be a false result — the exact

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -1032,7 +1032,11 @@ export async function startFleetNodeAttachProxy(
         }
       } else if (frame.type === 'terminal.flush_pending') {
         const frameRid = typeof frame.request_id === 'string' ? frame.request_id : undefined;
-        if (pendingFlush && (frameRid === undefined || frameRid === pendingFlush.requestId)) {
+        // Exact match only. The proxy always sends a request_id, and unlike
+        // delivery-mode there is no older-broker reply shape to stay
+        // compatible with, so a reply without one is not ours — accepting it
+        // would resolve the caller's flush with an unrelated result.
+        if (pendingFlush && frameRid === pendingFlush.requestId) {
           const pending = pendingFlush;
           pendingFlush = null;
           clearTimeout(pending.timer);

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -894,7 +894,18 @@ export async function startFleetNodeAttachProxy(
       const flush = pendingFlush;
       pendingFlush = null;
       clearTimeout(flush.timer);
-      flush.reject(error);
+      // A flush never changes delivery mode, so it must not inherit the
+      // delivery-mode disconnect wording. An operator debugging a failed flush
+      // would otherwise be told the "delivery-mode change" was interrupted —
+      // pointing at an operation their command never performed.
+      const flushError =
+        error.code === 'delivery_mode_disconnected'
+          ? new FleetNodeAttachError(
+              'terminal transport disconnected while the flush was in flight',
+              'flush_disconnected'
+            )
+          : error;
+      flush.reject(flushError);
     }
     if (!pendingDeliveryMode) return;
     const pending = pendingDeliveryMode;

--- a/packages/cli/src/cli/lib/attach-fleet-node.ts
+++ b/packages/cli/src/cli/lib/attach-fleet-node.ts
@@ -517,6 +517,18 @@ export async function startFleetNodeAttachProxy(
   let loopbackDeliveryMode: 'manual_flush' | 'auto_inject' =
     options.mode === 'drive' ? 'manual_flush' : 'auto_inject';
   type DeliveryModeResult = { mode: string; flushed: number; matched: boolean; revision: string };
+  type FlushResult = {
+    flushed: number;
+    dead_lettered: number;
+    held: number;
+    blocked_reason: string | null;
+  };
+  let pendingFlush: {
+    requestId: string;
+    resolve: (result: FlushResult) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
   /** At most one in-flight delivery-mode PUT at a time. */
   let pendingDeliveryMode: {
     requestId: string;
@@ -554,6 +566,67 @@ export async function startFleetNodeAttachProxy(
       return;
     }
     const name = encodeURIComponent(options.agent);
+    if (path === `/api/spawned/${name}/flush` && request.method === 'POST') {
+      // Forward the flush to the remote broker over the terminal websocket.
+      // Without this the `--node` form of `node agent message flush` reached
+      // only the LOCAL broker's worker registry and returned agent_not_found
+      // for a name that `node agent list` and `attach` both resolve.
+      try {
+        await waitForTerminalReady('terminal connection timed out');
+      } catch (error) {
+        const terminalError = error instanceof FleetNodeAttachError ? error : undefined;
+        json(response, terminalErrorStatus(terminalError?.code), {
+          error: {
+            code: terminalError?.code ?? 'node_unreachable',
+            message:
+              terminalError?.message ?? (error instanceof Error ? error.message : 'terminal unavailable'),
+          },
+        });
+        return;
+      }
+      if (!remote || remote.readyState !== WebSocket.OPEN) {
+        json(response, 503, {
+          error: { code: 'node_unreachable', message: 'terminal transport is not connected' },
+        });
+        return;
+      }
+      if (pendingFlush) {
+        json(response, 503, {
+          error: { code: 'flush_conflict', message: 'a flush request is already in flight' },
+        });
+        return;
+      }
+      const requestId = randomBytes(8).toString('hex');
+      const result = await new Promise<FlushResult | Error>((resolve) => {
+        const timer = setTimeout(() => {
+          pendingFlush = null;
+          resolve(new FleetNodeAttachError('flush request timed out', 'flush_timeout'));
+        }, DELIVERY_MODE_TIMEOUT_MS);
+        pendingFlush = {
+          requestId,
+          resolve: (r) => resolve(r),
+          reject: (e) => resolve(e),
+          timer,
+        };
+        remote!.send(
+          JSON.stringify({
+            type: 'terminal.flush_pending',
+            session_id: sessionId,
+            request_id: requestId,
+          })
+        );
+      });
+      if (result instanceof Error) {
+        const errCode =
+          result instanceof FleetNodeAttachError ? (result.code ?? 'flush_failed') : 'flush_failed';
+        json(response, terminalErrorStatus(errCode), {
+          error: { code: errCode, message: result.message },
+        });
+        return;
+      }
+      json(response, 200, result);
+      return;
+    }
     if (path === `/api/spawned/${name}/delivery-mode`) {
       if (request.method === 'GET') {
         json(response, 200, { mode: loopbackDeliveryMode });
@@ -817,6 +890,12 @@ export async function startFleetNodeAttachProxy(
   resumeUrl.searchParams.set('resume', resumeToken);
   /** Reject and clear any in-flight delivery-mode PUT, if one is pending. */
   const rejectPendingDeliveryMode = (error: FleetNodeAttachError) => {
+    if (pendingFlush) {
+      const flush = pendingFlush;
+      pendingFlush = null;
+      clearTimeout(flush.timer);
+      flush.reject(error);
+    }
     if (!pendingDeliveryMode) return;
     const pending = pendingDeliveryMode;
     pendingDeliveryMode = null;
@@ -951,6 +1030,19 @@ export async function startFleetNodeAttachProxy(
             revision: typeof frame.revision === 'string' ? frame.revision : '1',
           });
         }
+      } else if (frame.type === 'terminal.flush_pending') {
+        const frameRid = typeof frame.request_id === 'string' ? frame.request_id : undefined;
+        if (pendingFlush && (frameRid === undefined || frameRid === pendingFlush.requestId)) {
+          const pending = pendingFlush;
+          pendingFlush = null;
+          clearTimeout(pending.timer);
+          pending.resolve({
+            flushed: typeof frame.flushed === 'number' ? frame.flushed : 0,
+            dead_lettered: typeof frame.dead_lettered === 'number' ? frame.dead_lettered : 0,
+            held: typeof frame.held === 'number' ? frame.held : 0,
+            blocked_reason: typeof frame.blocked_reason === 'string' ? frame.blocked_reason : null,
+          });
+        }
       } else if (frame.type === 'terminal.error') {
         const message = typeof frame.message === 'string' ? frame.message : 'remote terminal failed';
         const code = typeof frame.code === 'string' ? frame.code : 'terminal_error';
@@ -959,7 +1051,15 @@ export async function startFleetNodeAttachProxy(
         // request_id matches (or the broker sent no request_id at all — older
         // broker compat). An unrelated session-level error must not cancel a
         // live delivery-mode PUT and vice-versa.
-        if (pendingDeliveryMode && (frameRid === undefined || frameRid === pendingDeliveryMode.requestId)) {
+        if (pendingFlush && frameRid !== undefined && frameRid === pendingFlush.requestId) {
+          const pending = pendingFlush;
+          pendingFlush = null;
+          clearTimeout(pending.timer);
+          pending.reject(new FleetNodeAttachError(message, code));
+        } else if (
+          pendingDeliveryMode &&
+          (frameRid === undefined || frameRid === pendingDeliveryMode.requestId)
+        ) {
           const pending = pendingDeliveryMode;
           pendingDeliveryMode = null;
           clearTimeout(pending.timer);

--- a/tests/relayflows/cases/1593-flush-node-registry/case.json
+++ b/tests/relayflows/cases/1593-flush-node-registry/case.json
@@ -6,7 +6,6 @@
   "runner": {
     "command": ["node", "tests/relayflows/cases/1593-flush-node-registry/run.mjs"]
   },
-  "requirements": ["broker-linux-x64"],
   "timeoutSeconds": 900,
   "expected": {
     "base": {

--- a/tests/relayflows/cases/1593-flush-node-registry/case.json
+++ b/tests/relayflows/cases/1593-flush-node-registry/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1593-flush-node-registry",
+  "kind": "bugfix",
+  "title": "node agent message flush cannot reach an agent on another node",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1593-flush-node-registry/run.mjs"]
+  },
+  "requirements": ["broker-linux-x64"],
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "flush_cannot_target_a_remote_node"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "flush_reaches_the_agents_own_node"
+    }
+  }
+}

--- a/tests/relayflows/cases/1593-flush-node-registry/run.mjs
+++ b/tests/relayflows/cases/1593-flush-node-registry/run.mjs
@@ -1,0 +1,165 @@
+/**
+ * relay#1593 (row 10) — `node agent message flush` could not reach an agent on
+ * another node, while `node agent list` and `node agent attach` both could.
+ *
+ * `flush`, `hold` and `auto` went straight to `runLocalBroker` and accepted no
+ * `--node`, so they only ever consulted the LOCAL broker's worker registry.
+ * `attach` has always taken `--node` and reaches remote agents through the
+ * fleet-node proxy. The result was two disjoint name registries behind one CLI:
+ * a name that `list` and `attach` resolved returned `agent_not_found` from
+ * `flush`, and there was no way to wake a parked agent on another machine
+ * without hand-driving its PTY.
+ *
+ * Observation: the CLI's own command surface, built from the target checkout.
+ * On base the three delivery-mode commands reject `--node` outright ("unknown
+ * option"), which is the operator-visible defect — no amount of correct
+ * arguments can target another node. On head they accept it and route through
+ * the same authenticated proxy `attach --node` uses.
+ *
+ * Deliberately NOT asserted here: a live cross-node flush against a real
+ * Relaycast. The self-hostable `@relaycast/engine` has no
+ * `/v1/nodes/{node}/terminal/sessions` route — terminal sessions are
+ * cloud-only — so the transport this depends on cannot be stood up in the
+ * proof sandbox without faking the very routing under test. The wire path is
+ * covered by unit tests instead (`attach-fleet-node.test.ts`, "flush route"),
+ * which are mutation-verified: disabling the route fails all three.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1593-flush-node-registry';
+const targetDir = requiredValue('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredValue('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+function run(command, args, cwd, label) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  if (result.status !== 0) {
+    throw new Error(
+      `${label} failed (exit ${result.status}): ${(result.stderr || result.stdout || '').slice(-2_000)}`
+    );
+  }
+  return result;
+}
+
+/** Ask the built CLI for a command's help and report whether it offers --node. */
+function offersNodeOption(cliEntry, subcommand) {
+  const result = spawnSync(process.execPath, [cliEntry, 'node', 'agent', 'message', subcommand, '--help'], {
+    cwd: targetDir,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  const text = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  return { offered: /--node\s+<node>/.test(text), text };
+}
+
+/**
+ * Run the command with `--node` and report whether the CLI parses it at all.
+ * A base CLI exits non-zero with "unknown option '--node'" before it ever
+ * contacts a broker; that parse rejection IS the defect, and it is observable
+ * without any Relaycast at all.
+ */
+function acceptsNodeArgument(cliEntry, subcommand) {
+  const result = spawnSync(
+    process.execPath,
+    [cliEntry, 'node', 'agent', 'message', subcommand, 'probe-agent', '--node', 'probe-node'],
+    {
+      cwd: targetDir,
+      encoding: 'utf8',
+      timeout: 60_000,
+      maxBuffer: 8 * 1024 * 1024,
+      env: { ...process.env, RELAY_SKIP_TELEMETRY: '1' },
+    }
+  );
+  const text = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  return { rejectedAsUnknown: /unknown option .*--node/i.test(text), text };
+}
+
+try {
+  run('npm', ['ci', '--ignore-scripts'], targetDir, 'workspace dependency installation');
+  for (const step of [
+    'build:session',
+    'build:config',
+    'build:cloud',
+    'build:utils',
+    'build:policy',
+    'build:sdk',
+    'build:harness-driver',
+    'build:harnesses',
+    'build:fleet',
+    'build:cli',
+  ]) {
+    run('npm', ['run', step], targetDir, `${step} build`);
+  }
+
+  const cliEntry = path.join(targetDir, 'packages/cli/dist/cli/index.js');
+  const subcommands = ['flush', 'hold', 'auto'];
+  const help = Object.fromEntries(subcommands.map((c) => [c, offersNodeOption(cliEntry, c)]));
+  const parse = Object.fromEntries(subcommands.map((c) => [c, acceptsNodeArgument(cliEntry, c)]));
+
+  const offeredCount = subcommands.filter((c) => help[c].offered).length;
+  const rejectedCount = subcommands.filter((c) => parse[c].rejectedAsUnknown).length;
+  const detail = `--node advertised by ${offeredCount}/3 commands; rejected as unknown by ${rejectedCount}/3`;
+
+  let outcome;
+  let signature;
+  let details;
+  if (offeredCount === 0 && rejectedCount === 3) {
+    outcome = 'bug';
+    signature = 'flush_cannot_target_a_remote_node';
+    details =
+      `The base CLI offers no --node on message flush/hold/auto and rejects it outright (${detail}). ` +
+      'An agent that `node agent list` and `node agent attach --node` both resolve therefore cannot be ' +
+      'flushed or woken from another machine at all.';
+  } else if (offeredCount === 3 && rejectedCount === 0) {
+    outcome = 'fixed';
+    signature = 'flush_reaches_the_agents_own_node';
+    details =
+      `The head CLI advertises and parses --node on all three delivery-mode commands (${detail}), ` +
+      'routing them through the same authenticated fleet-node proxy `attach --node` uses, so both ' +
+      'surfaces resolve agent names against the same registry.';
+  } else {
+    throw new Error(`Inconsistent observation (${detail}). flush help: ${help.flush.text.slice(-400)}`);
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+  process.stdout.write(`${signature}\n`);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  throw error;
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+function isWithin(root, candidate) {
+  const rel = path.relative(path.resolve(root), path.resolve(candidate));
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}

--- a/tests/relayflows/cases/1593-flush-node-registry/run.mjs
+++ b/tests/relayflows/cases/1593-flush-node-registry/run.mjs
@@ -67,6 +67,10 @@ function offersNodeOption(cliEntry, subcommand) {
   const result = spawnSync(process.execPath, [cliEntry, 'node', 'agent', 'message', subcommand, '--help'], {
     cwd: targetDir,
     encoding: 'utf8',
+    // spawnSync is synchronous: an unbounded --help that stalls would block
+    // until the case's whole 900s budget expired, surfacing as a timeout with
+    // no indication of which probe hung.
+    timeout: 60_000,
     maxBuffer: 8 * 1024 * 1024,
   });
   const text = `${result.stdout ?? ''}${result.stderr ?? ''}`;

--- a/tests/relayflows/cases/1593-flush-node-registry/run.mjs
+++ b/tests/relayflows/cases/1593-flush-node-registry/run.mjs
@@ -73,6 +73,17 @@ function offersNodeOption(cliEntry, subcommand) {
     timeout: 60_000,
     maxBuffer: 8 * 1024 * 1024,
   });
+  // A spawn failure is NOT an observation. Without this, a timed-out or
+  // un-spawnable `--help` yields empty output and reports `offered: false` —
+  // which on the head arm looks exactly like the base defect and could report
+  // `flush_cannot_target_a_remote_node` for a CLI that actually has the option.
+  if (result.error) {
+    throw new Error(
+      `--help probe for '${subcommand}' failed to run: ${result.error.message}${
+        result.signal ? ` (signal ${result.signal})` : ''
+      }`
+    );
+  }
   const text = `${result.stdout ?? ''}${result.stderr ?? ''}`;
   return { offered: /--node\s+<node>/.test(text), text };
 }
@@ -95,6 +106,15 @@ function acceptsNodeArgument(cliEntry, subcommand) {
       env: { ...process.env, RELAY_SKIP_TELEMETRY: '1' },
     }
   );
+  // Same reasoning as the help probe: a spawn failure here would report
+  // `rejectedAsUnknown: false`, which on the base arm mimics the fixed
+  // behaviour. Only a real, parsed CLI response may become an observation.
+  // A `timeout` kill is expected on head (the command reaches a real proxy
+  // attempt), so a killed process is tolerated — but an inability to spawn at
+  // all is not.
+  if (result.error && !result.signal) {
+    throw new Error(`--node parse probe for '${subcommand}' failed to run: ${result.error.message}`);
+  }
   const text = `${result.stdout ?? ''}${result.stderr ?? ''}`;
   return { rejectedAsUnknown: /unknown option .*--node/i.test(text), text };
 }


### PR DESCRIPTION
## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1593-flush-node-registry` <!-- relay-pr-proof:case -->

| arm | `--node` advertised | rejected as unknown | signature |
|---|---|---|---|
| base `daf8a7c7c` | **0/3** | **3/3** | `flush_cannot_target_a_remote_node` |
| head | **3/3** | **0/3** | `flush_reaches_the_agents_own_node` |

## The bug

`node agent message flush | hold | auto` called `runLocalBroker` and accepted no `--node`, so they only ever consulted the **local** broker's worker registry. `attach` has always taken `--node` and reaches remote agents through the fleet-node proxy.

Two disjoint name registries behind one CLI: a name that `node agent list` and `node agent attach --node` both resolved returned `agent_not_found` from `flush` — and there was no way to wake a parked agent on another machine without hand-driving its PTY.

**This is the mechanism board row 10 actually named.** #1639 fixed a different one (a parked queue jammed by a receipt naming a retired Relaycast identity). This is the registry mismatch, independently measured by another lane, and still present on current main.

## What changed

**Wire** — `flush` had no tunnelled route, so this adds a `terminal.flush_pending` frame pair. The reply carries `flushed`, `dead_lettered`, `held` and `blocked_reason`, so a `--node` flush renders identically to a local one. `hold`/`auto` ride the existing `terminal.set_delivery_mode` tunnel.

**Session modes differ, on purpose.** `flush` runs from a **view** session — it drains an already-held queue without touching delivery mode, so it cannot corrupt a concurrent driver's bookkeeping, and requiring `drive` would force an operator to seize the single drive slot from whoever is attached. `hold`/`auto` **do** change delivery mode, which the broker refuses from view (*"view sessions cannot change delivery mode"*), so they claim `drive` and honestly contend with an attached driver. Reviewers should weigh that trade-off rather than discover it.

**Error routing is stricter than delivery-mode's.** A `terminal.error` resolves a pending flush only on an exact `request_id` match. Delivery-mode keeps a no-`request_id` fallback for older brokers; flush is new, has no such compatibility to preserve, and a flush resolved by an unrelated session failure would report a fabricated result.

## Tests

Three proxy tests: forward-and-return, `agent_not_found` → 404 (the status that tells an operator the agent is on a *different machine*, not that flush broke), and a cross-talk guard.

**Mutation-verified.** Disabling the route:

```
× forwards the flush to the remote node and returns its real result
× maps a remote agent_not_found to 404 rather than a generic failure
× does not let an unrelated session error resolve a pending flush
```

Restoring it: **28/28 pass**, including all 25 pre-existing proxy tests. Broker: clippy clean under `-D warnings`, terminal tests 20/20. CLI: local-agent 51/51.

## What this case deliberately does NOT assert

A live cross-node flush against a real Relaycast. The self-hostable `@relaycast/engine` has **no** `/v1/nodes/{node}/terminal/sessions` route — terminal sessions are cloud-only — so that transport cannot be stood up in the proof sandbox without faking the very routing under test. Rather than build a fake that grants the premise (which is exactly how #1639's first proof case went wrong), the case observes the operator-visible defect on the CLI surface and the wire path is covered by the mutation-verified unit tests.

Refs: #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014N3p9VEngj9kLDFFhrzHNd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

