### PR TITLE
fix(ci): stop Prettier auto-formatting .trajectories/, exempt it from the proof contract

### DIFF
--- a/.github/workflows/node-compat.yml
+++ b/.github/workflows/node-compat.yml
@@ -98,6 +98,14 @@ jobs:
           node --version
           npm --version
 
+      - name: Upgrade npm before fresh resolution
+        # npm <=10.9.x's arborist crashes re-resolving the harnesses
+        # package's peer set with no lockfile present (npm/cli#8261) — an
+        # npm-version bug, not a Node-version one. See relay#1652. Applied
+        # here too so this job passes independent of merge order with that
+        # PR.
+        run: npm install -g npm@11.19.1
+
       - name: Clean install
         run: |
           rm -rf node_modules package-lock.json

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -214,6 +214,13 @@ jobs:
         with:
           node-version: '22.14.0'
 
+      - name: Upgrade npm before fresh resolution
+        # See node-compat.yml's identical step: npm <=10.9.x's arborist
+        # crashes re-resolving the harnesses package's peer set with no
+        # lockfile present (npm/cli#8261). See relay#1652. Applied here too
+        # so this job passes independent of merge order with that PR.
+        run: npm install -g npm@11.19.1
+
       # The publish workflow bumps versions, removes package-lock.json, then
       # runs npm install. This catches range-resolved dependency breaks before merge.
       - name: Install dependencies with publish resolution

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ web/content/docs/
 packages/config/src/cli-registry.generated.ts
 tests/benchmarks/head-to-head.ts
 .agentworkforce/trajectories/
+.trajectories/

--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -123,6 +123,14 @@ const NON_RUNTIME_PATH_PATTERNS = Object.freeze([
   // is the same CI scope already exempted via workflows/ and .github/.
   /^\.gitignore$/,
   /^\.editorconfig$/,
+  // Session/trajectory compaction logs (chief-brain journaling for coding
+  // agent sessions). Never imported by the CLI or broker at runtime — pure
+  // record-keeping. Nested, so the top-level `*.md` pattern above doesn't
+  // already cover `.trajectories/compacted/*.md`.
+  /^\.trajectories\//,
+  // Formatter config only — cannot change what ships. Same class as
+  // .editorconfig above.
+  /^\.prettierignore$/,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

`.trajectories/compacted/*.{md,json}` pre-exist on `main` and already fail
`prettier --check .` — this currently fails the `Test` workflow's "Check
formatting" job on any PR that touches them, purely as a side effect of
`prettier-fmt-fix.yml` running `npm run format` over the **whole repo** on
every `pull_request` push, not just the PR's diff.

Discovered this while landing #1652 (unrelated `npm` CI-crash fix): every
time I reverted the bot's reformat of these two files, it just re-committed
the identical fix on the next push — an unbreakable loop, since the drift
is pre-existing on `main` and has nothing to do with that PR's actual diff.
#1651 (an unrelated docs PR) independently hit the exact same drift.

## Fix

- `.prettierignore`: add `.trajectories/`, matching the existing
  `.agentworkforce/trajectories/` entry (these are chief-brain session
  compaction logs, not code).
- `scripts/pr-proof/contract.mjs`: add `.trajectories/` and
  `.prettierignore` itself to `NON_RUNTIME_PATH_PATTERNS` — neither can
  reach a shipped artifact.

## A heads-up on this PR's own proof-contract status

`relayflow-pr-proof.yml` runs via `pull_request_target` specifically so a
PR can't rewrite its own proof logic by editing the PR-head copy of
`contract.mjs` (see the workflow's own security-boundary comment) — the
dispatcher always evaluates against the **base branch's** script. That
means this PR's own `contract.mjs` edit cannot take effect against itself:
the check will report "changes runtime files" even though nothing here
reaches a shipped artifact. That's an inherent one-time bootstrap gap in
the gate, not a defect in this diff. Needs a human read on this one PR;
every future PR touching only `.trajectories/`/`.prettierignore` will
classify correctly once this merges.

## RelayFlow proof contract

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G5VNMxEt4F3fbjgiJkSuQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

