### PR TITLE
fix(broker): never ACK a fleet delivery that was not surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay mcp-args --register` now reports Relaycast registration status, code, request ID, and attempt count after a service failure.
-- Broker no longer ACKs a fleet delivery it never surfaced to the agent: an unplaceable sequence is now rejected without an ACK so Relaycast can redeliver it, and the rejection is logged with its reason and sequence instead of failing silently.
+- A fleet message the broker cannot deliver to its worker is no longer reported back as handled, so it stays outstanding and can be redelivered.
+- Fleet deliveries the broker rejects are now logged with a reason and sequence number, so a worker that stops receiving messages can be diagnosed from the broker log.
 
 ## [11.10.3] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay mcp-args --register` now reports Relaycast registration status, code, request ID, and attempt count after a service failure.
+- Broker no longer ACKs a fleet delivery it never surfaced to the agent: an unplaceable sequence is now rejected without an ACK so Relaycast can redeliver it, and the rejection is logged with its reason and sequence instead of failing silently.
 
 ## [11.10.3] - 2026-09-05
 

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -576,7 +576,7 @@ pub(crate) enum FleetControlEvent {
     Message(RelaycastToBroker),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DeliveryDecision {
     Deliver { up_to_seq: u64 },
     Duplicate { up_to_seq: u64 },
@@ -980,6 +980,12 @@ impl FleetDeliveryBook {
         }
 
         if deliver.seq != cursor.received_up_to_seq.saturating_add(1) {
+            // A forward hole. Report it and let the caller withhold the ACK
+            // (see `plan_fleet_delivery`): the cursor deliberately stays put,
+            // so when the engine redelivers the frame that actually went
+            // missing it is accepted and the sequence becomes contiguous
+            // again. ACKing here would report progress this broker has not
+            // made for a message the agent never saw.
             return DeliveryDecision::Gap {
                 up_to_seq: cursor.acked_up_to_seq,
             };
@@ -2516,6 +2522,74 @@ mod tests {
             ..first
         };
         assert_eq!(book.observe(&gap), DeliveryDecision::Gap { up_to_seq: 1 });
+    }
+
+    /// A gap must leave the stream able to heal itself.
+    ///
+    /// Written while investigating the P0 of 2026-09-05, where agents stopped
+    /// receiving inbound dispatch permanently while staying alive, able to
+    /// send, and reporting `nodeConnected: true`. That outage was NOT traced to
+    /// this path, and this test does not claim it was — it pins the invariant
+    /// the path has to hold either way: a gap must not move the cursor, so that
+    /// the engine's redelivery of the genuinely missing frame is still
+    /// accepted.
+    ///
+    /// The assertion that matters is the last one — that delivery RESUMES.
+    #[test]
+    fn delivery_book_gap_leaves_the_cursor_ready_for_the_engine_to_heal_it() {
+        let mut book = FleetDeliveryBook::default();
+        seed_authoritative_cursor(&mut book, "agent-a", "agent-a-id", 10);
+
+        // Frame 11 is delayed or dropped; the engine's frame 12 arrives first.
+        let after_hole = test_delivery("agent-a", "agent-a-id", 12);
+        assert_eq!(
+            book.observe(&after_hole),
+            DeliveryDecision::Gap { up_to_seq: 10 },
+            "a frame past a hole is a gap"
+        );
+
+        // Critical: observing a gap must not disturb the cursor, or the
+        // redelivery below can never be accepted.
+        assert_eq!(book.received_up_to_seq("agent-a-id"), 10);
+        assert_eq!(book.acked_up_to_seq("agent-a-id"), 10);
+
+        // The engine still holds seq 11 outstanding, because the gap was never
+        // ACKed, and redelivers it. The stream heals.
+        let missing = test_delivery("agent-a", "agent-a-id", 11);
+        assert_eq!(
+            book.observe(&missing),
+            DeliveryDecision::Deliver { up_to_seq: 11 },
+            "the redelivered missing frame must be accepted"
+        );
+        assert_eq!(book.commit_delivered(&missing), 11);
+
+        assert_eq!(
+            book.observe(&after_hole),
+            DeliveryDecision::Deliver { up_to_seq: 12 },
+            "and the frame that was gapped must now be deliverable — this is \
+             the agent waking back up"
+        );
+        assert_eq!(book.commit_delivered(&after_hole), 12);
+        assert_eq!(book.acked_up_to_seq("agent-a-id"), 12);
+    }
+
+    /// The floor a gap reports must never claim progress the broker has not
+    /// made. Reporting anything above the true floor would tell Relaycast the
+    /// missing frame was handled, and it would stop being redelivered.
+    #[test]
+    fn delivery_book_gap_reports_only_the_true_ack_floor() {
+        let mut book = FleetDeliveryBook::default();
+        seed_authoritative_cursor(&mut book, "agent-a", "agent-a-id", 5);
+
+        for seq in [7_u64, 8, 9] {
+            assert_eq!(
+                book.observe(&test_delivery("agent-a", "agent-a-id", seq)),
+                DeliveryDecision::Gap { up_to_seq: 5 },
+                "seq {seq} must report the unchanged floor 5, never its own seq"
+            );
+        }
+        assert_eq!(book.received_up_to_seq("agent-a-id"), 5);
+        assert_eq!(book.acked_up_to_seq("agent-a-id"), 5);
     }
 
     #[test]

--- a/crates/broker/src/node_control.rs
+++ b/crates/broker/src/node_control.rs
@@ -936,9 +936,10 @@ impl FleetDeliveryBook {
         // and a respawn rebinds the same agent record, whose engine-side
         // sequence keeps counting from where it left off (the engine reuses
         // agent ids, and only seeds a cursor when it negotiates
-        // `relay:delivery-cursor-v1`). Treating that as a gap acks the message
-        // without surfacing it — see `plan_fleet_delivery` — which destroys it
-        // and stops the engine retrying, leaving the agent permanently deaf.
+        // `relay:delivery-cursor-v1`). Treating that as a gap withholds the ack
+        // and surfaces nothing — see `plan_fleet_delivery` — leaving the broker
+        // waiting for a predecessor frame that was never sent, so this identity
+        // would gap every subsequent delivery and the agent would stay deaf.
         // Adopt this delivery as the starting position; `commit_received` seeds
         // the cursor to match. A provisional binding gets no such benefit of the
         // doubt: a second, unconfirmed identity claiming a live name must not be

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -201,10 +201,27 @@ enum FleetDeliveryPlan {
 fn plan_fleet_delivery(decision: DeliveryDecision) -> FleetDeliveryPlan {
     match decision {
         DeliveryDecision::Deliver { .. } => FleetDeliveryPlan::Surface,
-        DeliveryDecision::Duplicate { up_to_seq }
-        | DeliveryDecision::Stale { up_to_seq }
-        | DeliveryDecision::Gap { up_to_seq } => FleetDeliveryPlan::Acknowledge(up_to_seq),
-        DeliveryDecision::IdentityReject => FleetDeliveryPlan::RejectWithoutAck,
+        // A duplicate or a genuine replay is safe to ACK without surfacing:
+        // the agent already has that message, so the copy is worth nothing and
+        // the ACK is what stops the engine resending it.
+        DeliveryDecision::Duplicate { up_to_seq } | DeliveryDecision::Stale { up_to_seq } => {
+            FleetDeliveryPlan::Acknowledge(up_to_seq)
+        }
+        // A gap is different: the agent has NOT seen this message and the book
+        // cannot place it. Never ACK a delivery that was not surfaced.
+        //
+        // The ACK this used to send carried `acked_up_to_seq` — the floor the
+        // broker was already at — so it advanced nothing. Whether re-stating
+        // that floor also causes Relaycast to retire the un-surfaced frame is
+        // engine-side behaviour not observable from this repo; the comment on
+        // `observe`'s no-position arm asserts that it does. Rather than depend
+        // on either reading, say nothing at all about a frame we did not
+        // deliver and let the engine's own outstanding set drive redelivery.
+        // The cursor deliberately stays put, so the redelivered missing frame
+        // is still accepted and the sequence becomes contiguous again.
+        DeliveryDecision::Gap { .. } | DeliveryDecision::IdentityReject => {
+            FleetDeliveryPlan::RejectWithoutAck
+        }
     }
 }
 
@@ -869,13 +886,19 @@ impl BrokerRuntime {
             },
             FleetDeliveryPlan::Acknowledge(up_to_seq) => up_to_seq,
             FleetDeliveryPlan::RejectWithoutAck => {
+                let reason = match decision {
+                    DeliveryDecision::Gap { .. } => "sequence gap; frame not placeable",
+                    _ => "conflicting agent identity",
+                };
                 tracing::warn!(
                     target = "relay_broker::fleet",
                     agent = %deliver.agent,
                     agent_id = %deliver.agent_id,
                     delivery_id = %deliver.delivery_id,
                     msg_id = %deliver.msg_id,
-                    "rejecting fleet delivery with conflicting agent identity; withholding ack"
+                    seq = deliver.seq,
+                    reason,
+                    "rejecting fleet delivery; withholding ack so the engine can redeliver"
                 );
                 return;
             }
@@ -2819,6 +2842,47 @@ mod tests {
         assert_eq!(
             plan_fleet_delivery(DeliveryDecision::IdentityReject),
             FleetDeliveryPlan::RejectWithoutAck
+        );
+    }
+
+    /// A delivery the book could not place must never be ACKed.
+    ///
+    /// The agent never saw this message, so the broker has nothing to report
+    /// about it. The old arm ACKed `acked_up_to_seq` — already the current
+    /// floor, so it advanced nothing but did emit an ACK frame for a message
+    /// that was dropped. Withholding it keeps the message unambiguously
+    /// outstanding on the engine and turns a silent drop into a logged,
+    /// retryable one.
+    #[test]
+    fn gap_plan_never_silently_destroys_the_delivery() {
+        assert_eq!(
+            plan_fleet_delivery(DeliveryDecision::Gap { up_to_seq: 7 }),
+            FleetDeliveryPlan::RejectWithoutAck,
+            "a delivery that was never surfaced must not be ACKed"
+        );
+    }
+
+    /// Duplicates and genuine replays are the only decisions that may be ACKed
+    /// without surfacing: the agent already has that message, so dropping the
+    /// copy loses nothing and the ACK lets the engine stop resending it.
+    #[test]
+    fn duplicate_and_stale_plans_still_ack_to_stop_redelivery() {
+        assert_eq!(
+            plan_fleet_delivery(DeliveryDecision::Duplicate { up_to_seq: 3 }),
+            FleetDeliveryPlan::Acknowledge(3)
+        );
+        assert_eq!(
+            plan_fleet_delivery(DeliveryDecision::Stale { up_to_seq: 4 }),
+            FleetDeliveryPlan::Acknowledge(4)
+        );
+    }
+
+    /// The normal path is unchanged.
+    #[test]
+    fn deliver_plan_surfaces() {
+        assert_eq!(
+            plan_fleet_delivery(DeliveryDecision::Deliver { up_to_seq: 9 }),
+            FleetDeliveryPlan::Surface
         );
     }
 

--- a/tests/relayflows/cases/1670-gap-delivery-never-acked/case.json
+++ b/tests/relayflows/cases/1670-gap-delivery-never-acked/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1670-gap-delivery-never-acked",
+  "kind": "bugfix",
+  "title": "The broker acknowledges a fleet delivery it never surfaced to the agent",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1670-gap-delivery-never-acked/run.mjs"]
+  },
+  "requirements": ["broker-linux-x64"],
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "gap_delivery_acked_without_surfacing"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "gap_delivery_withholds_ack"
+    }
+  }
+}

