### PR TITLE
fix(broker): catch a wrapped terminal delivery error, and de-flake its test

### DIFF
--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -190,6 +190,78 @@ async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry 
     registry
 }
 
+/// A worker that is present in the registry but whose sole stdin writer is
+/// already gone: `command_rx` is dropped, so `send_to_worker`'s queue send
+/// fails immediately and `deliver()` surfaces the same
+/// `failed writing frame to worker '<name>'` error a live writer reports on a
+/// write fault. Deterministic on every attempt, every platform, every profile.
+///
+/// This replaces "SIGKILL a real `cat` child and hope the next write to its
+/// stdin returns EPIPE" (relay#980). That fixture raced: on macOS release
+/// builds under parallel load the writes to the dead child's pipe can keep
+/// SUCCEEDING. Because the retry cap gates on consecutive `failed_attempts`
+/// — reset to 0 by every successful write — while `attempts` only ever
+/// increments, a run where the writes succeed marches `attempts` straight
+/// past the cap and trips the test's own bound.
+///
+/// The child here is left alive deliberately. Its liveness is irrelevant to
+/// the path under test: the write fails at the command channel, before any
+/// file descriptor is touched. `cleanup_worker_registry` reaps it.
+async fn make_worker_registry_with_unwritable_worker(name: &str) -> WorkerRegistry {
+    let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+    let mut registry = WorkerRegistry::new(
+        tx,
+        Vec::new(),
+        PathBuf::from("/tmp/agent-relay-broker-tests"),
+        Instant::now(),
+    );
+    let child = tokio::process::Command::new("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("test worker process should spawn");
+    let generation = Uuid::new_v4();
+    let (command_tx, command_rx) = mpsc::channel(128);
+    // The whole point: no writer task, and the receiver is dropped rather than
+    // leaked, so every send fails closed instead of hanging or succeeding.
+    drop(command_rx);
+    registry.workers.insert(
+        WorkerName::from(name),
+        WorkerHandle {
+            generation,
+            spec: AgentSpec {
+                name: WorkerName::from(name),
+                runtime: AgentRuntime::Pty,
+                provider: None,
+                cli: Some("cat".to_string()),
+                session_id: None,
+                harness_config: None,
+                model: None,
+                cwd: None,
+                team: None,
+                shadow_of: None,
+                shadow_mode: None,
+                args: Vec::new(),
+                channels: Vec::new(),
+                restart_policy: None,
+            },
+            parent: None,
+            workspace_id: Some(WorkspaceId::new("ws_demo")),
+            child,
+            command_tx,
+            harness_pid: None,
+            spawned_at: Instant::now(),
+            ready_at: Some(Instant::now()),
+            last_activity_at: Instant::now(),
+            context_budget_pct: None,
+            state: AgentWorkState::Working,
+            exit_reason: None,
+        },
+    );
+    registry
+}
+
 async fn cleanup_worker_registry(mut registry: WorkerRegistry) {
     for handle in registry.workers.values_mut() {
         let _ = handle.child.start_kill();
@@ -2635,15 +2707,7 @@ async fn initial_delivery_failure_stays_owned_until_dead_lettered() {
 #[tokio::test]
 async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
     let worker_name = "worker-blip";
-    let mut workers = make_worker_registry_with_worker(worker_name).await;
-    {
-        let handle = workers
-            .workers
-            .get_mut(worker_name)
-            .expect("present worker handle");
-        let _ = handle.child.start_kill();
-        let _ = handle.child.wait().await;
-    }
+    let mut workers = make_worker_registry_with_unwritable_worker(worker_name).await;
     assert!(
         workers.has_worker(worker_name),
         "transient-blip regression must keep the recipient present"
@@ -2690,23 +2754,21 @@ async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
                     unreachable!();
                 };
                 assert_eq!(pending.attempts, MAX_DELIVERY_RETRIES);
-                // Some platforms can accept a final pipe write after the child exits,
-                // so terminal failure may arrive on the immediate post-cap check.
-                assert!(
-                    retry_index >= MAX_DELIVERY_RETRIES,
-                    "delivery should not fail before the retry cap is exhausted"
+                // Every attempt now fails, so the terminal failure lands on
+                // exactly the capped attempt: never early, and never deferred
+                // to the post-cap check the old pipe race allowed for.
+                assert_eq!(
+                    retry_index, MAX_DELIVERY_RETRIES,
+                    "delivery must fail on exactly the capped attempt"
                 );
                 final_outcome = Some(outcome);
                 break;
             }
             Ok(DeliveryAttemptOutcome::Attempted { attempts, .. }) => {
-                assert!(
-                    attempts <= MAX_DELIVERY_RETRIES,
-                    "retry attempts must stay within the retry cap"
-                );
-                assert!(
-                    retry_index <= MAX_DELIVERY_RETRIES,
-                    "the retry after the cap should return a terminal failure"
+                panic!(
+                    "a worker with no stdin writer must never accept a delivery, \
+                     but retry {retry_index} reported success at {attempts} \
+                     attempts (cap {MAX_DELIVERY_RETRIES})"
                 );
             }
             Ok(DeliveryAttemptOutcome::Noop) => {
@@ -2763,8 +2825,8 @@ async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
     );
     let last_error = frame.payload["lastError"].as_str().unwrap_or_default();
     assert!(
-        last_error.contains("failed writing frame to worker 'worker-blip'")
-            || last_error.contains("max delivery retries exceeded")
+        last_error.contains("failed writing frame to worker 'worker-blip'"),
+        "the terminal event must carry the real write error, not a placeholder: {last_error}"
     );
     assert!(
         frame.payload.get("last_error").is_none(),
@@ -2785,6 +2847,8 @@ async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
     let entry = dead_letters.get("del_blip").expect("dead letter by id");
     assert_eq!(entry.delivery.body, "transient auth blip");
     assert_eq!(entry.attempts, MAX_DELIVERY_RETRIES);
+
+    cleanup_worker_registry(workers).await;
 }
 
 #[tokio::test]

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -130,11 +130,19 @@ async fn make_worker_registry_with_worker(name: &str) -> WorkerRegistry {
     registry
 }
 
-/// Shared construction for the two deterministic delivery fixtures below.
-/// Spawns the `cat` stand-in, registers a `WorkerHandle` for it, and hands the
-/// command receiver back to the caller. What happens to that receiver is the
-/// ONLY axis on which those fixtures differ, so nothing else is duplicated and
-/// a future `WorkerHandle` field cannot drift between them.
+/// Shared construction for the deterministic delivery fixtures. Spawns the
+/// `cat` stand-in, registers a `WorkerHandle` for it, and hands the command
+/// receiver back to the caller. No writer task is ever spawned, so what the
+/// caller does with that receiver is the ONLY axis of behaviour — and nothing
+/// else is duplicated, so a future `WorkerHandle` field cannot drift.
+///
+/// - **Keep it bound** for a stalled handoff: the receiver stays alive, so the
+///   send always succeeds and the completion wait never returns on its own,
+///   modelling a handoff that outlives `retry_interval` with no timing race.
+///   The binding must live as long as the test body — releasing it early turns
+///   a hang into a failure, which is the opposite fixture.
+/// - **Drop it** for an unwritable worker: see
+///   [`make_worker_registry_with_unwritable_worker`].
 async fn make_worker_registry_with_fixture_worker(
     name: &str,
 ) -> (WorkerRegistry, mpsc::Receiver<WorkerWriteCommand>) {
@@ -149,6 +157,11 @@ async fn make_worker_registry_with_fixture_worker(
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        // Dropping a tokio `Child` does NOT kill the process. These fixtures
+        // leave the child running, so an assertion that panics before
+        // `cleanup_worker_registry` would otherwise strand a live `cat` for
+        // the rest of the run. Same idiom as spawner.rs and codex_session.rs.
+        .kill_on_drop(true)
         .spawn()
         .expect("test worker process should spawn");
     let generation = Uuid::new_v4();
@@ -189,20 +202,6 @@ async fn make_worker_registry_with_fixture_worker(
         },
     );
     (registry, command_rx)
-}
-
-/// A worker whose command channel accepts frames but never completes them —
-/// no writer task ever drains `command_rx`, so `deliver()` hangs forever.
-/// Models a handoff that outlives `retry_interval` deterministically (no
-/// timing race): the receiver stays alive (a dropped one would fail the
-/// send instead of hanging it), so the send always succeeds and the
-/// subsequent completion wait never returns on its own.
-async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry {
-    let (registry, command_rx) = make_worker_registry_with_fixture_worker(name).await;
-    // Deliberately leaked rather than dropped: keeps the receiver alive so
-    // sends succeed, with nothing ever draining it.
-    std::mem::forget(command_rx);
-    registry
 }
 
 /// A worker that is present in the registry but whose sole stdin writer is
@@ -1695,7 +1694,12 @@ fn withheld_ack_for(delivery_id: &str) -> Deliver {
 // a later successful retry's echo would then have had nothing to resolve.
 #[tokio::test]
 async fn timed_out_initial_handoff_still_registers_its_withheld_fleet_ack() {
-    let mut registry = make_worker_registry_with_stalled_worker("worker-a").await;
+    // The receiver must stay bound for the whole test body: holding it is what
+    // makes the handoff hang instead of fail. The fixture previously retained
+    // it by leaking, which kept the queued frame and its completion channel
+    // alive for the life of the process.
+    let (mut registry, _stalled_command_rx) =
+        make_worker_registry_with_fixture_worker("worker-a").await;
     let deliver = fleet_deliver(1);
     let msg = held_fleet_message(&deliver);
     let mut pending_deliveries = HashMap::new();

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -20,6 +20,7 @@ use crate::protocol::{
 use crate::telemetry::TelemetryClient;
 use crate::worker::{
     spawn_worker_writer, AgentWorkState, WorkerEvent, WorkerHandle, WorkerRegistry,
+    WorkerWriteCommand,
 };
 use crate::{
     broker::injection_format::format_injection,
@@ -129,13 +130,14 @@ async fn make_worker_registry_with_worker(name: &str) -> WorkerRegistry {
     registry
 }
 
-/// A worker whose command channel accepts frames but never completes them —
-/// no writer task ever drains `command_rx`, so `deliver()` hangs forever.
-/// Models a handoff that outlives `retry_interval` deterministically (no
-/// timing race): the receiver stays alive (a dropped one would fail the
-/// send instead of hanging it), so the send always succeeds and the
-/// subsequent completion wait never returns on its own.
-async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry {
+/// Shared construction for the two deterministic delivery fixtures below.
+/// Spawns the `cat` stand-in, registers a `WorkerHandle` for it, and hands the
+/// command receiver back to the caller. What happens to that receiver is the
+/// ONLY axis on which those fixtures differ, so nothing else is duplicated and
+/// a future `WorkerHandle` field cannot drift between them.
+async fn make_worker_registry_with_fixture_worker(
+    name: &str,
+) -> (WorkerRegistry, mpsc::Receiver<WorkerWriteCommand>) {
     let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
     let mut registry = WorkerRegistry::new(
         tx,
@@ -150,10 +152,9 @@ async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry 
         .spawn()
         .expect("test worker process should spawn");
     let generation = Uuid::new_v4();
+    // No writer task is ever spawned for these fixtures: the caller decides
+    // whether a send hangs (receiver kept alive) or fails closed (dropped).
     let (command_tx, command_rx) = mpsc::channel(128);
-    // Deliberately leaked, not spawned as a writer: keeps the receiver alive
-    // (so sends succeed) without anything ever draining it.
-    std::mem::forget(command_rx);
     registry.workers.insert(
         WorkerName::from(name),
         WorkerHandle {
@@ -187,6 +188,20 @@ async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry 
             exit_reason: None,
         },
     );
+    (registry, command_rx)
+}
+
+/// A worker whose command channel accepts frames but never completes them —
+/// no writer task ever drains `command_rx`, so `deliver()` hangs forever.
+/// Models a handoff that outlives `retry_interval` deterministically (no
+/// timing race): the receiver stays alive (a dropped one would fail the
+/// send instead of hanging it), so the send always succeeds and the
+/// subsequent completion wait never returns on its own.
+async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry {
+    let (registry, command_rx) = make_worker_registry_with_fixture_worker(name).await;
+    // Deliberately leaked rather than dropped: keeps the receiver alive so
+    // sends succeed, with nothing ever draining it.
+    std::mem::forget(command_rx);
     registry
 }
 
@@ -204,61 +219,14 @@ async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry 
 /// increments, a run where the writes succeed marches `attempts` straight
 /// past the cap and trips the test's own bound.
 ///
-/// The child here is left alive deliberately. Its liveness is irrelevant to
-/// the path under test: the write fails at the command channel, before any
-/// file descriptor is touched. `cleanup_worker_registry` reaps it.
+/// The child is left alive deliberately. Its liveness is irrelevant to the
+/// path under test: the write fails at the command channel, before any file
+/// descriptor is touched. `cleanup_worker_registry` reaps it.
 async fn make_worker_registry_with_unwritable_worker(name: &str) -> WorkerRegistry {
-    let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
-    let mut registry = WorkerRegistry::new(
-        tx,
-        Vec::new(),
-        PathBuf::from("/tmp/agent-relay-broker-tests"),
-        Instant::now(),
-    );
-    let child = tokio::process::Command::new("cat")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("test worker process should spawn");
-    let generation = Uuid::new_v4();
-    let (command_tx, command_rx) = mpsc::channel(128);
-    // The whole point: no writer task, and the receiver is dropped rather than
-    // leaked, so every send fails closed instead of hanging or succeeding.
+    let (registry, command_rx) = make_worker_registry_with_fixture_worker(name).await;
+    // The whole point: dropped rather than leaked, so every send fails closed
+    // instead of hanging or succeeding.
     drop(command_rx);
-    registry.workers.insert(
-        WorkerName::from(name),
-        WorkerHandle {
-            generation,
-            spec: AgentSpec {
-                name: WorkerName::from(name),
-                runtime: AgentRuntime::Pty,
-                provider: None,
-                cli: Some("cat".to_string()),
-                session_id: None,
-                harness_config: None,
-                model: None,
-                cwd: None,
-                team: None,
-                shadow_of: None,
-                shadow_mode: None,
-                args: Vec::new(),
-                channels: Vec::new(),
-                restart_policy: None,
-            },
-            parent: None,
-            workspace_id: Some(WorkspaceId::new("ws_demo")),
-            child,
-            command_tx,
-            harness_pid: None,
-            spawned_at: Instant::now(),
-            ready_at: Some(Instant::now()),
-            last_activity_at: Instant::now(),
-            context_budget_pct: None,
-            state: AgentWorkState::Working,
-            exit_reason: None,
-        },
-    );
     registry
 }
 
@@ -2824,9 +2792,10 @@ async fn delivery_retry_transient_blip_emits_failed_event_for_present_worker() {
         Some(u64::from(MAX_DELIVERY_RETRIES))
     );
     let last_error = frame.payload["lastError"].as_str().unwrap_or_default();
-    assert!(
-        last_error.contains("failed writing frame to worker 'worker-blip'"),
-        "the terminal event must carry the real write error, not a placeholder: {last_error}"
+    assert_eq!(
+        last_error, "failed writing frame to worker 'worker-blip'",
+        "the terminal event must carry the real write error verbatim, not a \
+         wrapped or substituted one"
     );
     assert!(
         frame.payload.get("last_error").is_none(),

--- a/tests/relayflows/cases/1688-delivery-failure-error-fidelity/case.json
+++ b/tests/relayflows/cases/1688-delivery-failure-error-fidelity/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1688-delivery-failure-error-fidelity",
+  "kind": "bugfix",
+  "title": "Terminal message_delivery_failed must carry the write error verbatim, not a wrapped or substituted one",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1688-delivery-failure-error-fidelity/run.mjs"]
+  },
+  "timeoutSeconds": 1800,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "wrapped_delivery_error_undetected"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "wrapped_delivery_error_detected"
+    }
+  }
+}

--- a/tests/relayflows/cases/1688-delivery-failure-error-fidelity/run.mjs
+++ b/tests/relayflows/cases/1688-delivery-failure-error-fidelity/run.mjs
@@ -1,0 +1,164 @@
+// RelayFlow proof case 1688-delivery-failure-error-fidelity.
+//
+// THE BUG (present on base, fixed on head)
+//
+// When a delivery exhausts its retry cap, the broker emits a terminal
+// `message_delivery_failed` event carrying `lastError`. That field is the only
+// machine-readable account of WHY the delivery died: it is what reaches the
+// dead-letter store, `/health` consumers and the orchestrator. On base the
+// broker's own suite only asserted that `lastError` *contains* an expected
+// fragment, so an error that had been wrapped or substituted somewhere in the
+// write path still satisfied it. A terminal event could therefore report a
+// different error than the one that actually killed the delivery, and nothing
+// in the suite would notice. Head compares the value exactly.
+//
+// WHY THIS CASE IS SHAPED AS MUTATION DETECTION
+//
+// `crates/broker/src/runtime/tests.rs` is behind `#[cfg(test)]`
+// (`crates/broker/src/runtime/mod.rs:89`), so it is compiled out of the shipped
+// broker. Base and head therefore produce functionally identical broker
+// binaries, and no case that merely RUNS the broker can distinguish them —
+// running one would prove nothing about this change no matter what it observed.
+// The honest observable is the suite's detection power, so both arms inject the
+// same defect into the write path and ask the target's own test whether it
+// notices.
+//
+// The injected defect is faithful to the bug, not a strawman: the message still
+// CONTAINS the expected fragment and only stops being EQUAL to it. That is
+// precisely the class base could not see.
+//
+// FAIL-CLOSED
+//
+// Only two outcomes are evidence: the target's test passing with the defect
+// live (bug), or failing on that exact comparison (fixed). A compile error, a
+// missing toolchain, a failure at any other assertion, or an unparseable run
+// throws instead — a crash must never be laundered into a proof.
+
+import { execFile, execFileSync } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const CASE_ID = '1688-delivery-failure-error-fidelity';
+const TEST_NAME = 'runtime::tests::delivery_retry_transient_blip_emits_failed_event_for_present_worker';
+// The context applied to every broker->worker write failure. All three sites
+// must be rewritten: base surfaces this error from the completion path and head
+// from the queue-send path, so mutating only one would leave the defect inert on
+// one arm and the comparison would be meaningless.
+const WRITE_ERROR_CONTEXT = `format!("failed writing frame to worker '{name}'")`;
+const WRAPPED_WRITE_ERROR_CONTEXT = `format!("failed writing frame to worker '{name}' (queue closed)")`;
+const EXPECTED_CONTEXT_SITES = 3;
+const DETECTION_MARKER = 'the terminal event must carry the real write error verbatim';
+
+const arm = required('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const targetDir = required('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = required('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = required('RELAY_PR_PROOF_RESULT_PATH');
+
+// Provenance: the code under test must be the exact SHA for this arm, and this
+// script must be the one committed to the PR head, not one found in the target.
+const expectedSha =
+  arm === 'base' ? required('RELAY_PR_PROOF_BASE_SHA') : required('RELAY_PR_PROOF_HEAD_SHA');
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The case runner must execute from the exact-head harness checkout.');
+}
+
+const workerPath = path.join(targetDir, 'crates', 'broker', 'src', 'worker.rs');
+const original = await readFile(workerPath, 'utf8');
+const sites = original.split(WRITE_ERROR_CONTEXT).length - 1;
+if (sites !== EXPECTED_CONTEXT_SITES) {
+  throw new Error(
+    `Expected ${EXPECTED_CONTEXT_SITES} write-error context sites in worker.rs, found ${sites}. ` +
+      'The defect could not be injected identically on both arms, so this run is not evidence.'
+  );
+}
+await writeFile(workerPath, original.split(WRITE_ERROR_CONTEXT).join(WRAPPED_WRITE_ERROR_CONTEXT), 'utf8');
+
+const run = await runTest();
+const { outcome, signature, details } = classify(run);
+
+await mkdir(path.dirname(resultPath), { recursive: true });
+await writeFile(
+  resultPath,
+  `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+  'utf8'
+);
+
+async function runTest() {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'cargo',
+      ['test', '-p', 'agent-relay-broker', '--lib', TEST_NAME, '--', '--exact'],
+      {
+        cwd: targetDir,
+        env: { ...process.env, AGENT_RELAY_TELEMETRY_DISABLED: '1', CARGO_TERM_COLOR: 'never' },
+        maxBuffer: 64 * 1024 * 1024,
+      }
+    );
+    return { exitCode: 0, output: `${stdout}\n${stderr}` };
+  } catch (error) {
+    if (typeof error.code !== 'number') {
+      throw new Error(`cargo test could not be run (${error.code ?? error.message}).`);
+    }
+    return { exitCode: error.code, output: `${error.stdout ?? ''}\n${error.stderr ?? ''}` };
+  }
+}
+
+function classify({ exitCode, output }) {
+  const ran = /^running \d+ tests?$/m.test(output);
+  if (!ran) {
+    throw new Error(`The target's test never ran, so nothing was observed. Tail:\n${output.slice(-1500)}`);
+  }
+  if (exitCode === 0) {
+    if (!/test result: ok\. 1 passed; 0 failed/.test(output)) {
+      throw new Error(`Unrecognised passing summary. Tail:\n${output.slice(-1500)}`);
+    }
+    return {
+      outcome: 'bug',
+      signature: 'wrapped_delivery_error_undetected',
+      details:
+        'With a wrapped lastError live in every broker->worker write path, the target suite ' +
+        'still passed: a terminal message_delivery_failed event may report an error other ' +
+        'than the one that killed the delivery, undetected.',
+    };
+  }
+  if (!output.includes(DETECTION_MARKER)) {
+    throw new Error(
+      `The test failed, but not on the terminal lastError comparison, so this is not evidence ` +
+        `of the declared fix. Tail:\n${output.slice(-1500)}`
+    );
+  }
+  return {
+    outcome: 'fixed',
+    signature: 'wrapped_delivery_error_detected',
+    details:
+      'The same wrapped lastError is now caught: the target suite fails on the exact ' +
+      'comparison of the terminal message_delivery_failed error, so a wrapped or substituted ' +
+      'write error can no longer reach the wire unnoticed.',
+  };
+}
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}


### PR DESCRIPTION
Closes the test-fixture half of #980.

> **Status:** rebased onto `5b1dc5c1d` (#1667). Both review threads (CodeRabbit,
> cubic) addressed in `7e770fedb`. Full broker suite green: 1045 passed, 0 failed.

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1688-delivery-failure-error-fidelity` <!-- relay-pr-proof:case -->

## What was wrong

`delivery_retry_transient_blip_emits_failed_event_for_present_worker` SIGKILLed a
real `cat` child and then relied on the next write to its stdin returning EPIPE.
On macOS release builds under parallel load, those writes can keep **succeeding**.

When they do, the test fails *itself*. The retry cap gates on consecutive
`failed_attempts`, which every successful write resets to `0`, while `attempts`
only ever increments. Once any write fails the writer task breaks and every later
send fails too — so for the `Attempted` arm to be reached on the final iteration,
**all 11** writes must have succeeded, marching `attempts` to 11 against a cap of
10 and tripping the test's own bound.

This is #980, open since 2026-05-25, which names this test by name. It fired
**four times on 2026-09-06 alone**, across three unrelated branches:

| head | branch | job | time |
|---|---|---|---|
| `021f7f572` | `chore/relay-cleanroom-verification` (#1665) | 101468170261 | 10:03Z |
| `79d0fbf6c` | `fix/relay-1671-release` | 101489498552 | 12:57Z |
| `69f0504035` | `chore/relay-cleanroom-verification` (#1665) | 101499652705 | 14:07Z |
| `27ab0d726` | `fix/broker-node-delivery-introspection` | 101500434162 | 14:21Z |

It is **release-profile only** — in each case the plain `cargo test` step passed
and only `cargo test --release` failed.

## What this changes

A new fixture, `make_worker_registry_with_unwritable_worker`: the worker is
present in the registry but has no stdin writer at all. `command_rx` is dropped,
so the queue send fails immediately and `deliver()` surfaces the same
`failed writing frame to worker '<name>'` error a live writer reports on a write
fault. No OS, timing, profile or load dependence remains.

This follows the existing `make_worker_registry_with_stalled_worker` idiom in the
same file — construct a deterministic `WorkerHandle` rather than race a real
process.

**Every assertion is tightened, none relaxed:**

- terminal failure must land on **exactly** the capped attempt (was `>=`, which
  existed only to tolerate the pipe race)
- the `Attempted` arm is now unreachable and panics, instead of asserting a bound
- the wire `lastError` must carry the real write error — the
  `|| "max delivery retries exceeded"` alternative is gone
- the fixture child is reaped via `cleanup_worker_registry`

**`crates/broker/src/runtime/delivery.rs` is not modified and
`MAX_DELIVERY_RETRIES` is unchanged.** The cap was never the problem; it does
exactly what it says on the consecutive-failure path.

## Tests bite

Mutating the guarded code in `delivery.rs` (both reverted; `delivery.rs` is
pristine in this PR):

**1. Cap boundary off-by-one** — `failed_attempts >= MAX` → `>`:

```
thread 'runtime::tests::delivery_retry_transient_blip_emits_failed_event_for_present_worker'
panicked at crates/broker/src/runtime/tests.rs:2743:17:
the final bounded retry should return a terminal failure
test result: FAILED. 0 passed; 1 failed
```

**2. Consecutive-failure counter stalls** — `failed_attempts += 1` → `= 0`:

```
thread 'runtime::tests::delivery_retry_transient_blip_emits_failed_event_for_present_worker'
panicked at crates/broker/src/runtime/tests.rs:2743:17:
the final bounded retry should return a terminal failure
test result: FAILED. 0 passed; 1 failed
```

**3. Terminal wire error wrapped** — `worker.rs` queue-send context gains a
suffix, so the message still *contains* the expected fragment but no longer
*equals* it. This slips past every `contains` check left in the test, including
the one in the `Noop` arm, and is caught only by the exact comparison added in
review:

```
panicked at crates/broker/src/runtime/tests.rs:2795:5:
assertion `left == right` failed: the terminal event must carry the real write error verbatim, not a wrapped or substituted one
  left: "failed writing frame to worker 'worker-blip' (queue closed)"
 right: "failed writing frame to worker 'worker-blip'"
```

`worker.rs` is unmodified in this PR; the mutation was reverted.

## Determinism evidence, and its limits

Release profile, the one that flaked:

- **100/100** single-test runs clean
- **10/10** full broker suite runs clean

Stated honestly: these numbers do **not** prove the flake is gone, because I was
never able to reproduce it locally in the first place — 35 release full-suite runs
on the old fixture at `69f0504035` produced 0 occurrences. An idle Apple Silicon
box is faster and far less contended than a GitHub macOS runner. The argument for
this fix is **structural**, not statistical: the write now fails at an in-process
channel with no file descriptor, no signal delivery and no scheduler involved, so
there is no longer a timing-dependent branch to lose. The runs are consistency
evidence on top of that, not the proof.

## Trade-off a reviewer should weigh: this removes an accidental detector

The flaky assertion was, on the runs where it tripped, **observing a real defect**:
a delivery whose writes succeed but which is never ACKed does march `attempts`
past the cap, forever, and is never dead-lettered. Making the fixture deterministic
means that behaviour is no longer detected by anything.

That is filed separately as **#1686**, with the reasoning and the reason it may
bear on the Monday "idle agent stops receiving" risk. It needs its own
deterministic test whichever way it is fixed — it must not be assumed covered
because this test used to trip on it by accident. I did not add a characterisation
test for it here, because pinning the current behaviour would cement the bug.

## RelayFlow proof case

Earlier revisions of this PR declared `non-functional` / `n/a`. That was rejected,
and correctly: `crates/broker/src/runtime/tests.rs` matches none of
`NON_RUNTIME_PATH_PATTERNS` (`^tests/` is anchored at the repo root), so a test
file under `crates/` counts as a runtime path however test-only the change is.
Verified by running the classifier directly — `runtimeSurfaceChanged()` returns
`true` for this file list.

Now declared `bugfix` with case **`1688-delivery-failure-error-fidelity`**.

The proven bug is real and is one this PR fixes. On a terminal delivery failure
the broker emits `message_delivery_failed` carrying `lastError` — the only
machine-readable account of what killed the delivery, and what reaches the
dead-letter store and the orchestrator. Base asserted only that it *contains* an
expected fragment, so an error wrapped or substituted anywhere in the write path
still satisfied it. Head compares it exactly.

**Why it is shaped as mutation detection.** `runtime/tests.rs` is behind
`#[cfg(test)]` (`runtime/mod.rs:89`), so it is compiled out of the shipped
broker. Base and head produce functionally identical binaries, and a case that
merely *runs* the broker would prove nothing about this change whatever it
observed. So both arms inject the same defect into the write path and ask the
target's own test whether it notices. The defect is faithful rather than a
strawman: the message still CONTAINS the fragment and only stops being EQUAL to
it — exactly the class base could not see.

All three write-error context sites are rewritten, not one. Base surfaces this
error from the completion path and head from the queue-send path, so mutating a
single site leaves the defect inert on one arm. A first draft did exactly that
and produced a base "pass" that proved nothing; the runner now asserts it finds
all three and refuses to run otherwise.

**Fail-closed.** Only two results count as evidence — the target's test passing
with the defect live (`bug`), or failing on that exact comparison (`fixed`). A
missing toolchain, a compile error, a failure at any other assertion, or an
unparseable run throws instead. A crash must never be laundered into a proof.

Both arms were executed locally against real checkouts before pushing:

```
base 5b1dc5c1d -> {"outcome":"bug",  "signature":"wrapped_delivery_error_undetected"}
head 3412db6f5 -> {"outcome":"fixed","signature":"wrapped_delivery_error_detected"}
```

`NON_RUNTIME_PATH_PATTERNS` and the proof workflow are untouched.

## Not in the changelog

Deliberate. Per `CLAUDE.md` the root changelog is the user-facing release
narrative; a test-fixture determinism fix changes nothing a user of `agent-relay`
can observe.

Refs #980
Refs #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LAYEYtXwYhV9MdfCPguQr
