### PR TITLE
ci(pr-proof): treat scripts/fleet-qualification/ as non-runtime

### DIFF
--- a/scripts/pr-proof/contract.mjs
+++ b/scripts/pr-proof/contract.mjs
@@ -103,6 +103,12 @@ const NON_RUNTIME_PATH_PATTERNS = Object.freeze([
   /^\.agentworkforce\//,
   /^scripts\/pr-proof\//,
   /^scripts\/evals\//,
+  // Fleet qualification tooling. Imported only by workflows/fleet-qualification.ts
+  // and tests/fixtures/, both already exempt above; referenced by nothing under
+  // packages/ or .github/, and not in any package's `files` array. It exists to
+  // grade a release campaign, not to ship in one. Same class as pr-proof/ and
+  // evals/ — and unlike inject-posthog-key.mjs, no publish step runs it.
+  /^scripts\/fleet-qualification\//,
   /^tests\//,
   /^[^/]*\.md$/,
   // Top-level repo metadata that cannot reach a shipped artifact.

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1838,6 +1838,16 @@ describe('classification reads the diff, not the title', () => {
   it('still exempts the CI-only script subtrees', () => {
     expect(runtimeSurfaceChanged(['scripts/pr-proof/prepare.mjs'])).toBe(false);
     expect(runtimeSurfaceChanged(['scripts/evals/run-relay-evals.mjs'])).toBe(false);
+    expect(runtimeSurfaceChanged(['scripts/fleet-qualification/evidence.mjs'])).toBe(false);
+  });
+
+  /**
+   * The exemption is the subtree, not the word. A sibling that merely starts
+   * with the same prefix must still demand a proof.
+   */
+  it('does not extend the fleet-qualification exemption to sibling paths', () => {
+    expect(runtimeSurfaceChanged(['scripts/fleet-qualification-runner.mjs'])).toBe(true);
+    expect(runtimeSurfaceChanged(['packages/cli/src/fleet-qualification/run.ts'])).toBe(true);
   });
 
   /**


### PR DESCRIPTION
Unblocks #1694.

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

## Why

The proof contract's non-runtime allowlist fails closed, so
`scripts/fleet-qualification/` currently counts as runtime surface and demands a
red/green proof case. It is qualification tooling that grades a release
campaign — nothing a user's `agent-relay` ever executes — so no honest runtime
proof exists for it. This is the exact situation the allowlist's own comment
describes:

> Rejecting it purely because the title says `fix(` forced workflow-only and
> docs-only PRs to fabricate a runtime proof they could not honestly build.

## Verified before adding the pattern

- nothing under `packages/` or `.github/` references `fleet-qualification`
- its only importers are `workflows/fleet-qualification.ts` and
  `tests/fixtures/`, both already exempt
- the only `scripts/` path in any package's `files` array is
  `packages/cli/scripts/build-cjs.mjs`, a different tree
- unlike `scripts/inject-posthog-key.mjs` — the stated reason `scripts/` is not
  exempt wholesale — no publish step runs any of it

## Tests

Both directions are pinned. The subtree is exempt, and a sibling that merely
shares the prefix still demands a proof:

```ts
expect(runtimeSurfaceChanged(['scripts/fleet-qualification/evidence.mjs'])).toBe(false);
expect(runtimeSurfaceChanged(['scripts/fleet-qualification-runner.mjs'])).toBe(true);
expect(runtimeSurfaceChanged(['packages/cli/src/fleet-qualification/run.ts'])).toBe(true);
```

## Why this is a separate PR

`relayflow-pr-proof.yml` runs on `pull_request_target` and deliberately checks
out `github.event.pull_request.base.sha`, never PR-head code — a correct
security boundary. So an allowlist change structurally cannot unblock its own
PR; it only takes effect for PRs opened after it lands on the base. Carrying it
inside #1694 left that PR red for a reason no reviewer could act on, so it is
split out here to be judged on its own merits.

**Merge order:** this PR, then #1694 goes green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YoCXdjLQ2TyWUjKPqbjfx


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

