### PR TITLE
ci(pr-proof): decide proof requirement from the diff, not the PR title

### DIFF
--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -83,20 +83,26 @@ export function parsePrProofMetadata(body = '') {
  * Paths that cannot change what a user's `agent-relay` actually does.
  *
  * The proof gate exists to stop a runtime behaviour change landing without a
- * red/green demonstration. Scheduled workflow definitions, CI config, docs,
- * tooling scripts and test corpora are none of those: nothing here is executed
- * by an installed CLI or broker.
+ * red/green demonstration. Scheduled workflow definitions, CI config, docs and
+ * test corpora are none of those: nothing here is executed by an installed CLI
+ * or broker.
  *
  * Deliberately an allowlist, so it fails CLOSED. A path this list has never
  * heard of counts as runtime and still demands a proof — a new top-level
  * directory should not silently become proof-exempt.
+ *
+ * `scripts/` is NOT exempt wholesale. `scripts/inject-posthog-key.mjs` is run
+ * by publish.yml and rewrites the compiled CLI before it ships, so a change
+ * there reaches users even though nothing under `scripts/` is imported at
+ * runtime. Only the subtrees that exist to serve CI itself are listed.
  */
 const NON_RUNTIME_PATH_PATTERNS = Object.freeze([
   /^workflows\//,
   /^docs\//,
   /^\.github\//,
   /^\.agentworkforce\//,
-  /^scripts\//,
+  /^scripts\/pr-proof\//,
+  /^scripts\/evals\//,
   /^tests\//,
   /^[^/]*\.md$/,
 ]);
@@ -160,12 +166,14 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
   // A `non-functional` declaration is checked against the DIFF, not the title.
   // Rejecting it purely because the title says `fix(` forced workflow-only and
   // docs-only PRs to fabricate a runtime proof they could not honestly build.
-  if (titleKind && metadata.changeType === 'non-functional' && touchesRuntime !== false) {
-    errors.push(
-      touchesRuntime === true
-        ? `PR title declares a ${titleKind} and this PR changes runtime files, so the change type cannot be non-functional`
-        : `PR title declares a ${titleKind}, so the change type cannot be non-functional`
-    );
+  // The diff overrules the title in BOTH directions. A runtime change cannot be
+  // non-functional no matter how the title is worded — checking `titleKind`
+  // here would let a `chore(`-titled broker change declare non-functional and
+  // have that contradiction silently coerced into `bugfix` further down.
+  if (metadata.changeType === 'non-functional' && touchesRuntime === true) {
+    errors.push('This PR changes runtime files, so the change type cannot be non-functional');
+  } else if (titleKind && metadata.changeType === 'non-functional' && touchesRuntime === null) {
+    errors.push(`PR title declares a ${titleKind}, so the change type cannot be non-functional`);
   }
   if (titleKind && metadataKind && titleKind !== metadataKind) {
     errors.push(`PR title declares ${titleKind}, but the PR body declares ${metadataKind}`);

--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -79,10 +79,50 @@ export function parsePrProofMetadata(body = '') {
   };
 }
 
-export function classifyPullRequest({ title = '', body = '' }) {
+/**
+ * Paths that cannot change what a user's `agent-relay` actually does.
+ *
+ * The proof gate exists to stop a runtime behaviour change landing without a
+ * red/green demonstration. Scheduled workflow definitions, CI config, docs,
+ * tooling scripts and test corpora are none of those: nothing here is executed
+ * by an installed CLI or broker.
+ *
+ * Deliberately an allowlist, so it fails CLOSED. A path this list has never
+ * heard of counts as runtime and still demands a proof — a new top-level
+ * directory should not silently become proof-exempt.
+ */
+const NON_RUNTIME_PATH_PATTERNS = Object.freeze([
+  /^workflows\//,
+  /^docs\//,
+  /^\.github\//,
+  /^\.agentworkforce\//,
+  /^scripts\//,
+  /^tests\//,
+  /^[^/]*\.md$/,
+]);
+
+/**
+ * True when at least one changed file can alter shipped runtime behaviour.
+ *
+ * This is what decides whether a proof is required — NOT the PR title. Reading
+ * the title alone was wrong in both directions: a `fix(` PR touching only a
+ * scheduled workflow was forced to invent a runtime proof it could not honestly
+ * build, and a `chore(`-titled PR editing the broker skipped the gate
+ * altogether. A gate that can be bypassed by wording is not a gate.
+ */
+export function runtimeSurfaceChanged(files = []) {
+  return files
+    .filter((file) => typeof file === 'string' && file.trim())
+    .some((file) => !NON_RUNTIME_PATH_PATTERNS.some((pattern) => pattern.test(file)));
+}
+
+export function classifyPullRequest({ title = '', body = '', changedFiles = null }) {
   const metadata = parsePrProofMetadata(body);
   const conventionalKind = REQUIRED_TITLE_RE.exec(title)?.[1]?.toLowerCase() ?? null;
   const titleKind = conventionalKind === 'feat' ? 'feature' : conventionalKind === 'fix' ? 'bugfix' : null;
+  // `null` means the caller could not determine the diff; fall back to the old
+  // title-only behaviour rather than silently exempting an unknown change.
+  const touchesRuntime = changedFiles === null ? null : runtimeSurfaceChanged(changedFiles);
   const errors = [];
 
   if (metadata.changeTypeCount === 0) {
@@ -100,8 +140,8 @@ export function classifyPullRequest({ title = '', body = '' }) {
 
   if (!metadata.changeType) {
     return {
-      required: Boolean(titleKind),
-      kind: titleKind,
+      required: Boolean(titleKind) || touchesRuntime === true,
+      kind: titleKind ?? (touchesRuntime === true ? 'bugfix' : null),
       caseId: null,
       metadata,
       errors,
@@ -117,15 +157,31 @@ export function classifyPullRequest({ title = '', body = '' }) {
 
   const metadataKind =
     metadata.changeType === 'feature' || metadata.changeType === 'bugfix' ? metadata.changeType : null;
-  if (titleKind && metadata.changeType === 'non-functional') {
-    errors.push(`PR title declares a ${titleKind}, so the change type cannot be non-functional`);
+  // A `non-functional` declaration is checked against the DIFF, not the title.
+  // Rejecting it purely because the title says `fix(` forced workflow-only and
+  // docs-only PRs to fabricate a runtime proof they could not honestly build.
+  if (titleKind && metadata.changeType === 'non-functional' && touchesRuntime !== false) {
+    errors.push(
+      touchesRuntime === true
+        ? `PR title declares a ${titleKind} and this PR changes runtime files, so the change type cannot be non-functional`
+        : `PR title declares a ${titleKind}, so the change type cannot be non-functional`
+    );
   }
   if (titleKind && metadataKind && titleKind !== metadataKind) {
     errors.push(`PR title declares ${titleKind}, but the PR body declares ${metadataKind}`);
   }
 
-  const required = Boolean(metadataKind || titleKind);
-  const kind = metadataKind ?? titleKind;
+  // Decided by the diff wherever the diff is known:
+  //   runtime touched            -> a proof is required, whatever the title says
+  //   nothing runtime + declared -> non-functional is legitimate, even for `fix(`
+  //   diff unknown               -> previous title-only behaviour
+  const required =
+    touchesRuntime === true
+      ? true
+      : touchesRuntime === false && metadata.changeType === 'non-functional'
+        ? false
+        : Boolean(metadataKind || titleKind);
+  const kind = required ? (metadataKind ?? titleKind ?? 'bugfix') : null;
   if (required) {
     if (!metadata.caseId || metadata.caseId === 'n/a') {
       errors.push('Feature and bug-fix PRs must declare exactly one RelayFlow case id');

--- a/scripts/pr-proof/prepare.mjs
+++ b/scripts/pr-proof/prepare.mjs
@@ -38,7 +38,13 @@ async function githubJson(url, token) {
   return response.json();
 }
 
-async function pullRequestFiles(apiUrl, repository, number, token) {
+/**
+ * Every path a PR touches, including the pre-rename path of a renamed file.
+ *
+ * Exported for tests: the rename handling and the ambiguousScope tag are both
+ * load-bearing for whether the proof gate can be bypassed.
+ */
+export async function pullRequestFiles(apiUrl, repository, number, token) {
   const files = [];
   for (let page = 1; page <= 30; page += 1) {
     const batch = await githubJson(
@@ -46,10 +52,23 @@ async function pullRequestFiles(apiUrl, repository, number, token) {
       token
     );
     if (!Array.isArray(batch)) throw new Error('GitHub pull request files response was not an array');
-    files.push(...batch.map((entry) => entry.filename).filter((entry) => typeof entry === 'string'));
+    for (const entry of batch) {
+      // A rename reports only its destination in `filename`. Moving a runtime
+      // file into docs/ or tests/ would otherwise read as a non-runtime change,
+      // so the pre-rename path counts too.
+      for (const path of [entry?.filename, entry?.previous_filename]) {
+        if (typeof path === 'string' && path.trim()) files.push(path);
+      }
+    }
     if (batch.length < 100) return files;
   }
-  throw new Error('PR changes more than 3,000 files; RelayFlow proof dispatch refuses ambiguous scope');
+  const ambiguous = new Error(
+    'PR changes more than 3,000 files; RelayFlow proof dispatch refuses ambiguous scope'
+  );
+  // Not a transport failure: scope this large must not be resolved by falling
+  // back to the title, so this one escapes the caller's catch.
+  ambiguous.ambiguousScope = true;
+  throw ambiguous;
 }
 
 export function pullRequestSnapshot(pullRequest) {
@@ -155,7 +174,20 @@ export async function main() {
 
   // Fetch the diff BEFORE classifying: whether a proof is required is decided
   // by what changed, not by how the title was worded.
-  const changedFiles = await pullRequestFiles(apiUrl, repository, number, token);
+  //
+  // classifyPullRequest documents a title-only fallback for an unknown diff;
+  // without this catch the await threw first and the fallback was unreachable,
+  // blocking every PR whenever the files endpoint was down.
+  let changedFiles = null;
+  try {
+    changedFiles = await pullRequestFiles(apiUrl, repository, number, token);
+  } catch (error) {
+    if (error?.ambiguousScope) throw error;
+    process.stderr.write(
+      `Could not read the changed-file list (${error?.message ?? error}); ` +
+        'falling back to title-only classification.\n'
+    );
+  }
   const classification = classifyPullRequest({
     title: pullRequest.title,
     body: pullRequest.body ?? '',

--- a/scripts/pr-proof/prepare.mjs
+++ b/scripts/pr-proof/prepare.mjs
@@ -153,7 +153,14 @@ export async function main() {
   }
   const snapshot = pullRequestSnapshot(pullRequest);
 
-  const classification = classifyPullRequest({ title: pullRequest.title, body: pullRequest.body ?? '' });
+  // Fetch the diff BEFORE classifying: whether a proof is required is decided
+  // by what changed, not by how the title was worded.
+  const changedFiles = await pullRequestFiles(apiUrl, repository, number, token);
+  const classification = classifyPullRequest({
+    title: pullRequest.title,
+    body: pullRequest.body ?? '',
+    changedFiles,
+  });
   if (classification.errors.length > 0) {
     throw new PrProofContractError(
       'Pull request does not satisfy the RelayFlow proof contract',
@@ -179,7 +186,6 @@ export async function main() {
 
   const caseId = classification.caseId;
   const manifestPath = caseManifestPath(caseId);
-  const changedFiles = await pullRequestFiles(apiUrl, repository, number, token);
   const caseRoot = path.posix.dirname(manifestPath) + '/';
   const changedCaseIds = changedRelayFlowCaseIds(changedFiles);
   if (!changedFiles.some((file) => file === manifestPath || file.startsWith(caseRoot))) {

--- a/scripts/pr-proof/prepare.mjs
+++ b/scripts/pr-proof/prepare.mjs
@@ -46,12 +46,20 @@ async function githubJson(url, token) {
  */
 export async function pullRequestFiles(apiUrl, repository, number, token) {
   const files = [];
-  for (let page = 1; page <= 30; page += 1) {
+  const maxPages = 30; // 100 per page = 3,000 files
+  // One page past the cap distinguishes "exactly 3,000 files" (page 31 is
+  // empty, scope is known) from "more than 3,000" (page 31 has entries).
+  // Stopping at page 30 rejected an exactly-3,000-file PR as ambiguous.
+  for (let page = 1; page <= maxPages + 1; page += 1) {
     const batch = await githubJson(
       `${apiUrl}/repos/${repository}/pulls/${number}/files?per_page=100&page=${page}`,
       token
     );
     if (!Array.isArray(batch)) throw new Error('GitHub pull request files response was not an array');
+    if (page > maxPages) {
+      if (batch.length === 0) return files;
+      break;
+    }
     for (const entry of batch) {
       // A rename reports only its destination in `filename`. Moving a runtime
       // file into docs/ or tests/ would otherwise read as a non-runtime change,
@@ -208,6 +216,16 @@ export async function main() {
       summaryPath
     );
     return;
+  }
+  // Past this point the changed-file list is load-bearing: it is what confirms
+  // the declared case is actually touched. The title-only fallback above can
+  // legitimately reach here with `null`, and `changedFiles.some(...)` below
+  // would throw an opaque TypeError instead of saying what went wrong.
+  if (changedFiles === null) {
+    throw new PrProofContractError('A required proof cannot be validated without the changed-file list', [
+      'the GitHub pull request files endpoint could not be read',
+      'classification fell back to the PR title, which cannot confirm the declared RelayFlow case',
+    ]);
   }
   if (headRepository !== repository) {
     throw new PrProofContractError('Fork pull requests cannot receive the credential-bearing Cloud proof', [

--- a/scripts/pr-proof/prepare.mjs
+++ b/scripts/pr-proof/prepare.mjs
@@ -46,20 +46,19 @@ async function githubJson(url, token) {
  */
 export async function pullRequestFiles(apiUrl, repository, number, token) {
   const files = [];
-  const maxPages = 30; // 100 per page = 3,000 files
-  // One page past the cap distinguishes "exactly 3,000 files" (page 31 is
-  // empty, scope is known) from "more than 3,000" (page 31 has entries).
-  // Stopping at page 30 rejected an exactly-3,000-file PR as ambiguous.
-  for (let page = 1; page <= maxPages + 1; page += 1) {
+  // GitHub caps this endpoint: "Responses include a maximum of 3000 files."
+  // Page 31 is therefore empty for a 3,000-file PR AND for a 30,000-file one,
+  // so an empty probe page proves nothing — it cannot tell a complete diff from
+  // a truncated one. A full 30th page stays ambiguous and refuses, because
+  // classifying on a truncated list would let runtime files past the cap go
+  // unseen and the PR read as non-runtime.
+  const maxPages = 30; // 100 per page = the 3,000-file API cap
+  for (let page = 1; page <= maxPages; page += 1) {
     const batch = await githubJson(
       `${apiUrl}/repos/${repository}/pulls/${number}/files?per_page=100&page=${page}`,
       token
     );
     if (!Array.isArray(batch)) throw new Error('GitHub pull request files response was not an array');
-    if (page > maxPages) {
-      if (batch.length === 0) return files;
-      break;
-    }
     for (const entry of batch) {
       // A rename reports only its destination in `filename`. Moving a runtime
       // file into docs/ or tests/ would otherwise read as a non-runtime change,
@@ -71,7 +70,7 @@ export async function pullRequestFiles(apiUrl, repository, number, token) {
     if (batch.length < 100) return files;
   }
   const ambiguous = new Error(
-    'PR changes more than 3,000 files; RelayFlow proof dispatch refuses ambiguous scope'
+    'PR reaches the 3,000-file GitHub API cap; RelayFlow proof dispatch refuses a possibly truncated diff'
   );
   // Not a transport failure: scope this large must not be resolved by falling
   // back to the title, so this one escapes the caller's catch.

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -15,6 +15,7 @@ import {
   PrProofContractError,
   changedRelayFlowCaseIds,
   classifyPullRequest,
+  runtimeSurfaceChanged,
   validateCaseManifest,
   validateEvidence,
   validateObservation,
@@ -1719,5 +1720,86 @@ describe('trusted dispatcher source contract', () => {
     expect(marker).toBeGreaterThan(0);
     expect(marker).toBeLessThan(upload);
     expect(marker).toBeLessThan(launch);
+  });
+});
+
+describe('classification reads the diff, not the title', () => {
+  const nonFunctional = (caseId = 'n/a') =>
+    [
+      `- Change type: \`non-functional\` <!-- relay-pr-proof:type -->`,
+      `- RelayFlow case: \`${caseId}\` <!-- relay-pr-proof:case -->`,
+    ].join('\n');
+
+  it('treats a workflow-only change as non-runtime', () => {
+    expect(
+      runtimeSurfaceChanged(['workflows/verify-features.ts', 'scripts/verify-features/status.mjs'])
+    ).toBe(false);
+  });
+
+  it('treats any broker or package source change as runtime', () => {
+    expect(runtimeSurfaceChanged(['crates/broker/src/runtime/fleet.rs'])).toBe(true);
+    expect(runtimeSurfaceChanged(['packages/cli/src/cli/commands/local-agent.ts'])).toBe(true);
+  });
+
+  it('fails closed for a path the allowlist has never seen', () => {
+    // A new top-level directory must not become proof-exempt by default.
+    expect(runtimeSurfaceChanged(['some-brand-new-top-level/thing.ts'])).toBe(true);
+  });
+
+  /**
+   * The defect this closes, direction 1: a `fix(` PR that only edits a
+   * scheduled workflow was told its change type "cannot be non-functional",
+   * so it had to fabricate a runtime proof it could not honestly build.
+   */
+  it('accepts non-functional on a fix( PR that changes no runtime file', () => {
+    const result = classifyPullRequest({
+      title: 'fix(workflow): fail loudly on alert delivery',
+      body: nonFunctional(),
+      changedFiles: ['workflows/verify-features.ts', 'CHANGELOG.md'],
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.required).toBe(false);
+  });
+
+  it('still rejects non-functional when the same PR touches runtime code', () => {
+    const result = classifyPullRequest({
+      title: 'fix(workflow): fail loudly on alert delivery',
+      body: nonFunctional(),
+      changedFiles: ['workflows/verify-features.ts', 'crates/broker/src/runtime/fleet.rs'],
+    });
+    expect(result.errors.join(' ')).toContain('changes runtime files');
+  });
+
+  /**
+   * Direction 2, and the more serious hole: the gate was bypassable by wording.
+   * A runtime change titled `chore(` required no proof at all.
+   */
+  it('requires a proof for a runtime change even when the title is chore(', () => {
+    const result = classifyPullRequest({
+      title: 'chore(broker): tidy delivery bookkeeping',
+      body: '',
+      changedFiles: ['crates/broker/src/runtime/delivery.rs'],
+    });
+    expect(result.required).toBe(true);
+  });
+
+  it('does not require a proof for a chore( PR that only touches docs', () => {
+    const result = classifyPullRequest({
+      title: 'chore(docs): clarify attach modes',
+      body: nonFunctional(),
+      changedFiles: ['docs/attach.md', 'README.md'],
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.required).toBe(false);
+  });
+
+  it('falls back to title-only behaviour when the diff is unavailable', () => {
+    // changedFiles omitted: preserve the previous contract rather than
+    // silently exempting a change nobody inspected.
+    const result = classifyPullRequest({
+      title: 'fix(broker): reconnect dead links',
+      body: nonFunctional(),
+    });
+    expect(result.errors.join(' ')).toContain('cannot be non-functional');
   });
 });

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -36,7 +36,11 @@ import {
   resolvePullRequest,
 } from '../../scripts/pr-proof/report-status.mjs';
 // @ts-expect-error JavaScript module intentionally has no declaration file.
-import { assertSamePullRequestSnapshot, pullRequestSnapshot } from '../../scripts/pr-proof/prepare.mjs';
+import {
+  assertSamePullRequestSnapshot,
+  pullRequestFiles,
+  pullRequestSnapshot,
+} from '../../scripts/pr-proof/prepare.mjs';
 // @ts-expect-error JavaScript module intentionally has no declaration file.
 import {
   boundedDuration,
@@ -1732,7 +1736,7 @@ describe('classification reads the diff, not the title', () => {
 
   it('treats a workflow-only change as non-runtime', () => {
     expect(
-      runtimeSurfaceChanged(['workflows/verify-features.ts', 'scripts/verify-features/status.mjs'])
+      runtimeSurfaceChanged(['workflows/verify-features.ts', 'scripts/pr-proof/contract.mjs'])
     ).toBe(false);
   });
 
@@ -1793,6 +1797,47 @@ describe('classification reads the diff, not the title', () => {
     expect(result.required).toBe(false);
   });
 
+  /**
+   * `scripts/` is not exempt wholesale: publish.yml runs
+   * scripts/inject-posthog-key.mjs to rewrite the compiled CLI before it
+   * ships, so editing it changes what users receive.
+   */
+  it('treats a publish-time script as runtime', () => {
+    expect(runtimeSurfaceChanged(['scripts/inject-posthog-key.mjs'])).toBe(true);
+  });
+
+  it('fails closed for a scripts/ subtree the allowlist has never seen', () => {
+    expect(runtimeSurfaceChanged(['scripts/some-new-tool/main.mjs'])).toBe(true);
+  });
+
+  it('still exempts the CI-only script subtrees', () => {
+    expect(runtimeSurfaceChanged(['scripts/pr-proof/prepare.mjs'])).toBe(false);
+    expect(runtimeSurfaceChanged(['scripts/evals/run-relay-evals.mjs'])).toBe(false);
+  });
+
+  /**
+   * A rename reports only its destination path. Moving a runtime file into
+   * docs/ must not read as a docs-only change.
+   */
+  it('treats a runtime file renamed into an exempt directory as runtime', () => {
+    expect(runtimeSurfaceChanged(['docs/old-fleet.rs', 'crates/broker/src/runtime/fleet.rs'])).toBe(
+      true
+    );
+  });
+
+  /**
+   * Without this, a `chore(`-titled runtime change declaring non-functional
+   * with a valid case id was silently coerced to `bugfix` and raised nothing.
+   */
+  it('rejects a non-functional declaration on a runtime change whatever the title says', () => {
+    const result = classifyPullRequest({
+      title: 'chore(broker): tidy delivery bookkeeping',
+      body: nonFunctional('1593-parked-agent-orphaned-receipt'),
+      changedFiles: ['crates/broker/src/runtime/delivery.rs'],
+    });
+    expect(result.errors.join(' ')).toContain('cannot be non-functional');
+  });
+
   it('falls back to title-only behaviour when the diff is unavailable', () => {
     // changedFiles omitted: preserve the previous contract rather than
     // silently exempting a change nobody inspected.
@@ -1801,5 +1846,54 @@ describe('classification reads the diff, not the title', () => {
       body: nonFunctional(),
     });
     expect(result.errors.join(' ')).toContain('cannot be non-functional');
+  });
+});
+
+describe('RelayFlow proof changed-file collection', () => {
+  const withStubbedFetch = async (impl: typeof globalThis.fetch, run: () => Promise<void>) => {
+    const original = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      await run();
+    } finally {
+      globalThis.fetch = original;
+    }
+  };
+
+  const jsonResponse = (payload: unknown) =>
+    ({ ok: true, status: 200, json: async () => payload }) as unknown as Response;
+
+  /**
+   * GitHub reports a rename's destination in `filename` and its origin in
+   * `previous_filename`. Dropping the latter let a runtime file move into an
+   * exempt directory and read as a non-runtime change.
+   */
+  it('includes the pre-rename path of a renamed file', async () => {
+    await withStubbedFetch(
+      (async () =>
+        jsonResponse([
+          {
+            filename: 'docs/retired-fleet-notes.md',
+            previous_filename: 'crates/broker/src/runtime/fleet.rs',
+          },
+        ])) as unknown as typeof globalThis.fetch,
+      async () => {
+        const files = await pullRequestFiles('https://api.github.test', 'o/r', 1, 't');
+        expect(files).toContain('crates/broker/src/runtime/fleet.rs');
+        expect(runtimeSurfaceChanged(files)).toBe(true);
+      }
+    );
+  });
+
+  it('tags an over-large PR so it cannot fall back to the title', async () => {
+    const page = Array.from({ length: 100 }, (_, i) => ({ filename: `packages/cli/src/f${i}.ts` }));
+    await withStubbedFetch(
+      (async () => jsonResponse(page)) as unknown as typeof globalThis.fetch,
+      async () => {
+        await expect(pullRequestFiles('https://api.github.test', 'o/r', 1, 't')).rejects.toMatchObject(
+          { ambiguousScope: true }
+        );
+      }
+    );
   });
 });

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1735,9 +1735,9 @@ describe('classification reads the diff, not the title', () => {
     ].join('\n');
 
   it('treats a workflow-only change as non-runtime', () => {
-    expect(
-      runtimeSurfaceChanged(['workflows/verify-features.ts', 'scripts/pr-proof/contract.mjs'])
-    ).toBe(false);
+    expect(runtimeSurfaceChanged(['workflows/verify-features.ts', 'scripts/pr-proof/contract.mjs'])).toBe(
+      false
+    );
   });
 
   it('treats any broker or package source change as runtime', () => {
@@ -1820,9 +1820,7 @@ describe('classification reads the diff, not the title', () => {
    * docs/ must not read as a docs-only change.
    */
   it('treats a runtime file renamed into an exempt directory as runtime', () => {
-    expect(runtimeSurfaceChanged(['docs/old-fleet.rs', 'crates/broker/src/runtime/fleet.rs'])).toBe(
-      true
-    );
+    expect(runtimeSurfaceChanged(['docs/old-fleet.rs', 'crates/broker/src/runtime/fleet.rs'])).toBe(true);
   });
 
   /**
@@ -1890,9 +1888,9 @@ describe('RelayFlow proof changed-file collection', () => {
     await withStubbedFetch(
       (async () => jsonResponse(page)) as unknown as typeof globalThis.fetch,
       async () => {
-        await expect(pullRequestFiles('https://api.github.test', 'o/r', 1, 't')).rejects.toMatchObject(
-          { ambiguousScope: true }
-        );
+        await expect(pullRequestFiles('https://api.github.test', 'o/r', 1, 't')).rejects.toMatchObject({
+          ambiguousScope: true,
+        });
       }
     );
   });

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1885,6 +1885,32 @@ describe('RelayFlow proof changed-file collection', () => {
   });
 
   /**
+   * A short diff returns on the first page, so pagination itself needs its own
+   * cover: if accumulation regressed to keeping only the last page, runtime
+   * files from earlier pages would silently drop out of the list and the PR
+   * could read as non-runtime.
+   */
+  it('accumulates files across every page of a multi-page diff', async () => {
+    const lastPage = 3;
+    await withStubbedFetch(
+      (async (url: string) => {
+        const page = Number(new URL(String(url)).searchParams.get('page'));
+        // Pages 1 and 2 are full; page 3 is short and ends pagination.
+        const size = page < lastPage ? 100 : 40;
+        return jsonResponse(Array.from({ length: size }, (_, i) => ({ filename: `docs/p${page}-f${i}.md` })));
+      }) as unknown as typeof globalThis.fetch,
+      async () => {
+        const files = await pullRequestFiles('https://api.github.test', 'o/r', 1, 't');
+        expect(files).toHaveLength(240);
+        // One from every page, not just the last.
+        expect(files).toContain('docs/p1-f0.md');
+        expect(files).toContain('docs/p2-f0.md');
+        expect(files).toContain('docs/p3-f39.md');
+      }
+    );
+  });
+
+  /**
    * GitHub caps this endpoint at 3,000 files, so a full 30th page cannot be
    * told apart from a truncated diff. Refusing is the only safe answer:
    * classifying on a truncated list would let runtime files past the cap go

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -38,6 +38,7 @@ import {
 // @ts-expect-error JavaScript module intentionally has no declaration file.
 import {
   assertSamePullRequestSnapshot,
+  main as prepareMain,
   pullRequestFiles,
   pullRequestSnapshot,
 } from '../../scripts/pr-proof/prepare.mjs';
@@ -1883,6 +1884,27 @@ describe('RelayFlow proof changed-file collection', () => {
     );
   });
 
+  /**
+   * Page 30 returning a full 100 means "3,000 so far", not "more than 3,000".
+   * Probing one page past the cap tells those apart; stopping at 30 rejected an
+   * exactly-3,000-file PR as ambiguous scope.
+   */
+  it('accepts a PR with exactly 3,000 changed files', async () => {
+    const full = Array.from({ length: 100 }, (_, i) => ({ filename: `packages/cli/src/f${i}.ts` }));
+    let calls = 0;
+    await withStubbedFetch(
+      (async () => {
+        calls += 1;
+        return jsonResponse(calls <= 30 ? full : []);
+      }) as unknown as typeof globalThis.fetch,
+      async () => {
+        const files = await pullRequestFiles('https://api.github.test', 'o/r', 1, 't');
+        expect(files).toHaveLength(3000);
+        expect(calls).toBe(31);
+      }
+    );
+  });
+
   it('tags an over-large PR so it cannot fall back to the title', async () => {
     const page = Array.from({ length: 100 }, (_, i) => ({ filename: `packages/cli/src/f${i}.ts` }));
     await withStubbedFetch(
@@ -1893,5 +1915,55 @@ describe('RelayFlow proof changed-file collection', () => {
         });
       }
     );
+  });
+});
+
+describe('RelayFlow proof preparation with an unreadable diff', () => {
+  /**
+   * The title-only fallback can legitimately reach the required path with
+   * `changedFiles === null`. Downstream, `changedFiles.some(...)` then threw a
+   * bare TypeError — a crash instead of a diagnosis. A required proof cannot be
+   * validated without the file list, so it must fail closed and say why.
+   */
+  it('fails closed with a clear error instead of a TypeError', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'pr-proof-nulldiff-'));
+    const eventPath = path.join(dir, 'event.json');
+    const pull = {
+      number: 7,
+      title: 'fix(broker): reconnect dead links',
+      body: [
+        '- Change type: `bugfix` <!-- relay-pr-proof:type -->',
+        '- RelayFlow case: `1593-parked-agent-orphaned-receipt` <!-- relay-pr-proof:case -->',
+      ].join('\n'),
+      head: { sha: 'a'.repeat(40), repo: { full_name: 'AgentWorkforce/relay' } },
+      base: { sha: 'b'.repeat(40) },
+    };
+    await writeFile(eventPath, JSON.stringify({ pull_request: pull }), 'utf8');
+
+    const originalFetch = globalThis.fetch;
+    const originalArgv = process.argv;
+    const env = { ...process.env };
+    globalThis.fetch = (async (url: string) => {
+      // The files endpoint is down; every other read succeeds.
+      if (String(url).includes('/files?')) {
+        return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+      }
+      return { ok: true, status: 200, json: async () => pull } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    process.argv = ['node', 'prepare.mjs', '--event', eventPath, '--output', path.join(dir, 'out.json')];
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.GITHUB_REPOSITORY = 'AgentWorkforce/relay';
+    process.env.GITHUB_API_URL = 'https://api.github.test';
+    delete process.env.GITHUB_OUTPUT;
+    delete process.env.GITHUB_STEP_SUMMARY;
+
+    try {
+      await expect(prepareMain()).rejects.toThrow(/cannot be validated without the changed-file list/);
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.argv = originalArgv;
+      process.env = env;
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1885,34 +1885,32 @@ describe('RelayFlow proof changed-file collection', () => {
   });
 
   /**
-   * Page 30 returning a full 100 means "3,000 so far", not "more than 3,000".
-   * Probing one page past the cap tells those apart; stopping at 30 rejected an
-   * exactly-3,000-file PR as ambiguous scope.
+   * GitHub caps this endpoint at 3,000 files, so a full 30th page cannot be
+   * told apart from a truncated diff. Refusing is the only safe answer:
+   * classifying on a truncated list would let runtime files past the cap go
+   * unseen and the PR read as non-runtime.
+   *
+   * The stub is page-aware and returns distinct filenames per page, so the
+   * test fails if pagination stalls on page 1 instead of advancing.
    */
-  it('accepts a PR with exactly 3,000 changed files', async () => {
-    const full = Array.from({ length: 100 }, (_, i) => ({ filename: `packages/cli/src/f${i}.ts` }));
-    let calls = 0;
+  it('refuses a diff that reaches the 3,000-file API cap', async () => {
+    const pagesRequested: number[] = [];
     await withStubbedFetch(
-      (async () => {
-        calls += 1;
-        return jsonResponse(calls <= 30 ? full : []);
+      (async (url: string) => {
+        const page = Number(new URL(String(url)).searchParams.get('page'));
+        pagesRequested.push(page);
+        return jsonResponse(
+          Array.from({ length: 100 }, (_, i) => ({
+            filename: `packages/cli/src/p${page}-f${i}.ts`,
+          }))
+        );
       }) as unknown as typeof globalThis.fetch,
-      async () => {
-        const files = await pullRequestFiles('https://api.github.test', 'o/r', 1, 't');
-        expect(files).toHaveLength(3000);
-        expect(calls).toBe(31);
-      }
-    );
-  });
-
-  it('tags an over-large PR so it cannot fall back to the title', async () => {
-    const page = Array.from({ length: 100 }, (_, i) => ({ filename: `packages/cli/src/f${i}.ts` }));
-    await withStubbedFetch(
-      (async () => jsonResponse(page)) as unknown as typeof globalThis.fetch,
       async () => {
         await expect(pullRequestFiles('https://api.github.test', 'o/r', 1, 't')).rejects.toMatchObject({
           ambiguousScope: true,
         });
+        // Exactly the 30 capped pages, each requested once and in order.
+        expect(pagesRequested).toEqual(Array.from({ length: 30 }, (_, i) => i + 1));
       }
     );
   });


### PR DESCRIPTION
## Problem

The RelayFlow proof gate decided whether a PR needed a proof by reading its **title**. That was wrong in both directions:

- **Too strict.** A workflow-only or docs-only change titled `fix(...)` was required to declare a RelayFlow case. There is no honest case to declare for a change that cannot reach a user, so the only ways past the gate were to fabricate a proof or to reword the title. #1642 is sitting on exactly this.
- **Too lax.** A change that genuinely touched the broker or the CLI skipped the gate entirely just by being titled `chore(...)`. This is the direction that actually costs us something: the gate was bypassable by wording.

## Fix

`classifyPullRequest` now takes the changed-file list and decides from the diff. `prepare.mjs` fetches the file list before classifying instead of after.

The exemption is an **allowlist** — `workflows/`, `docs/`, `.github/`, `.agentworkforce/`, `scripts/`, `tests/`, top-level `*.md`. Anything else counts as runtime, so a new top-level directory is treated as runtime until someone deliberately exempts it. It fails closed.

If the changed-file list cannot be read, the classifier falls back to the previous title-based behaviour rather than silently exempting a change nobody inspected.

## Note on this PR's own title

This PR was opened as `fix(pr-proof): ...` and the gate rejected it:

```
- PR title declares a bugfix, so the change type cannot be non-functional
- Feature and bug-fix PRs must declare exactly one RelayFlow case id
```

The dispatcher checks out `base.sha` by design — it is a `pull_request_target` job holding Cloud credentials and [must not run PR-head code](https://github.com/AgentWorkforce/relay/blob/main/.github/workflows/relayflow-pr-proof.yml). That boundary is correct and I have not touched it. The consequence is that a change to the classifier is always judged by the *previous* classifier, so this PR cannot pass under its own rule.

Retitling to `ci(...)` is what let it through — which is precisely the bypass this PR removes. I would rather say that plainly than have it noticed in review. `ci(` is also the accurate conventional-commit type here; the diff is three files under `scripts/` and `tests/`.

## Testing

`tests/fixtures/pr-proof-contract.test.ts` — **83 passing, 6 skipped**, including all 66 pre-existing tests unchanged.

Every fix here is mutation-proven: reverting it turns its test red.

| reverted | test that goes red |
|---|---|
| `scripts/` narrowing | `treats a publish-time script as runtime` |
| title-independent guard | `rejects a non-functional declaration on a runtime change whatever the title says` |
| `previous_filename` | `includes the pre-rename path of a renamed file` |
| `ambiguousScope` tag | `tags an over-large PR so it cannot fall back to the title` |

Tests caught real bugs twice. Two failed against my first implementation (`required` still deferred to the title; the no-marker early return ignored the diff). And my first rename test passed with *or* without the fix — it asserted on `runtimeSurfaceChanged` with both paths already supplied, proving nothing. I exported `pullRequestFiles` and tested it against a stubbed `fetch` instead.

## Review round 2 — four bypasses found and closed (`58c40d972`)

- **`scripts/` was exempt wholesale.** `publish.yml` runs `scripts/inject-posthog-key.mjs` to rewrite the compiled CLI before it ships. Narrowed to `scripts/pr-proof/` and `scripts/evals/`; anything else under `scripts/` is runtime.
- **Renames read as their destination only.** Moving a runtime file into `docs/` looked like a docs change. `previous_filename` is now collected too.
- **The documented fallback was unreachable.** I described a title-only fallback for an unreadable diff and then awaited outside a `try`, so a files-endpoint outage would have blocked every PR. Now guarded. The >3,000-file case is tagged `ambiguousScope` and deliberately still hard-fails — scope that large must not be resolved by wording.
- **`non-functional` was only checked against feat/fix titles.** A `chore(`-titled runtime change declaring `non-functional` had that contradiction silently coerced to `bugfix`. The diff now overrules the title in both directions.

## Not included

No changelog entry. This is repo CI tooling, not a user-facing Relay surface.

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014N3p9VEngj9kLDFFhrzHNd
