### PR TITLE
ci: bootstrap qualification workflow dispatch

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Bootstrap default-branch Relay qualification workflow dispatch
+
+> **Status:** ✅ Completed
+> **Task:** relay#1665-fleet-qualification
+> **Confidence:** 95%
+> **Started:** September 6, 2026 at 07:06 AM
+> **Completed:** September 6, 2026 at 07:06 AM
+
+---
+
+## Summary
+
+Added fail-closed default-branch workflow_dispatch bootstraps for Relay package and cleanroom qualification, plus exact trigger/input/no-evidence contract tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Land inert default-branch dispatch definitions instead of the full candidate verifier
+- **Chose:** Land inert default-branch dispatch definitions instead of the full candidate verifier
+- **Reasoning:** GitHub requires workflow_dispatch files on default, but #1665 must remain unmerged until live qualification. Manual-only stubs with zero permissions and fail-closed jobs expose the exact input contract without importing product code or producing qualification evidence.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Land inert default-branch dispatch definitions instead of the full candidate verifier: Land inert default-branch dispatch definitions instead of the full candidate verifier
+- The three-file bootstrap closes only the GitHub discovery gap; the live denominator remains 0/376 until immutable cross-repo producers exist and two candidate dispatches pass.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/trajectory.json
@@ -1,0 +1,78 @@
+{
+  "id": "traj_3p66udrdfua5",
+  "version": 1,
+  "task": {
+    "title": "Bootstrap default-branch Relay qualification workflow dispatch",
+    "source": {
+      "system": "plain",
+      "id": "relay#1665-fleet-qualification"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-06T05:06:23.109Z",
+  "completedAt": "2026-09-06T05:06:39.133Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-06T05:06:29.559Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_u5g11y0qpm51",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-06T05:06:29.559Z",
+      "endedAt": "2026-09-06T05:06:39.133Z",
+      "events": [
+        {
+          "ts": 1788671189560,
+          "type": "decision",
+          "content": "Land inert default-branch dispatch definitions instead of the full candidate verifier: Land inert default-branch dispatch definitions instead of the full candidate verifier",
+          "raw": {
+            "question": "Land inert default-branch dispatch definitions instead of the full candidate verifier",
+            "chosen": "Land inert default-branch dispatch definitions instead of the full candidate verifier",
+            "alternatives": [],
+            "reasoning": "GitHub requires workflow_dispatch files on default, but #1665 must remain unmerged until live qualification. Manual-only stubs with zero permissions and fail-closed jobs expose the exact input contract without importing product code or producing qualification evidence."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788671189985,
+          "type": "reflection",
+          "content": "The three-file bootstrap closes only the GitHub discovery gap; the live denominator remains 0/376 until immutable cross-repo producers exist and two candidate dispatches pass.",
+          "raw": {
+            "focalPoints": [
+              "dispatchability",
+              "scope",
+              "qualification-boundary"
+            ],
+            "adjustments": "Keep all Fleet runtime and producer implementation on #1665; require exact branch workflow plus artifacts before any evidence claim",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:dispatchability",
+            "focal:scope",
+            "focal:qualification-boundary",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added fail-closed default-branch workflow_dispatch bootstraps for Relay package and cleanroom qualification, plus exact trigger/input/no-evidence contract tests.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "bef0c2be900a51c4393ccca9063a136413a6fc92",
+    "endRef": "bef0c2be900a51c4393ccca9063a136413a6fc92"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/trajectory.json
@@ -67,12 +67,18 @@
     "approach": "Standard approach",
     "confidence": 0.95
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": ["7957f89e2", "fa9f2cc63"],
+  "filesChanged": [
+    ".agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/summary.md",
+    ".agentworkforce/trajectories/completed/2026-09/traj_3p66udrdfua5/trajectory.json",
+    ".github/workflows/relay-cleanroom-qualification.yml",
+    ".github/workflows/relay-package-qualification.yml",
+    "tests/fixtures/qualification-dispatch-bootstrap.test.ts"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "bef0c2be900a51c4393ccca9063a136413a6fc92",
-    "endRef": "bef0c2be900a51c4393ccca9063a136413a6fc92"
+    "endRef": "fa9f2cc630b37afe368733a4a261b482bcdf96db"
   }
 }

--- a/.github/workflows/relay-cleanroom-qualification.yml
+++ b/.github/workflows/relay-cleanroom-qualification.yml
@@ -1,0 +1,37 @@
+name: Relay orchestration cleanroom qualification
+
+# GitHub only exposes workflow_dispatch for workflow files present on the
+# default branch. This deliberately inert definition publishes the input
+# contract. A qualification/<nonce> ref must replace this file with the full
+# verifier before any cleanroom or Fleet evidence can be created.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Run the read-only diagnosis or an immutable candidate qualification
+        type: choice
+        required: true
+        default: diagnosis
+        options:
+          - diagnosis
+          - qualification
+      relayfile_candidate_ref:
+        description: Immutable Relayfile candidate SHA for diagnosis (defaults to main)
+        type: string
+        required: false
+      qualification_manifest_json:
+        description: Manual qualification manifest JSON; releases use relay-qualification.json
+        type: string
+        required: false
+
+permissions: {}
+
+jobs:
+  dispatch-bootstrap-only:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: Refuse to claim cleanroom qualification from the bootstrap
+        run: |
+          echo "::error title=Dispatch bootstrap only::Select a qualification/<nonce> ref containing the complete cleanroom verifier."
+          exit 1

--- a/.github/workflows/relay-package-qualification.yml
+++ b/.github/workflows/relay-package-qualification.yml
@@ -1,0 +1,20 @@
+name: Relay package qualification
+
+# GitHub only exposes workflow_dispatch for workflow files present on the
+# default branch. This deliberately inert definition makes the candidate
+# workflow discoverable. A qualification/<nonce> ref must replace this file
+# with the complete, source-bound producer before it can create evidence.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  dispatch-bootstrap-only:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: Refuse to claim package qualification from the bootstrap
+        run: |
+          echo "::error title=Dispatch bootstrap only::Select a qualification/<nonce> ref containing the complete candidate producer."
+          exit 1

--- a/tests/fixtures/qualification-dispatch-bootstrap.test.ts
+++ b/tests/fixtures/qualification-dispatch-bootstrap.test.ts
@@ -28,31 +28,49 @@ function requireObject(value: unknown, label: string): Record<string, unknown> {
 
 describe('qualification workflow dispatch bootstrap', () => {
   it.each([
-    ['relay-package-qualification.yml', 'Relay package qualification'],
-    ['relay-cleanroom-qualification.yml', 'Relay orchestration cleanroom qualification'],
-  ])('exposes only a manual default-branch dispatch contract for %s', async (file, name) => {
-    const { source, value } = await workflow(file);
-    expect(value.name).toBe(name);
-    expect(Object.keys(requireObject(value.on, `${file} triggers`))).toEqual(['workflow_dispatch']);
-    expect(value.permissions).toEqual({});
+    [
+      'relay-package-qualification.yml',
+      'Relay package qualification',
+      'Refuse to claim package qualification from the bootstrap',
+      'Select a qualification/<nonce> ref containing the complete candidate producer.',
+    ],
+    [
+      'relay-cleanroom-qualification.yml',
+      'Relay orchestration cleanroom qualification',
+      'Refuse to claim cleanroom qualification from the bootstrap',
+      'Select a qualification/<nonce> ref containing the complete cleanroom verifier.',
+    ],
+  ])(
+    'exposes only a manual default-branch dispatch contract for %s',
+    async (file, name, stepName, diagnostic) => {
+      const { source, value } = await workflow(file);
+      expect(value.name).toBe(name);
+      expect(Object.keys(requireObject(value.on, `${file} triggers`))).toEqual(['workflow_dispatch']);
+      expect(value.permissions).toEqual({});
 
-    const jobs = requireObject(value.jobs, `${file} jobs`);
-    expect(Object.keys(jobs)).toEqual(['dispatch-bootstrap-only']);
-    const job = requireObject(jobs['dispatch-bootstrap-only'], `${file} bootstrap job`);
-    expect(job).not.toHaveProperty('environment');
-    expect(job).not.toHaveProperty('permissions');
-    expect(job['timeout-minutes']).toBe(1);
+      const jobs = requireObject(value.jobs, `${file} jobs`);
+      expect(Object.keys(jobs)).toEqual(['dispatch-bootstrap-only']);
+      const job = requireObject(jobs['dispatch-bootstrap-only'], `${file} bootstrap job`);
+      expect(job).toEqual({
+        'runs-on': 'ubuntu-24.04',
+        'timeout-minutes': 1,
+        steps: [
+          {
+            name: stepName,
+            run: `echo "::error title=Dispatch bootstrap only::${diagnostic}"\nexit 1\n`,
+          },
+        ],
+      });
 
-    expect(source).not.toContain('secrets.');
-    expect(source).not.toContain('actions/checkout');
-    expect(source).not.toContain('actions/upload-artifact');
-    expect(source).not.toContain('schedule:');
-    expect(source).not.toContain('release:');
-    expect(source).not.toContain('repository_dispatch:');
-    expect(source).not.toContain('environment: snapshot-qualification');
-    expect(source).toContain('exit 1');
-    expect(source).toContain('Dispatch bootstrap only');
-  });
+      expect(source).not.toContain('secrets.');
+      expect(source).not.toContain('actions/checkout');
+      expect(source).not.toContain('actions/upload-artifact');
+      expect(source).not.toContain('schedule:');
+      expect(source).not.toContain('release:');
+      expect(source).not.toContain('repository_dispatch:');
+      expect(source).not.toContain('environment: snapshot-qualification');
+    }
+  );
 
   it('keeps the cleanroom dispatch inputs compatible with the candidate workflow', async () => {
     const { value } = await workflow('relay-cleanroom-qualification.yml');

--- a/tests/fixtures/qualification-dispatch-bootstrap.test.ts
+++ b/tests/fixtures/qualification-dispatch-bootstrap.test.ts
@@ -1,0 +1,98 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_DIRECTORY = path.join(ROOT, '.github', 'workflows');
+
+type Workflow = {
+  name?: unknown;
+  on?: unknown;
+  permissions?: unknown;
+  jobs?: unknown;
+};
+
+async function workflow(name: string): Promise<{ source: string; value: Workflow }> {
+  const source = await readFile(path.join(WORKFLOW_DIRECTORY, name), 'utf8');
+  return { source, value: parse(source) as Workflow };
+}
+
+function requireObject(value: unknown, label: string): Record<string, unknown> {
+  expect(value, label).toBeTypeOf('object');
+  expect(value, label).not.toBeNull();
+  expect(Array.isArray(value), label).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+describe('qualification workflow dispatch bootstrap', () => {
+  it.each([
+    ['relay-package-qualification.yml', 'Relay package qualification'],
+    ['relay-cleanroom-qualification.yml', 'Relay orchestration cleanroom qualification'],
+  ])('exposes only a manual default-branch dispatch contract for %s', async (file, name) => {
+    const { source, value } = await workflow(file);
+    expect(value.name).toBe(name);
+    expect(Object.keys(requireObject(value.on, `${file} triggers`))).toEqual(['workflow_dispatch']);
+    expect(value.permissions).toEqual({});
+
+    const jobs = requireObject(value.jobs, `${file} jobs`);
+    expect(Object.keys(jobs)).toEqual(['dispatch-bootstrap-only']);
+    const job = requireObject(jobs['dispatch-bootstrap-only'], `${file} bootstrap job`);
+    expect(job).not.toHaveProperty('environment');
+    expect(job).not.toHaveProperty('permissions');
+    expect(job['timeout-minutes']).toBe(1);
+
+    expect(source).not.toContain('secrets.');
+    expect(source).not.toContain('actions/checkout');
+    expect(source).not.toContain('actions/upload-artifact');
+    expect(source).not.toContain('schedule:');
+    expect(source).not.toContain('release:');
+    expect(source).not.toContain('repository_dispatch:');
+    expect(source).not.toContain('environment: snapshot-qualification');
+    expect(source).toContain('exit 1');
+    expect(source).toContain('Dispatch bootstrap only');
+  });
+
+  it('keeps the cleanroom dispatch inputs compatible with the candidate workflow', async () => {
+    const { value } = await workflow('relay-cleanroom-qualification.yml');
+    const triggers = requireObject(value.on, 'cleanroom triggers');
+    const dispatch = requireObject(triggers.workflow_dispatch, 'workflow_dispatch');
+    const inputs = requireObject(dispatch.inputs, 'workflow_dispatch inputs');
+
+    expect(inputs).toEqual({
+      mode: {
+        description: 'Run the read-only diagnosis or an immutable candidate qualification',
+        type: 'choice',
+        required: true,
+        default: 'diagnosis',
+        options: ['diagnosis', 'qualification'],
+      },
+      relayfile_candidate_ref: {
+        description: 'Immutable Relayfile candidate SHA for diagnosis (defaults to main)',
+        type: 'string',
+        required: false,
+      },
+      qualification_manifest_json: {
+        description: 'Manual qualification manifest JSON; releases use relay-qualification.json',
+        type: 'string',
+        required: false,
+      },
+    });
+  });
+
+  it('cannot upload or attest qualification evidence from either bootstrap workflow', async () => {
+    for (const file of ['relay-package-qualification.yml', 'relay-cleanroom-qualification.yml']) {
+      const { source } = await workflow(file);
+      for (const forbidden of [
+        'artifact-digest',
+        'qualification.seal.json',
+        'relay-package-qualification-attestation.json',
+        'runtime-effects.json',
+        'verify-full-relay-fleet',
+      ]) {
+        expect(source, `${file} must not produce ${forbidden}`).not.toContain(forbidden);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Outcome

Make Relay's two candidate qualification workflows discoverable by GitHub's `workflow_dispatch` API without merging or claiming any of the still-unproven Relay/Fleet implementation from #1665.

## Scope

- add default-branch definitions at the exact package-producer and cleanroom-verifier workflow paths;
- expose the exact cleanroom manual input contract used by #1665;
- keep both default definitions manual-only, zero-permission, credential-free, checkout-free, and fail-closed;
- add fixtures proving trigger, input, privilege, job, and no-evidence invariants.

The bootstrap jobs always exit nonzero. They cannot upload artifacts, attest packages, create sandboxes, run Fleet, or satisfy a qualification gate. A `qualification/<nonce>` ref must contain the complete candidate workflow at the same path; GitHub then executes that ref's workflow definition.

## Validation

- `actionlint .github/workflows/relay-package-qualification.yml .github/workflows/relay-cleanroom-qualification.yml`
- `npx vitest run tests/fixtures/qualification-dispatch-bootstrap.test.ts` — 4/4
- `npm run build:core`
- `npm test` — 152 files passed, 2 skipped; 2,373 tests passed, 22 skipped
- `npm run typecheck`
- `npm run format:check`
- dispatch inputs compared exactly with #1665 head `d34fe0c2053f76b43ac3999059870b1f30877e95`

The full live Fleet gate remains intentionally unmet: 0/2 qualification dispatches, 0/4 independent board attempts, 0/376 base operation executions, and 0/20 critical lifecycle trials. This PR only removes the default-branch workflow-discovery circular dependency.

Related: #1665, #1663, AgentWorkforce/cloud#3363, AgentWorkforce/relayfile#467, AgentWorkforce/relayfile-cloud#187

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->
