### PR TITLE
docs: document the RelayFlow PR proof contract

### DIFF
--- a/.trajectories/compacted/release-11.10.2.json
+++ b/.trajectories/compacted/release-11.10.2.json
@@ -3,9 +3,7 @@
   "version": 1,
   "type": "compacted",
   "compactedAt": "2026-09-03T06:52:02.784Z",
-  "sourceTrajectories": [
-    "traj_7yref3wye283"
-  ],
+  "sourceTrajectories": ["traj_7yref3wye283"],
   "dateRange": {
     "start": "2026-09-02T10:25:41.382Z",
     "end": "2026-09-02T12:08:45.907Z"
@@ -13,9 +11,7 @@
   "summary": {
     "totalDecisions": 7,
     "totalEvents": 11,
-    "uniqueAgents": [
-      "default"
-    ]
+    "uniqueAgents": ["default"]
   },
   "decisionGroups": [
     {
@@ -103,12 +99,5 @@
     "tests/relayflows/cases/1638-attach-input-replay/case.json",
     "tests/relayflows/cases/1638-attach-input-replay/run.mjs"
   ],
-  "commits": [
-    "e85f4ca23",
-    "bf66a2e86",
-    "13971aa8f",
-    "1191af9bd",
-    "cefc1ab4d",
-    "2559e668a"
-  ]
+  "commits": ["e85f4ca23", "bf66a2e86", "13971aa8f", "1191af9bd", "cefc1ab4d", "2559e668a"]
 }

--- a/.trajectories/compacted/release-11.10.2.md
+++ b/.trajectories/compacted/release-11.10.2.md
@@ -1,6 +1,7 @@
 # Trajectory Compaction: Sep 2, 2026 - Sep 2, 2026
 
 ## Summary
+
 - Sessions: 1
 - Decisions: 7
 - Events: 11
@@ -9,6 +10,7 @@
 - Commits: 6
 
 ## Api
+
 - Treat Relaycast publication and recipient reachability as separate observations -> Treat Relaycast publication and recipient reachability as separate observations (traj_7yref3wye283)
 - Keep the reachability probe outside the publication timeout -> Keep the reachability probe outside the publication timeout (traj_7yref3wye283)
 - Keep the synchronous reachability snapshot bounded at five seconds -> Keep the synchronous reachability snapshot bounded at five seconds (traj_7yref3wye283)
@@ -16,13 +18,17 @@
 - Cancel reachability observation when publication fails -> Cancel reachability observation when publication fails (traj_7yref3wye283)
 
 ## Security
+
 - Resolve Relaycast @self before reachability probing -> Resolve Relaycast @self before reachability probing (traj_7yref3wye283)
 
 ## Other
+
 - Treat legacy away as reachable -> Treat legacy away as reachable (traj_7yref3wye283)
 
 ## Key Learnings
+
 - None
 
 ## Key Findings
+
 - None

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,41 @@ git push origin main  # NO!
 
 This ensures the user maintains control over what goes into the main branch.
 
+## RelayFlow PR Proof
+
+Every feature or bug-fix PR body must declare its RelayFlow proof metadata, or
+the required `RelayFlow PR proof` check fails at classification with:
+
+```
+Pull request does not satisfy the RelayFlow proof contract
+ - PR body must declare a RelayFlow Proof change type
+ - PR body must declare a RelayFlow Proof case
+```
+
+Add exactly these two lines to the PR body — the HTML comments are load-bearing
+and the values must be in backticks:
+
+```
+- Change type: `<type>` <!-- relay-pr-proof:type -->
+- RelayFlow case: `<case-id>` <!-- relay-pr-proof:case -->
+```
+
+- `<type>` is one of `feature`, `bugfix`, or `non-functional` (see
+  `scripts/pr-proof/contract.mjs`). A runtime change cannot declare
+  `non-functional` regardless of title wording.
+- `<case-id>` names a directory under `tests/relayflows/cases/` (see
+  `tests/relayflows/cases/README.md` for how to add one). `feature`/`bugfix`
+  PRs must pick or add a case that actually exercises the changed behavior —
+  reusing a convenient existing case that doesn't cover the change defeats the
+  gate. `non-functional` PRs declare the case as `n/a`.
+- The PR title must still match `^(feat|fix)(\([^)]*\))?!?:` for the check to
+  run its title-based fallback classification when the diff can't be read.
+
+Regexes are multiline and case-insensitive but anchored, so a stray indent or a
+missing HTML comment fails the same way as omitting the line entirely. After
+editing the PR body, re-run the dispatcher and confirm it classifies — don't
+assume the edit parsed.
+
 ## Changelog
 
 Curate `[Unreleased]` in `CHANGELOG.md` as you land PRs. The root changelog is


### PR DESCRIPTION
## Summary
- Add a "RelayFlow PR Proof" section to `AGENTS.md` (mirrored into `CLAUDE.md`, a symlink to it) documenting the proof gate's PR-body requirements.
- Written after relay#1650's fix sat blocked because the marker-line format, accepted change types, and case-id source lived only in `scripts/pr-proof/contract.mjs` and `tests/relayflows/cases/README.md`, with nothing at the repo root pointing future PR authors there.

## What's documented
- The two literal marker lines the gate requires, with the load-bearing HTML comments and backticked values.
- The accepted `Change type` values (`feature`, `bugfix`, `non-functional`) and that a runtime change can't declare `non-functional`.
- Where `RelayFlow case` ids come from, and that picking a case must actually exercise the changed behavior rather than reusing a convenient passing one.
- The exact failure message so a blocked PR author can grep straight to the fix.

Docs-only change (`.md`), so it is exempt from the proof requirement itself — declared `non-functional` / `n/a` below, matching the contract this PR documents.

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

Do not merge — chartered for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N67EcJC36mKdzUsZUBCTaB

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

