### PR TITLE
ci: isolate Cloud qualification dispatch

### DIFF
--- a/.github/workflows/relay-package-qualification-delivery.yml
+++ b/.github/workflows/relay-package-qualification-delivery.yml
@@ -1,0 +1,125 @@
+name: Relay package qualification Cloud delivery
+
+on:
+  workflow_run:
+    workflows:
+      - Relay package qualification
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  verify-request:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      run_id: ${{ steps.artifacts.outputs.run_id }}
+      run_attempt: ${{ steps.artifacts.outputs.run_attempt }}
+      source_git_sha: ${{ steps.artifacts.outputs.source_git_sha }}
+      attestation_artifact_digest: ${{ steps.artifacts.outputs.attestation_artifact_digest }}
+    steps:
+      - name: Check out only the trusted dispatcher source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up exact Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.22.0
+
+      - name: Validate the completed producer identity
+        id: producer
+        run: |
+          set -euo pipefail
+          node scripts/verify-features/relay-package-qualification-delivery.mjs validate-event \
+            --event "${GITHUB_EVENT_PATH}" \
+            --output "${RUNNER_TEMP}/producer-context.json" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Select the exact bounded request and attestation artifacts
+        id: artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.producer.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp \
+            "repos/AgentWorkforce/relay/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            > "${RUNNER_TEMP}/artifact-pages.json"
+          node scripts/verify-features/relay-package-qualification-delivery.mjs select-artifacts \
+            --context "${RUNNER_TEMP}/producer-context.json" \
+            --artifact-pages "${RUNNER_TEMP}/artifact-pages.json" \
+            --output "${RUNNER_TEMP}/artifact-selection.json" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Download only the selected request artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          artifact-ids: ${{ steps.artifacts.outputs.request_artifact_id }}
+          github-token: ${{ github.token }}
+          repository: AgentWorkforce/relay
+          run-id: ${{ steps.artifacts.outputs.run_id }}
+          path: ${{ runner.temp }}/relay-package-cloud-request
+          merge-multiple: true
+
+      - name: Validate the exact request payload and archive shape
+        run: |
+          set -euo pipefail
+          node scripts/verify-features/relay-package-qualification-delivery.mjs validate-request \
+            --context "${RUNNER_TEMP}/producer-context.json" \
+            --selection "${RUNNER_TEMP}/artifact-selection.json" \
+            --directory "${RUNNER_TEMP}/relay-package-cloud-request"
+
+  deliver-request:
+    needs: verify-request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    environment: snapshot-qualification
+    steps:
+      - name: Mint a Cloud-only token from the trusted dispatcher
+        id: cloud-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.GH_APP_PUSHER_ID }}
+          private-key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
+          owner: AgentWorkforce
+          repositories: cloud
+          permission-contents: write
+
+      - name: Deliver the verified immutable pointer
+        env:
+          GH_TOKEN: ${{ steps.cloud-token.outputs.token }}
+          RUN_ID: ${{ needs.verify-request.outputs.run_id }}
+          RUN_ATTEMPT: ${{ needs.verify-request.outputs.run_attempt }}
+          SOURCE_GIT_SHA: ${{ needs.verify-request.outputs.source_git_sha }}
+          ATTESTATION_ARTIFACT_DIGEST: ${{ needs.verify-request.outputs.attestation_artifact_digest }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --argjson runId "${RUN_ID}" \
+            --argjson runAttempt "${RUN_ATTEMPT}" \
+            --arg sourceGitSha "${SOURCE_GIT_SHA}" \
+            --arg attestationArtifactDigest "${ATTESTATION_ARTIFACT_DIGEST}" \
+            '{
+              event_type: "relay_package_qualification_ready",
+              client_payload: {
+                schemaVersion: 1,
+                kind: "relayPackageQualificationReady",
+                relay: {
+                  runId: $runId,
+                  runAttempt: $runAttempt,
+                  sourceGitSha: $sourceGitSha,
+                  attestationArtifactDigest: $attestationArtifactDigest
+                }
+              }
+            }' > "${RUNNER_TEMP}/cloud-request.json"
+          gh api --method POST repos/AgentWorkforce/cloud/dispatches \
+            --input "${RUNNER_TEMP}/cloud-request.json"