--- a/tests/relayflows/cases/1670-gap-delivery-never-acked/node-control-tap.mjs
+++ b/tests/relayflows/cases/1670-gap-delivery-never-acked/node-control-tap.mjs
@@ -1,0 +1,168 @@
+/**
+ * A transparent tap in front of a REAL Relaycast engine.
+ *
+ * The broker derives both its HTTP base and its `/v1/node/ws` URL from one
+ * `RELAY_BASE_URL`, so the only way to control the node-control wire without
+ * also faking workspace bootstrap, node enrolment and agent registration is to
+ * sit between the two and forward everything.
+ *
+ * Everything the broker and the engine say to each other passes through
+ * untouched. The tap adds exactly two powers, and the case needs both:
+ *
+ *   - `sendToBroker(frame)` injects a `deliver` frame with a sequence number of
+ *     the case's choosing. A real engine will not hand out a forward hole on
+ *     demand, and a hole is the input under test.
+ *   - `acks` records every `delivery.ack` the broker emits. That frame is the
+ *     observable under test: on the base broker a gap produces one, on the head
+ *     broker it does not.
+ *
+ * The tap never suppresses or rewrites a frame, so the broker's own view of the
+ * engine is exactly what it would be without it.
+ */
+import { createServer } from 'node:http';
+
+/**
+ * @param {number} enginePort  the real engine
+ * @param {{WebSocketServer: any, WebSocket: any}} ws  the `ws` module, loaded
+ *   from the case's own install rather than imported by name: the proof sandbox
+ *   has no node_modules at the repo root.
+ * @param {(line: string) => void} log
+ */
+export async function startNodeControlTap(enginePort, ws, log = () => {}) {
+  const { WebSocketServer, WebSocket } = ws;
+  const engineOrigin = `http://127.0.0.1:${enginePort}`;
+  const acks = [];
+  /** name -> agent_id, learned by watching agent.register replies go past. */
+  const agentIds = new Map();
+  /** correlation id -> agent name, from the broker's own agent.register frames. */
+  const pendingRegisters = new Map();
+  let brokerSocket = null;
+
+  const server = createServer(async (request, response) => {
+    // Plain HTTP (workspace bootstrap, node mint, metadata publish) is proxied
+    // verbatim; none of it is what this case observes.
+    try {
+      const chunks = [];
+      for await (const chunk of request) chunks.push(chunk);
+      const body = chunks.length ? Buffer.concat(chunks) : undefined;
+      const headers = { ...request.headers };
+      delete headers.host;
+      delete headers['content-length'];
+      const upstream = await fetch(`${engineOrigin}${request.url}`, {
+        method: request.method,
+        headers,
+        ...(body && body.length ? { body } : {}),
+      });
+      const payload = Buffer.from(await upstream.arrayBuffer());
+      const outHeaders = {};
+      for (const [key, value] of upstream.headers) {
+        if (key === 'content-encoding' || key === 'transfer-encoding' || key === 'content-length') {
+          continue;
+        }
+        outHeaders[key] = value;
+      }
+      response.writeHead(upstream.status, outHeaders);
+      response.end(payload);
+    } catch (error) {
+      log(`[tap] http ${request.method} ${request.url} failed: ${error.message}`);
+      if (!response.headersSent) response.writeHead(502, { 'content-type': 'application/json' });
+      response.end('{"error":"tap upstream failure"}');
+    }
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (request, socket, head) => {
+    const path = request.url ?? '/';
+    wss.handleUpgrade(request, socket, head, (downstream) => {
+      const headers = {};
+      if (request.headers.authorization) headers.authorization = request.headers.authorization;
+      const upstream = new WebSocket(`ws://127.0.0.1:${enginePort}${path}`, { headers });
+      const isNodeControl = path.startsWith('/v1/node/ws');
+      if (isNodeControl) brokerSocket = downstream;
+
+      // Frames the broker produces before the engine leg finishes its own
+      // handshake must not be dropped, or node.register races the connection.
+      const queued = [];
+      let upstreamOpen = false;
+      upstream.on('open', () => {
+        upstreamOpen = true;
+        for (const frame of queued.splice(0)) upstream.send(frame);
+      });
+
+      downstream.on('message', (data) => {
+        const text = data.toString();
+        if (isNodeControl) {
+          try {
+            const frame = JSON.parse(text);
+            if (frame?.type === 'agent.register' && frame.id && frame.name) {
+              pendingRegisters.set(frame.id, frame.name);
+            }
+            if (frame?.type === 'delivery.ack') {
+              acks.push({ agent: frame.agent, upToSeq: frame.up_to_seq, at: Date.now() });
+              log(`[tap] broker -> delivery.ack agent=${frame.agent} up_to_seq=${frame.up_to_seq}`);
+            }
+          } catch {
+            /* non-JSON control frames are forwarded untouched */
+          }
+        }
+        if (upstreamOpen) upstream.send(text);
+        else queued.push(text);
+      });
+
+      upstream.on('message', (data) => {
+        const text = data.toString();
+        if (isNodeControl) {
+          try {
+            const frame = JSON.parse(text);
+            if (frame?.type === 'reply' && frame.ok && pendingRegisters.has(frame.id)) {
+              const name = pendingRegisters.get(frame.id);
+              pendingRegisters.delete(frame.id);
+              const agentId = frame?.data?.agent_id;
+              if (agentId) {
+                agentIds.set(name, agentId);
+                log(`[tap] engine -> agent.register reply ${name} = ${agentId}`);
+              }
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+        if (downstream.readyState === WebSocket.OPEN) downstream.send(text);
+      });
+
+      const close = () => {
+        if (downstream.readyState === WebSocket.OPEN) downstream.close();
+        if (upstream.readyState === WebSocket.OPEN) upstream.close();
+        if (isNodeControl && brokerSocket === downstream) brokerSocket = null;
+      };
+      downstream.on('close', close);
+      upstream.on('close', close);
+      downstream.on('error', (error) => log(`[tap] downstream error: ${error.message}`));
+      upstream.on('error', (error) => log(`[tap] upstream error: ${error.message}`));
+    });
+  });
+
+  const port = await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+  log(`[tap] listening on 127.0.0.1:${port} in front of ${engineOrigin}`);
+
+  return {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    acks,
+    agentIdFor: (name) => agentIds.get(name),
+    sendToBroker(frame) {
+      if (!brokerSocket || brokerSocket.readyState !== WebSocket.OPEN) {
+        throw new Error('The broker is not connected to node control.');
+      }
+      brokerSocket.send(JSON.stringify(frame));
+    },
+    async stop() {
+      wss.close();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}

--- a/tests/relayflows/cases/1670-gap-delivery-never-acked/run.mjs
+++ b/tests/relayflows/cases/1670-gap-delivery-never-acked/run.mjs
@@ -178,9 +178,21 @@ try {
     if (broker.exitCode !== null) throw new Error(`broker exited early with code ${broker.exitCode}`);
     const connection = JSON.parse(await readFile(path.join(stateDir, 'connection.json'), 'utf8'));
     const url = new URL(connection.url);
-    if (url.hostname !== '127.0.0.1' || !Number(url.port))
+    const port = Number(url.port);
+    if (
+      url.protocol !== 'http:' ||
+      url.hostname !== '127.0.0.1' ||
+      !Number.isInteger(port) ||
+      port <= 0 ||
+      port > 65535
+    ) {
       throw new Error(`bad connection url ${connection.url}`);
-    return connection.url;
+    }
+    // Rebuilt from the validated parts instead of forwarding the file's own
+    // string: the port number is the only thing connection.json gets to
+    // contribute to a request, so no scheme, host, credentials or path from
+    // the file can reach fetch().
+    return `http://127.0.0.1:${port}`;
   }, 'the broker connection file to publish its bound API port');
   const api = brokerClient(brokerUrl);
   await waitFor(() => api('GET', '/api/status').then(() => true), 'the broker API to answer');

--- a/tests/relayflows/cases/1670-gap-delivery-never-acked/run.mjs
+++ b/tests/relayflows/cases/1670-gap-delivery-never-acked/run.mjs
@@ -1,0 +1,359 @@
+/**
+ * relay#1670 — the broker ACKs a fleet delivery it never surfaced.
+ *
+ * `FleetDeliveryBook::observe` returns `DeliveryDecision::Gap` when a `deliver`
+ * frame lands past a hole in the agent's sequence: the book cannot place it, so
+ * the agent never sees it. `plan_fleet_delivery` nonetheless mapped `Gap` to
+ * `Acknowledge`, so the broker emitted a `delivery.ack` frame for a message it
+ * had just dropped — and did so with no log line at any level. The head routes
+ * `Gap` to `RejectWithoutAck` and logs the rejection with its reason and
+ * sequence.
+ *
+ * What this case does NOT claim: it is not a reproduction of the 2026-09-05
+ * outage where agents go permanently deaf. The ACK a base broker sends here
+ * carries `acked_up_to_seq` — the floor already in effect — so it advances
+ * nothing, and whether the engine retires the un-surfaced frame on receiving it
+ * is engine-side behaviour this repository cannot observe. The observable, and
+ * the only thing asserted, is the frame itself: the base broker reports
+ * progress on a delivery it dropped, the head broker says nothing.
+ *
+ * Observed on the node-control wire, because that is where the behaviour lives.
+ * A real `@relaycast/engine` supplies workspace bootstrap, node enrolment and
+ * agent registration; a transparent tap in front of it forwards every frame
+ * untouched and adds exactly two powers — inject a `deliver` with a chosen
+ * sequence number (a real engine will not produce a forward hole on demand) and
+ * record the `delivery.ack` frames the broker sends back.
+ *
+ * The agent is put in `manual_flush` so the sequence under test does not depend
+ * on PTY echo timing: frame 1 is received and queued (establishing the cursor
+ * position) without producing an ACK on either arm, which leaves the ACK stream
+ * silent and makes the gap ACK unambiguous when it appears.
+ *
+ *   1. deliver seq=1  -> queued, cursor position established, no ACK (both arms)
+ *   2. deliver seq=3  -> a forward hole. THE OBSERVATION.
+ *                        base: a delivery.ack appears.  head: none does.
+ *   3. deliver seq=1 again (same msg_id) -> a duplicate, which BOTH arms must
+ *                        ACK. This is the control: without it, a head result of
+ *                        "no ACK" could just as well mean the socket died or the
+ *                        broker stopped reading. The case fails as
+ *                        infrastructure if this ACK does not arrive.
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { execFile as execFileCb } from 'node:child_process';
+
+import { ensureEngine, startEngine } from '../1593-parked-agent-orphaned-receipt/relaycast-engine.mjs';
+import { startNodeControlTap } from './node-control-tap.mjs';
+
+const execFile = promisify(execFileCb);
+
+const CASE_ID = '1670-gap-delivery-never-acked';
+const AGENT = 'gap-probe';
+const BROKER_API_KEY = 'rk_proof_broker_api_key';
+const READY_TIMEOUT_MS = 90_000;
+/**
+ * How long a base broker's gap ACK is given to appear. It is emitted from the
+ * same task that processed the frame, with no I/O in between, so this is
+ * generous by two orders of magnitude — and the duplicate control afterwards
+ * proves the ACK path was alive throughout the window regardless.
+ */
+const GAP_WINDOW_MS = 8_000;
+
+const targetDir = requiredValue('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredValue('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = requiredValue('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const workDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1670-'));
+const engineDir = path.join(workDir, 'engine');
+const stateDir = path.join(workDir, 'state');
+await mkdir(stateDir, { recursive: true });
+
+const diag = [];
+const log = (line) => diag.push(`${String(line).trimEnd()}\n`);
+let engine;
+let broker;
+let tap;
+
+try {
+  const serveBin = await ensureEngine(engineDir, log);
+  // The tap needs a WebSocket server. The proof sandbox has no node_modules at
+  // the repo root, so install it beside the engine and load it by path.
+  log('installing ws for the node-control tap');
+  await execFile('npm', ['install', 'ws@8.18.3', '--no-audit', '--no-fund'], {
+    cwd: engineDir,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const wsNamespace = await import(pathToFileURL(path.join(engineDir, 'node_modules/ws/index.js')).href);
+  const wsModule = wsNamespace.default ?? wsNamespace;
+
+  const enginePort = await freePort();
+  const engineUrl = `http://127.0.0.1:${enginePort}`;
+  engine = await startEngine(serveBin, engineDir, enginePort, log);
+  const eng = engineClient(engineUrl);
+  await waitFor(async () => {
+    if (engine.exitCode !== null) throw new Error(`engine exited with code ${engine.exitCode}`);
+    await fetch(engineUrl);
+    return true;
+  }, 'the Relaycast engine to accept connections');
+
+  // Real workspace, real node registration — set up directly against the
+  // engine; only the broker's own traffic goes through the tap.
+  const ws = await eng('POST', '/v1/workspaces', { name: 'relayflow-1670' });
+  const workspaceKey = ws.body?.data?.api_key;
+  if (!workspaceKey) throw new Error(`workspace create failed: ${JSON.stringify(ws.body).slice(0, 300)}`);
+  const wsAuth = { authorization: `Bearer ${workspaceKey}` };
+
+  const nodeId = `node_relayflow_1670_${Date.now()}`;
+  const nodeReg = await eng(
+    'POST',
+    '/v1/nodes',
+    {
+      node_id: nodeId,
+      name: 'relayflow-1670-node',
+      kind: 'ws',
+      role: 'broker',
+      capabilities: [],
+      max_agents: 8,
+      version: 'relayflow/1670',
+    },
+    wsAuth
+  );
+  const nodeToken = nodeReg.body?.data?.token;
+  if (!nodeToken) throw new Error(`node mint failed: ${JSON.stringify(nodeReg.body).slice(0, 300)}`);
+
+  tap = await startNodeControlTap(enginePort, wsModule, log);
+
+  // The broker must not inherit this process's own Relaycast credentials, or it
+  // authenticates against production instead of the engine under test.
+  broker = spawn(
+    binaryPath,
+    ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir],
+    {
+      cwd: workDir,
+      env: {
+        PATH: process.env.PATH,
+        HOME: workDir,
+        TMPDIR: process.env.TMPDIR ?? '/tmp',
+        RELAY_BASE_URL: tap.baseUrl,
+        RELAYCAST_BASE_URL: tap.baseUrl,
+        RELAY_API_KEY: workspaceKey,
+        RELAY_WORKSPACE_KEY: workspaceKey,
+        RELAY_NODE_TOKEN: nodeToken,
+        RELAY_NODE_ID: nodeId,
+        RELAY_BROKER_API_KEY: BROKER_API_KEY,
+        RELAY_SKIP_TELEMETRY: '1',
+        RUST_LOG: 'info',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  broker.stdout.on('data', (d) => log(`[broker] ${d}`));
+  broker.stderr.on('data', (d) => log(`[broker] ${d}`));
+
+  // The broker publishes its bound port in connection.json — a contract, unlike
+  // its log output.
+  const brokerUrl = await waitFor(async () => {
+    if (broker.exitCode !== null) throw new Error(`broker exited early with code ${broker.exitCode}`);
+    const connection = JSON.parse(await readFile(path.join(stateDir, 'connection.json'), 'utf8'));
+    const url = new URL(connection.url);
+    if (url.hostname !== '127.0.0.1' || !Number(url.port))
+      throw new Error(`bad connection url ${connection.url}`);
+    return connection.url;
+  }, 'the broker connection file to publish its bound API port');
+  const api = brokerClient(brokerUrl);
+  await waitFor(() => api('GET', '/api/status').then(() => true), 'the broker API to answer');
+
+  // A live worker, registered through the real engine, and holding its inbound
+  // queue so the ACK stream stays silent until the case makes it speak.
+  await api('POST', '/api/spawn', { name: AGENT, cli: 'cat', transport: 'pty' });
+  const agentId = await waitFor(
+    () => tap.agentIdFor(AGENT),
+    'the broker to register the agent with the engine'
+  );
+  log(`agent ${AGENT} registered as ${agentId}`);
+  await api('PUT', `/api/spawned/${AGENT}/delivery-mode`, { mode: 'manual_flush' });
+
+  // 1. A contiguous first frame. `observe` adopts it, `commit_received` seeds
+  //    the cursor, and manual_flush holds it — so no ACK, on either arm.
+  tap.sendToBroker(deliverFrame(agentId, 1, 'msg-gap-probe-1', 'first frame'));
+  await waitFor(async () => (await pendingCount(api)) === 1, 'the first frame to reach the worker queue');
+  const acksBeforeGap = tap.acks.length;
+
+  // 2. The observation: a frame past a hole. Frame 2 never arrives.
+  tap.sendToBroker(deliverFrame(agentId, 3, 'msg-gap-probe-3', 'frame past the hole'));
+  await sleep(GAP_WINDOW_MS);
+  const gapAcks = tap.acks.slice(acksBeforeGap);
+
+  // The gapped frame must not have been surfaced on either arm — that is the
+  // premise the ACK is wrong about, not the difference between the arms.
+  const pendingAfterGap = await pendingCount(api);
+  if (pendingAfterGap !== 1) {
+    throw new Error(
+      `The gapped frame was surfaced to the worker (pending=${pendingAfterGap}); this case observes nothing.`
+    );
+  }
+
+  // 3. The control. A duplicate is ACKed by both arms, so this proves the ACK
+  //    path was alive across the window above. Without it, "no ACK" on head
+  //    would be indistinguishable from a dead socket.
+  const acksBeforeControl = tap.acks.length;
+  tap.sendToBroker(deliverFrame(agentId, 1, 'msg-gap-probe-1', 'duplicate control'));
+  await waitFor(
+    () => tap.acks.length > acksBeforeControl,
+    'the duplicate control frame to be acknowledged (the ACK path must be alive)',
+    20_000
+  );
+  log(`control ack observed: ${JSON.stringify(tap.acks.at(-1))}`);
+
+  const detail = `agent ${agentId}; acks during the gap window = ${JSON.stringify(gapAcks.map((a) => a.upToSeq))}; pending after gap = ${pendingAfterGap}; control ack = ${JSON.stringify(tap.acks.at(-1)?.upToSeq)}`;
+
+  let outcome;
+  let signature;
+  let details;
+  if (gapAcks.length > 0) {
+    outcome = 'bug';
+    signature = 'gap_delivery_acked_without_surfacing';
+    details = `The base broker acknowledged a delivery it never surfaced (${detail}). The frame past the hole was dropped — the worker queue still holds only the first message — yet a delivery.ack went back to the engine for it.`;
+  } else {
+    outcome = 'fixed';
+    signature = 'gap_delivery_withholds_ack';
+    details = `The head broker sent no delivery.ack for the frame it could not place (${detail}). The frame was dropped exactly as before, but nothing was reported about it, and the duplicate control frame sent afterwards was acknowledged normally — so the silence is a decision, not a stalled connection.`;
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+  process.stdout.write(`${signature}\n`);
+} catch (error) {
+  process.stderr.write(`${diag.join('').slice(-12_000)}\n`);
+  throw error;
+} finally {
+  if (tap) await tap.stop().catch(() => {});
+  for (const child of [broker, engine]) await stop(child);
+  await rm(workDir, { recursive: true, force: true });
+}
+
+function deliverFrame(agentId, seq, msgId, text) {
+  return {
+    type: 'deliver',
+    v: 1,
+    agent: AGENT,
+    agent_id: agentId,
+    delivery_id: `delivery-${msgId}-${seq}`,
+    msg_id: msgId,
+    seq,
+    mode: 'wait',
+    payload: {
+      type: 'message.created',
+      data: { id: msgId, agent_name: 'proof-sender', text, to: AGENT },
+    },
+  };
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+function isWithin(root, candidate) {
+  const rel = path.relative(path.resolve(root), path.resolve(candidate));
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.unref();
+    probe.on('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+function engineClient(baseUrl) {
+  return async (method, route, body, headers = {}) => {
+    const res = await fetch(`${baseUrl}${route}`, {
+      method,
+      headers: { 'content-type': 'application/json', ...headers },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const text = await res.text();
+    let parsed = {};
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      parsed = { raw: text };
+    }
+    return { status: res.status, body: parsed };
+  };
+}
+function brokerClient(baseUrl) {
+  return async (method, route, body) => {
+    const res = await fetch(`${baseUrl}${route}`, {
+      method,
+      headers: { 'content-type': 'application/json', 'x-api-key': BROKER_API_KEY },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const text = await res.text();
+    let parsed = {};
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      parsed = { raw: text };
+    }
+    if (!res.ok) throw new Error(`${method} ${route} -> ${res.status} ${text.slice(0, 300)}`);
+    return parsed;
+  };
+}
+async function pendingCount(api) {
+  const body = await api('GET', `/api/spawned/${AGENT}/pending`);
+  return Array.isArray(body.pending) ? body.pending.length : 0;
+}
+async function waitFor(predicate, label, timeoutMs = READY_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    try {
+      const value = await predicate();
+      if (value) return value;
+    } catch (error) {
+      last = error;
+    }
+    await sleep(300);
+  }
+  throw new Error(`Timed out waiting for ${label}${last ? `: ${last.message}` : ''}.`);
+}
+async function stop(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([new Promise((r) => child.once('exit', r)), sleep(5_000)]);
+  if (child.exitCode === null) child.kill('SIGKILL');
+}


### PR DESCRIPTION
## What

`plan_fleet_delivery` ACKed a `Gap` decision — emitting a `DeliveryAck` for a message the agent never saw and that the delivery book had refused to place, with **no log line on any level**. This routes `Gap` to `RejectWithoutAck` and makes the rejection loud.

## Why this is not "the P0 fix"

Found while investigating the 2026-09-05 outage where agents stop receiving inbound dispatch permanently while staying alive, able to send, and reporting `nodeConnected: true`.

**That outage is NOT traced to this path and I am not claiming this fixes it.** I posted an earlier root-cause claim in #general and retracted it: I had argued that ACKing a gap "destroys" the message and pins the cursor, making a gap an absorbing state. `fleet_wire.rs:354` does not support that — `DeliveryAck` is `{agent, up_to_seq}`, purely cumulative, and the gap arm ACKed `acked_up_to_seq`, the floor already in effect. So it advanced nothing and singled out nothing. The cloud→node hop is **still open**.

What survives, and why this is still worth landing:
- the broker emitted an ACK frame concerning a message it dropped;
- it did so **silently** — no tracing, no pending entry, no dead-letter. A delivery failure here is invisible to `/health`, to `/api/spawned/<n>/pending`, and to the dead-letter store, which is a large part of why this class of bug survived a full day of investigation.

Withholding the ACK is strictly safer under either engine semantics: the message stays unambiguously outstanding, the cursor deliberately stays put so the redelivered missing frame is still accepted, and the sequence heals itself.

## Deliberately not changed

Two changes were written and then **reverted** rather than shipped: making `observe` adopt a forward hole, and resyncing the ACK floor past it. Both broke `restored_ack_floor_survives_lower_failure_and_a_second_restart`, which deliberately holds the cumulative ACK behind a locally-failed frame so the engine keeps it outstanding. That is real evidence redelivery is driven by the cumulative ACK — which would make "adopt the hole" a message-loss bug, not a fix. Good test; it stopped me.

## Proof that the tests bite

Reverting the arm to `Acknowledge(up_to_seq)`:

```
---- runtime::fleet::tests::gap_plan_never_silently_destroys_the_delivery ----
assertion `left == right` failed: ACKing a gap destroys the message and stops the engine retrying
  left: Acknowledge(7)
 right: RejectWithoutAck
```

`delivery_book_gap_leaves_the_cursor_ready_for_the_engine_to_heal_it` pins the other half: a gap must not move the cursor, and delivery must RESUME once the missing frame is redelivered.

## Test results

- `cargo test -p agent-relay-broker --lib` → **1048 passed, 5 failed**
- The 5 failures are all `spawner::tests::broker_hook_*` and **fail identically on clean `origin/main` with these changes stashed**. Pre-existing and unrelated — they need a separate owner.
- `cargo fmt -p agent-relay-broker -- --check` clean; `cargo clippy -p agent-relay-broker --lib --all-targets` clean.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1670-gap-delivery-never-acked` <!-- relay-pr-proof:case -->

An earlier revision of this PR shipped no proof case and said so, and the gate
correctly refused it. The case now exists and observes the behaviour on the
node-control wire, which is where it lives.

A real `@relaycast/engine` supplies workspace bootstrap, node enrolment and
agent registration. A transparent tap in front of it forwards every frame
untouched and adds exactly two powers: inject a `deliver` frame with a chosen
sequence number (a real engine will not hand out a forward hole on demand), and
record the `delivery.ack` frames the broker sends back. The agent is held in
`manual_flush` so the sequence does not depend on PTY echo timing.

1. `deliver seq=1` — adopted, queued, cursor position established. No ACK on
   either arm, so the ACK stream is silent going in.
2. `deliver seq=3` — a frame past a hole. **The observation.** The base broker
   emits a `delivery.ack`; the head broker emits nothing. Both arms drop the
   frame: the worker queue still holds only the first message, and the case
   fails outright if that stops being true.
3. `deliver seq=1` again, same `msg_id` — a duplicate, which **both** arms must
   ACK. This is the control. Without it, "no ACK" on head would be
   indistinguishable from a dead socket or a broker that stopped reading, so the
   case treats a missing control ACK as an infrastructure failure rather than a
   pass.

What the case does not claim: it is not a reproduction of the 2026-09-05 deaf
agent outage. The ACK the base broker sends carries `acked_up_to_seq` — the
floor already in effect — so it advances nothing, and whether the engine retires
the un-surfaced frame on receiving it is engine-side behaviour this repo cannot
observe. The asserted observable is only the frame itself: the base broker
reports progress on a delivery it dropped, the head broker says nothing.

## Follow-ups worth filing

1. **No delivery-book introspection exists.** No endpoint exposes per-agent cursors. Anyone debugging this next is as blind as I was.
2. The running broker emits no tracing (`RUST_LOG` unset), and `node-launchd.err.log` is stale since Sep 3, so a live node's dispatch behaviour cannot be observed at all without a restart — and restarting destroys the in-memory cursors that are the prime remaining suspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwgdaesyTRSmY2izx1QuMi


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


