### PR TITLE
fix(pr-proof): require a proof when the changed-file list is unreadable

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json
@@ -1,0 +1,491 @@
+{
+  "version": "1.0.0",
+  "id": "50e106cb-ac6a-4e53-b765-2d2793de3351",
+  "timestamp": "2026-09-08T14:22:59.839Z",
+  "trajectory": "traj_udk54gcrs0ot",
+  "files": [
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 5,
+              "end_line": 13,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 16,
+              "end_line": 22,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/relaycast/auth.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 729,
+              "end_line": 765,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 768,
+              "end_line": 783,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 913,
+              "end_line": 1033,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 1195,
+              "end_line": 1219,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 1235,
+              "end_line": 1245,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 1536,
+              "end_line": 1544,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 1739,
+              "end_line": 2159,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/brand/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/broker-darwin-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/broker-darwin-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/broker-linux-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/broker-linux-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/broker-win32-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 43,
+              "end_line": 56,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cloud/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 62,
+              "end_line": 68,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/config/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/evals/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 71,
+              "end_line": 78,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/fleet/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 26,
+              "end_line": 33,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/harness-driver/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 56,
+              "end_line": 71,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/harnesses/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 26,
+              "end_line": 33,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/integration-prompts/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/policy/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 25,
+              "end_line": 31,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-py/pyproject.toml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 4,
+              "end_line": 10,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/session/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/utils/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            },
+            {
+              "start_line": 109,
+              "end_line": 115,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/case.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 21,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/run.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 317,
+              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json
@@ -1,487 +1,99 @@
 {
   "version": "1.0.0",
   "id": "50e106cb-ac6a-4e53-b765-2d2793de3351",
-  "timestamp": "2026-09-08T14:22:59.839Z",
+  "timestamp": "2026-09-08T14:23:09.839Z",
   "trajectory": "traj_udk54gcrs0ot",
   "files": [
     {
-      "path": "CHANGELOG.md",
+      "path": ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 5,
-              "end_line": 13,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+              "start_line": 1,
+              "end_line": 1,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md",
+      "conversations": [
+        {
+          "contributor": { "type": "ai" },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 1,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json",
+      "conversations": [
+        {
+          "contributor": { "type": "ai" },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 107,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/pr-proof/contract.mjs",
+      "conversations": [
+        {
+          "contributor": { "type": "ai" },
+          "ranges": [
+            {
+              "start_line": 151,
+              "end_line": 167,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
             },
             {
-              "start_line": 16,
-              "end_line": 22,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+              "start_line": 227,
+              "end_line": 265,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
             }
           ]
         }
       ]
     },
     {
-      "path": "crates/broker/src/relaycast/auth.rs",
+      "path": "scripts/pr-proof/prepare.mjs",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 729,
-              "end_line": 765,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 768,
-              "end_line": 783,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 913,
-              "end_line": 1033,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 1195,
-              "end_line": 1219,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 1235,
-              "end_line": 1245,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 1536,
-              "end_line": 1544,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 1739,
-              "end_line": 2159,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+              "start_line": 182,
+              "end_line": 229,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
             }
           ]
         }
       ]
     },
     {
-      "path": "package.json",
+      "path": "tests/fixtures/pr-proof-contract.test.ts",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/brand/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/broker-darwin-arm64/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/broker-darwin-x64/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/broker-linux-arm64/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/broker-linux-x64/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/broker-win32-x64/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/cli/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 43,
-              "end_line": 56,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/cloud/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 62,
-              "end_line": 68,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/config/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/evals/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 71,
-              "end_line": 78,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/fleet/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 26,
-              "end_line": 33,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/harness-driver/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 56,
-              "end_line": 71,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/harnesses/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 26,
-              "end_line": 33,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/integration-prompts/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/policy/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 25,
-              "end_line": 31,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/sdk-py/pyproject.toml",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 4,
-              "end_line": 10,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/sdk/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/session/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/utils/package.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 6,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            },
-            {
-              "start_line": 109,
-              "end_line": 115,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/case.json",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 21,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/run.mjs",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 1,
-              "end_line": 317,
-              "revision": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad"
+              "start_line": 1872,
+              "end_line": 1948,
+              "revision": "2138f756447f42f268ab0b6b1ccc5a229fb29880"
             }
           ]
         }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Rebased PR #1691 onto current main and fixed unreadable non-functional classification to require proof with kind null; added regression coverage. Focused contract tests and formatting pass.
+Repaired PR #1691 so unreadable non-functional declarations require proof without a fabricated bugfix kind, preserved explicit feature/bugfix kinds, added regression coverage, and corrected the Trail scope metadata.
 
 **Approach:** Standard approach
 
@@ -36,5 +36,12 @@ Rebased PR #1691 onto current main and fixed unreadable non-functional classific
 
 ## Artifacts
 
-**Commits:** 8051b4dae, d754fff14, dadaf8531
-**Files changed:** 24
+**Commits:** 8051b4dae, 2138f7564
+**Files changed:** 6
+
+- `.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json`
+- `.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md`
+- `.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json`
+- `scripts/pr-proof/contract.mjs`
+- `scripts/pr-proof/prepare.mjs`
+- `tests/fixtures/pr-proof-contract.test.ts`

--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md
@@ -1,0 +1,40 @@
+# Trajectory: Audit and repair PR #1691 unreadable diff classification
+
+> **Status:** ✅ Completed
+> **Task:** PR-1691
+> **Confidence:** 94%
+> **Started:** September 8, 2026 at 04:19 PM
+> **Completed:** September 8, 2026 at 04:22 PM
+
+---
+
+## Summary
+
+Rebased PR #1691 onto current main and fixed unreadable non-functional classification to require proof with kind null; added regression coverage. Focused contract tests and formatting pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations
+- **Chose:** Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations
+- **Reasoning:** The contract knows a declared bugfix kind even when the diff is unavailable; the defect is coercing non-functional plus unknown diff to bugfix. This is the narrowest semantic repair and avoids widening unrelated behavior.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations: Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations
+- Audit confirmed the single hosted P3 is valid: unreadable non-functional declarations were required but mislabeled as bugfix by the fallback. Rebased cleanly onto origin/main, narrowed kind to null only for that unverifiable path, preserved explicit bugfix metadata, and focused contract coverage passes.
+
+---
+
+## Artifacts
+
+**Commits:** 8051b4dae, d754fff14, dadaf8531
+**Files changed:** 24

--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json
@@ -10,7 +10,7 @@
   },
   "status": "completed",
   "startedAt": "2026-09-08T14:19:33.476Z",
-  "completedAt": "2026-09-08T14:22:59.575Z",
+  "completedAt": "2026-09-08T14:23:09.000Z",
   "agents": [
     {
       "name": "default",
@@ -24,7 +24,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-09-08T14:20:43.980Z",
-      "endedAt": "2026-09-08T14:22:59.575Z",
+      "endedAt": "2026-09-08T14:23:09.000Z",
       "events": [
         {
           "ts": 1788877243983,
@@ -41,7 +41,7 @@
         {
           "ts": 1788877372174,
           "type": "reflection",
-          "content": "Audit confirmed the single hosted P3 is valid: unreadable non-functional declarations were required but mislabeled as bugfix by the fallback. Rebased cleanly onto origin/main, narrowed kind to null only for that unverifiable path, preserved explicit bugfix metadata, and focused contract coverage passes.",
+          "content": "Audit confirmed the single hosted P3 is valid: unreadable non-functional declarations were required but mislabeled as bugfix by the fallback. Rebased cleanly onto origin/main, narrowed kind to null only for that unverifiable path, preserved explicit bugfix metadata, and corrected the Trail metadata to the two PR commits and six-file scope.",
           "raw": {
             "focalPoints": [
               "classification semantics",
@@ -62,46 +62,27 @@
     }
   ],
   "retrospective": {
-    "summary": "Rebased PR #1691 onto current main and fixed unreadable non-functional classification to require proof with kind null; added regression coverage. Focused contract tests and formatting pass.",
+    "summary": "Repaired PR #1691 so unreadable non-functional declarations require proof without a fabricated bugfix kind, preserved explicit feature/bugfix kinds, added regression coverage, and corrected the Trail scope metadata.",
     "approach": "Standard approach",
     "confidence": 0.94
   },
   "commits": [
-    "8051b4dae",
-    "d754fff14",
-    "dadaf8531"
+    "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad",
+    "2138f756447f42f268ab0b6b1ccc5a229fb29880"
   ],
   "filesChanged": [
-    "CHANGELOG.md",
-    "crates/broker/src/relaycast/auth.rs",
-    "package.json",
-    "packages/brand/package.json",
-    "packages/broker-darwin-arm64/package.json",
-    "packages/broker-darwin-x64/package.json",
-    "packages/broker-linux-arm64/package.json",
-    "packages/broker-linux-x64/package.json",
-    "packages/broker-win32-x64/package.json",
-    "packages/cli/package.json",
-    "packages/cloud/package.json",
-    "packages/config/package.json",
-    "packages/evals/package.json",
-    "packages/fleet/package.json",
-    "packages/harness-driver/package.json",
-    "packages/harnesses/package.json",
-    "packages/integration-prompts/package.json",
-    "packages/policy/package.json",
-    "packages/sdk-py/pyproject.toml",
-    "packages/sdk/package.json",
-    "packages/session/package.json",
-    "packages/utils/package.json",
-    "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/case.json",
-    "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/run.mjs"
+    ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot.trace.json",
+    ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/summary.md",
+    ".agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json",
+    "scripts/pr-proof/contract.mjs",
+    "scripts/pr-proof/prepare.mjs",
+    "tests/fixtures/pr-proof-contract.test.ts"
   ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
-    "startRef": "3e64b58fceb075bfe8836200e410ece87985329a",
-    "endRef": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad",
+    "startRef": "d754fff143c464c367ac743ccc3c8085bf5ef04d",
+    "endRef": "2138f756447f42f268ab0b6b1ccc5a229fb29880",
     "traceId": "50e106cb-ac6a-4e53-b765-2d2793de3351"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_udk54gcrs0ot/trajectory.json
@@ -1,0 +1,107 @@
+{
+  "id": "traj_udk54gcrs0ot",
+  "version": 1,
+  "task": {
+    "title": "Audit and repair PR #1691 unreadable diff classification",
+    "source": {
+      "system": "plain",
+      "id": "PR-1691"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-08T14:19:33.476Z",
+  "completedAt": "2026-09-08T14:22:59.575Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-08T14:20:43.980Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_k8jd8pj3clz2",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-08T14:20:43.980Z",
+      "endedAt": "2026-09-08T14:22:59.575Z",
+      "events": [
+        {
+          "ts": 1788877243983,
+          "type": "decision",
+          "content": "Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations: Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations",
+          "raw": {
+            "question": "Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations",
+            "chosen": "Treat the cubic P3 as valid and preserve declared bugfix kinds while clearing the synthetic fallback only for unreadable non-functional declarations",
+            "alternatives": [],
+            "reasoning": "The contract knows a declared bugfix kind even when the diff is unavailable; the defect is coercing non-functional plus unknown diff to bugfix. This is the narrowest semantic repair and avoids widening unrelated behavior."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788877372174,
+          "type": "reflection",
+          "content": "Audit confirmed the single hosted P3 is valid: unreadable non-functional declarations were required but mislabeled as bugfix by the fallback. Rebased cleanly onto origin/main, narrowed kind to null only for that unverifiable path, preserved explicit bugfix metadata, and focused contract coverage passes.",
+          "raw": {
+            "focalPoints": [
+              "classification semantics",
+              "hosted feedback",
+              "rebase"
+            ],
+            "confidence": 0.94
+          },
+          "significance": "high",
+          "tags": [
+            "focal:classification semantics",
+            "focal:hosted feedback",
+            "focal:rebase",
+            "confidence:0.94"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Rebased PR #1691 onto current main and fixed unreadable non-functional classification to require proof with kind null; added regression coverage. Focused contract tests and formatting pass.",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  },
+  "commits": [
+    "8051b4dae",
+    "d754fff14",
+    "dadaf8531"
+  ],
+  "filesChanged": [
+    "CHANGELOG.md",
+    "crates/broker/src/relaycast/auth.rs",
+    "package.json",
+    "packages/brand/package.json",
+    "packages/broker-darwin-arm64/package.json",
+    "packages/broker-darwin-x64/package.json",
+    "packages/broker-linux-arm64/package.json",
+    "packages/broker-linux-x64/package.json",
+    "packages/broker-win32-x64/package.json",
+    "packages/cli/package.json",
+    "packages/cloud/package.json",
+    "packages/config/package.json",
+    "packages/evals/package.json",
+    "packages/fleet/package.json",
+    "packages/harness-driver/package.json",
+    "packages/harnesses/package.json",
+    "packages/integration-prompts/package.json",
+    "packages/policy/package.json",
+    "packages/sdk-py/pyproject.toml",
+    "packages/sdk/package.json",
+    "packages/session/package.json",
+    "packages/utils/package.json",
+    "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/case.json",
+    "tests/relayflows/cases/1700-broker-startup-transient-relaycast-retry/run.mjs"
+  ],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "3e64b58fceb075bfe8836200e410ece87985329a",
+    "endRef": "8051b4dae9e41fd666b6c8222dbbf08a28cb72ad",
+    "traceId": "50e106cb-ac6a-4e53-b765-2d2793de3351"
+  }
+}

--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -152,9 +152,19 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
   const metadata = parsePrProofMetadata(body);
   const conventionalKind = REQUIRED_TITLE_RE.exec(title)?.[1]?.toLowerCase() ?? null;
   const titleKind = conventionalKind === 'feat' ? 'feature' : conventionalKind === 'fix' ? 'bugfix' : null;
-  // `null` means the caller could not determine the diff; fall back to the old
-  // title-only behaviour rather than silently exempting an unknown change.
+  // `null` means the diff is unknown: the caller could not read it, or never
+  // had one. Unknown is NOT "nothing to prove". The title-only fallback that
+  // used to run here turned a transient GitHub files-API failure into a green
+  // skip for every PR whose title and body both read as non-functional -- a
+  // `chore(`-titled runtime change declaring `non-functional` classified as
+  // `required: false`, and the proof was never dispatched.
+  //
+  // Unknown now fails closed, so every use of `touchesRuntime` below has to
+  // distinguish `false` (a diff was read and nothing in it ships) from `null`.
   const touchesRuntime = changedFiles === null ? null : runtimeSurfaceChanged(changedFiles);
+  // A `non-functional` declaration is a claim ABOUT the diff. With no diff to
+  // check it against, the claim is unverifiable, not accepted.
+  const unverifiableNonFunctional = touchesRuntime === null && metadata.changeType === 'non-functional';
   const errors = [];
 
   if (metadata.changeTypeCount === 0) {
@@ -172,8 +182,8 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
 
   if (!metadata.changeType) {
     return {
-      required: Boolean(titleKind) || touchesRuntime === true,
-      kind: titleKind ?? (touchesRuntime === true ? 'bugfix' : null),
+      required: Boolean(titleKind) || touchesRuntime !== false,
+      kind: titleKind ?? (touchesRuntime !== false ? 'bugfix' : null),
       caseId: null,
       metadata,
       errors,
@@ -198,32 +208,43 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
   // have that contradiction silently coerced into `bugfix` further down.
   if (metadata.changeType === 'non-functional' && touchesRuntime === true) {
     errors.push('This PR changes runtime files, so the change type cannot be non-functional');
-  } else if (titleKind && metadata.changeType === 'non-functional' && touchesRuntime === null) {
-    errors.push(`PR title declares a ${titleKind}, so the change type cannot be non-functional`);
+  } else if (unverifiableNonFunctional) {
+    // Raised for ANY unreadable diff, not just a conventionally-titled PR.
+    // Gating this on `titleKind` was the false green: a `chore(`-titled PR
+    // declaring non-functional matched no branch at all and sailed through.
+    errors.push(
+      'The changed-file list could not be read, so a non-functional declaration cannot be verified'
+    );
   }
   if (titleKind && metadataKind && titleKind !== metadataKind) {
     errors.push(`PR title declares ${titleKind}, but the PR body declares ${metadataKind}`);
   }
 
-  // Decided by the diff wherever the diff is known:
+  // Decided by the diff:
   //   runtime touched            -> a proof is required, whatever the title says
   //   nothing runtime + declared -> non-functional is legitimate, even for `fix(`
-  //   diff unknown               -> previous title-only behaviour
+  //   diff unknown               -> required; an unread diff exempts nothing
   const required =
-    touchesRuntime === true
+    touchesRuntime !== false
       ? true
-      : touchesRuntime === false && metadata.changeType === 'non-functional'
+      : metadata.changeType === 'non-functional'
         ? false
         : Boolean(metadataKind || titleKind);
   const kind = required ? (metadataKind ?? titleKind ?? 'bugfix') : null;
-  if (required) {
-    if (!metadata.caseId || metadata.caseId === 'n/a') {
-      errors.push('Feature and bug-fix PRs must declare exactly one RelayFlow case id');
-    } else if (!CASE_ID_RE.test(metadata.caseId)) {
-      errors.push(`Invalid RelayFlow case id: ${metadata.caseId}`);
+  // A PR held open only by an unreadable diff declared `n/a` consistently with
+  // its own change type. Demanding a case id from it would bury the one error
+  // that matters — the unreadable diff, already reported above — under a
+  // selector complaint the author cannot act on.
+  if (!unverifiableNonFunctional) {
+    if (required) {
+      if (!metadata.caseId || metadata.caseId === 'n/a') {
+        errors.push('Feature and bug-fix PRs must declare exactly one RelayFlow case id');
+      } else if (!CASE_ID_RE.test(metadata.caseId)) {
+        errors.push(`Invalid RelayFlow case id: ${metadata.caseId}`);
+      }
+    } else if (metadata.caseId !== 'n/a') {
+      errors.push('Non-functional PRs must declare the RelayFlow case as n/a');
     }
-  } else if (metadata.caseId !== 'n/a') {
-    errors.push('Non-functional PRs must declare the RelayFlow case as n/a');
   }
 
   return {
@@ -232,7 +253,11 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
     caseId: required && metadata.caseId !== 'n/a' ? metadata.caseId : null,
     metadata,
     errors,
-    reason: required ? `declared ${kind}` : 'declared non-functional',
+    reason: !required
+      ? 'declared non-functional'
+      : touchesRuntime === null
+        ? 'changed-file list unavailable'
+        : `declared ${kind}`,
   };
 }
 

--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -230,7 +230,11 @@ export function classifyPullRequest({ title = '', body = '', changedFiles = null
       : metadata.changeType === 'non-functional'
         ? false
         : Boolean(metadataKind || titleKind);
-  const kind = required ? (metadataKind ?? titleKind ?? 'bugfix') : null;
+  // An unreadable diff makes a non-functional declaration unverifiable. Keep
+  // its kind unknown rather than manufacturing a bug-fix classification from
+  // the required proof fallback. Explicit feature/bug-fix metadata remains
+  // meaningful even while the changed-file list is unavailable.
+  const kind = required && !unverifiableNonFunctional ? (metadataKind ?? titleKind ?? 'bugfix') : null;
   // A PR held open only by an unreadable diff declared `n/a` consistently with
   // its own change type. Demanding a case id from it would bury the one error
   // that matters — the unreadable diff, already reported above — under a

--- a/scripts/pr-proof/prepare.mjs
+++ b/scripts/pr-proof/prepare.mjs
@@ -182,9 +182,10 @@ export async function main() {
   // Fetch the diff BEFORE classifying: whether a proof is required is decided
   // by what changed, not by how the title was worded.
   //
-  // classifyPullRequest documents a title-only fallback for an unknown diff;
-  // without this catch the await threw first and the fallback was unreachable,
-  // blocking every PR whenever the files endpoint was down.
+  // A read failure is caught rather than thrown so classification can report
+  // it as a contract error naming the unreadable diff. It is NOT a fallback to
+  // a laxer rule: classifyPullRequest treats an unknown diff as proof-required,
+  // so an unreachable files endpoint blocks the PR instead of skipping it.
   let changedFiles = null;
   try {
     changedFiles = await pullRequestFiles(apiUrl, repository, number, token);
@@ -192,7 +193,7 @@ export async function main() {
     if (error?.ambiguousScope) throw error;
     process.stderr.write(
       `Could not read the changed-file list (${error?.message ?? error}); ` +
-        'falling back to title-only classification.\n'
+        'the proof gate fails closed and this PR cannot be classified as exempt.\n'
     );
   }
   const classification = classifyPullRequest({
@@ -217,13 +218,14 @@ export async function main() {
     return;
   }
   // Past this point the changed-file list is load-bearing: it is what confirms
-  // the declared case is actually touched. The title-only fallback above can
-  // legitimately reach here with `null`, and `changedFiles.some(...)` below
-  // would throw an opaque TypeError instead of saying what went wrong.
+  // the declared case is actually touched. An unreadable diff reaches here with
+  // `null` — that is the fail-closed path, not an exemption — and
+  // `changedFiles.some(...)` below would throw an opaque TypeError instead of
+  // saying what went wrong.
   if (changedFiles === null) {
     throw new PrProofContractError('A required proof cannot be validated without the changed-file list', [
       'the GitHub pull request files endpoint could not be read',
-      'classification fell back to the PR title, which cannot confirm the declared RelayFlow case',
+      'without it the declared RelayFlow case cannot be confirmed as touched by this PR',
     ]);
   }
   if (headRepository !== repository) {

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -148,7 +148,13 @@ describe('RelayFlow PR proof classification', () => {
   });
 
   it('requires explicit classification even without a conventional title', () => {
-    const result = classifyPullRequest({ title: 'Update reconnect documentation', body: '' });
+    // A read diff that touches nothing shippable: the exemption has to come
+    // from the files, so the assertion below is about the missing metadata.
+    const result = classifyPullRequest({
+      title: 'Update reconnect documentation',
+      body: '',
+      changedFiles: ['docs/reconnect.md'],
+    });
     expect(result.required).toBe(false);
     expect(result.errors).toContainEqual(
       expect.stringContaining('must declare a RelayFlow Proof change type')
@@ -168,14 +174,16 @@ describe('RelayFlow PR proof classification', () => {
     const result = classifyPullRequest({
       title: 'docs: explain reconnect behavior',
       body: proofBody('non-functional', 'n/a'),
+      changedFiles: ['docs/reconnect.md'],
     });
     expect(result).toMatchObject({ required: false, caseId: null, errors: [] });
   });
 
-  it('rejects attempts to mark a fix title non-functional', () => {
+  it('rejects attempts to mark a runtime fix non-functional', () => {
     const result = classifyPullRequest({
       title: 'fix(broker): reconnect dead links',
       body: proofBody('non-functional', 'n/a'),
+      changedFiles: ['crates/broker/src/runtime/delivery.rs'],
     });
     expect(result.errors).toContainEqual(expect.stringContaining('cannot be non-functional'));
   });
@@ -1861,14 +1869,78 @@ describe('classification reads the diff, not the title', () => {
     expect(result.errors.join(' ')).toContain('cannot be non-functional');
   });
 
-  it('falls back to title-only behaviour when the diff is unavailable', () => {
-    // changedFiles omitted: preserve the previous contract rather than
-    // silently exempting a change nobody inspected.
+  /**
+   * The false green this closes. When the GitHub files API is unreadable,
+   * `prepare.mjs` classifies with `changedFiles: null`. Classification then
+   * fell back to the title, and a PR whose title carried no conventional
+   * `feat(`/`fix(` prefix returned `required: false` — so a transient API
+   * failure published a green "proof not required" skip on the one check that
+   * gates the merge. An unread diff exempts nothing.
+   */
+  it('requires a proof for a chore( non-functional PR when the diff is unreadable', () => {
+    const result = classifyPullRequest({
+      title: 'chore(broker): tidy delivery bookkeeping',
+      body: nonFunctional(),
+      changedFiles: null,
+    });
+    expect(result.required).toBe(true);
+    expect(result.reason).toBe('changed-file list unavailable');
+    expect(result.errors.join(' ')).toContain('changed-file list could not be read');
+    // The declared `n/a` case is consistent with the declared change type, so
+    // the unreadable diff must not be reported as a case-selector mistake.
+    expect(result.errors.join(' ')).not.toContain('RelayFlow case id');
+  });
+
+  it('requires a proof when the diff is unreadable and the title is conventional', () => {
     const result = classifyPullRequest({
       title: 'fix(broker): reconnect dead links',
       body: nonFunctional(),
+      changedFiles: null,
     });
-    expect(result.errors.join(' ')).toContain('cannot be non-functional');
+    expect(result.required).toBe(true);
+    expect(result.errors.join(' ')).toContain('changed-file list could not be read');
+  });
+
+  it('requires a proof for an unreadable diff with no proof metadata at all', () => {
+    const result = classifyPullRequest({
+      title: 'chore(broker): tidy delivery bookkeeping',
+      body: '',
+      changedFiles: null,
+    });
+    expect(result.required).toBe(true);
+  });
+
+  /**
+   * The fail-closed rule must not swallow a legitimate exemption: a diff that
+   * WAS read and touches nothing shippable still classifies as exempt.
+   */
+  it('still exempts a declared non-functional PR whose diff was read', () => {
+    const result = classifyPullRequest({
+      title: 'chore(docs): clarify attach modes',
+      body: nonFunctional(),
+      changedFiles: ['docs/attach.md'],
+    });
+    expect(result.required).toBe(false);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('keeps a declared bug-fix case selectable when the diff is unreadable', () => {
+    // Still required, still the declared case: the fail-closed path adds no
+    // spurious errors to a PR that already declares a proof.
+    const result = classifyPullRequest({
+      title: 'fix(broker): reconnect dead links',
+      body: [
+        '- Change type: `bugfix` <!-- relay-pr-proof:type -->',
+        '- RelayFlow case: `1593-parked-agent-orphaned-receipt` <!-- relay-pr-proof:case -->',
+      ].join('\n'),
+      changedFiles: null,
+    });
+    expect(result).toMatchObject({
+      required: true,
+      kind: 'bugfix',
+      caseId: '1593-parked-agent-orphaned-receipt',
+      errors: [],
+    });
   });
 });
 

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1883,7 +1883,11 @@ describe('classification reads the diff, not the title', () => {
       body: nonFunctional(),
       changedFiles: null,
     });
-    expect(result.required).toBe(true);
+    expect(result).toMatchObject({
+      required: true,
+      kind: null,
+      reason: 'changed-file list unavailable',
+    });
     expect(result.reason).toBe('changed-file list unavailable');
     expect(result.errors.join(' ')).toContain('changed-file list could not be read');
     // The declared `n/a` case is consistent with the declared change type, so


### PR DESCRIPTION
## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

This PR touches only `scripts/pr-proof/` and `tests/`, both of which
`NON_RUNTIME_PATH_PATTERNS` exempts: nothing here is executed by an installed
CLI or broker.

## The bug

`classifyPullRequest` treated an **unknown** changed-file list as "nothing to
prove". When the GitHub files endpoint is unreadable, `prepare.mjs` catches the
error and classifies with `changedFiles: null`, and classification fell back to
the PR title. A PR with a non-conventional title declaring `non-functional`
returned `required: false`; `relayflow-pr-proof.yml` gates every step on
`steps.prepare.outputs.required == 'true'`, so the required merge check went
green without anything inspecting the diff.

`prepare.mjs` already fails closed for a null diff — but only *after* the
`if (!classification.required) { ...return }` early exit, so the false green
returned before that guard was reachable.

## The fix

- `required` is decided by `touchesRuntime !== false`: only a diff that was
  actually **read** can exempt a PR. Unknown fails closed, for the same reason
  `NON_RUNTIME_PATH_PATTERNS` is an allowlist rather than a denylist.
- The "cannot be verified" error for an unverifiable `non-functional`
  declaration no longer gates on `titleKind`. That gate was the hole: a
  `chore(`-titled PR matched no branch at all.
- A PR held open only by an unreadable diff is not additionally told to declare
  a case id. It declared `n/a` consistently with its own change type, and that
  complaint would bury the one error the author can act on.
- Stale comments in `prepare.mjs` that described the removed title-only
  fallback are corrected, including the stderr line that told operators the run
  was "falling back to title-only classification".

Four existing tests relied on the omitted-`changedFiles` default. They now pass
an explicit non-runtime file list, so their exemption comes from the diff
rather than from the fallback that was removed — the assertions themselves are
unchanged.

## Proof that the regression test bites

Restoring the pre-fix `contract.mjs` under the new tests (`git show
HEAD:scripts/pr-proof/contract.mjs > scripts/pr-proof/contract.mjs`):

```
 × requires a proof for a chore( non-functional PR when the diff is unreadable
 × requires a proof when the diff is unreadable and the title is conventional
 × requires a proof for an unreadable diff with no proof metadata at all
AssertionError: expected false to be true // Object.is equality
AssertionError: expected 'PR title declares a bugfix, so the ch…' to contain 'changed-file list could not be read'
  Received: "PR title declares a bugfix, so the change type cannot be non-functional
             Feature and bug-fix PRs must declare exactly one RelayFlow case id"
   Tests  3 failed | 89 passed | 6 skipped (98)
```

With the fix in place, off `origin/main`:

```
 Test Files  1 passed (1)
      Tests  92 passed | 6 skipped (98)
```

The suite also keeps a positive control — `still exempts a declared
non-functional PR whose diff was read` — so the fail-closed rule cannot pass by
simply requiring a proof for everything.

Closes #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NP5QmkQ31G9fJxscFmxTgp


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