--- a/scripts/verify-features/relay-package-qualification-delivery.mjs
+++ b/scripts/verify-features/relay-package-qualification-delivery.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { appendFile, lstat, readFile, readdir, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { appendFile, open, readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -169,6 +170,28 @@ export function validateCloudDispatchRequest(requestValue, context, selection) {
   return expected;
 }
 
+export async function readBoundedRequestFile(requestPath, openFile = open) {
+  assert(Number.isInteger(fsConstants.O_NOFOLLOW), 'trusted request validation requires O_NOFOLLOW support');
+  const handle = await openFile(requestPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const metadata = await handle.stat();
+    assert(metadata.isFile(), 'request artifact must be a regular file');
+    assert(
+      metadata.size > 0 && metadata.size <= REQUEST_SIZE_LIMIT,
+      'request artifact file exceeds its size bound'
+    );
+
+    const source = await handle.readFile('utf8');
+    assert(
+      Buffer.byteLength(source, 'utf8') <= REQUEST_SIZE_LIMIT,
+      'request artifact content exceeds its size bound'
+    );
+    return source;
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function validateRequestArtifactDirectory(directory, context, selection) {
   const entries = await readdir(directory, { withFileTypes: true });
   assert.equal(entries.length, 1, 'request artifact must contain exactly one entry');
@@ -176,18 +199,7 @@ export async function validateRequestArtifactDirectory(directory, context, selec
   assert(entries[0].isFile(), 'request artifact entry must be a regular file');
 
   const requestPath = path.join(directory, REQUEST_FILE_NAME);
-  const metadata = await lstat(requestPath);
-  assert(metadata.isFile() && !metadata.isSymbolicLink(), 'request artifact must not be a symlink');
-  assert(
-    metadata.size > 0 && metadata.size <= REQUEST_SIZE_LIMIT,
-    'request artifact file exceeds its size bound'
-  );
-
-  const source = await readFile(requestPath, 'utf8');
-  assert(
-    Buffer.byteLength(source, 'utf8') <= REQUEST_SIZE_LIMIT,
-    'request artifact content exceeds its size bound'
-  );
+  const source = await readBoundedRequestFile(requestPath);
   return validateCloudDispatchRequest(JSON.parse(source), context, selection);
 }
 

--- a/scripts/verify-features/relay-package-qualification-delivery.mjs
+++ b/scripts/verify-features/relay-package-qualification-delivery.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { appendFile, lstat, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const RELAY_REPOSITORY = 'AgentWorkforce/relay';
+export const PRODUCER_WORKFLOW_NAME = 'Relay package qualification';
+export const PRODUCER_WORKFLOW_PATH = '.github/workflows/relay-package-qualification.yml';
+export const REQUEST_ARTIFACT_NAME = 'relay-package-cloud-request';
+export const REQUEST_FILE_NAME = 'relay-package-cloud-request.json';
+export const ATTESTATION_ARTIFACT_NAME = 'relay-package-qualification-attestation';
+export const CLOUD_DISPATCH_EVENT = 'relay_package_qualification_ready';
+
+const QUALIFICATION_BRANCH = /^qualification\/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?$/;
+const GIT_SHA = /^[a-f0-9]{40}$/;
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const REQUEST_SIZE_LIMIT = 64 * 1024;
+const ATTESTATION_SIZE_LIMIT = 256 * 1024;
+const MAX_ARTIFACTS = 8;
+
+function object(value, label) {
+  assert(value !== null && typeof value === 'object' && !Array.isArray(value), `${label} must be an object`);
+  return value;
+}
+
+function positiveSafeInteger(value, label) {
+  assert(Number.isSafeInteger(value) && value > 0, `${label} must be a positive safe integer`);
+  return value;
+}
+
+function exactString(value, expected, label) {
+  assert.equal(value, expected, `${label} must be ${JSON.stringify(expected)}`);
+  return value;
+}
+
+function boundedString(value, pattern, label) {
+  assert(typeof value === 'string' && pattern.test(value), `${label} is invalid`);
+  return value;
+}
+
+export function validateWorkflowRunEvent(value) {
+  const event = object(value, 'event');
+  const repository = object(event.repository, 'event.repository');
+  exactString(repository.full_name, RELAY_REPOSITORY, 'event.repository.full_name');
+
+  const run = object(event.workflow_run, 'event.workflow_run');
+  exactString(run.name, PRODUCER_WORKFLOW_NAME, 'workflow_run.name');
+  exactString(run.path, PRODUCER_WORKFLOW_PATH, 'workflow_run.path');
+  exactString(run.event, 'workflow_dispatch', 'workflow_run.event');
+  exactString(run.status, 'completed', 'workflow_run.status');
+  exactString(run.conclusion, 'success', 'workflow_run.conclusion');
+  exactString(
+    object(run.head_repository, 'workflow_run.head_repository').full_name,
+    RELAY_REPOSITORY,
+    'workflow_run.head_repository.full_name'
+  );
+
+  const sourceBranch = boundedString(run.head_branch, QUALIFICATION_BRANCH, 'workflow_run.head_branch');
+  assert(!sourceBranch.includes('..'), 'workflow_run.head_branch must not contain traversal segments');
+
+  return {
+    repository: RELAY_REPOSITORY,
+    workflowName: PRODUCER_WORKFLOW_NAME,
+    workflowPath: PRODUCER_WORKFLOW_PATH,
+    runId: positiveSafeInteger(run.id, 'workflow_run.id'),
+    runAttempt: positiveSafeInteger(run.run_attempt, 'workflow_run.run_attempt'),
+    sourceGitSha: boundedString(run.head_sha, GIT_SHA, 'workflow_run.head_sha'),
+    sourceBranch,
+  };
+}
+
+function validateArtifact(artifact, context, name, sizeLimit) {
+  const value = object(artifact, `artifact ${name}`);
+  exactString(value.name, name, `artifact ${name}.name`);
+  assert.equal(value.expired, false, `artifact ${name} must not be expired`);
+  positiveSafeInteger(value.id, `artifact ${name}.id`);
+  assert(
+    Number.isSafeInteger(value.size_in_bytes) && value.size_in_bytes > 0 && value.size_in_bytes <= sizeLimit,
+    `artifact ${name}.size_in_bytes must be between 1 and ${sizeLimit}`
+  );
+  boundedString(value.digest, SHA256_DIGEST, `artifact ${name}.digest`);
+  assert.equal(
+    positiveSafeInteger(
+      object(value.workflow_run, `artifact ${name}.workflow_run`).id,
+      `artifact ${name}.workflow_run.id`
+    ),
+    context.runId,
+    `artifact ${name} must belong to the triggering run`
+  );
+  return value;
+}
+
+export function selectQualificationArtifacts(contextValue, pageValues) {
+  const context = object(contextValue, 'context');
+  assert(Array.isArray(pageValues) && pageValues.length > 0, 'artifact pages must be a non-empty array');
+
+  const artifacts = pageValues.flatMap((page, index) => {
+    const value = object(page, `artifact page ${index}`);
+    assert(Array.isArray(value.artifacts), `artifact page ${index}.artifacts must be an array`);
+    return value.artifacts;
+  });
+  assert(artifacts.length <= MAX_ARTIFACTS, `producer run must expose at most ${MAX_ARTIFACTS} artifacts`);
+
+  const artifactIds = artifacts.map((artifact, index) =>
+    positiveSafeInteger(object(artifact, `artifact ${index}`).id, `artifact ${index}.id`)
+  );
+  assert.equal(new Set(artifactIds).size, artifactIds.length, 'artifact ids must be unique');
+
+  const exactlyOne = (name) => {
+    const matches = artifacts.filter((artifact) => artifact.name === name);
+    assert.equal(matches.length, 1, `producer run must expose exactly one ${name} artifact`);
+    return matches[0];
+  };
+
+  const request = validateArtifact(
+    exactlyOne(REQUEST_ARTIFACT_NAME),
+    context,
+    REQUEST_ARTIFACT_NAME,
+    REQUEST_SIZE_LIMIT
+  );
+  const attestation = validateArtifact(
+    exactlyOne(ATTESTATION_ARTIFACT_NAME),
+    context,
+    ATTESTATION_ARTIFACT_NAME,
+    ATTESTATION_SIZE_LIMIT
+  );
+
+  return {
+    requestArtifactId: request.id,
+    requestArtifactDigest: request.digest,
+    attestationArtifactDigest: attestation.digest,
+  };
+}
+
+export function expectedCloudDispatch(contextValue, selectionValue) {
+  const context = object(contextValue, 'context');
+  const selection = object(selectionValue, 'selection');
+  return {
+    event_type: CLOUD_DISPATCH_EVENT,
+    client_payload: {
+      schemaVersion: 1,
+      kind: 'relayPackageQualificationReady',
+      relay: {
+        runId: positiveSafeInteger(context.runId, 'context.runId'),
+        runAttempt: positiveSafeInteger(context.runAttempt, 'context.runAttempt'),
+        sourceGitSha: boundedString(context.sourceGitSha, GIT_SHA, 'context.sourceGitSha'),
+        attestationArtifactDigest: boundedString(
+          selection.attestationArtifactDigest,
+          SHA256_DIGEST,
+          'selection.attestationArtifactDigest'
+        ),
+      },
+    },
+  };
+}
+
+export function validateCloudDispatchRequest(requestValue, context, selection) {
+  const expected = expectedCloudDispatch(context, selection);
+  assert.deepEqual(requestValue, expected, 'request artifact must exactly match trusted producer identity');
+  return expected;
+}
+
+export async function validateRequestArtifactDirectory(directory, context, selection) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  assert.equal(entries.length, 1, 'request artifact must contain exactly one entry');
+  assert.equal(entries[0].name, REQUEST_FILE_NAME, `request artifact entry must be ${REQUEST_FILE_NAME}`);
+  assert(entries[0].isFile(), 'request artifact entry must be a regular file');
+
+  const requestPath = path.join(directory, REQUEST_FILE_NAME);
+  const metadata = await lstat(requestPath);
+  assert(metadata.isFile() && !metadata.isSymbolicLink(), 'request artifact must not be a symlink');
+  assert(
+    metadata.size > 0 && metadata.size <= REQUEST_SIZE_LIMIT,
+    'request artifact file exceeds its size bound'
+  );
+
+  const source = await readFile(requestPath, 'utf8');
+  assert(
+    Buffer.byteLength(source, 'utf8') <= REQUEST_SIZE_LIMIT,
+    'request artifact content exceeds its size bound'
+  );
+  return validateCloudDispatchRequest(JSON.parse(source), context, selection);
+}
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  const options = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    assert(key?.startsWith('--') && value !== undefined, `invalid argument ${key ?? '<missing>'}`);
+    const name = key.slice(2);
+    assert(!(name in options), `duplicate argument --${name}`);
+    options[name] = value;
+  }
+  return { command, options };
+}
+
+function requireOptions(options, names) {
+  assert.deepEqual(
+    Object.keys(options).sort(),
+    [...names].sort(),
+    'command arguments must exactly match the contract'
+  );
+}
+
+async function readJson(file, label) {
+  const source = await readFile(file, 'utf8');
+  assert(Buffer.byteLength(source, 'utf8') <= 1024 * 1024, `${label} exceeds its size bound`);
+  return JSON.parse(source);
+}
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+
+async function appendOutputs(file, values) {
+  const lines = Object.entries(values).map(([name, value]) => {
+    const rendered = String(value);
+    assert(!rendered.includes('\n') && !rendered.includes('\r'), `output ${name} contains a newline`);
+    return `${name}=${rendered}`;
+  });
+  await appendFile(file, `${lines.join('\n')}\n`, 'utf8');
+}
+
+export async function runCli(argv) {
+  const { command, options } = parseArguments(argv);
+  if (command === 'validate-event') {
+    requireOptions(options, ['event', 'output', 'github-output']);
+    const context = validateWorkflowRunEvent(await readJson(options.event, 'workflow event'));
+    await writeJson(options.output, context);
+    await appendOutputs(options['github-output'], { run_id: context.runId });
+    return;
+  }
+  if (command === 'select-artifacts') {
+    requireOptions(options, ['context', 'artifact-pages', 'output', 'github-output']);
+    const context = await readJson(options.context, 'producer context');
+    const selection = selectQualificationArtifacts(
+      context,
+      await readJson(options['artifact-pages'], 'artifact pages')
+    );
+    await writeJson(options.output, selection);
+    await appendOutputs(options['github-output'], {
+      request_artifact_id: selection.requestArtifactId,
+      run_id: context.runId,
+      run_attempt: context.runAttempt,
+      source_git_sha: context.sourceGitSha,
+      attestation_artifact_digest: selection.attestationArtifactDigest,
+    });
+    return;
+  }
+  if (command === 'validate-request') {
+    requireOptions(options, ['context', 'selection', 'directory']);
+    await validateRequestArtifactDirectory(
+      options.directory,
+      await readJson(options.context, 'producer context'),
+      await readJson(options.selection, 'artifact selection')
+    );
+    return;
+  }
+  throw new Error(`unknown command ${command ?? '<missing>'}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-features/relay-package-qualification-delivery.mjs
+++ b/scripts/verify-features/relay-package-qualification-delivery.mjs
@@ -40,6 +40,13 @@ function boundedString(value, pattern, label) {
   return value;
 }
 
+function workflowPathWithoutRef(value) {
+  assert(typeof value === 'string', 'workflow_run.path must be a string');
+  const parts = value.split('@');
+  assert(parts.length <= 2, 'workflow_run.path must contain at most one ref suffix');
+  return parts[0];
+}
+
 export function validateWorkflowRunEvent(value) {
   const event = object(value, 'event');
   const repository = object(event.repository, 'event.repository');
@@ -47,7 +54,7 @@ export function validateWorkflowRunEvent(value) {
 
   const run = object(event.workflow_run, 'event.workflow_run');
   exactString(run.name, PRODUCER_WORKFLOW_NAME, 'workflow_run.name');
-  exactString(run.path, PRODUCER_WORKFLOW_PATH, 'workflow_run.path');
+  exactString(workflowPathWithoutRef(run.path), PRODUCER_WORKFLOW_PATH, 'workflow_run.path');
   exactString(run.event, 'workflow_dispatch', 'workflow_run.event');
   exactString(run.status, 'completed', 'workflow_run.status');
   exactString(run.conclusion, 'success', 'workflow_run.conclusion');

--- a/scripts/verify-features/relay-package-qualification-delivery.mjs
+++ b/scripts/verify-features/relay-package-qualification-delivery.mjs
@@ -41,13 +41,6 @@ function boundedString(value, pattern, label) {
   return value;
 }
 
-function workflowPathWithoutRef(value) {
-  assert(typeof value === 'string', 'workflow_run.path must be a string');
-  const parts = value.split('@');
-  assert(parts.length <= 2, 'workflow_run.path must contain at most one ref suffix');
-  return parts[0];
-}
-
 export function validateWorkflowRunEvent(value) {
   const event = object(value, 'event');
   const repository = object(event.repository, 'event.repository');
@@ -55,7 +48,7 @@ export function validateWorkflowRunEvent(value) {
 
   const run = object(event.workflow_run, 'event.workflow_run');
   exactString(run.name, PRODUCER_WORKFLOW_NAME, 'workflow_run.name');
-  exactString(workflowPathWithoutRef(run.path), PRODUCER_WORKFLOW_PATH, 'workflow_run.path');
+  exactString(run.path, PRODUCER_WORKFLOW_PATH, 'workflow_run.path');
   exactString(run.event, 'workflow_dispatch', 'workflow_run.event');
   exactString(run.status, 'completed', 'workflow_run.status');
   exactString(run.conclusion, 'success', 'workflow_run.conclusion');
@@ -103,10 +96,20 @@ function validateArtifact(artifact, context, name, sizeLimit) {
 export function selectQualificationArtifacts(contextValue, pageValues) {
   const context = object(contextValue, 'context');
   assert(Array.isArray(pageValues) && pageValues.length > 0, 'artifact pages must be a non-empty array');
+  assert.equal(pageValues.length, 1, 'bounded producer artifacts must fit in exactly one API page');
 
   const artifacts = pageValues.flatMap((page, index) => {
     const value = object(page, `artifact page ${index}`);
     assert(Array.isArray(value.artifacts), `artifact page ${index}.artifacts must be an array`);
+    assert(
+      Number.isSafeInteger(value.total_count) && value.total_count >= 0,
+      `artifact page ${index}.total_count must be a non-negative safe integer`
+    );
+    assert.equal(
+      value.total_count,
+      value.artifacts.length,
+      `artifact page ${index} must contain every producer artifact`
+    );
     return value.artifacts;
   });
   assert(artifacts.length <= MAX_ARTIFACTS, `producer run must expose at most ${MAX_ARTIFACTS} artifacts`);

--- a/tests/fixtures/relay-package-qualification-delivery.test.ts
+++ b/tests/fixtures/relay-package-qualification-delivery.test.ts
@@ -242,8 +242,13 @@ describe('trusted Relay package qualification delivery', () => {
     expect(verify.if).toBe("${{ github.event.workflow_run.conclusion == 'success' }}");
     expect(verify.permissions).toEqual({ actions: 'read', contents: 'read' });
     expect(JSON.stringify(verify)).not.toContain('secrets.');
-    expect(JSON.stringify(verify)).toContain('${{ github.workflow_sha }}');
-    expect(JSON.stringify(verify)).toContain('persist-credentials');
+    const checkout = verify.steps.find(
+      (step: any) => step.uses === 'actions/checkout@11d5960a326750d5838078e36cf38b85af677262'
+    );
+    expect(checkout?.with).toEqual({
+      ref: '${{ github.workflow_sha }}',
+      'persist-credentials': false,
+    });
     expect(JSON.stringify(verify)).toContain('request_artifact_id');
 
     const deliver = workflow.jobs['deliver-request'];

--- a/tests/fixtures/relay-package-qualification-delivery.test.ts
+++ b/tests/fixtures/relay-package-qualification-delivery.test.ts
@@ -80,12 +80,30 @@ describe('trusted Relay package qualification delivery', () => {
     });
   });
 
+  it('accepts the Actions API path form with a ref suffix while keeping the path exact', () => {
+    expect(
+      validateWorkflowRunEvent(
+        workflowRunEvent({
+          path: `${CONTEXT.workflowPath}@${CONTEXT.sourceBranch}`,
+        })
+      )
+    ).toEqual(CONTEXT);
+  });
+
   it.each([
     ['main', { head_branch: 'main' }],
     ['an attacker-controlled nested qualification ref', { head_branch: 'qualification/attacker/payload' }],
     ['a traversal-shaped qualification ref', { head_branch: 'qualification/../main' }],
     ['a fork producer', { head_repository: { full_name: 'attacker/relay' } }],
     ['the wrong workflow path', { path: '.github/workflows/attacker.yml' }],
+    [
+      'the wrong workflow path with a trusted-looking ref suffix',
+      { path: '.github/workflows/attacker.yml@qualification/candidate' },
+    ],
+    [
+      'a workflow path with multiple ref suffixes',
+      { path: `${CONTEXT.workflowPath}@main@qualification/candidate` },
+    ],
     ['a non-manual event', { event: 'push' }],
     ['an incomplete run', { status: 'in_progress' }],
     ['a failed run', { conclusion: 'failure' }],

--- a/tests/fixtures/relay-package-qualification-delivery.test.ts
+++ b/tests/fixtures/relay-package-qualification-delivery.test.ts
@@ -81,22 +81,15 @@ describe('trusted Relay package qualification delivery', () => {
     });
   });
 
-  it('accepts the Actions API path form with a ref suffix while keeping the path exact', () => {
-    expect(
-      validateWorkflowRunEvent(
-        workflowRunEvent({
-          path: `${CONTEXT.workflowPath}@${CONTEXT.sourceBranch}`,
-        })
-      )
-    ).toEqual(CONTEXT);
-  });
-
   it.each([
     ['main', { head_branch: 'main' }],
     ['an attacker-controlled nested qualification ref', { head_branch: 'qualification/attacker/payload' }],
     ['a traversal-shaped qualification ref', { head_branch: 'qualification/../main' }],
     ['a fork producer', { head_repository: { full_name: 'attacker/relay' } }],
     ['the wrong workflow path', { path: '.github/workflows/attacker.yml' }],
+    ['an empty workflow path ref suffix', { path: `${CONTEXT.workflowPath}@` }],
+    ['a matching workflow path ref suffix', { path: `${CONTEXT.workflowPath}@${CONTEXT.sourceBranch}` }],
+    ['a mismatched workflow path ref suffix', { path: `${CONTEXT.workflowPath}@main` }],
     [
       'the wrong workflow path with a trusted-looking ref suffix',
       { path: '.github/workflows/attacker.yml@qualification/candidate' },
@@ -138,7 +131,23 @@ describe('trusted Relay package qualification delivery', () => {
     const pages = artifactPages();
     pages[0].artifacts[0] = artifact(10, REQUEST_ARTIFACT_NAME, REQUEST_DIGEST, requestOverrides);
     pages[0].artifacts.push(...extras);
+    pages[0].total_count = pages[0].artifacts.length;
     expect(() => selectQualificationArtifacts(CONTEXT, pages)).toThrow();
+  });
+
+  it('rejects incomplete, extra-page, and over-limit artifact listings', () => {
+    const incomplete = artifactPages({ total_count: 4 });
+    expect(() => selectQualificationArtifacts(CONTEXT, incomplete)).toThrow(/every producer artifact/);
+
+    const extraPage = [...artifactPages(), { total_count: 0, artifacts: [] }];
+    expect(() => selectQualificationArtifacts(CONTEXT, extraPage)).toThrow(/exactly one API page/);
+
+    const overLimit = artifactPages();
+    for (let id = 13; id <= 18; id += 1) {
+      overLimit[0].artifacts.push(artifact(id, `unrelated-${id}`, `sha256:${id.toString(16).repeat(64)}`));
+    }
+    overLimit[0].total_count = overLimit[0].artifacts.length;
+    expect(() => selectQualificationArtifacts(CONTEXT, overLimit)).toThrow(/at most 8 artifacts/);
   });
 
   it('requires the uploaded request payload to exactly match the trusted run and attestation identity', () => {

--- a/tests/fixtures/relay-package-qualification-delivery.test.ts
+++ b/tests/fixtures/relay-package-qualification-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   REQUEST_ARTIFACT_NAME,
   REQUEST_FILE_NAME,
   expectedCloudDispatch,
+  readBoundedRequestFile,
   selectQualificationArtifacts,
   validateCloudDispatchRequest,
   validateRequestArtifactDirectory,
@@ -184,6 +185,42 @@ describe('trusted Relay package qualification delivery', () => {
     await expect(validateRequestArtifactDirectory(symlinkDirectory, CONTEXT, selection)).rejects.toThrow(
       /regular file/
     );
+    await expect(readBoundedRequestFile(path.join(symlinkDirectory, REQUEST_FILE_NAME))).rejects.toThrow();
+  });
+
+  it('closes the no-follow request handle after a successful read', async () => {
+    let closed = false;
+    const handle = {
+      stat: async () => ({ isFile: () => true, size: 3 }),
+      readFile: async () => '{}\n',
+      close: async () => {
+        closed = true;
+      },
+    };
+
+    await expect(readBoundedRequestFile('/not-opened', async () => handle)).resolves.toBe('{}\n');
+    expect(closed).toBe(true);
+  });
+
+  it.each(['stat', 'readFile'])('closes the no-follow request handle after a %s failure', async (failure) => {
+    let closed = false;
+    const handle = {
+      stat: async () => {
+        if (failure === 'stat') throw new Error('stat failed');
+        return { isFile: () => true, size: 10 };
+      },
+      readFile: async () => {
+        throw new Error('read failed');
+      },
+      close: async () => {
+        closed = true;
+      },
+    };
+
+    await expect(readBoundedRequestFile('/not-opened', async () => handle)).rejects.toThrow(
+      new RegExp(`${failure === 'stat' ? 'stat' : 'read'} failed`)
+    );
+    expect(closed).toBe(true);
   });
 
   it('keeps Cloud credentials and dispatch code in a no-checkout trusted second job', async () => {

--- a/tests/fixtures/relay-package-qualification-delivery.test.ts
+++ b/tests/fixtures/relay-package-qualification-delivery.test.ts
@@ -1,0 +1,206 @@
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import {
+  ATTESTATION_ARTIFACT_NAME,
+  REQUEST_ARTIFACT_NAME,
+  REQUEST_FILE_NAME,
+  expectedCloudDispatch,
+  selectQualificationArtifacts,
+  validateCloudDispatchRequest,
+  validateRequestArtifactDirectory,
+  validateWorkflowRunEvent,
+} from '../../scripts/verify-features/relay-package-qualification-delivery.mjs';
+
+const SOURCE_SHA = 'a'.repeat(40);
+const ATTESTATION_DIGEST = `sha256:${'b'.repeat(64)}`;
+const REQUEST_DIGEST = `sha256:${'c'.repeat(64)}`;
+
+function workflowRunEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    repository: { full_name: 'AgentWorkforce/relay' },
+    workflow_run: {
+      id: 123456,
+      run_attempt: 2,
+      name: 'Relay package qualification',
+      path: '.github/workflows/relay-package-qualification.yml',
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      head_branch: 'qualification/relay-11.10.4-cleanroom.20260906.1665.6',
+      head_sha: SOURCE_SHA,
+      head_repository: { full_name: 'AgentWorkforce/relay' },
+      ...overrides,
+    },
+  };
+}
+
+const CONTEXT = validateWorkflowRunEvent(workflowRunEvent());
+
+function artifact(id: number, name: string, digest: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name,
+    expired: false,
+    size_in_bytes: 2048,
+    digest,
+    workflow_run: { id: CONTEXT.runId },
+    ...overrides,
+  };
+}
+
+function artifactPages(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      total_count: 3,
+      artifacts: [
+        artifact(10, REQUEST_ARTIFACT_NAME, REQUEST_DIGEST),
+        artifact(11, ATTESTATION_ARTIFACT_NAME, ATTESTATION_DIGEST),
+        artifact(12, 'relay-package-qualification', `sha256:${'d'.repeat(64)}`),
+      ],
+      ...overrides,
+    },
+  ];
+}
+
+describe('trusted Relay package qualification delivery', () => {
+  it('derives producer identity only from an exact successful qualification workflow run', () => {
+    expect(CONTEXT).toEqual({
+      repository: 'AgentWorkforce/relay',
+      workflowName: 'Relay package qualification',
+      workflowPath: '.github/workflows/relay-package-qualification.yml',
+      runId: 123456,
+      runAttempt: 2,
+      sourceGitSha: SOURCE_SHA,
+      sourceBranch: 'qualification/relay-11.10.4-cleanroom.20260906.1665.6',
+    });
+  });
+
+  it.each([
+    ['main', { head_branch: 'main' }],
+    ['an attacker-controlled nested qualification ref', { head_branch: 'qualification/attacker/payload' }],
+    ['a traversal-shaped qualification ref', { head_branch: 'qualification/../main' }],
+    ['a fork producer', { head_repository: { full_name: 'attacker/relay' } }],
+    ['the wrong workflow path', { path: '.github/workflows/attacker.yml' }],
+    ['a non-manual event', { event: 'push' }],
+    ['an incomplete run', { status: 'in_progress' }],
+    ['a failed run', { conclusion: 'failure' }],
+    ['an invalid SHA', { head_sha: 'not-a-sha' }],
+    ['an invalid run attempt', { run_attempt: 0 }],
+  ])('rejects %s', (_label, overrides) => {
+    expect(() => validateWorkflowRunEvent(workflowRunEvent(overrides))).toThrow();
+  });
+
+  it('rejects a workflow event delivered to the wrong repository', () => {
+    const event = workflowRunEvent();
+    event.repository.full_name = 'attacker/relay';
+    expect(() => validateWorkflowRunEvent(event)).toThrow(/event.repository.full_name/);
+  });
+
+  it('selects one bounded request and attestation artifact from the triggering run', () => {
+    expect(selectQualificationArtifacts(CONTEXT, artifactPages())).toEqual({
+      requestArtifactId: 10,
+      requestArtifactDigest: REQUEST_DIGEST,
+      attestationArtifactDigest: ATTESTATION_DIGEST,
+    });
+  });
+
+  it.each([
+    ['a duplicate request', [artifact(13, REQUEST_ARTIFACT_NAME, REQUEST_DIGEST)]],
+    ['an expired request', [], { expired: true }],
+    ['an oversized request', [], { size_in_bytes: 65 * 1024 }],
+    ['a request from another run', [], { workflow_run: { id: CONTEXT.runId + 1 } }],
+    ['a request without a v4 digest', [], { digest: 'not-a-digest' }],
+  ])('rejects %s artifact', (_label, extras, requestOverrides = {}) => {
+    const pages = artifactPages();
+    pages[0].artifacts[0] = artifact(10, REQUEST_ARTIFACT_NAME, REQUEST_DIGEST, requestOverrides);
+    pages[0].artifacts.push(...extras);
+    expect(() => selectQualificationArtifacts(CONTEXT, pages)).toThrow();
+  });
+
+  it('requires the uploaded request payload to exactly match the trusted run and attestation identity', () => {
+    const selection = selectQualificationArtifacts(CONTEXT, artifactPages());
+    const expected = expectedCloudDispatch(CONTEXT, selection);
+    expect(validateCloudDispatchRequest(structuredClone(expected), CONTEXT, selection)).toEqual(expected);
+
+    const injected = structuredClone(expected);
+    (injected.client_payload as Record<string, unknown>).attacker = true;
+    expect(() => validateCloudDispatchRequest(injected, CONTEXT, selection)).toThrow(/exactly match/);
+
+    const redirected = structuredClone(expected);
+    redirected.client_payload.relay.sourceGitSha = 'e'.repeat(40);
+    expect(() => validateCloudDispatchRequest(redirected, CONTEXT, selection)).toThrow(/exactly match/);
+  });
+
+  it('requires a bounded single-file request artifact with no symlink', async () => {
+    const selection = selectQualificationArtifacts(CONTEXT, artifactPages());
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'relay-cloud-request-'));
+    await writeFile(
+      path.join(directory, REQUEST_FILE_NAME),
+      JSON.stringify(expectedCloudDispatch(CONTEXT, selection))
+    );
+    await expect(validateRequestArtifactDirectory(directory, CONTEXT, selection)).resolves.toEqual(
+      expectedCloudDispatch(CONTEXT, selection)
+    );
+
+    await writeFile(path.join(directory, 'unexpected.txt'), 'unexpected');
+    await expect(validateRequestArtifactDirectory(directory, CONTEXT, selection)).rejects.toThrow(
+      /exactly one/
+    );
+
+    const symlinkDirectory = await mkdtemp(path.join(os.tmpdir(), 'relay-cloud-request-link-'));
+    const targetDirectory = await mkdtemp(path.join(os.tmpdir(), 'relay-cloud-request-target-'));
+    await mkdir(path.join(targetDirectory, 'nested'));
+    await writeFile(
+      path.join(targetDirectory, 'nested', REQUEST_FILE_NAME),
+      JSON.stringify(expectedCloudDispatch(CONTEXT, selection))
+    );
+    await symlink(
+      path.join(targetDirectory, 'nested', REQUEST_FILE_NAME),
+      path.join(symlinkDirectory, REQUEST_FILE_NAME)
+    );
+    await expect(validateRequestArtifactDirectory(symlinkDirectory, CONTEXT, selection)).rejects.toThrow(
+      /regular file/
+    );
+  });
+
+  it('keeps Cloud credentials and dispatch code in a no-checkout trusted second job', async () => {
+    const file = path.resolve('.github/workflows/relay-package-qualification-delivery.yml');
+    const source = await import('node:fs/promises').then(({ readFile }) => readFile(file, 'utf8'));
+    const workflow = parse(source) as Record<string, any>;
+
+    expect(workflow.name).toBe('Relay package qualification Cloud delivery');
+    expect(workflow.on).toEqual({
+      workflow_run: {
+        workflows: ['Relay package qualification'],
+        types: ['completed'],
+      },
+    });
+    expect(workflow.permissions).toEqual({});
+    expect(Object.keys(workflow.jobs)).toEqual(['verify-request', 'deliver-request']);
+
+    const verify = workflow.jobs['verify-request'];
+    expect(verify.if).toBe("${{ github.event.workflow_run.conclusion == 'success' }}");
+    expect(verify.permissions).toEqual({ actions: 'read', contents: 'read' });
+    expect(JSON.stringify(verify)).not.toContain('secrets.');
+    expect(JSON.stringify(verify)).toContain('${{ github.workflow_sha }}');
+    expect(JSON.stringify(verify)).toContain('persist-credentials');
+    expect(JSON.stringify(verify)).toContain('request_artifact_id');
+
+    const deliver = workflow.jobs['deliver-request'];
+    expect(deliver.needs).toBe('verify-request');
+    expect(deliver.permissions).toEqual({});
+    expect(deliver.environment).toBe('snapshot-qualification');
+    expect(JSON.stringify(deliver)).not.toContain('actions/checkout');
+    expect(JSON.stringify(deliver)).not.toContain('scripts/verify-features');
+    expect(JSON.stringify(deliver)).toContain(
+      'actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b'
+    );
+    expect(JSON.stringify(deliver)).toContain('repos/AgentWorkforce/cloud/dispatches');
+    expect(JSON.stringify(deliver)).toContain('permission-contents');
+  });
+});

--- a/tests/relayflows/cases/1676-trusted-cloud-dispatch/case.json
+++ b/tests/relayflows/cases/1676-trusted-cloud-dispatch/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1676-trusted-cloud-dispatch",
+  "kind": "bugfix",
+  "title": "Deliver qualification pointers without exposing Cloud credentials to candidate refs",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1676-trusted-cloud-dispatch/run.mjs"]
+  },
+  "requirements": [],
+  "timeoutSeconds": 120,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "trusted_cloud_dispatcher_missing"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "trusted_dispatch_rejects_attacker_refs"
+    }
+  }
+}

--- a/tests/relayflows/cases/1676-trusted-cloud-dispatch/run.mjs
+++ b/tests/relayflows/cases/1676-trusted-cloud-dispatch/run.mjs
@@ -1,0 +1,207 @@
+import { execFileSync } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CASE_ID = '1676-trusted-cloud-dispatch';
+const COMMAND_TIMEOUT_MS = 30_000;
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = path.resolve(requiredValue('RELAY_PR_PROOF_RESULT_PATH'));
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+  timeout: COMMAND_TIMEOUT_MS,
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const scriptPath = path.join(targetDir, 'scripts/verify-features/relay-package-qualification-delivery.mjs');
+const workflowPath = path.join(targetDir, '.github/workflows/relay-package-qualification-delivery.yml');
+const scriptExists = await exists(scriptPath);
+const workflowExists = await exists(workflowPath);
+
+let outcome;
+let signature;
+let details;
+
+if (!scriptExists && !workflowExists) {
+  outcome = 'bug';
+  signature = 'trusted_cloud_dispatcher_missing';
+  details =
+    'The exact base has no default-branch workflow_run consumer, so it cannot deliver a candidate pointer without putting Cloud credentials in candidate-controlled workflow code.';
+} else if (!scriptExists || !workflowExists) {
+  throw new Error('The target contains only part of the trusted Cloud dispatcher contract.');
+} else {
+  const delivery = await import(`${pathToFileURL(scriptPath).href}?sha=${targetSha}`);
+  const sourceSha = 'a'.repeat(40);
+  const branch = 'qualification/relay-11.10.4-cleanroom.20260906.1665.6';
+  const validEvent = {
+    repository: { full_name: 'AgentWorkforce/relay' },
+    workflow_run: {
+      id: 987654,
+      run_attempt: 2,
+      name: 'Relay package qualification',
+      path: `.github/workflows/relay-package-qualification.yml@${branch}`,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      head_branch: branch,
+      head_sha: sourceSha,
+      head_repository: { full_name: 'AgentWorkforce/relay' },
+    },
+  };
+  const context = delivery.validateWorkflowRunEvent(validEvent);
+
+  for (const [label, mutate] of [
+    ['default branch', (event) => (event.workflow_run.head_branch = 'main')],
+    [
+      'nested attacker branch',
+      (event) => (event.workflow_run.head_branch = 'qualification/attacker/payload'),
+    ],
+    ['traversal branch', (event) => (event.workflow_run.head_branch = 'qualification/../main')],
+    ['fork repository', (event) => (event.workflow_run.head_repository.full_name = 'attacker/relay')],
+    ['wrong workflow path', (event) => (event.workflow_run.path = '.github/workflows/attacker.yml')],
+    ['push event', (event) => (event.workflow_run.event = 'push')],
+    ['failed conclusion', (event) => (event.workflow_run.conclusion = 'failure')],
+  ]) {
+    const attack = structuredClone(validEvent);
+    mutate(attack);
+    assertThrows(() => delivery.validateWorkflowRunEvent(attack), label);
+  }
+
+  const requestDigest = `sha256:${'b'.repeat(64)}`;
+  const attestationDigest = `sha256:${'c'.repeat(64)}`;
+  const artifacts = [
+    {
+      total_count: 3,
+      artifacts: [
+        artifact(101, delivery.REQUEST_ARTIFACT_NAME, requestDigest, context.runId),
+        artifact(102, delivery.ATTESTATION_ARTIFACT_NAME, attestationDigest, context.runId),
+        artifact(103, 'relay-package-qualification', `sha256:${'d'.repeat(64)}`, context.runId),
+      ],
+    },
+  ];
+  const selection = delivery.selectQualificationArtifacts(context, artifacts);
+  const expectedRequest = delivery.expectedCloudDispatch(context, selection);
+
+  const requestDirectory = await mkdtemp(path.join(os.tmpdir(), 'relay-pr1676-request-'));
+  try {
+    await writeFile(
+      path.join(requestDirectory, delivery.REQUEST_FILE_NAME),
+      `${JSON.stringify(expectedRequest)}\n`
+    );
+    await delivery.validateRequestArtifactDirectory(requestDirectory, context, selection);
+
+    const injected = structuredClone(expectedRequest);
+    injected.client_payload.attacker = true;
+    assertThrows(
+      () => delivery.validateCloudDispatchRequest(injected, context, selection),
+      'request payload injection'
+    );
+  } finally {
+    await rm(requestDirectory, { recursive: true, force: true });
+  }
+
+  const workflowSource = await readFile(workflowPath, 'utf8');
+  const deliveryJobOffset = workflowSource.indexOf('\n  deliver-request:');
+  if (deliveryJobOffset < 0) throw new Error('Trusted workflow omits the delivery job.');
+  const verifyJobSource = workflowSource.slice(0, deliveryJobOffset);
+  const deliveryJobSource = workflowSource.slice(deliveryJobOffset);
+  requirePattern(verifyJobSource, /workflow_run:/, 'workflow_run trigger');
+  requirePattern(verifyJobSource, /ref:\s*\$\{\{ github\.workflow_sha \}\}/, 'trusted checkout SHA');
+  requirePattern(verifyJobSource, /persist-credentials:\s*false/, 'credential-free trusted checkout');
+  rejectPattern(verifyJobSource, /secrets\./, 'secret in verifier job');
+  requirePattern(deliveryJobSource, /environment:\s*snapshot-qualification/, 'protected environment');
+  requirePattern(deliveryJobSource, /permission-contents:\s*write/, 'Cloud-only contents permission');
+  requirePattern(
+    deliveryJobSource,
+    /repos\/AgentWorkforce\/cloud\/dispatches/,
+    'static Cloud repository dispatch endpoint'
+  );
+  rejectPattern(deliveryJobSource, /actions\/checkout/, 'checkout in credentialed job');
+  rejectPattern(deliveryJobSource, /scripts\/verify-features/, 'repository script in credentialed job');
+
+  outcome = 'fixed';
+  signature = 'trusted_dispatch_rejects_attacker_refs';
+  details =
+    'The exact head accepted a source-bound request from the canonical producer, rejected attacker/fork/path/event/conclusion substitutions and payload injection, and kept Cloud credentials in a separate no-checkout default-branch job.';
+}
+
+await mkdir(path.dirname(resultPath), { recursive: true });
+await writeFile(
+  resultPath,
+  `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`
+);
+
+function artifact(id, name, digest, runId) {
+  return {
+    id,
+    name,
+    expired: false,
+    size_in_bytes: 2048,
+    digest,
+    workflow_run: { id: runId },
+  };
+}
+
+function assertThrows(operation, label) {
+  let threw = false;
+  try {
+    operation();
+  } catch {
+    threw = true;
+  }
+  if (!threw) throw new Error(`Trusted validator accepted ${label}.`);
+}
+
+function requirePattern(source, pattern, label) {
+  if (!pattern.test(source)) throw new Error(`Trusted workflow omits ${label}.`);
+}
+
+function rejectPattern(source, pattern, label) {
+  if (pattern.test(source)) throw new Error(`Trusted workflow contains ${label}.`);
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+async function exists(file) {
+  try {
+    await access(file);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/tests/relayflows/cases/1676-trusted-cloud-dispatch/run.mjs
+++ b/tests/relayflows/cases/1676-trusted-cloud-dispatch/run.mjs
@@ -57,7 +57,7 @@ if (!scriptExists && !workflowExists) {
       id: 987654,
       run_attempt: 2,
       name: 'Relay package qualification',
-      path: `.github/workflows/relay-package-qualification.yml@${branch}`,
+      path: '.github/workflows/relay-package-qualification.yml',
       event: 'workflow_dispatch',
       status: 'completed',
       conclusion: 'success',
@@ -68,21 +68,34 @@ if (!scriptExists && !workflowExists) {
   };
   const context = delivery.validateWorkflowRunEvent(validEvent);
 
-  for (const [label, mutate] of [
-    ['default branch', (event) => (event.workflow_run.head_branch = 'main')],
+  for (const [label, expectedMessage, mutate] of [
+    ['default branch', /workflow_run\.head_branch/, (event) => (event.workflow_run.head_branch = 'main')],
     [
       'nested attacker branch',
+      /workflow_run\.head_branch/,
       (event) => (event.workflow_run.head_branch = 'qualification/attacker/payload'),
     ],
-    ['traversal branch', (event) => (event.workflow_run.head_branch = 'qualification/../main')],
-    ['fork repository', (event) => (event.workflow_run.head_repository.full_name = 'attacker/relay')],
-    ['wrong workflow path', (event) => (event.workflow_run.path = '.github/workflows/attacker.yml')],
-    ['push event', (event) => (event.workflow_run.event = 'push')],
-    ['failed conclusion', (event) => (event.workflow_run.conclusion = 'failure')],
+    [
+      'traversal branch',
+      /workflow_run\.head_branch/,
+      (event) => (event.workflow_run.head_branch = 'qualification/../main'),
+    ],
+    [
+      'fork repository',
+      /workflow_run\.head_repository\.full_name/,
+      (event) => (event.workflow_run.head_repository.full_name = 'attacker/relay'),
+    ],
+    [
+      'wrong workflow path',
+      /workflow_run\.path/,
+      (event) => (event.workflow_run.path = '.github/workflows/attacker.yml'),
+    ],
+    ['push event', /workflow_run\.event/, (event) => (event.workflow_run.event = 'push')],
+    ['failed conclusion', /workflow_run\.conclusion/, (event) => (event.workflow_run.conclusion = 'failure')],
   ]) {
     const attack = structuredClone(validEvent);
     mutate(attack);
-    assertThrows(() => delivery.validateWorkflowRunEvent(attack), label);
+    assertThrows(() => delivery.validateWorkflowRunEvent(attack), label, expectedMessage);
   }
 
   const requestDigest = `sha256:${'b'.repeat(64)}`;
@@ -112,30 +125,64 @@ if (!scriptExists && !workflowExists) {
     injected.client_payload.attacker = true;
     assertThrows(
       () => delivery.validateCloudDispatchRequest(injected, context, selection),
-      'request payload injection'
+      'request payload injection',
+      /request artifact must exactly match trusted producer identity/
     );
   } finally {
     await rm(requestDirectory, { recursive: true, force: true });
   }
 
   const workflowSource = await readFile(workflowPath, 'utf8');
-  const deliveryJobOffset = workflowSource.indexOf('\n  deliver-request:');
-  if (deliveryJobOffset < 0) throw new Error('Trusted workflow omits the delivery job.');
-  const verifyJobSource = workflowSource.slice(0, deliveryJobOffset);
-  const deliveryJobSource = workflowSource.slice(deliveryJobOffset);
-  requirePattern(verifyJobSource, /workflow_run:/, 'workflow_run trigger');
-  requirePattern(verifyJobSource, /ref:\s*\$\{\{ github\.workflow_sha \}\}/, 'trusted checkout SHA');
-  requirePattern(verifyJobSource, /persist-credentials:\s*false/, 'credential-free trusted checkout');
-  rejectPattern(verifyJobSource, /secrets\./, 'secret in verifier job');
-  requirePattern(deliveryJobSource, /environment:\s*snapshot-qualification/, 'protected environment');
-  requirePattern(deliveryJobSource, /permission-contents:\s*write/, 'Cloud-only contents permission');
-  requirePattern(
-    deliveryJobSource,
-    /repos\/AgentWorkforce\/cloud\/dispatches/,
-    'static Cloud repository dispatch endpoint'
-  );
-  rejectPattern(deliveryJobSource, /actions\/checkout/, 'checkout in credentialed job');
-  rejectPattern(deliveryJobSource, /scripts\/verify-features/, 'repository script in credentialed job');
+  validateTrustedWorkflow(workflowSource);
+  for (const [label, expectedMessage, tampered] of [
+    [
+      'comment-only trusted checkout ref',
+      /trusted checkout inputs mismatch/,
+      replaceExactly(
+        workflowSource,
+        '          ref: ${{ github.workflow_sha }}',
+        '          ref: refs/heads/attacker\n          # ref: ${{ github.workflow_sha }}'
+      ),
+    ],
+    [
+      'comment-only credential disablement',
+      /trusted checkout inputs mismatch/,
+      replaceExactly(
+        workflowSource,
+        '          persist-credentials: false',
+        '          persist-credentials: true\n          # persist-credentials: false'
+      ),
+    ],
+    [
+      'comment-only Cloud permission',
+      /Cloud-only token inputs mismatch/,
+      replaceExactly(
+        workflowSource,
+        '          permission-contents: write',
+        '          permission-contents: read\n          # permission-contents: write'
+      ),
+    ],
+    [
+      'comment-only Cloud dispatch command',
+      /Trusted delivery command omits/,
+      replaceExactly(
+        workflowSource,
+        '          gh api --method POST repos/AgentWorkforce/cloud/dispatches \\',
+        '          # gh api --method POST repos/AgentWorkforce/cloud/dispatches \\'
+      ),
+    ],
+    [
+      'unnamed credentialed checkout step',
+      /Every trusted workflow step must begin with an explicit name/,
+      replaceExactly(
+        workflowSource,
+        '    steps:\n      - name: Mint a Cloud-only token from the trusted dispatcher',
+        '    steps:\n      - uses: actions/checkout@attacker\n      - name: Mint a Cloud-only token from the trusted dispatcher'
+      ),
+    ],
+  ]) {
+    assertThrows(() => validateTrustedWorkflow(tampered), label, expectedMessage);
+  }
 
   outcome = 'fixed';
   signature = 'trusted_dispatch_rejects_attacker_refs';
@@ -160,22 +207,270 @@ function artifact(id, name, digest, runId) {
   };
 }
 
-function assertThrows(operation, label) {
-  let threw = false;
+function assertThrows(operation, label, expectedMessage) {
+  let rejection;
   try {
     operation();
-  } catch {
-    threw = true;
+  } catch (error) {
+    rejection = error;
   }
-  if (!threw) throw new Error(`Trusted validator accepted ${label}.`);
+  if (!rejection) throw new Error(`Trusted validator accepted ${label}.`);
+  const message = rejection instanceof Error ? rejection.message : String(rejection);
+  if (!expectedMessage.test(message)) {
+    throw new Error(`Trusted validator rejected ${label} for the wrong reason: ${JSON.stringify(message)}.`);
+  }
 }
 
-function requirePattern(source, pattern, label) {
-  if (!pattern.test(source)) throw new Error(`Trusted workflow omits ${label}.`);
+function validateTrustedWorkflow(source) {
+  const lines = source.split(/\r?\n/);
+  if (lines.some((line) => line.includes('\t'))) {
+    throw new Error('Trusted workflow must not contain YAML tab indentation.');
+  }
+
+  const trigger = yamlBlock(lines, 'on', 0);
+  const workflowRun = yamlBlock(lines, 'workflow_run', 2, trigger);
+  expectSequence(lines, yamlBlock(lines, 'workflows', 4, workflowRun), 6, ['Relay package qualification']);
+  expectSequence(lines, yamlBlock(lines, 'types', 4, workflowRun), 6, ['completed']);
+  expectScalar(lines, null, 0, 'permissions', '{}');
+
+  const jobs = yamlBlock(lines, 'jobs', 0);
+  const jobNames = directMappingKeys(lines, jobs, 2);
+  expectJsonEqual(jobNames, ['verify-request', 'deliver-request'], 'trusted workflow jobs');
+  const verifyJob = yamlBlock(lines, 'verify-request', 2, jobs);
+  const deliveryJob = yamlBlock(lines, 'deliver-request', 2, jobs);
+
+  expectScalar(lines, verifyJob, 4, 'if', "${{ github.event.workflow_run.conclusion == 'success' }}");
+  const verifyPermissions = yamlBlock(lines, 'permissions', 4, verifyJob);
+  expectJsonEqual(
+    directScalarMapping(lines, verifyPermissions, 6),
+    { actions: 'read', contents: 'read' },
+    'verifier permissions'
+  );
+  const verifySteps = yamlSteps(lines, verifyJob);
+  const checkout = exactStep(verifySteps, 'Check out only the trusted dispatcher source');
+  expectScalar(
+    checkout.lines,
+    checkout.block,
+    8,
+    'uses',
+    'actions/checkout@11d5960a326750d5838078e36cf38b85af677262'
+  );
+  expectJsonEqual(
+    directScalarMapping(checkout.lines, yamlBlock(checkout.lines, 'with', 8, checkout.block), 10),
+    { ref: '${{ github.workflow_sha }}', 'persist-credentials': 'false' },
+    'trusted checkout inputs'
+  );
+  if (blockSource(lines, verifyJob).includes('secrets.')) {
+    throw new Error('Trusted verifier job must not reference secrets.');
+  }
+
+  expectScalar(lines, deliveryJob, 4, 'needs', 'verify-request');
+  expectScalar(lines, deliveryJob, 4, 'permissions', '{}');
+  expectScalar(lines, deliveryJob, 4, 'environment', 'snapshot-qualification');
+  const deliverySteps = yamlSteps(lines, deliveryJob);
+  expectJsonEqual(
+    deliverySteps.map((step) => step.name),
+    ['Mint a Cloud-only token from the trusted dispatcher', 'Deliver the verified immutable pointer'],
+    'credentialed delivery steps'
+  );
+
+  const mint = exactStep(deliverySteps, 'Mint a Cloud-only token from the trusted dispatcher');
+  expectScalar(
+    mint.lines,
+    mint.block,
+    8,
+    'uses',
+    'actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b'
+  );
+  expectJsonEqual(
+    directScalarMapping(mint.lines, yamlBlock(mint.lines, 'with', 8, mint.block), 10),
+    {
+      'app-id': '${{ secrets.GH_APP_PUSHER_ID }}',
+      'private-key': '${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}',
+      owner: 'AgentWorkforce',
+      repositories: 'cloud',
+      'permission-contents': 'write',
+    },
+    'Cloud-only token inputs'
+  );
+
+  const deliver = exactStep(deliverySteps, 'Deliver the verified immutable pointer');
+  expectJsonEqual(
+    directScalarMapping(deliver.lines, yamlBlock(deliver.lines, 'env', 8, deliver.block), 10),
+    {
+      GH_TOKEN: '${{ steps.cloud-token.outputs.token }}',
+      RUN_ID: '${{ needs.verify-request.outputs.run_id }}',
+      RUN_ATTEMPT: '${{ needs.verify-request.outputs.run_attempt }}',
+      SOURCE_GIT_SHA: '${{ needs.verify-request.outputs.source_git_sha }}',
+      ATTESTATION_ARTIFACT_DIGEST: '${{ needs.verify-request.outputs.attestation_artifact_digest }}',
+    },
+    'verified delivery environment'
+  );
+  const run = blockScalar(deliver.lines, deliver.block, 8, 'run');
+  for (const commandLine of [
+    'gh api --method POST repos/AgentWorkforce/cloud/dispatches \\',
+    '  --input "${RUNNER_TEMP}/cloud-request.json"',
+  ]) {
+    if (!run.split('\n').includes(commandLine)) {
+      throw new Error(`Trusted delivery command omits ${JSON.stringify(commandLine)}.`);
+    }
+  }
+  if (
+    deliverySteps.some((step) =>
+      scalarValue(step.lines, step.block, 8, 'uses')?.startsWith('actions/checkout')
+    )
+  ) {
+    throw new Error('Credentialed delivery job must not check out repository code.');
+  }
+  if (deliverySteps.some((step) => blockSource(step.lines, step.block).includes('scripts/verify-features'))) {
+    throw new Error('Credentialed delivery job must not execute repository scripts.');
+  }
 }
 
-function rejectPattern(source, pattern, label) {
-  if (pattern.test(source)) throw new Error(`Trusted workflow contains ${label}.`);
+function yamlBlock(lines, key, indent, parent = { start: -1, end: lines.length }) {
+  const prefix = `${' '.repeat(indent)}${key}:`;
+  const matches = [];
+  for (let index = parent.start + 1; index < parent.end; index += 1) {
+    if (lines[index] === prefix) matches.push(index);
+  }
+  if (matches.length !== 1) {
+    throw new Error(`Trusted workflow must contain exactly one structural ${key} block.`);
+  }
+  const start = matches[0];
+  let end = parent.end;
+  for (let index = start + 1; index < parent.end; index += 1) {
+    if (isIgnorableYamlLine(lines[index])) continue;
+    if (leadingSpaces(lines[index]) <= indent) {
+      end = index;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+function yamlSteps(lines, job) {
+  const steps = yamlBlock(lines, 'steps', 4, job);
+  const starts = [];
+  for (let index = steps.start + 1; index < steps.end; index += 1) {
+    const item = /^ {6}- (\S.*)$/.exec(lines[index]);
+    if (!item) continue;
+    const match = /^name: (\S.*)$/.exec(item[1]);
+    if (!match) throw new Error('Every trusted workflow step must begin with an explicit name.');
+    starts.push({ index, name: match[1] });
+  }
+  return starts.map(({ index, name }, offset) => ({
+    name,
+    lines,
+    block: { start: index, end: starts[offset + 1]?.index ?? steps.end },
+  }));
+}
+
+function exactStep(steps, name) {
+  const matches = steps.filter((step) => step.name === name);
+  if (matches.length !== 1) throw new Error(`Trusted workflow must contain exactly one ${name} step.`);
+  return matches[0];
+}
+
+function directMappingKeys(lines, block, indent) {
+  const matcher = new RegExp(`^ {${indent}}([A-Za-z0-9_-]+):(?: .*)?$`);
+  return lines
+    .slice(block.start + 1, block.end)
+    .map((line) => matcher.exec(line)?.[1])
+    .filter(Boolean);
+}
+
+function directScalarMapping(lines, block, indent) {
+  const entry = new RegExp(`^ {${indent}}([A-Za-z0-9_-]+):(.*)$`);
+  const result = {};
+  for (const line of lines.slice(block.start + 1, block.end)) {
+    const match = entry.exec(line);
+    if (!match) continue;
+    if (match[1] in result) throw new Error(`Trusted workflow duplicates ${match[1]}.`);
+    const value = stripYamlComment(match[2].trimStart());
+    if (!value) throw new Error(`Trusted workflow ${match[1]} must be a direct scalar.`);
+    result[match[1]] = value;
+  }
+  return result;
+}
+
+function expectSequence(lines, block, indent, expected) {
+  const matcher = new RegExp(`^ {${indent}}- (\\S.*)$`);
+  const actual = lines
+    .slice(block.start + 1, block.end)
+    .map((line) => {
+      const value = matcher.exec(line)?.[1];
+      return value === undefined ? undefined : stripYamlComment(value);
+    })
+    .filter(Boolean);
+  expectJsonEqual(actual, expected, 'trusted workflow sequence');
+}
+
+function expectScalar(lines, parent, indent, key, expected) {
+  const actual = scalarValue(lines, parent, indent, key);
+  if (actual !== expected) {
+    throw new Error(`Trusted workflow ${key} must be ${JSON.stringify(expected)}.`);
+  }
+}
+
+function scalarValue(lines, parent, indent, key) {
+  const bounds = parent ?? { start: -1, end: lines.length };
+  const matcher = new RegExp(`^ {${indent}}${escapeRegExp(key)}: (\\S.*)$`);
+  const matches = lines
+    .slice(bounds.start + 1, bounds.end)
+    .map((line) => matcher.exec(line)?.[1])
+    .filter(Boolean);
+  if (matches.length > 1) throw new Error(`Trusted workflow duplicates scalar ${key}.`);
+  return matches[0] === undefined ? undefined : stripYamlComment(matches[0]);
+}
+
+function blockScalar(lines, parent, indent, key) {
+  const marker = scalarValue(lines, parent, indent, key);
+  if (marker !== '|') throw new Error(`Trusted workflow ${key} must be a literal block scalar.`);
+  const start = lines.findIndex(
+    (line, index) => index > parent.start && index < parent.end && line === `${' '.repeat(indent)}${key}: |`
+  );
+  const content = [];
+  for (let index = start + 1; index < parent.end; index += 1) {
+    if (lines[index] && leadingSpaces(lines[index]) <= indent) break;
+    content.push(lines[index].startsWith(' '.repeat(indent + 2)) ? lines[index].slice(indent + 2) : '');
+  }
+  return content.join('\n');
+}
+
+function blockSource(lines, block) {
+  return lines.slice(block.start, block.end).join('\n');
+}
+
+function leadingSpaces(line) {
+  return /^ */.exec(line)[0].length;
+}
+
+function isIgnorableYamlLine(line) {
+  return /^\s*(?:#.*)?$/.test(line);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripYamlComment(value) {
+  return value.replace(/\s+#.*$/, '').trimEnd();
+}
+
+function expectJsonEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}.`
+    );
+  }
+}
+
+function replaceExactly(source, before, after) {
+  const first = source.indexOf(before);
+  if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
+    throw new Error(`Trusted workflow mutation requires exactly one ${JSON.stringify(before)}.`);
+  }
+  return `${source.slice(0, first)}${after}${source.slice(first + before.length)}`;
 }
 
 function requiredValue(name) {


### PR DESCRIPTION
## Outcome

Prevent an arbitrary qualification ref from receiving or rewriting a Cloud-scoped GitHub App token while preserving authenticated producer delivery.

## Scope

- add a default-branch workflow_run consumer with no qualification-ref checkout;
- validate the exact producer workflow identity, event, repository, branch, conclusion, run identity, bounded complete artifact listing, v4 digests, and request payload;
- mint the Cloud-only token only in a separate no-checkout job protected by snapshot-qualification;
- include attacker-ref, duplicate, expired, oversized, wrong-run, malformed-digest, payload-injection, symlink, no-follow, handle-cleanup, comment-impostor, and hidden-step negatives.

No candidate or Fleet qualification is claimed by this prerequisite.

## Validation

- focused trusted-delivery contract: 30/30 passed
- fixture suite: 163 passed, 6 skipped
- exact base RelayFlow arm: bug / trusted_cloud_dispatcher_missing
- exact head RelayFlow arm: fixed / trusted_dispatch_rejects_attacker_refs
- serial full Vitest: 2403 passed, 22 skipped
- npm run build:core: passed
- npm run typecheck: passed
- actionlint: passed
- Prettier and git diff --check: passed

Part of #1676; #1665 will next switch the producer to this request-artifact contract.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1676-trusted-cloud-dispatch` <!-- relay-pr-proof:case -->