### PR TITLE
fix(fleet): stop interpolating operator input into qualification shell steps

### DIFF
--- a/scripts/fleet-qualification/final-acceptance.mjs
+++ b/scripts/fleet-qualification/final-acceptance.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+import { readQualificationParams } from './params.mjs';
+
+const EXPECTED_OPERATION_COUNT = 95;
+const EXPECTED_ATTEMPT_COUNT = 190;
+
+try {
+  const params = readQualificationParams();
+  if (!params) {
+    console.error('Usage: final-acceptance.mjs --params <params.json>');
+    process.exit(2);
+  }
+  const verdict = JSON.parse(readFileSync(params.verdictPath, 'utf8'));
+  if (
+    verdict.verdict !== 'PASS' ||
+    verdict.operationCount !== EXPECTED_OPERATION_COUNT ||
+    verdict.attemptCount !== EXPECTED_ATTEMPT_COUNT ||
+    !Array.isArray(verdict.nodeResourceIds) ||
+    verdict.nodeResourceIds.length < 2 ||
+    verdict.relayCommitSha !== params.expectedHead
+  ) {
+    console.error('NOT_PASS: verdict does not satisfy final hard acceptance');
+    process.exit(1);
+  }
+  console.log(
+    `FINAL_ACCEPTANCE_OK head=${params.expectedHead} operations=${EXPECTED_OPERATION_COUNT} attempts=${EXPECTED_ATTEMPT_COUNT} nodes=${verdict.nodeResourceIds.length}`
+  );
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message.startsWith('NOT_PASS:') ? message : `NOT_PASS: ${message}`);
+  process.exit(1);
+}

--- a/scripts/fleet-qualification/params.mjs
+++ b/scripts/fleet-qualification/params.mjs
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+
+import { QUALIFICATION_PARAMS_SCHEMA } from './preflight.mjs';
+
+const REQUIRED_FIELDS = [
+  'rawEvidence',
+  'candidateArtifact',
+  'candidateManifest',
+  'expectedHead',
+  'verdictPath',
+];
+
+function argument(argv, name) {
+  const index = argv.indexOf(name);
+  return index === -1 ? undefined : argv[index + 1];
+}
+
+/**
+ * Read the params file that carries operator-supplied paths to the verifier
+ * steps. These values never travel through a shell command, so they are read
+ * back here as plain JSON strings.
+ */
+export function readQualificationParams(argv = process.argv) {
+  const paramsPath = argument(argv, '--params');
+  if (!paramsPath) return undefined;
+  const params = JSON.parse(readFileSync(paramsPath, 'utf8'));
+  if (params?.schemaVersion !== QUALIFICATION_PARAMS_SCHEMA) {
+    throw new Error(`NOT_PASS: params file schemaVersion must be ${QUALIFICATION_PARAMS_SCHEMA}`);
+  }
+  for (const field of REQUIRED_FIELDS) {
+    if (typeof params[field] !== 'string' || !params[field]) {
+      throw new Error(`NOT_PASS: params.${field} is required`);
+    }
+  }
+  return params;
+}
+
+export { argument };

--- a/scripts/fleet-qualification/params.mjs
+++ b/scripts/fleet-qualification/params.mjs
@@ -10,9 +10,31 @@ const REQUIRED_FIELDS = [
   'verdictPath',
 ];
 
