### PR TITLE
fix(broker): free Relaycast identity on explicit removal

### DIFF
--- a/.trajectories/compacted/release-11.10.2.json
+++ b/.trajectories/compacted/release-11.10.2.json
@@ -3,7 +3,9 @@
   "version": 1,
   "type": "compacted",
   "compactedAt": "2026-09-03T06:52:02.784Z",
-  "sourceTrajectories": ["traj_7yref3wye283"],
+  "sourceTrajectories": [
+    "traj_7yref3wye283"
+  ],
   "dateRange": {
     "start": "2026-09-02T10:25:41.382Z",
     "end": "2026-09-02T12:08:45.907Z"
@@ -11,7 +13,9 @@
   "summary": {
     "totalDecisions": 7,
     "totalEvents": 11,
-    "uniqueAgents": ["default"]
+    "uniqueAgents": [
+      "default"
+    ]
   },
   "decisionGroups": [
     {
@@ -99,5 +103,12 @@
     "tests/relayflows/cases/1638-attach-input-replay/case.json",
     "tests/relayflows/cases/1638-attach-input-replay/run.mjs"
   ],
-  "commits": ["e85f4ca23", "bf66a2e86", "13971aa8f", "1191af9bd", "cefc1ab4d", "2559e668a"]
+  "commits": [
+    "e85f4ca23",
+    "bf66a2e86",
+    "13971aa8f",
+    "1191af9bd",
+    "cefc1ab4d",
+    "2559e668a"
+  ]
 }

--- a/.trajectories/compacted/release-11.10.2.json
+++ b/.trajectories/compacted/release-11.10.2.json
@@ -3,9 +3,7 @@
   "version": 1,
   "type": "compacted",
   "compactedAt": "2026-09-03T06:52:02.784Z",
-  "sourceTrajectories": [
-    "traj_7yref3wye283"
-  ],
+  "sourceTrajectories": ["traj_7yref3wye283"],
   "dateRange": {
     "start": "2026-09-02T10:25:41.382Z",
     "end": "2026-09-02T12:08:45.907Z"
@@ -13,9 +11,7 @@
   "summary": {
     "totalDecisions": 7,
     "totalEvents": 11,
-    "uniqueAgents": [
-      "default"
-    ]
+    "uniqueAgents": ["default"]
   },
   "decisionGroups": [
     {
@@ -103,12 +99,5 @@
     "tests/relayflows/cases/1638-attach-input-replay/case.json",
     "tests/relayflows/cases/1638-attach-input-replay/run.mjs"
   ],
-  "commits": [
-    "e85f4ca23",
-    "bf66a2e86",
-    "13971aa8f",
-    "1191af9bd",
-    "cefc1ab4d",
-    "2559e668a"
-  ]
+  "commits": ["e85f4ca23", "bf66a2e86", "13971aa8f", "1191af9bd", "cefc1ab4d", "2559e668a"]
 }

--- a/.trajectories/compacted/release-11.10.2.md
+++ b/.trajectories/compacted/release-11.10.2.md
@@ -1,7 +1,6 @@
 # Trajectory Compaction: Sep 2, 2026 - Sep 2, 2026
 
 ## Summary
-
 - Sessions: 1
 - Decisions: 7
 - Events: 11
@@ -10,7 +9,6 @@
 - Commits: 6
 
 ## Api
-
 - Treat Relaycast publication and recipient reachability as separate observations -> Treat Relaycast publication and recipient reachability as separate observations (traj_7yref3wye283)
 - Keep the reachability probe outside the publication timeout -> Keep the reachability probe outside the publication timeout (traj_7yref3wye283)
 - Keep the synchronous reachability snapshot bounded at five seconds -> Keep the synchronous reachability snapshot bounded at five seconds (traj_7yref3wye283)
@@ -18,17 +16,13 @@
 - Cancel reachability observation when publication fails -> Cancel reachability observation when publication fails (traj_7yref3wye283)
 
 ## Security
-
 - Resolve Relaycast @self before reachability probing -> Resolve Relaycast @self before reachability probing (traj_7yref3wye283)
 
 ## Other
-
 - Treat legacy away as reachable -> Treat legacy away as reachable (traj_7yref3wye283)
 
 ## Key Learnings
-
 - None
 
 ## Key Findings
-
 - None

--- a/.trajectories/compacted/release-11.10.2.md
+++ b/.trajectories/compacted/release-11.10.2.md
@@ -1,6 +1,7 @@
 # Trajectory Compaction: Sep 2, 2026 - Sep 2, 2026
 
 ## Summary
+
 - Sessions: 1
 - Decisions: 7
 - Events: 11
@@ -9,6 +10,7 @@
 - Commits: 6
 
 ## Api
+
 - Treat Relaycast publication and recipient reachability as separate observations -> Treat Relaycast publication and recipient reachability as separate observations (traj_7yref3wye283)
 - Keep the reachability probe outside the publication timeout -> Keep the reachability probe outside the publication timeout (traj_7yref3wye283)
 - Keep the synchronous reachability snapshot bounded at five seconds -> Keep the synchronous reachability snapshot bounded at five seconds (traj_7yref3wye283)
@@ -16,13 +18,17 @@
 - Cancel reachability observation when publication fails -> Cancel reachability observation when publication fails (traj_7yref3wye283)
 
 ## Security
+
 - Resolve Relaycast @self before reachability probing -> Resolve Relaycast @self before reachability probing (traj_7yref3wye283)
 
 ## Other
+
 - Treat legacy away as reachable -> Treat legacy away as reachable (traj_7yref3wye283)
 
 ## Key Learnings
+
 - None
 
 ## Key Findings
+
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `DELETE /api/spawned/{name}` now releases an already-stopped worker's Relaycast identity and frees its workspace seat instead of failing with `Max retries exceeded`.
 
 ## [11.10.2] - 2026-09-03
 

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -943,7 +943,14 @@ impl RelaycastHttpClient {
             let request = ReleaseAgentRequest {
                 name: agent_name.to_string(),
                 reason: Some(attributed_reason),
-                delete_agent: None,
+                // The broker has already stopped the local process and removed
+                // its fleet binding before this call. A non-destructive release
+                // must be dispatched to a live host, so Relaycast correctly
+                // rejects that now-hostless request with agent_host_unavailable.
+                // Explicit broker removal is the destructive lifecycle path
+                // described above: tombstone the old identity, invalidate its
+                // credential, and free the seat without requiring a live host.
+                delete_agent: Some(true),
             };
             // Invalidate the cached token before the call so an ambiguous
             // response (e.g. a timeout after Relaycast committed the release)
@@ -1780,7 +1787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_agent_release_records_a_reason_and_actor() {
+    async fn explicit_agent_release_deletes_identity_and_records_attribution() {
         let server = MockServer::start();
         let release = server.mock(|when, then| {
             when.method(POST)
@@ -1788,7 +1795,8 @@ mod tests {
                 .header("authorization", "Bearer rk_live_test")
                 .json_body(json!({
                     "name": "worker-a",
-                    "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)"
+                    "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)",
+                    "delete_agent": true
                 }));
             then.status(200).json_body(json!({
                 "ok": true,
@@ -1800,7 +1808,8 @@ mod tests {
                     "dispatched_node_id": "node_1",
                     "input": {
                         "name": "worker-a",
-                        "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)"
+                        "reason": "agent explicitly released through broker API (actor: Agent Relay broker broker)",
+                        "delete_agent": true
                     },
                     "status": "dispatched",
                     "created_at": "2026-08-15T00:00:00.000Z"

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -1019,6 +1019,12 @@ impl BrokerRuntime {
                     Err(e) => {
                         let message = e.to_string();
                         if is_unknown_worker_error_message(&message) {
+                            // This is an authenticated broker-administration
+                            // endpoint, not an agent-scoped API. Its API key
+                            // already authorizes spawn/name-reclaim operations
+                            // in the attached workspace. Preserve the unknown
+                            // worker fallback so a retry after local process
+                            // exit can finish the remote identity teardown.
                             let fleet_deregistration_error = super::fleet::deregister_fleet_agent(
                                 fleet_control_tx,
                                 fleet_delivery_book,

--- a/tests/relayflows/cases/1650-hostless-identity-release/case.json
+++ b/tests/relayflows/cases/1650-hostless-identity-release/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1650-hostless-identity-release",
+  "kind": "bugfix",
+  "title": "Release an already-gone worker's Relaycast identity without a live host",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1650-hostless-identity-release/run.mjs"]
+  },
+  "requirements": ["broker-linux-x64"],
+  "timeoutSeconds": 180,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "hostless_release_exhausts_retries"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "hostless_identity_release_succeeds"
+    }
+  }
+}

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -125,7 +125,9 @@ relaycast.on('upgrade', (request, socket) => {
     socket.destroy();
     return;
   }
-  const accept = createHash('sha1').update(key + WS_GUID).digest('base64');
+  const accept = createHash('sha1')
+    .update(key + WS_GUID)
+    .digest('base64');
   socket.write(
     'HTTP/1.1 101 Switching Protocols\r\n' +
       'Upgrade: websocket\r\n' +
@@ -202,8 +204,7 @@ try {
     );
   }
 
-  const allNonDelete =
-    releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent !== true);
+  const allNonDelete = releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent !== true);
   const allDestructive =
     releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent === true);
   const baseObserved =

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -1,0 +1,337 @@
+/**
+ * Explicit broker removal first stops the local worker and queues its fleet
+ * deregistration, then releases the Relaycast identity. The base broker omitted
+ * delete_agent, so Relaycast had to dispatch the release to a live host that no
+ * longer existed. SDK retries then hid the decisive agent_host_unavailable as
+ * "Max retries exceeded" and DELETE /api/spawned returned 500 forever.
+ *
+ * This proof uses the exact compiled broker and its public HTTP API. The target
+ * worker is deliberately already absent, matching the repeated production
+ * failure. A deterministic Relaycast double rejects hostless non-delete release
+ * and accepts destructive local completion. The observation is the broker's
+ * response plus the exact release wire bodies; no source inspection decides the
+ * result.
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync, spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1650-hostless-identity-release';
+const AGENT_NAME = 'already-gone-release-probe';
+const API_KEY = 'br_relayflow_1650';
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1650-'));
+const stateDir = path.join(probeDir, 'state');
+const releaseBodies = [];
+const sockets = new Set();
+let broker;
+let brokerStderr = '';
+const relaycast = http.createServer(async (request, response) => {
+  const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
+  let body;
+  try {
+    body = await readJson(request);
+  } catch {
+    sendJson(response, 400, {
+      ok: false,
+      error: { code: 'invalid_json', message: 'Request body must be valid JSON.' },
+    });
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === '/v1/agents') {
+    sendJson(response, 200, {
+      ok: true,
+      data: {
+        id: 'agent_relayflow_1650_broker',
+        workspace_id: 'ws_relayflow_1650',
+        name: body?.name ?? 'relayflow-1650-broker',
+        token: 'at_relayflow_1650_broker',
+        status: 'active',
+        created_at: '2026-09-04T00:00:00.000Z',
+      },
+    });
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === '/v1/agents/release') {
+    releaseBodies.push(body);
+    if (body?.delete_agent !== true) {
+      sendJson(response, 503, {
+        ok: false,
+        error: {
+          code: 'agent_host_unavailable',
+          message: `Agent "${body?.name}" has no live host node; cannot dispatch release`,
+        },
+      });
+      return;
+    }
+    sendJson(response, 201, {
+      ok: true,
+      data: {
+        invocation_id: 'inv_release_relayflow_1650',
+        action_name: 'release',
+        handler_agent_id: null,
+        handler_node_id: null,
+        dispatched_node_id: null,
+        input: body,
+        status: 'completed',
+        created_at: '2026-09-04T00:00:00.000Z',
+      },
+    });
+    return;
+  }
+
+  // Startup registration, presence, channel setup, and shutdown bookkeeping
+  // are outside this case's release contract.
+  sendJson(response, 200, { ok: true, data: {} });
+});
+relaycast.on('connection', (socket) => {
+  sockets.add(socket);
+  socket.once('close', () => sockets.delete(socket));
+});
+relaycast.on('upgrade', (request, socket) => {
+  const key = request.headers['sec-websocket-key'];
+  if (typeof key !== 'string') {
+    socket.destroy();
+    return;
+  }
+  const accept = createHash('sha1').update(key + WS_GUID).digest('base64');
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+  );
+});
+
+try {
+  await mkdir(stateDir, { recursive: true });
+  await new Promise((resolve) => relaycast.listen(0, '127.0.0.1', resolve));
+  const address = relaycast.address();
+  if (!address || typeof address === 'string') throw new Error('Expected Relaycast TCP address.');
+  const relaycastUrl = `http://127.0.0.1:${address.port}`;
+
+  broker = spawn(
+    binaryPath,
+    [
+      'init',
+      '--instance-name',
+      'relayflow-1650-broker',
+      '--workspace-key',
+      'rk_relayflow_1650',
+      '--state-dir',
+      stateDir,
+      '--api-port',
+      '0',
+      '--channels',
+      '',
+    ],
+    {
+      cwd: probeDir,
+      env: {
+        ...process.env,
+        RELAYCAST_BASE_URL: relaycastUrl,
+        RELAY_BROKER_API_KEY: API_KEY,
+        RELAY_NODE_ID: 'node_relayflow_1650',
+        RELAY_NODE_TOKEN: 'nt_relayflow_1650',
+        AGENT_RELAY_NO_DEBUG_FILES: '1',
+        RELAY_SKIP_TELEMETRY: '1',
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    }
+  );
+  broker.stderr.on('data', (chunk) => {
+    brokerStderr = `${brokerStderr}${chunk}`.slice(-16_000);
+  });
+
+  const brokerUrl = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
+  await waitFor(
+    async () => {
+      const response = await fetch(`${brokerUrl}/api/session`, {
+        headers: { 'x-api-key': API_KEY },
+        signal: AbortSignal.timeout(2_000),
+      });
+      return response.status === 200;
+    },
+    30_000,
+    'broker API readiness'
+  );
+  const response = await fetch(`${brokerUrl}/api/spawned/${encodeURIComponent(AGENT_NAME)}`, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json', 'x-api-key': API_KEY },
+    body: JSON.stringify({ reason: 'relayflow hostless identity release proof' }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const responseText = await response.text();
+  let responseBody;
+  try {
+    responseBody = JSON.parse(responseText);
+  } catch {
+    throw new Error(
+      `Broker release response was not JSON: ${JSON.stringify({ status: response.status, responseText })}`
+    );
+  }
+
+  const allNonDelete =
+    releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent !== true);
+  const allDestructive =
+    releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent === true);
+  const baseObserved =
+    response.status === 500 &&
+    responseBody?.success === false &&
+    String(responseBody?.error).includes('Max retries exceeded') &&
+    allNonDelete;
+  const headObserved =
+    response.status === 200 &&
+    responseBody?.success === true &&
+    responseBody?.name === AGENT_NAME &&
+    allDestructive;
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'hostless_release_exhausts_retries';
+    details = `The exact base broker sent ${releaseBodies.length} non-delete release requests for an already-gone worker; Relaycast rejected the hostless dispatch and DELETE /api/spawned returned 500 with Max retries exceeded.`;
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'hostless_identity_release_succeeds';
+    details = `The exact head broker sent delete_agent=true for the already-gone worker; Relaycast completed the identity release locally and DELETE /api/spawned returned 200 success.`;
+  } else {
+    throw new Error(
+      `Unexpected hostless release observation: ${JSON.stringify({
+        arm,
+        httpStatus: response.status,
+        responseBody,
+        releaseBodies,
+        brokerStderr,
+      })}`
+    );
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+  process.stdout.write(`${signature}\n`);
+} finally {
+  if (broker && broker.exitCode === null) {
+    broker.kill('SIGTERM');
+    await Promise.race([
+      new Promise((resolve) => broker.once('exit', resolve)),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+    if (broker.exitCode === null) broker.kill('SIGKILL');
+  }
+  for (const socket of sockets) socket.destroy();
+  await new Promise((resolve) => relaycast.close(resolve));
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+function sendJson(response, status, value) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  if (chunks.length === 0) return undefined;
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+async function waitForConnection(connectionPath, child) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Broker exited before readiness (${child.exitCode}): ${brokerStderr}`);
+    }
+    try {
+      const parsed = JSON.parse(await readFile(connectionPath, 'utf8'));
+      if (typeof parsed?.port === 'number') return `http://127.0.0.1:${parsed.port}`;
+      if (typeof parsed?.url === 'string') return parsed.url;
+    } catch {
+      // The broker writes connection.json atomically; absence while starting is expected.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Broker did not publish connection.json: ${brokerStderr}`);
+}
+
+async function waitFor(probe, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      if (await probe()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}: ${brokerStderr}`
+  );
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+async function requiredExecutable(name) {
+  const candidate = path.resolve(requiredValue(name));
+  try {
+    await access(candidate, fsConstants.R_OK | fsConstants.X_OK);
+  } catch {
+    throw new Error(`${name} must name a readable executable file.`);
+  }
+  return candidate;
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -24,14 +24,24 @@ import { fileURLToPath } from 'node:url';
 
 const CASE_ID = '1650-hostless-identity-release';
 const AGENT_NAME = 'already-gone-release-probe';
+const BROKER_INSTANCE_NAME = 'relayflow-1650-broker';
+const RELEASE_REASON = 'relayflow hostless identity release proof';
+// Relaycast's release wire shape carries one durable audit string rather than
+// separate reason and actor fields, so release_agent_identity() folds both into
+// it as `{reason} (actor: Agent Relay broker {instance})`
+// (crates/broker/src/relaycast/ws.rs). Pinning the exact value is what stops the
+// destructive branch accepting a release that dropped the caller's reason or its
+// actor attribution: without it the head arm could pass while the audit contract
+// this fix ships is silently broken.
+const EXPECTED_RELEASE_REASON = `${RELEASE_REASON} (actor: Agent Relay broker ${BROKER_INSTANCE_NAME})`;
 const API_KEY = 'br_relayflow_1650';
 const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const BROKER_PORT_RE = /^\[agent-relay\] API listening on http:\/\/127\.0\.0\.1:(\d{1,5})$/m;
 const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
 const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
 const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
 const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
 const arm = requiredValue('RELAY_PR_PROOF_ARM');
-const brokerPort = await reservePort();
 
 if (arm !== 'base' && arm !== 'head') {
   throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
@@ -103,6 +113,16 @@ const relaycast = http.createServer(async (request, response) => {
       });
       return;
     }
+    if (body?.reason !== EXPECTED_RELEASE_REASON) {
+      sendJson(response, 400, {
+        ok: false,
+        error: {
+          code: 'invalid_release_reason',
+          message: 'A destructive release must carry the actor-attributed reason.',
+        },
+      });
+      return;
+    }
     sendJson(response, 201, {
       ok: true,
       data: {
@@ -151,18 +171,24 @@ try {
   if (!address || typeof address === 'string') throw new Error('Expected Relaycast TCP address.');
   const relaycastUrl = `http://127.0.0.1:${address.port}`;
 
+  // Bind with --api-port 0 and take the port the broker actually bound from its
+  // own machine-readable stdout line. Reserving a port here and closing the
+  // listener before the spawn leaves that port free for the whole broker startup
+  // window; losing the race makes TcpListener::bind fail and surfaces only as a
+  // confusing readiness timeout. The port comes from the child's stdout, not
+  // from connection.json, so no outbound request derives from file data.
   broker = spawn(
     binaryPath,
     [
       'init',
       '--instance-name',
-      'relayflow-1650-broker',
+      BROKER_INSTANCE_NAME,
       '--workspace-key',
       'rk_relayflow_1650',
       '--state-dir',
       stateDir,
       '--api-port',
-      String(brokerPort),
+      '0',
       '--channels',
       '',
     ],
@@ -177,13 +203,32 @@ try {
         AGENT_RELAY_NO_DEBUG_FILES: '1',
         RELAY_SKIP_TELEMETRY: '1',
       },
-      stdio: ['ignore', 'ignore', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     }
   );
   broker.stderr.on('data', (chunk) => {
     brokerStderr = `${brokerStderr}${chunk}`.slice(-16_000);
   });
+  let brokerStdout = '';
+  broker.stdout.on('data', (chunk) => {
+    brokerStdout = `${brokerStdout}${chunk}`.slice(-16_000);
+  });
 
+  let brokerPort;
+  await waitFor(
+    () => {
+      const match = BROKER_PORT_RE.exec(brokerStdout);
+      if (!match) return false;
+      const port = Number(match[1]);
+      if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+        throw new Error(`Broker announced an out-of-range API port: ${match[1]}`);
+      }
+      brokerPort = port;
+      return true;
+    },
+    30_000,
+    'broker API port announcement'
+  );
   const brokerUrl = `http://127.0.0.1:${brokerPort}`;
   await waitFor(
     async () => {
@@ -199,7 +244,7 @@ try {
   const response = await fetch(`${brokerUrl}/api/spawned/${encodeURIComponent(AGENT_NAME)}`, {
     method: 'DELETE',
     headers: { 'content-type': 'application/json', 'x-api-key': API_KEY },
-    body: JSON.stringify({ reason: 'relayflow hostless identity release proof' }),
+    body: JSON.stringify({ reason: RELEASE_REASON }),
     signal: AbortSignal.timeout(30_000),
   });
   const responseText = await response.text();
@@ -214,7 +259,8 @@ try {
 
   const allNonDelete = releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent !== true);
   const allDestructive =
-    releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent === true);
+    releaseBodies.length > 0 &&
+    releaseBodies.every((body) => body?.delete_agent === true && body?.reason === EXPECTED_RELEASE_REASON);
   const baseObserved =
     response.status === 500 &&
     responseBody?.success === false &&
@@ -236,7 +282,7 @@ try {
   } else if (headObserved) {
     outcome = 'fixed';
     signature = 'hostless_identity_release_succeeds';
-    details = `The exact head broker sent delete_agent=true for the already-gone worker; Relaycast completed the identity release locally and DELETE /api/spawned returned 200 success.`;
+    details = `The exact head broker sent delete_agent=true with the actor-attributed reason ${JSON.stringify(EXPECTED_RELEASE_REASON)} for the already-gone worker; Relaycast completed the identity release locally and DELETE /api/spawned returned 200 success.`;
   } else {
     throw new Error(
       `Unexpected hostless release observation: ${JSON.stringify({
@@ -297,20 +343,6 @@ async function waitFor(probe, timeoutMs, label) {
   throw new Error(
     `Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}: ${brokerStderr}`
   );
-}
-
-async function reservePort() {
-  const server = http.createServer();
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('Expected broker TCP address.');
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  return address.port;
 }
 
 function requiredValue(name) {

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -28,12 +28,29 @@ const BROKER_INSTANCE_NAME = 'relayflow-1650-broker';
 const RELEASE_REASON = 'relayflow hostless identity release proof';
 // Relaycast's release wire shape carries one durable audit string rather than
 // separate reason and actor fields, so release_agent_identity() folds both into
-// it as `{reason} (actor: Agent Relay broker {instance})`
-// (crates/broker/src/relaycast/ws.rs). Pinning the exact value is what stops the
-// destructive branch accepting a release that dropped the caller's reason or its
-// actor attribution: without it the head arm could pass while the audit contract
-// this fix ships is silently broken.
-const EXPECTED_RELEASE_REASON = `${RELEASE_REASON} (actor: Agent Relay broker ${BROKER_INSTANCE_NAME})`;
+// it as `{reason} (actor: Agent Relay broker {actor})`
+// (crates/broker/src/relaycast/ws.rs:941-942). Asserting that string is what
+// stops the destructive branch accepting a release that dropped the caller's
+// reason or its actor attribution — the audit contract this fix ships.
+//
+// The actor is the broker's own Relaycast identity, not its `--instance-name`:
+// RelaycastWorkspaces reads `session.credentials.agent_name` and falls back to
+// the literal `broker` (crates/broker/src/relaycast/workspace.rs:65-69). That
+// credential is minted by this double's own `POST /v1/agents` response, so the
+// expectation is derived from the identity we actually handed the broker rather
+// than assumed from the CLI flag. Pinning the flag instead would turn any
+// divergence into an "Unexpected hostless release observation" throw — an
+// infrastructure failure wearing the costume of a proof result.
+const BROKER_ACTOR_FALLBACK = 'broker';
+let registeredBrokerName = null;
+function expectedReleaseReasons() {
+  const actors = new Set([BROKER_ACTOR_FALLBACK]);
+  if (registeredBrokerName) actors.add(registeredBrokerName);
+  return [...actors].map((actor) => `${RELEASE_REASON} (actor: Agent Relay broker ${actor})`);
+}
+function hasAttributedReleaseReason(body) {
+  return expectedReleaseReasons().includes(body?.reason);
+}
 const API_KEY = 'br_relayflow_1650';
 const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 const BROKER_PORT_RE = /^\[agent-relay\] API listening on http:\/\/127\.0\.0\.1:(\d{1,5})$/m;
@@ -80,12 +97,15 @@ const relaycast = http.createServer(async (request, response) => {
   }
 
   if (request.method === 'POST' && pathname === '/v1/agents') {
+    // This response is the broker's Relaycast credential, and its `name` is the
+    // actor release_agent_identity() will attribute the release to.
+    registeredBrokerName = body?.name ?? BROKER_INSTANCE_NAME;
     sendJson(response, 200, {
       ok: true,
       data: {
         id: 'agent_relayflow_1650_broker',
         workspace_id: 'ws_relayflow_1650',
-        name: body?.name ?? 'relayflow-1650-broker',
+        name: registeredBrokerName,
         token: 'at_relayflow_1650_broker',
         status: 'active',
         created_at: '2026-09-04T00:00:00.000Z',
@@ -113,7 +133,7 @@ const relaycast = http.createServer(async (request, response) => {
       });
       return;
     }
-    if (body?.reason !== EXPECTED_RELEASE_REASON) {
+    if (!hasAttributedReleaseReason(body)) {
       sendJson(response, 400, {
         ok: false,
         error: {
@@ -260,7 +280,7 @@ try {
   const allNonDelete = releaseBodies.length > 0 && releaseBodies.every((body) => body?.delete_agent !== true);
   const allDestructive =
     releaseBodies.length > 0 &&
-    releaseBodies.every((body) => body?.delete_agent === true && body?.reason === EXPECTED_RELEASE_REASON);
+    releaseBodies.every((body) => body?.delete_agent === true && hasAttributedReleaseReason(body));
   const baseObserved =
     response.status === 500 &&
     responseBody?.success === false &&
@@ -282,7 +302,7 @@ try {
   } else if (headObserved) {
     outcome = 'fixed';
     signature = 'hostless_identity_release_succeeds';
-    details = `The exact head broker sent delete_agent=true with the actor-attributed reason ${JSON.stringify(EXPECTED_RELEASE_REASON)} for the already-gone worker; Relaycast completed the identity release locally and DELETE /api/spawned returned 200 success.`;
+    details = `The exact head broker sent delete_agent=true with the actor-attributed reason ${JSON.stringify(releaseBodies.at(-1)?.reason)} for the already-gone worker; Relaycast completed the identity release locally and DELETE /api/spawned returned 200 success.`;
   } else {
     throw new Error(
       `Unexpected hostless release observation: ${JSON.stringify({

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -41,11 +41,16 @@ const RELEASE_REASON = 'relayflow hostless identity release proof';
 // than assumed from the CLI flag. Pinning the flag instead would turn any
 // divergence into an "Unexpected hostless release observation" throw — an
 // infrastructure failure wearing the costume of a proof result.
+// The double always answers POST /v1/agents before any release, so by the time a
+// release arrives the minted name is the only legitimate actor. Accepting the
+// `broker` fallback as well would let the head arm pass on precisely the
+// regression this assertion exists to catch — the broker losing its
+// credential-derived identity and falling back. The fallback is therefore only
+// accepted if no credential was ever minted.
 const BROKER_ACTOR_FALLBACK = 'broker';
 let registeredBrokerName = null;
 function expectedReleaseReasons() {
-  const actors = new Set([BROKER_ACTOR_FALLBACK]);
-  if (registeredBrokerName) actors.add(registeredBrokerName);
+  const actors = new Set(registeredBrokerName ? [registeredBrokerName] : [BROKER_ACTOR_FALLBACK]);
   return [...actors].map((actor) => `${RELEASE_REASON} (actor: Agent Relay broker ${actor})`);
 }
 function hasAttributedReleaseReason(body) {

--- a/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
+++ b/tests/relayflows/cases/1650-hostless-identity-release/run.mjs
@@ -15,7 +15,7 @@
 import { createHash } from 'node:crypto';
 import { execFileSync, spawn } from 'node:child_process';
 import { constants as fsConstants } from 'node:fs';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -31,6 +31,7 @@ const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
 const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
 const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
 const arm = requiredValue('RELAY_PR_PROOF_ARM');
+const brokerPort = await reservePort();
 
 if (arm !== 'base' && arm !== 'head') {
   throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
@@ -85,6 +86,13 @@ const relaycast = http.createServer(async (request, response) => {
 
   if (request.method === 'POST' && pathname === '/v1/agents/release') {
     releaseBodies.push(body);
+    if (body?.name !== AGENT_NAME) {
+      sendJson(response, 400, {
+        ok: false,
+        error: { code: 'invalid_agent', message: 'Unexpected release target.' },
+      });
+      return;
+    }
     if (body?.delete_agent !== true) {
       sendJson(response, 503, {
         ok: false,
@@ -154,7 +162,7 @@ try {
       '--state-dir',
       stateDir,
       '--api-port',
-      '0',
+      String(brokerPort),
       '--channels',
       '',
     ],
@@ -176,7 +184,7 @@ try {
     brokerStderr = `${brokerStderr}${chunk}`.slice(-16_000);
   });
 
-  const brokerUrl = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
+  const brokerUrl = `http://127.0.0.1:${brokerPort}`;
   await waitFor(
     async () => {
       const response = await fetch(`${brokerUrl}/api/session`, {
@@ -275,24 +283,6 @@ async function readJson(request) {
   return raw ? JSON.parse(raw) : undefined;
 }
 
-async function waitForConnection(connectionPath, child) {
-  const deadline = Date.now() + 30_000;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
-      throw new Error(`Broker exited before readiness (${child.exitCode}): ${brokerStderr}`);
-    }
-    try {
-      const parsed = JSON.parse(await readFile(connectionPath, 'utf8'));
-      if (typeof parsed?.port === 'number') return `http://127.0.0.1:${parsed.port}`;
-      if (typeof parsed?.url === 'string') return parsed.url;
-    } catch {
-      // The broker writes connection.json atomically; absence while starting is expected.
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`Broker did not publish connection.json: ${brokerStderr}`);
-}
-
 async function waitFor(probe, timeoutMs, label) {
   const deadline = Date.now() + timeoutMs;
   let lastError;
@@ -307,6 +297,20 @@ async function waitFor(probe, timeoutMs, label) {
   throw new Error(
     `Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}: ${brokerStderr}`
   );
+}
+
+async function reservePort() {
+  const server = http.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected broker TCP address.');
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
 }
 
 function requiredValue(name) {


### PR DESCRIPTION
## Summary
- send `delete_agent: true` for explicit broker removals
- preserve the existing reason/actor audit attribution
- pin the destructive wire contract in the Relaycast client unit test
- add a base-vs-head RelayFlow proof through the exact compiled broker and `DELETE /api/spawned`

## Root cause
`DELETE /api/spawned/<name>` stops the local worker and queues fleet deregistration before `release_agent_identity` calls Relaycast. The broker then sent a non-delete release. Relaycast deliberately requires a live host for non-delete release and returned `503 agent_host_unavailable`; the Rust SDK retried the deterministic 5xx through its final slot and surfaced only `Invalid response: Max retries exceeded`.

The broker comments already define explicit removal as the lifecycle path that invalidates the old credential. Setting `delete_agent: true` matches that contract and lets Relaycast tombstone the hostless identity locally, freeing the name and seat without dispatching back to a process the broker has already removed.

## Production reproduction
Using the broker's actual `rk_live_...` workspace credential and a browser-like User-Agent against `https://cast.agentrelay.com`:

- `POST /v1/agents` for a disposable identity: `201`
- `POST /v1/agents/release` without `delete_agent`: `503 agent_host_unavailable`
- cleanup release with `delete_agent: true`: the disposable name was removed from `GET /v1/agents`

This proves the earlier CLI access-token `401` was a credential-class mismatch, not the broker failure.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test -p agent-relay-broker explicit_agent_release_deletes_identity_and_records_attribution`
- [x] RelayFlow head arm: `hostless_identity_release_succeeds`
- [ ] CI base arm: `hostless_release_exhausts_retries`
- [ ] after an authorized broker deployment, spawn a disposable worker and verify `DELETE /api/spawned/<name>` succeeds without `Max retries exceeded` and the Relaycast seat is absent

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1650-hostless-identity-release` <!-- relay-pr-proof:case -->

Do not merge until the deployment owner has reviewed the cross-service verification plan.