+/**
+ * Every flag this module and verify-evidence.mjs accept. A value that is itself
+ * one of these is a malformed command line, not a value.
+ */
+const KNOWN_FLAGS = new Set([
+  '--params',
+  '--input',
+  '--output',
+  '--expected-head',
+  '--candidate-artifact',
+  '--candidate-manifest',
+]);
+
+/**
+ * Read the token after `name`. Returns undefined when the flag is last on the
+ * line or its "value" is another known flag, so a malformed
+ * `--input --expected-head <sha>` fails the caller's required-argument check
+ * instead of silently binding the SHA to `--input`.
+ */
 function argument(argv, name) {
   const index = argv.indexOf(name);
-  return index === -1 ? undefined : argv[index + 1];
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (value === undefined || KNOWN_FLAGS.has(value)) return undefined;
+  return value;
 }
 
 /**

--- a/scripts/fleet-qualification/params.mjs
+++ b/scripts/fleet-qualification/params.mjs
@@ -43,8 +43,15 @@ function argument(argv, name) {
  * back here as plain JSON strings.
  */
 export function readQualificationParams(argv = process.argv) {
+  // `argument` returns undefined both when --params is absent and when it is
+  // present but valueless. Only the first is a legitimate direct invocation;
+  // conflating them would let a malformed --params fall through to the direct
+  // flags and silently verify a different set of inputs.
+  if (!argv.includes('--params')) return undefined;
   const paramsPath = argument(argv, '--params');
-  if (!paramsPath) return undefined;
+  if (!paramsPath) {
+    throw new Error('NOT_PASS: --params requires a file path');
+  }
   const params = JSON.parse(readFileSync(paramsPath, 'utf8'));
   if (params?.schemaVersion !== QUALIFICATION_PARAMS_SCHEMA) {
     throw new Error(`NOT_PASS: params file schemaVersion must be ${QUALIFICATION_PARAMS_SCHEMA}`);

--- a/scripts/fleet-qualification/preflight.mjs
+++ b/scripts/fleet-qualification/preflight.mjs
@@ -1,0 +1,151 @@
+/**
+ * Input resolution and command construction for the Fleet qualification Relayflow.
+ *
+ * Relayflow deterministic steps take a shell string (`sh -c`), so there is no
+ * argv form to pass operator input through. Rather than hand-escape untrusted
+ * values into that string, no operator-supplied value is ever interpolated into
+ * a command at all: paths and digests are validated here and handed to the
+ * verifier through a params file whose own path is derived solely from a
+ * charset-restricted run id. The only values that reach the shell are literals
+ * this module generates and asserts to be shell-inert.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const GIT_SHA = /^[0-9a-fA-F]{40}$/;
+/** No shell metacharacter, quote, whitespace or backslash can match. */
+const SHELL_INERT = /^[A-Za-z0-9._/-]+$/;
+
+export const QUALIFICATION_PARAMS_SCHEMA = 'relay-fleet-qualification-params/1';
+export const BLOCKED_EXIT_CODE = 2;
+
+export class QualificationBlockedError extends Error {
+  constructor(message) {
+    super(`BLOCKED: ${message}`);
+    this.name = 'QualificationBlockedError';
+    this.exitCode = BLOCKED_EXIT_CODE;
+  }
+}
+
+function blocked(message) {
+  throw new QualificationBlockedError(message);
+}
+
+/**
+ * Assert that a self-generated value is safe to place in a shell command
+ * unquoted. This deliberately rejects rather than escapes: any value that needs
+ * escaping is one that should have travelled through the params file instead.
+ */
+export function shellInertLiteral(value, field) {
+  if (typeof value !== 'string' || !SHELL_INERT.test(value)) {
+    blocked(`${field} is not a shell-inert literal`);
+  }
+  return value;
+}
+
+function requiredPath(env, key, description, fileExists) {
+  const value = env[key] ?? '';
+  if (!value) blocked(`${key} is required`);
+  if (!fileExists(value)) blocked(`${description} is absent`);
+  return value;
+}
+
+/**
+ * Validate every operator-supplied input up front, outside the shell.
+ * @param {Record<string, string | undefined>} env
+ * @param {{ fileExists?: (p: string) => boolean, now?: () => number }} [deps]
+ */
+export function resolveQualificationInputs(env = process.env, deps = {}) {
+  const fileExists = deps.fileExists ?? existsSync;
+  const now = deps.now ?? Date.now;
+
+  const runId = env.FLEET_QUALIFICATION_RUN_ID ?? `fleet-${now()}`;
+  if (!RUN_ID.test(runId)) {
+    blocked('FLEET_QUALIFICATION_RUN_ID must be a safe 1-128 character artifact name');
+  }
+
+  const rawEvidence = requiredPath(env, 'FLEET_QUALIFICATION_RAW_EVIDENCE', 'raw evidence file', fileExists);
+  const candidateArtifact = requiredPath(
+    env,
+    'FLEET_QUALIFICATION_CANDIDATE_ARTIFACT',
+    'packed candidate artifact',
+    fileExists
+  );
+  const candidateManifest = requiredPath(
+    env,
+    'FLEET_QUALIFICATION_CANDIDATE_MANIFEST',
+    'candidate manifest',
+    fileExists
+  );
+
+  const expectedHead = env.FLEET_QUALIFICATION_EXPECTED_HEAD ?? '';
+  if (!GIT_SHA.test(expectedHead)) {
+    blocked('FLEET_QUALIFICATION_EXPECTED_HEAD must be a full Git SHA');
+  }
+
+  const artifacts = `.workflow-artifacts/fleet-qualification/${runId}`;
+  return {
+    runId,
+    artifacts,
+    paramsPath: `${artifacts}/params.json`,
+    verdictPath: `${artifacts}/verdict.json`,
+    rawEvidence,
+    candidateArtifact,
+    candidateManifest,
+    expectedHead: expectedHead.toLowerCase(),
+  };
+}
+
+/** Serialize the resolved inputs for the verifier steps. */
+export function qualificationParams(inputs) {
+  return {
+    schemaVersion: QUALIFICATION_PARAMS_SCHEMA,
+    runId: inputs.runId,
+    artifacts: inputs.artifacts,
+    rawEvidence: inputs.rawEvidence,
+    candidateArtifact: inputs.candidateArtifact,
+    candidateManifest: inputs.candidateManifest,
+    expectedHead: inputs.expectedHead,
+    verdictPath: inputs.verdictPath,
+  };
+}
+
+/** Write the params file the deterministic steps read instead of argv. */
+export function writeQualificationParams(inputs, { cwd = process.cwd() } = {}) {
+  const absolute = path.resolve(cwd, inputs.paramsPath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${JSON.stringify(qualificationParams(inputs), null, 2)}\n`);
+  return absolute;
+}
+
+/**
+ * Build the deterministic step commands. Only shell-inert, self-generated
+ * literals are interpolated; every operator-supplied value is reached through
+ * the params file.
+ */
+export function buildQualificationCommands(inputs) {
+  const params = shellInertLiteral(inputs.paramsPath, 'params path');
+  const verdict = shellInertLiteral(inputs.verdictPath, 'verdict path');
+  const head = shellInertLiteral(inputs.expectedHead, 'expected head');
+
+  return {
+    preflight: [
+      'set -eu',
+      `test -s ${params} || { echo "BLOCKED: qualification params file is absent"; exit 2; }`,
+      'test "$(git status --porcelain --untracked-files=no)" = "" || { echo "BLOCKED: tracked worktree is dirty"; exit 2; }',
+      `test "$(git rev-parse HEAD)" = ${head} || { echo "BLOCKED: worktree HEAD differs from FLEET_QUALIFICATION_EXPECTED_HEAD"; exit 2; }`,
+    ].join('\n'),
+    sourceInventory:
+      './node_modules/.bin/vitest run tests/fixtures/fleet-qualification-evidence.test.ts -t "source enumeration"',
+    verifyEvidence: [
+      'set -eu',
+      `node scripts/fleet-qualification/verify-evidence.mjs --params ${params}`,
+      `test -s ${verdict}`,
+    ].join('\n'),
+    finalAcceptance: [
+      'set -eu',
+      `node scripts/fleet-qualification/final-acceptance.mjs --params ${params}`,
+    ].join('\n'),
+  };
+}

--- a/scripts/fleet-qualification/preflight.mjs
+++ b/scripts/fleet-qualification/preflight.mjs
@@ -171,21 +171,33 @@ export function qualificationParams(inputs) {
 }
 
 /**
- * Reject a symlink or non-directory anywhere in the artifact root this module
- * is about to create. `mkdirSync(..., { recursive: true })` happily accepts a
- * pre-planted symlink-to-directory and would then write the params file into
- * the link target. Only the segments this module owns are walked; the
- * workspace root above them belongs to the operator.
+ * Create the run's artifact root, and own it exclusively.
+ *
+ * The shared parents (`.workflow-artifacts`, `.workflow-artifacts/fleet-qualification`)
+ * may already exist, but each is checked with `lstat` first:
+ * `mkdirSync(..., { recursive: true })` accepts a pre-planted
+ * symlink-to-directory and would redirect everything below it into the link
+ * target.
+ *
+ * The run-specific leaf must NOT exist. A plain `mkdirSync` fails `EEXIST`
+ * atomically for a directory, a file or a symlink, so there is no window
+ * between deciding the path is free and taking it. That also rejects a stale
+ * root left by an earlier run — one holding a `verdict.json` but no
+ * `params.json` would otherwise pass, start the workflow, and only fail later
+ * when verify-evidence.mjs's own exclusive verdict write hit `EEXIST`.
  */
-function assertRealArtifactRoot(cwd, relative) {
+function createQualificationArtifactRoot(cwd, relative) {
+  const segments = relative.split('/');
+  const leaf = segments.pop();
   let current = path.resolve(cwd);
-  for (const segment of relative.split('/')) {
+
+  for (const segment of segments) {
     current = path.join(current, segment);
     let stats;
     try {
       stats = lstatSync(current);
     } catch {
-      return; // Absent, so every deeper segment is too: mkdirSync creates real dirs.
+      break; // Absent, so every deeper segment is too.
     }
     if (stats.isSymbolicLink()) {
       blocked(`${relative} must be a real directory, but ${segment} is a symlink`);
@@ -194,21 +206,34 @@ function assertRealArtifactRoot(cwd, relative) {
       blocked(`${relative} must be a real directory, but ${segment} is not a directory`);
     }
   }
+
+  const parent = path.resolve(cwd, ...segments);
+  mkdirSync(parent, { recursive: true });
+  const root = path.join(parent, leaf);
+  try {
+    mkdirSync(root);
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      blocked(`${relative} already exists; use a fresh FLEET_QUALIFICATION_RUN_ID`);
+    }
+    throw error;
+  }
+  return root;
 }
 
 /**
- * Write the params file the deterministic steps read instead of argv.
+ * Write the params file the deterministic steps read instead of argv, into an
+ * artifact root this call has just created exclusively.
  *
- * Created exclusively (`wx`, i.e. O_EXCL), matching how verify-evidence.mjs
- * writes the verdict. A pre-existing params.json — a reused run id, or a
- * symlink planted at that path — is BLOCKED rather than followed and
- * overwritten.
+ * The write is still exclusive (`wx`, i.e. `O_EXCL`, as verify-evidence.mjs
+ * does for the verdict). With the root freshly created that is unreachable in
+ * practice; it is kept as a backstop against anything racing into the new
+ * directory, and it is the reason this function can never follow a symlink.
  */
 export function writeQualificationParams(inputs, { cwd = process.cwd() } = {}) {
   assertNoOutputAliases(inputs, cwd);
-  assertRealArtifactRoot(cwd, inputs.artifacts);
+  createQualificationArtifactRoot(cwd, inputs.artifacts);
   const absolute = path.resolve(cwd, inputs.paramsPath);
-  mkdirSync(path.dirname(absolute), { recursive: true });
   try {
     writeFileSync(absolute, `${JSON.stringify(qualificationParams(inputs), null, 2)}\n`, {
       flag: 'wx',

--- a/scripts/fleet-qualification/preflight.mjs
+++ b/scripts/fleet-qualification/preflight.mjs
@@ -9,7 +9,7 @@
  * charset-restricted run id. The only values that reach the shell are literals
  * this module generates and asserts to be shell-inert.
  */
-import { lstatSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import { accessSync, constants, lstatSync, mkdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -53,9 +53,37 @@ export function shellInertLiteral(value, field) {
  */
 function regularFile(candidate) {
   try {
-    return statSync(candidate).isFile();
+    if (!statSync(candidate).isFile()) return false;
+    // Type alone is not enough: an unreadable file would otherwise pass
+    // preflight and surface as a late NOT_PASS from the verifier's read.
+    // This is a setup check, not a race-free guarantee — the operator is not
+    // the adversary here; a hostile local user could still swap the file
+    // between this check and the read.
+    accessSync(candidate, constants.R_OK);
+    return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Absolute, symlink-free form of a path, so two names for one file compare
+ * equal. `path.resolve` only normalises `..` and `.`; it would happily treat a
+ * symlink pointing at the verdict file as a different path. Falls back to the
+ * deepest existing ancestor for a path that does not exist yet.
+ */
+function canonical(target) {
+  let current = path.resolve(target);
+  const trailing = [];
+  for (;;) {
+    try {
+      return path.join(realpathSync(current), ...trailing);
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return path.resolve(target);
+      trailing.unshift(path.basename(current));
+      current = parent;
+    }
   }
 }
 
@@ -109,18 +137,21 @@ export function resolveQualificationInputs(env = process.env, deps = {}) {
 }
 
 /**
- * An input path that resolves to a file this run is about to write is a
+ * An input path that names a file this run is about to write is a
  * destructive setup error: the params write would truncate the operator's own
  * evidence before the verifier reads it, and an input aliasing the verdict
  * would only surface halfway through the run. Both are BLOCKED here instead.
+ *
+ * Paths are compared canonically, so a symlink aimed at either output is
+ * caught by its target rather than accepted under a different name.
  */
 export function assertNoOutputAliases(inputs, cwd = process.cwd()) {
   const reserved = new Map([
-    [path.resolve(cwd, inputs.paramsPath), 'the qualification params file'],
-    [path.resolve(cwd, inputs.verdictPath), 'the qualification verdict file'],
+    [canonical(path.resolve(cwd, inputs.paramsPath)), 'the qualification params file'],
+    [canonical(path.resolve(cwd, inputs.verdictPath)), 'the qualification verdict file'],
   ]);
   for (const key of ['rawEvidence', 'candidateArtifact', 'candidateManifest']) {
-    const clash = reserved.get(path.resolve(cwd, inputs[key]));
+    const clash = reserved.get(canonical(path.resolve(cwd, inputs[key])));
     if (clash) blocked(`${key} must not be ${clash}`);
   }
 }

--- a/scripts/fleet-qualification/preflight.mjs
+++ b/scripts/fleet-qualification/preflight.mjs
@@ -9,7 +9,7 @@
  * charset-restricted run id. The only values that reach the shell are literals
  * this module generates and asserts to be shell-inert.
  */
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { lstatSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -44,40 +44,49 @@ export function shellInertLiteral(value, field) {
   return value;
 }
 
-function requiredPath(env, key, description, fileExists) {
+/**
+ * `test -f` semantics, which the shell preflight this replaced relied on:
+ * follow symlinks, accept only a regular file. `existsSync` alone would let a
+ * directory, FIFO, socket or device through — a directory then surfaces as a
+ * terminal NOT_PASS deep in the verifier, and reading a FIFO blocks until the
+ * workflow times out, instead of failing fast as a BLOCKED setup error.
+ */
+function regularFile(candidate) {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function requiredPath(env, key, description) {
   const value = env[key] ?? '';
   if (!value) blocked(`${key} is required`);
-  if (!fileExists(value)) blocked(`${description} is absent`);
+  if (!regularFile(value)) blocked(`${description} is not a readable regular file`);
   return value;
 }
 
 /**
  * Validate every operator-supplied input up front, outside the shell.
  * @param {Record<string, string | undefined>} env
- * @param {{ fileExists?: (p: string) => boolean, now?: () => number }} [deps]
+ * @param {{ now?: () => number, cwd?: string }} [deps]
  */
 export function resolveQualificationInputs(env = process.env, deps = {}) {
-  const fileExists = deps.fileExists ?? existsSync;
   const now = deps.now ?? Date.now;
+  const cwd = deps.cwd ?? process.cwd();
 
   const runId = env.FLEET_QUALIFICATION_RUN_ID ?? `fleet-${now()}`;
   if (!RUN_ID.test(runId)) {
     blocked('FLEET_QUALIFICATION_RUN_ID must be a safe 1-128 character artifact name');
   }
 
-  const rawEvidence = requiredPath(env, 'FLEET_QUALIFICATION_RAW_EVIDENCE', 'raw evidence file', fileExists);
+  const rawEvidence = requiredPath(env, 'FLEET_QUALIFICATION_RAW_EVIDENCE', 'raw evidence file');
   const candidateArtifact = requiredPath(
     env,
     'FLEET_QUALIFICATION_CANDIDATE_ARTIFACT',
-    'packed candidate artifact',
-    fileExists
+    'packed candidate artifact'
   );
-  const candidateManifest = requiredPath(
-    env,
-    'FLEET_QUALIFICATION_CANDIDATE_MANIFEST',
-    'candidate manifest',
-    fileExists
-  );
+  const candidateManifest = requiredPath(env, 'FLEET_QUALIFICATION_CANDIDATE_MANIFEST', 'candidate manifest');
 
   const expectedHead = env.FLEET_QUALIFICATION_EXPECTED_HEAD ?? '';
   if (!GIT_SHA.test(expectedHead)) {
@@ -85,7 +94,7 @@ export function resolveQualificationInputs(env = process.env, deps = {}) {
   }
 
   const artifacts = `.workflow-artifacts/fleet-qualification/${runId}`;
-  return {
+  const inputs = {
     runId,
     artifacts,
     paramsPath: `${artifacts}/params.json`,
@@ -95,6 +104,25 @@ export function resolveQualificationInputs(env = process.env, deps = {}) {
     candidateManifest,
     expectedHead: expectedHead.toLowerCase(),
   };
+  assertNoOutputAliases(inputs, cwd);
+  return inputs;
+}
+
+/**
+ * An input path that resolves to a file this run is about to write is a
+ * destructive setup error: the params write would truncate the operator's own
+ * evidence before the verifier reads it, and an input aliasing the verdict
+ * would only surface halfway through the run. Both are BLOCKED here instead.
+ */
+export function assertNoOutputAliases(inputs, cwd = process.cwd()) {
+  const reserved = new Map([
+    [path.resolve(cwd, inputs.paramsPath), 'the qualification params file'],
+    [path.resolve(cwd, inputs.verdictPath), 'the qualification verdict file'],
+  ]);
+  for (const key of ['rawEvidence', 'candidateArtifact', 'candidateManifest']) {
+    const clash = reserved.get(path.resolve(cwd, inputs[key]));
+    if (clash) blocked(`${key} must not be ${clash}`);
+  }
 }
 
 /** Serialize the resolved inputs for the verifier steps. */
@@ -111,11 +139,55 @@ export function qualificationParams(inputs) {
   };
 }
 
-/** Write the params file the deterministic steps read instead of argv. */
+/**
+ * Reject a symlink or non-directory anywhere in the artifact root this module
+ * is about to create. `mkdirSync(..., { recursive: true })` happily accepts a
+ * pre-planted symlink-to-directory and would then write the params file into
+ * the link target. Only the segments this module owns are walked; the
+ * workspace root above them belongs to the operator.
+ */
+function assertRealArtifactRoot(cwd, relative) {
+  let current = path.resolve(cwd);
+  for (const segment of relative.split('/')) {
+    current = path.join(current, segment);
+    let stats;
+    try {
+      stats = lstatSync(current);
+    } catch {
+      return; // Absent, so every deeper segment is too: mkdirSync creates real dirs.
+    }
+    if (stats.isSymbolicLink()) {
+      blocked(`${relative} must be a real directory, but ${segment} is a symlink`);
+    }
+    if (!stats.isDirectory()) {
+      blocked(`${relative} must be a real directory, but ${segment} is not a directory`);
+    }
+  }
+}
+
+/**
+ * Write the params file the deterministic steps read instead of argv.
+ *
+ * Created exclusively (`wx`, i.e. O_EXCL), matching how verify-evidence.mjs
+ * writes the verdict. A pre-existing params.json — a reused run id, or a
+ * symlink planted at that path — is BLOCKED rather than followed and
+ * overwritten.
+ */
 export function writeQualificationParams(inputs, { cwd = process.cwd() } = {}) {
+  assertNoOutputAliases(inputs, cwd);
+  assertRealArtifactRoot(cwd, inputs.artifacts);
   const absolute = path.resolve(cwd, inputs.paramsPath);
   mkdirSync(path.dirname(absolute), { recursive: true });
-  writeFileSync(absolute, `${JSON.stringify(qualificationParams(inputs), null, 2)}\n`);
+  try {
+    writeFileSync(absolute, `${JSON.stringify(qualificationParams(inputs), null, 2)}\n`, {
+      flag: 'wx',
+    });
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      blocked(`${inputs.paramsPath} already exists; use a fresh FLEET_QUALIFICATION_RUN_ID`);
+    }
+    throw error;
+  }
   return absolute;
 }
 

--- a/scripts/fleet-qualification/verify-evidence.mjs
+++ b/scripts/fleet-qualification/verify-evidence.mjs
@@ -9,20 +9,31 @@ import {
   validateQualificationEvidence,
 } from './evidence.mjs';
 import { FLEET_QUALIFICATION_OPERATIONS } from './matrix.mjs';
+import { argument, readQualificationParams } from './params.mjs';
 
-function argument(name) {
-  const index = process.argv.indexOf(name);
-  return index === -1 ? undefined : process.argv[index + 1];
+/**
+ * Operator-supplied paths arrive through the params file written by the
+ * Relayflow, never through a shell command line, so a value containing shell
+ * metacharacters cannot be interpreted. The explicit flags remain for direct
+ * invocation outside the workflow.
+ */
+let params;
+try {
+  params = readQualificationParams();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message.startsWith('NOT_PASS:') ? message : `NOT_PASS: ${message}`);
+  process.exit(1);
 }
-
-const input = argument('--input');
-const output = argument('--output');
-const expectedHead = argument('--expected-head');
-const candidateArtifact = argument('--candidate-artifact');
-const candidateManifest = argument('--candidate-manifest');
+const input = params?.rawEvidence ?? argument(process.argv, '--input');
+const output = params?.verdictPath ?? argument(process.argv, '--output');
+const expectedHead = params?.expectedHead ?? argument(process.argv, '--expected-head');
+const candidateArtifact = params?.candidateArtifact ?? argument(process.argv, '--candidate-artifact');
+const candidateManifest = params?.candidateManifest ?? argument(process.argv, '--candidate-manifest');
 if (!input || !output || !expectedHead || !candidateArtifact || !candidateManifest) {
   console.error(
-    'Usage: verify-evidence.mjs --input <raw-evidence.json> --output <verdict.json> --expected-head <40-char-sha> --candidate-artifact <packed.tgz> --candidate-manifest <manifest.json>'
+    'Usage: verify-evidence.mjs --params <params.json>\n' +
+      '   or: verify-evidence.mjs --input <raw-evidence.json> --output <verdict.json> --expected-head <40-char-sha> --candidate-artifact <packed.tgz> --candidate-manifest <manifest.json>'
   );
   process.exit(2);
 }

--- a/tests/fixtures/fleet-qualification-shell-injection.test.ts
+++ b/tests/fixtures/fleet-qualification-shell-injection.test.ts
@@ -1,0 +1,182 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildQualificationCommands,
+  QualificationBlockedError,
+  resolveQualificationInputs,
+  shellInertLiteral,
+  writeQualificationParams,
+} from '../../scripts/fleet-qualification/preflight.mjs';
+
+const HEAD = 'a'.repeat(40);
+
+let sandbox: string;
+let markers: string[];
+
+/**
+ * Operator-supplied paths whose *names* carry shell payloads. These are real
+ * files on disk, so they survive existence validation and reach every place the
+ * Relayflow uses them — which is exactly where a quoting bug would fire.
+ */
+function maliciousInputs() {
+  // Payload targets are bare names so they stay inside a single path segment;
+  // the sandbox is the cwd for every shell invocation under test.
+  const names = ['pwned-evidence', 'pwned-artifact', 'pwned-manifest'];
+  markers = names.map((name) => path.join(sandbox, name));
+
+  const files = {
+    rawEvidence: path.join(sandbox, `evidence$(touch ${names[0]}).json`),
+    candidateArtifact: path.join(sandbox, `artifact\`touch ${names[1]}\`.tgz`),
+    candidateManifest: path.join(sandbox, `manifest';touch ${names[2]};'.json`),
+  };
+  for (const file of Object.values(files)) writeFileSync(file, '{}\n');
+  return { files };
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(tmpdir(), 'fleet-qual-inject-'));
+  markers = [];
+});
+
+afterEach(() => {
+  for (const marker of markers) rmSync(marker, { force: true });
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('fleet qualification shell injection', () => {
+  it('keeps every operator-supplied value out of the deterministic commands', () => {
+    const { files } = maliciousInputs();
+    const inputs = resolveQualificationInputs({
+      FLEET_QUALIFICATION_RUN_ID: 'inject-probe',
+      FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+    });
+
+    const rendered = Object.values(buildQualificationCommands(inputs)).join('\n');
+    for (const value of Object.values(files)) {
+      expect(rendered).not.toContain(value);
+    }
+    expect(rendered).not.toContain('touch ');
+
+    // The commands must depend only on the charset-restricted run id, so
+    // swapping the operator inputs for benign ones changes nothing.
+    const benign = path.join(sandbox, 'benign.json');
+    writeFileSync(benign, '{}\n');
+    const benignInputs = resolveQualificationInputs({
+      FLEET_QUALIFICATION_RUN_ID: 'inject-probe',
+      FLEET_QUALIFICATION_RAW_EVIDENCE: benign,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: benign,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: benign,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+    });
+    expect(rendered).toBe(Object.values(buildQualificationCommands(benignInputs)).join('\n'));
+  });
+
+  it('does not execute a $(...), backtick or quote-break payload from the evidence paths', () => {
+    const { files } = maliciousInputs();
+    const inputs = resolveQualificationInputs({
+      FLEET_QUALIFICATION_RUN_ID: 'inject-probe',
+      FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+    });
+    writeQualificationParams(inputs, { cwd: sandbox });
+
+    for (const command of Object.values(buildQualificationCommands(inputs))) {
+      try {
+        execFileSync('/bin/sh', ['-c', command], { cwd: sandbox, stdio: 'pipe' });
+      } catch {
+        // A blocked/failing step is expected here; only the side effect matters.
+      }
+    }
+
+    for (const marker of markers) {
+      expect(existsSync(marker), `payload executed and created ${marker}`).toBe(false);
+    }
+  });
+
+  it('round-trips the exact operator paths through the params file', () => {
+    const { files } = maliciousInputs();
+    const inputs = resolveQualificationInputs({
+      FLEET_QUALIFICATION_RUN_ID: 'inject-probe',
+      FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+    });
+    const paramsPath = writeQualificationParams(inputs, { cwd: sandbox });
+    const params = JSON.parse(readFileSync(paramsPath, 'utf8'));
+
+    expect(params.rawEvidence).toBe(files.rawEvidence);
+    expect(params.candidateArtifact).toBe(files.candidateArtifact);
+    expect(params.candidateManifest).toBe(files.candidateManifest);
+    expect(params.expectedHead).toBe(HEAD);
+  });
+
+  it('rejects a shell-active literal rather than escaping it', () => {
+    for (const value of [
+      'a$(touch x)',
+      'a`touch x`',
+      "a';touch x;'",
+      'a;touch x',
+      'a touch x',
+      'a\ntouch x',
+      'a|touch x',
+      'a&touch x',
+      'a>x',
+      'a\\x',
+      'a*x',
+      'a~x',
+      '',
+    ]) {
+      expect(() => shellInertLiteral(value, 'probe')).toThrow(QualificationBlockedError);
+    }
+    expect(shellInertLiteral('.workflow-artifacts/fleet-qualification/run-1/params.json', 'probe')).toBe(
+      '.workflow-artifacts/fleet-qualification/run-1/params.json'
+    );
+  });
+
+  it('blocks a run id that could escape the artifacts path', () => {
+    const { files } = maliciousInputs();
+    for (const runId of ['../../etc', 'run$(touch x)', 'run id', '-run', 'a'.repeat(129)]) {
+      expect(() =>
+        resolveQualificationInputs({
+          FLEET_QUALIFICATION_RUN_ID: runId,
+          FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+          FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+          FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+          FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+        })
+      ).toThrow(QualificationBlockedError);
+    }
+  });
+
+  it('blocks absent evidence, artifact, manifest and malformed heads', () => {
+    const { files } = maliciousInputs();
+    const base = {
+      FLEET_QUALIFICATION_RUN_ID: 'inject-probe',
+      FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+    };
+    const absent = path.join(sandbox, 'missing');
+    for (const override of [
+      { FLEET_QUALIFICATION_RAW_EVIDENCE: '' },
+      { FLEET_QUALIFICATION_RAW_EVIDENCE: absent },
+      { FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: absent },
+      { FLEET_QUALIFICATION_CANDIDATE_MANIFEST: absent },
+      { FLEET_QUALIFICATION_EXPECTED_HEAD: 'not-a-sha' },
+      { FLEET_QUALIFICATION_EXPECTED_HEAD: `${'a'.repeat(39)}g` },
+    ]) {
+      expect(() => resolveQualificationInputs({ ...base, ...override })).toThrow(QualificationBlockedError);
+    }
+  });
+});

--- a/tests/fixtures/fleet-qualification-shell-injection.test.ts
+++ b/tests/fixtures/fleet-qualification-shell-injection.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -273,6 +274,38 @@ describe('fleet qualification params write is not a destructive primitive', () =
     expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
     expect(readdirSync(elsewhere)).toEqual([]);
     rmSync(elsewhere, { recursive: true, force: true });
+  });
+
+  it('resolves a symlinked input to its target before accepting it', () => {
+    // `path.resolve` alone would compare the link's own name and let this pass.
+    for (const name of ['params.json', 'verdict.json']) {
+      const output = path.join(sandbox, ARTIFACT_ROOT, name);
+      mkdirSync(path.dirname(output), { recursive: true });
+      writeFileSync(output, 'OPERATOR EVIDENCE\n');
+      const link = path.join(sandbox, `link-to-${name}`);
+      symlinkSync(output, link);
+
+      expect(() => resolveInSandbox({ FLEET_QUALIFICATION_RAW_EVIDENCE: link })).toThrow(
+        QualificationBlockedError
+      );
+      expect(readFileSync(output, 'utf8')).toBe('OPERATOR EVIDENCE\n');
+      rmSync(link);
+      rmSync(output);
+    }
+  });
+
+  it('blocks an input the run cannot read', () => {
+    if (process.getuid?.() === 0) return; // root ignores the mode bits.
+    const unreadable = path.join(sandbox, 'unreadable.json');
+    writeFileSync(unreadable, '{}\n');
+    chmodSync(unreadable, 0o000);
+    try {
+      expect(() => resolveInSandbox({ FLEET_QUALIFICATION_RAW_EVIDENCE: unreadable })).toThrow(
+        QualificationBlockedError
+      );
+    } finally {
+      chmodSync(unreadable, 0o600);
+    }
   });
 
   it('blocks a reused run id rather than overwriting its params file', () => {

--- a/tests/fixtures/fleet-qualification-shell-injection.test.ts
+++ b/tests/fixtures/fleet-qualification-shell-injection.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { argument } from '../../scripts/fleet-qualification/params.mjs';
+import { argument, readQualificationParams } from '../../scripts/fleet-qualification/params.mjs';
 import {
   buildQualificationCommands,
   QualificationBlockedError,
@@ -308,6 +308,30 @@ describe('fleet qualification params write is not a destructive primitive', () =
     }
   });
 
+  it('does not follow a symlink planted on a shared parent directory', () => {
+    const elsewhere = mkdtempSync(path.join(tmpdir(), 'fleet-qual-victim-'));
+    const parent = path.join(sandbox, '.workflow-artifacts', 'fleet-qualification');
+    mkdirSync(path.dirname(parent), { recursive: true });
+    symlinkSync(elsewhere, parent);
+
+    const inputs = resolveInSandbox();
+    expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
+    expect(readdirSync(elsewhere)).toEqual([]);
+    rmSync(elsewhere, { recursive: true, force: true });
+  });
+
+  it('blocks a stale artifact root that holds a verdict but no params', () => {
+    // The params write would have succeeded here; the run would only have
+    // failed later, on verify-evidence.mjs's own exclusive verdict write.
+    const root = path.join(sandbox, ARTIFACT_ROOT);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(path.join(root, 'verdict.json'), '{"verdict":"PASS"}\n');
+
+    const inputs = resolveInSandbox();
+    expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
+    expect(existsSync(path.join(root, 'params.json'))).toBe(false);
+  });
+
   it('blocks a reused run id rather than overwriting its params file', () => {
     const inputs = resolveInSandbox();
     writeQualificationParams(inputs, { cwd: sandbox });
@@ -324,6 +348,22 @@ describe('fleet qualification argv parsing', () => {
 
   it('does not read past the end of the command line', () => {
     expect(argument(['node', 'verify-evidence.mjs', '--params'], '--params')).toBeUndefined();
+  });
+
+  it('rejects a present-but-valueless --params instead of falling back', () => {
+    // Returning undefined here would let verify-evidence.mjs silently verify
+    // the direct --input/--output flags instead of the params file it was told
+    // to use.
+    expect(() =>
+      readQualificationParams(['node', 'verify-evidence.mjs', '--params', '--input', 'e.json'])
+    ).toThrow(/--params requires a file path/);
+    expect(() => readQualificationParams(['node', 'verify-evidence.mjs', '--params'])).toThrow(
+      /--params requires a file path/
+    );
+  });
+
+  it('leaves a genuinely absent --params as a direct invocation', () => {
+    expect(readQualificationParams(['node', 'verify-evidence.mjs', '--input', 'e.json'])).toBeUndefined();
   });
 
   it('still reads a well-formed value', () => {

--- a/tests/fixtures/fleet-qualification-shell-injection.test.ts
+++ b/tests/fixtures/fleet-qualification-shell-injection.test.ts
@@ -1,9 +1,19 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { argument } from '../../scripts/fleet-qualification/params.mjs';
 import {
   buildQualificationCommands,
   QualificationBlockedError,
@@ -178,5 +188,112 @@ describe('fleet qualification shell injection', () => {
     ]) {
       expect(() => resolveQualificationInputs({ ...base, ...override })).toThrow(QualificationBlockedError);
     }
+  });
+});
+
+/**
+ * The params file is the one thing this run writes before the workflow starts,
+ * and its path is derived from the run id — which the operator also supplies.
+ * These cover the ways a hostile or careless setup can aim that write at
+ * something it must not touch.
+ */
+describe('fleet qualification params write is not a destructive primitive', () => {
+  const RUN_ID = 'inject-probe';
+  const ARTIFACT_ROOT = `.workflow-artifacts/fleet-qualification/${RUN_ID}`;
+
+  function envFor(overrides: Record<string, string>) {
+    const { files } = maliciousInputs();
+    return {
+      FLEET_QUALIFICATION_RUN_ID: RUN_ID,
+      FLEET_QUALIFICATION_RAW_EVIDENCE: files.rawEvidence,
+      FLEET_QUALIFICATION_CANDIDATE_ARTIFACT: files.candidateArtifact,
+      FLEET_QUALIFICATION_CANDIDATE_MANIFEST: files.candidateManifest,
+      FLEET_QUALIFICATION_EXPECTED_HEAD: HEAD,
+      ...overrides,
+    };
+  }
+
+  function resolveInSandbox(overrides: Record<string, string> = {}) {
+    return resolveQualificationInputs(envFor(overrides), { cwd: sandbox });
+  }
+
+  it('blocks an input that is a directory rather than a regular file', () => {
+    const directory = path.join(sandbox, 'evidence-dir');
+    mkdirSync(directory);
+    for (const key of [
+      'FLEET_QUALIFICATION_RAW_EVIDENCE',
+      'FLEET_QUALIFICATION_CANDIDATE_ARTIFACT',
+      'FLEET_QUALIFICATION_CANDIDATE_MANIFEST',
+    ]) {
+      expect(() => resolveInSandbox({ [key]: directory })).toThrow(QualificationBlockedError);
+    }
+  });
+
+  it('blocks an input that is a FIFO instead of blocking the run on it', () => {
+    const fifo = path.join(sandbox, 'evidence-fifo');
+    execFileSync('mkfifo', [fifo]);
+    expect(() => resolveInSandbox({ FLEET_QUALIFICATION_RAW_EVIDENCE: fifo })).toThrow(
+      QualificationBlockedError
+    );
+  });
+
+  it('blocks an input path that aliases the params or verdict file', () => {
+    for (const name of ['params.json', 'verdict.json']) {
+      const alias = path.join(sandbox, ARTIFACT_ROOT, name);
+      mkdirSync(path.dirname(alias), { recursive: true });
+      writeFileSync(alias, 'OPERATOR EVIDENCE\n');
+      expect(() => resolveInSandbox({ FLEET_QUALIFICATION_RAW_EVIDENCE: alias })).toThrow(
+        QualificationBlockedError
+      );
+      // The caller's own file is still intact — nothing truncated it.
+      expect(readFileSync(alias, 'utf8')).toBe('OPERATOR EVIDENCE\n');
+      rmSync(alias);
+    }
+  });
+
+  it('does not follow a symlink planted at the params path', () => {
+    const victim = path.join(sandbox, 'victim.json');
+    writeFileSync(victim, 'DO NOT OVERWRITE\n');
+    const paramsPath = path.join(sandbox, ARTIFACT_ROOT, 'params.json');
+    mkdirSync(path.dirname(paramsPath), { recursive: true });
+    symlinkSync(victim, paramsPath);
+
+    const inputs = resolveInSandbox();
+    expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
+    expect(readFileSync(victim, 'utf8')).toBe('DO NOT OVERWRITE\n');
+  });
+
+  it('does not follow a symlinked artifact root', () => {
+    const elsewhere = mkdtempSync(path.join(tmpdir(), 'fleet-qual-victim-'));
+    const root = path.join(sandbox, ARTIFACT_ROOT);
+    mkdirSync(path.dirname(root), { recursive: true });
+    symlinkSync(elsewhere, root);
+
+    const inputs = resolveInSandbox();
+    expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
+    expect(readdirSync(elsewhere)).toEqual([]);
+    rmSync(elsewhere, { recursive: true, force: true });
+  });
+
+  it('blocks a reused run id rather than overwriting its params file', () => {
+    const inputs = resolveInSandbox();
+    writeQualificationParams(inputs, { cwd: sandbox });
+    expect(() => writeQualificationParams(inputs, { cwd: sandbox })).toThrow(QualificationBlockedError);
+  });
+});
+
+describe('fleet qualification argv parsing', () => {
+  it("does not accept a known flag as another flag's value", () => {
+    const argv = ['node', 'verify-evidence.mjs', '--input', '--expected-head', 'a'.repeat(40)];
+    expect(argument(argv, '--input')).toBeUndefined();
+    expect(argument(argv, '--expected-head')).toBe('a'.repeat(40));
+  });
+
+  it('does not read past the end of the command line', () => {
+    expect(argument(['node', 'verify-evidence.mjs', '--params'], '--params')).toBeUndefined();
+  });
+
+  it('still reads a well-formed value', () => {
+    expect(argument(['node', 'x.mjs', '--params', 'a/params.json'], '--params')).toBe('a/params.json');
   });
 });

--- a/workflows/fleet-qualification.ts
+++ b/workflows/fleet-qualification.ts
@@ -5,23 +5,27 @@
  * FLEET_QUALIFICATION_RAW_EVIDENCE. This Relayflow, at a committed head, owns
  * the source-inventory gate and the only path that can emit a PASS verdict.
  * Narrative or agent transcripts are never inputs to the verdict.
+ *
+ * Operator-supplied inputs are validated in-process and handed to the
+ * deterministic steps through a params file. They are never interpolated into
+ * a shell command, so shell metacharacters in an evidence path cannot execute.
+ * See scripts/fleet-qualification/preflight.mjs.
  */
 import { workflow } from '@relayflows/core';
 
-const requestedRunId = process.env.FLEET_QUALIFICATION_RUN_ID ?? `fleet-${Date.now()}`;
-if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(requestedRunId)) {
-  throw new Error('FLEET_QUALIFICATION_RUN_ID must be a safe 1-128 character artifact name');
-}
-const runId = requestedRunId;
-const artifacts = `.workflow-artifacts/fleet-qualification/${runId}`;
-const rawEvidence = process.env.FLEET_QUALIFICATION_RAW_EVIDENCE ?? '';
-const expectedHead = process.env.FLEET_QUALIFICATION_EXPECTED_HEAD ?? '';
-const candidateArtifact = process.env.FLEET_QUALIFICATION_CANDIDATE_ARTIFACT ?? '';
-const candidateManifest = process.env.FLEET_QUALIFICATION_CANDIDATE_MANIFEST ?? '';
-
-const shQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`;
+import {
+  BLOCKED_EXIT_CODE,
+  buildQualificationCommands,
+  QualificationBlockedError,
+  resolveQualificationInputs,
+  writeQualificationParams,
+} from '../scripts/fleet-qualification/preflight.mjs';
 
 async function runWorkflow() {
+  const inputs = resolveQualificationInputs(process.env);
+  writeQualificationParams(inputs, { cwd: process.cwd() });
+  const commands = buildQualificationCommands(inputs);
+
   const result = await workflow('relay-fleet-qualification')
     .description(
       'Verify the source-derived 95-operation public non-Cloud matrix and emit the final dual-Daytona qualification verdict from deterministic harness evidence.'
@@ -35,46 +39,28 @@ async function runWorkflow() {
     .onError('fail-fast')
     .step('preflight', {
       type: 'deterministic',
-      command: [
-        'set -eu',
-        `test -n ${shQuote(rawEvidence)} || { echo "BLOCKED: FLEET_QUALIFICATION_RAW_EVIDENCE is required"; exit 2; }`,
-        `test -f ${shQuote(rawEvidence)} || { echo "BLOCKED: raw evidence file is absent"; exit 2; }`,
-        `test -f ${shQuote(candidateArtifact)} || { echo "BLOCKED: packed candidate artifact is absent"; exit 2; }`,
-        `test -f ${shQuote(candidateManifest)} || { echo "BLOCKED: candidate manifest is absent"; exit 2; }`,
-        `printf '%s' ${shQuote(expectedHead)} | grep -Eq '^[0-9a-fA-F]{40}$' || { echo "BLOCKED: FLEET_QUALIFICATION_EXPECTED_HEAD must be a full Git SHA"; exit 2; }`,
-        `mkdir -p ${shQuote(artifacts)}`,
-        'test "$(git status --porcelain --untracked-files=no)" = "" || { echo "BLOCKED: tracked worktree is dirty"; exit 2; }',
-        `test "$(git rev-parse HEAD)" = ${shQuote(expectedHead.toLowerCase())} || { echo "BLOCKED: worktree HEAD differs from FLEET_QUALIFICATION_EXPECTED_HEAD"; exit 2; }`,
-      ].join('\n'),
+      command: commands.preflight,
       captureOutput: true,
       failOnError: true,
     })
     .step('source-inventory', {
       type: 'deterministic',
       dependsOn: ['preflight'],
-      command:
-        './node_modules/.bin/vitest run tests/fixtures/fleet-qualification-evidence.test.ts -t "source enumeration"',
+      command: commands.sourceInventory,
       captureOutput: true,
       failOnError: true,
     })
     .step('verify-evidence', {
       type: 'deterministic',
       dependsOn: ['source-inventory'],
-      command: [
-        'set -eu',
-        `node scripts/fleet-qualification/verify-evidence.mjs --input ${shQuote(rawEvidence)} --output ${shQuote(`${artifacts}/verdict.json`)} --expected-head ${shQuote(expectedHead.toLowerCase())} --candidate-artifact ${shQuote(candidateArtifact)} --candidate-manifest ${shQuote(candidateManifest)}`,
-        `test -s ${shQuote(`${artifacts}/verdict.json`)}`,
-      ].join('\n'),
+      command: commands.verifyEvidence,
       captureOutput: true,
       failOnError: true,
     })
     .step('final-hard-acceptance', {
       type: 'deterministic',
       dependsOn: ['verify-evidence'],
-      command: [
-        'set -eu',
-        `node -e 'const fs=require("node:fs");const v=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));if(v.verdict!=="PASS"||v.operationCount!==95||v.attemptCount!==190||v.nodeResourceIds.length<2||v.relayCommitSha!==process.argv[2])process.exit(1);console.log("FINAL_ACCEPTANCE_OK head="+process.argv[2]+" operations=95 attempts=190 nodes="+v.nodeResourceIds.length)' ${shQuote(`${artifacts}/verdict.json`)} ${shQuote(expectedHead.toLowerCase())}`,
-      ].join('\n'),
+      command: commands.finalAcceptance,
       captureOutput: true,
       failOnError: true,
     })
@@ -84,6 +70,10 @@ async function runWorkflow() {
 }
 
 runWorkflow().catch((error) => {
+  if (error instanceof QualificationBlockedError) {
+    console.error(error.message);
+    process.exit(BLOCKED_EXIT_CODE);
+  }
   console.error(error);
   process.exit(1);
 });


### PR DESCRIPTION
Closes #1692. **Does not close #1693** — see "What this PR does not fix" below.

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

> **Blocked on #1695 — merge that first.** The `RelayFlow PR proof` check will
> stay red until it lands; nothing in this PR can turn it green. Details in
> "Known-red CI" below.

## What was wrong

`workflows/fleet-qualification.ts` interpolated operator-supplied env values
(`FLEET_QUALIFICATION_RAW_EVIDENCE`, the candidate artifact/manifest paths, the
expected head) into the shell string of the "deterministic" preflight step.

At `f182abbe3` that used `JSON.stringify`, which produces a **double-quoted**
shell word — `$`, backticks and `${}` still expand.

### Reproduction, with a real side effect

```
=== f182abbe3  JSON.stringify (as reported by F3) ===
rendered shell:
set -eu
test -n "x$(touch /tmp/F3-PWNED-6141)" || { echo "BLOCKED: FLEET_QUALIFICATION_RAW_EVIDENCE is required"; exit 2; }
SIDE EFFECT /tmp/F3-PWNED-6141 created: YES -> INJECTION

=== 57a270cb2  shQuote (branch HEAD) ===
rendered shell:
set -eu
test -n 'x$(touch /tmp/F3-PWNED-6141)' || { echo "BLOCKED: FLEET_QUALIFICATION_RAW_EVIDENCE is required"; exit 2; }
SIDE EFFECT /tmp/F3-PWNED-6141 created: no

RESULT: vulnerable=true head=false
```

**`4f74f4069` already fixed the `$(...)` form** by swapping `JSON.stringify` for
a hand-rolled POSIX single-quote `shQuote`, so this PR's base is not vulnerable
to the reported payload. I'm not claiming that fix. What is still missing:

1. **No regression test.** Nothing asserted an evidence path can't execute, so
   reintroducing `JSON.stringify` or `"..."` would land silently.
2. **The values were still in the command string** when the Relayflow runner
   does its own `{{param}}` substitution pass *after* our quoting
   (`runner.js`: `interpolateStepTask` → `.replace(/\{\{...\}\}/g, ...)` →
   `cpSpawn('sh', ['-c', resolvedCommand])`). Escaping correctly at build time
   doesn't help when something else rewrites the string afterwards.

## The fix

Relayflow deterministic steps only take a shell string — `DeterministicStepOptions`
has `command: string` and no argv form — and the runner's env is allowlisted
(`filteredEnv`), so `FLEET_QUALIFICATION_*` can't be read as `"$VAR"` inside the
step either. So instead of escaping better, operator input never reaches a
command at all:

- **`scripts/fleet-qualification/preflight.mjs`** (new) validates every env
  input in-process and writes them to a params file whose path derives solely
  from the charset-restricted run id. `shellInertLiteral` **rejects** any value
  that would need escaping rather than escaping it.
- **`scripts/fleet-qualification/params.mjs`** (new) reads that file back.
- **`final-acceptance.mjs`** (new) replaces the inline `node -e '…'` one-liner.
- **`verify-evidence.mjs`** gains `--params`; the explicit flags still work for
  direct invocation.
- **`shQuote` is deleted.** The rendered commands are byte-identical no matter
  what the operator supplies — asserted directly by the test.

Behaviour change worth a reviewer's eye: blocked inputs keep the same `BLOCKED:`
message and exit code 2, but now fail *before* the workflow starts instead of
inside the preflight step, so a bad input no longer produces a run record.

## Regression test

`tests/fixtures/fleet-qualification-shell-injection.test.ts` creates real files
whose **names** carry `$(touch …)`, backtick and `';touch …;'` payloads, so they
pass existence validation and reach every place the workflow uses them. It then
executes every rendered command under `/bin/sh -c` and asserts no marker file
appears.

### Proof the test bites

Reintroducing the `f182abbe3` interpolation into `buildQualificationCommands`:

```
MUTATED: reintroduced f182abbe3 JSON.stringify interpolation
 × keeps every operator-supplied value out of the deterministic commands 10ms
 × does not execute a $(...), backtick or quote-break payload from the evidence paths 217ms

AssertionError: expected 'set -eu\ntest -n "/var/folders/6d/0x5…' not to contain '/var/folders/…'
AssertionError: payload executed and created /var/folders/…/fleet-qual-inject-PyeHow/pwned-evidence: expected true to be false

Tests  2 failed | 4 passed (6)
```

Restored:

```
Test Files  2 passed (2)
     Tests  25 passed (25)
```

(`fleet-qualification-shell-injection.test.ts` + `fleet-qualification-evidence.test.ts`.)

### Functional smoke, malicious path preserved end to end

```
--- verify-evidence --params (evidence path contains $(touch ...)) ---
exit=1
NOT_PASS: schemaVersion must be relay-fleet-qualification/1
marker created: no
(reaching the validator proves the malicious-named file was actually READ, not just rejected)

--- verify-evidence with a bad params file honors the NOT_PASS contract ---
exit=1
NOT_PASS: params file schemaVersion must be relay-fleet-qualification-params/1

--- final-acceptance --params (PASS verdict) ---
exit=0
FINAL_ACCEPTANCE_OK head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa operations=95 attempts=190 nodes=2

--- final-acceptance rejects a head mismatch ---
exit=1
NOT_PASS: verdict does not satisfy final hard acceptance
```

## Known-red CI

**`RelayFlow PR proof` — blocked on #1695.** The gate's non-runtime allowlist
fails closed, so `scripts/fleet-qualification/` counts as runtime surface and
demands a red/green proof case. I could not build an honest one: this PR's base
is `57a270cb2`, where `shQuote` already blocks the `$(...)` payload, so a
`base → outcome: bug` arm would be a lie about the injection. #1695 adds the
subtree to the allowlist, with the reachability check and both-direction tests
that justify it.

It has to be a separate PR: `relayflow-pr-proof.yml` runs on
`pull_request_target` and deliberately checks out
`github.event.pull_request.base.sha`, never PR-head code — a correct security
boundary — so an allowlist change structurally cannot unblock its own PR. Once
#1695 is on the base branch, this check goes green on the next run here.

**`Auto-format Prettier files` — inherited from the base.** It fails at `npm ci`
on a lockfile desync that predates this branch: `Missing: @agent-relay/sdk@8.9.2`,
`@relaycast/sdk@4.2.0`, `@relaycast/types@4.2.0`. This PR touches neither
`package.json` nor `package-lock.json`. `feat/fleet-matrix-qualification-0905`
has no PR of its own, so this is the first CI run the branch has ever had. Out
of scope here — say the word if it should be in scope.

## What this PR does not fix

**#1693: the evidence ledger has no producer.** Nothing in the repo writes a
`relay-fleet-qualification/1` ledger — only the validator and its own fixture
mention the schema. Every substantive claim (`source: 'running-node'`,
`absentById: true`, `kind: 'packed'`, `collector.machineGenerated: true`,
`processEvidence.pid`/`comm`) is a self-reported literal the validator
string-compares.

I confirmed this is still live at this PR's base by fabricating a ledger with no
Daytona sandbox, a "packed candidate artifact" whose contents are the text
`this is not a relay tarball`, and all 190 attempts claiming `targetHostPid: 1`
and `comm: 'x'`:

```
verify-evidence.mjs exit=0
FLEET_QUALIFICATION_PASS operations=95 attempts=190 nodes=sandbox-imaginary-1,sandbox-imaginary-2
```

That is a design gap, not an escaping gap, and it needs a collector rather than
a validator edit — so it is deliberately out of scope here. Please don't read a
green CI run on this PR as the qualification gate being sound. Details and
recommended shape in #1693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YoCXdjLQ2TyWUjKPqbjfx
