### PR TITLE
fix(cli): resolve broker URL and API key as an atomic pair

### DIFF
--- a/packages/cli/src/cli/lib/attach-native.test.ts
+++ b/packages/cli/src/cli/lib/attach-native.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { EventEmitter } from 'node:events';
 
-import { attachNative, renderNativeHarnessDiagnostic, renderAgentEvent } from './attach-native.js';
+import {
+  attachNative,
+  isNativeHarness,
+  renderNativeHarnessDiagnostic,
+  renderAgentEvent,
+} from './attach-native.js';
 
 const envelope = (kind: string, fields: Record<string, unknown> = {}) =>
   ({
@@ -203,5 +208,19 @@ describe('native harness attach rendering', () => {
     expect(() =>
       JSON.parse(renderNativeHarnessDiagnostic(diagnostic, { diagnostics: true, json: true })!.trim())
     ).not.toThrow();
+  });
+});
+
+describe('isNativeHarness', () => {
+  // Regression (#1382): a mismatched or unreachable broker connection must
+  // degrade this capability probe to `false`, not reject and abort the
+  // whole attach before it ever tries the non-native fallback path.
+  it('degrades to false when the capability probe fails instead of throwing', async () => {
+    const failingFetch = (async () => {
+      throw new Error('401 Unauthorized');
+    }) as unknown as typeof globalThis.fetch;
+    await expect(
+      isNativeHarness('Worker', { brokerUrl: 'http://broker' }, failingFetch)
+    ).resolves.toBe(false);
   });
 });

--- a/packages/cli/src/cli/lib/attach-native.test.ts
+++ b/packages/cli/src/cli/lib/attach-native.test.ts
@@ -219,8 +219,8 @@ describe('isNativeHarness', () => {
     const failingFetch = (async () => {
       throw new Error('401 Unauthorized');
     }) as unknown as typeof globalThis.fetch;
-    await expect(
-      isNativeHarness('Worker', { brokerUrl: 'http://broker' }, failingFetch)
-    ).resolves.toBe(false);
+    await expect(isNativeHarness('Worker', { brokerUrl: 'http://broker' }, failingFetch)).resolves.toBe(
+      false
+    );
   });
 });

--- a/packages/cli/src/cli/lib/attach-native.ts
+++ b/packages/cli/src/cli/lib/attach-native.ts
@@ -304,7 +304,16 @@ export async function isNativeHarness(
     env: process.env,
   });
   if (!connection) return false;
-  const client = createBrokerClient(connection, fetchFn);
-  const agent = (await client.listAgents()).find((candidate) => candidate.name === name);
-  return agent?.runtime_kind === 'native';
+  // This is a capability probe, not the attach itself: a rejection here
+  // (auth failure, network error, broker unreachable) must degrade to
+  // `false` so `runAttach` falls back to the non-native attach path
+  // instead of the whole attach aborting on a probe it never asked to be
+  // load-bearing (#1382).
+  try {
+    const client = createBrokerClient(connection, fetchFn);
+    const agent = (await client.listAgents()).find((candidate) => candidate.name === name);
+    return agent?.runtime_kind === 'native';
+  } catch {
+    return false;
+  }
 }

--- a/packages/cli/src/cli/lib/broker-connection.test.ts
+++ b/packages/cli/src/cli/lib/broker-connection.test.ts
@@ -64,11 +64,10 @@ describe('resolveBrokerConnection', () => {
 
   it('falls through to env API key when --api-key is blank/whitespace', () => {
     const deps = makeDeps({
-      env: { RELAY_BROKER_API_KEY: 'env-key' },
-      readConnectionFile: vi.fn(() => ({ url: 'http://localhost:3889' })),
+      env: { RELAY_BROKER_URL: 'http://env-host:1234', RELAY_BROKER_API_KEY: 'env-key' },
     });
     const conn = resolveBrokerConnection({ apiKey: '   ' }, deps);
-    expect(conn?.apiKey).toBe('env-key');
+    expect(conn).toEqual({ url: 'http://env-host:1234', apiKey: 'env-key' });
   });
 
   it('falls through to file URL when env URL is blank/whitespace', () => {
@@ -87,6 +86,37 @@ describe('resolveBrokerConnection', () => {
     });
     const conn = resolveBrokerConnection({}, deps);
     expect(conn?.apiKey).toBe('file-key');
+  });
+
+  // ---- Regression: URL and API key must resolve as an atomic pair (#1382) ----
+
+  it('does not pair an env-sourced API key with a file-sourced URL', () => {
+    // A relay agent's own broker key sitting in env (RELAY_BROKER_API_KEY)
+    // must not get paired with a different repo's broker URL, resolved
+    // here from that repo's connection.json with no explicit/env URL.
+    const deps = makeDeps({
+      env: { RELAY_BROKER_API_KEY: 'own-broker-key' },
+      readConnectionFile: vi.fn(() => ({ url: 'http://target-repo-host:4000' })),
+    });
+    const conn = resolveBrokerConnection({}, deps);
+    expect(conn).toEqual({ url: 'http://target-repo-host:4000', apiKey: undefined });
+  });
+
+  it('an explicit --api-key still overrides a file-sourced URL', () => {
+    const deps = makeDeps({
+      env: { RELAY_BROKER_API_KEY: 'own-broker-key' },
+      readConnectionFile: vi.fn(() => ({ url: 'http://target-repo-host:4000' })),
+    });
+    const conn = resolveBrokerConnection({ apiKey: 'explicit-key' }, deps);
+    expect(conn).toEqual({ url: 'http://target-repo-host:4000', apiKey: 'explicit-key' });
+  });
+
+  it('an explicit --broker-url still discovers its key from env or file normally', () => {
+    const deps = makeDeps({
+      readConnectionFile: vi.fn(() => ({ url: 'http://file-host:5678', api_key: 'file-key' })),
+    });
+    const conn = resolveBrokerConnection({ brokerUrl: 'http://flag-host:9999' }, deps);
+    expect(conn).toEqual({ url: 'http://flag-host:9999', apiKey: 'file-key' });
   });
 });
 

--- a/packages/cli/src/cli/lib/broker-connection.ts
+++ b/packages/cli/src/cli/lib/broker-connection.ts
@@ -84,6 +84,19 @@ function trimOrUndefined(value: string | undefined): string | undefined {
 /**
  * Resolve the broker connection in priority order. Returns `null` when no
  * source provides a URL — the caller decides how to surface that.
+ *
+ * URL and API key are not resolved independently past the explicit tier.
+ * A process that is itself a relay agent carries its own broker's
+ * `RELAY_BROKER_API_KEY` in env; if that key got paired with a URL that
+ * resolved from a *different* source (typically another repo's
+ * `connection.json`, e.g. `agent-relay node agent attach` against another
+ * repo's broker), the pair can never authenticate (#1382). Once the URL
+ * resolves from env or the connection file, the key must resolve from that
+ * same tier (or an explicit `--api-key` override) — never reach past it
+ * into a different tier. An explicit `--broker-url` is exempt: it is a
+ * deliberate, single-field override, and the key still resolves normally
+ * beneath it (env, then file) so `--broker-url` alone does not force the
+ * caller to also pass `--api-key`.
  */
 export function resolveBrokerConnection(
   options: BrokerConnectionOptions,
@@ -95,13 +108,23 @@ export function resolveBrokerConnection(
   const connectionFile = deps.readConnectionFile(stateDir);
   const fileUrl = readString(connectionFile, 'url');
 
-  const url = explicitUrl ?? envUrl ?? fileUrl;
-  if (!url) return null;
-
   const explicitKey = trimOrUndefined(options.apiKey);
   const envKey = trimOrUndefined(deps.env.RELAY_BROKER_API_KEY);
   const fileKey = readString(connectionFile, 'api_key');
-  const apiKey = explicitKey ?? envKey ?? fileKey;
+
+  let url: string | undefined;
+  let apiKey: string | undefined;
+  if (explicitUrl) {
+    url = explicitUrl;
+    apiKey = explicitKey ?? envKey ?? fileKey;
+  } else if (envUrl) {
+    url = envUrl;
+    apiKey = explicitKey ?? envKey;
+  } else if (fileUrl) {
+    url = fileUrl;
+    apiKey = explicitKey ?? fileKey;
+  }
+  if (!url) return null;
 
   return {
     url: url.replace(/\/+$/, ''),

--- a/tests/relayflows/cases/1382-broker-atomic-credential-pairing/case.json
+++ b/tests/relayflows/cases/1382-broker-atomic-credential-pairing/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1382-broker-atomic-credential-pairing",
+  "kind": "bugfix",
+  "title": "Resolve broker URL and API key as an atomic pair; degrade the native-harness probe on failure",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1382-broker-atomic-credential-pairing/run.mjs"]
+  },
+  "timeoutSeconds": 300,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "cross_wired_credential_pair_and_probe_abort"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "atomic_credential_pair_and_probe_degrades"
+    }
+  }
+}

--- a/tests/relayflows/cases/1382-broker-atomic-credential-pairing/probe.test.mts
+++ b/tests/relayflows/cases/1382-broker-atomic-credential-pairing/probe.test.mts
@@ -9,7 +9,9 @@ const ARM = process.env.RELAY_PR_PROOF_ARM;
 function makeDeps(overrides: { env?: NodeJS.ProcessEnv; fileUrl?: string; fileKey?: string } = {}) {
   return {
     readConnectionFile: () =>
-      overrides.fileUrl ? { url: overrides.fileUrl, ...(overrides.fileKey ? { api_key: overrides.fileKey } : {}) } : null,
+      overrides.fileUrl
+        ? { url: overrides.fileUrl, ...(overrides.fileKey ? { api_key: overrides.fileKey } : {}) }
+        : null,
     getDefaultStateDir: () => '/tmp/fake/.agentworkforce/relay',
     env: overrides.env ?? {},
   };

--- a/tests/relayflows/cases/1382-broker-atomic-credential-pairing/probe.test.mts
+++ b/tests/relayflows/cases/1382-broker-atomic-credential-pairing/probe.test.mts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+// The runner copies this probe to <target>/.relay-pr-proof before execution.
+import { resolveBrokerConnection } from '../packages/cli/src/cli/lib/broker-connection.js';
+import { isNativeHarness } from '../packages/cli/src/cli/lib/attach-native.js';
+
+const ARM = process.env.RELAY_PR_PROOF_ARM;
+
+function makeDeps(overrides: { env?: NodeJS.ProcessEnv; fileUrl?: string; fileKey?: string } = {}) {
+  return {
+    readConnectionFile: () =>
+      overrides.fileUrl ? { url: overrides.fileUrl, ...(overrides.fileKey ? { api_key: overrides.fileKey } : {}) } : null,
+    getDefaultStateDir: () => '/tmp/fake/.agentworkforce/relay',
+    env: overrides.env ?? {},
+  };
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    return { resolved: await promise };
+  } catch (error) {
+    return { rejected: error };
+  }
+}
+
+describe('broker connection atomic credential pairing proof', () => {
+  it('observes the declared base bug or the complete head fix', async () => {
+    expect(['base', 'head']).toContain(ARM);
+
+    // Scenario: a relay agent's own RELAY_BROKER_API_KEY sits in env (its own
+    // broker's credential) while attaching to a *different* repo's broker,
+    // whose URL resolves from that repo's connection.json. No explicit or
+    // env URL is provided.
+    const deps = makeDeps({
+      env: { RELAY_BROKER_API_KEY: 'own-broker-key' },
+      fileUrl: 'http://target-repo-host:4000',
+    });
+    const connection = resolveBrokerConnection({}, deps);
+
+    // A probe that always fails, standing in for a broker rejecting a
+    // mismatched credential with 401 (or being unreachable at all) — the
+    // point under test is whether isNativeHarness propagates that failure
+    // or degrades to `false`, not the transport itself.
+    const failingFetch = (async () => {
+      throw new Error('401 Unauthorized');
+    }) as unknown as typeof globalThis.fetch;
+    const probeOutcome = await captureRejection(
+      isNativeHarness('Worker', { brokerUrl: connection?.url }, failingFetch)
+    );
+
+    if (ARM === 'base') {
+      // Bug 1: the env-sourced key rides along with the file-sourced URL.
+      expect(connection).toEqual({ url: 'http://target-repo-host:4000', apiKey: 'own-broker-key' });
+      // Bug 2: the capability probe's rejection propagates and would abort
+      // the whole attach before any non-native fallback runs.
+      expect(probeOutcome).toHaveProperty('rejected');
+      return;
+    }
+
+    // Fix 1: the key never reaches past the tier that supplied the URL, so
+    // an unrelated env-sourced key is never paired with the file's URL.
+    expect(connection).toEqual({ url: 'http://target-repo-host:4000', apiKey: undefined });
+    // Fix 2: the probe degrades to `false` instead of aborting the attach.
+    expect(probeOutcome).toEqual({ resolved: false });
+
+    // An explicit --api-key still overrides, and an explicit --broker-url
+    // still discovers its key normally beneath it — the fix narrows only
+    // the cross-tier leak, it does not remove either override path.
+    const explicitKeyDeps = makeDeps({
+      env: { RELAY_BROKER_API_KEY: 'own-broker-key' },
+      fileUrl: 'http://target-repo-host:4000',
+    });
+    expect(resolveBrokerConnection({ apiKey: 'explicit-key' }, explicitKeyDeps)).toEqual({
+      url: 'http://target-repo-host:4000',
+      apiKey: 'explicit-key',
+    });
+    const explicitUrlDeps = makeDeps({ fileUrl: 'http://file-host:5678', fileKey: 'file-key' });
+    expect(resolveBrokerConnection({ brokerUrl: 'http://flag-host:9999' }, explicitUrlDeps)).toEqual({
+      url: 'http://flag-host:9999',
+      apiKey: 'file-key',
+    });
+  });
+});

--- a/tests/relayflows/cases/1382-broker-atomic-credential-pairing/run.mjs
+++ b/tests/relayflows/cases/1382-broker-atomic-credential-pairing/run.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { access, copyFile, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1382-broker-atomic-credential-pairing';
+const arm = process.env.RELAY_PR_PROOF_ARM;
+const targetDir = process.env.RELAY_PR_PROOF_TARGET_DIR;
+const resultPath = process.env.RELAY_PR_PROOF_RESULT_PATH;
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+
+if ((arm !== 'base' && arm !== 'head') || !targetDir || !resultPath) {
+  throw new Error('RelayFlow proof environment is incomplete');
+}
+
+async function pathExists(candidate) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  process.stdout.write(result.stdout ?? '');
+  process.stderr.write(result.stderr ?? '');
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
+  }
+}
+
+const vitestEntry = path.join(targetDir, 'node_modules', 'vitest', 'vitest.mjs');
+if (!(await pathExists(vitestEntry))) {
+  run('npm', ['ci', '--no-audit', '--no-fund'], targetDir);
+}
+
+const proofDir = path.join(targetDir, '.relay-pr-proof');
+const probePath = path.join(proofDir, 'broker-atomic-credential-pairing.test.mts');
+const configPath = path.join(proofDir, 'vitest.config.mts');
+await mkdir(proofDir, { recursive: true });
+await copyFile(path.join(caseDir, 'probe.test.mts'), probePath);
+// Reuse the root config's `resolve.alias` only (not its `test.include`,
+// which `mergeConfig` would otherwise concatenate with ours and run the
+// whole repo suite): `broker-connection.ts` imports `@agent-relay/config`
+// by package name, which only resolves without a prior build via the root
+// config's workspace-package -> `src/index.ts` aliases.
+await writeFile(
+  configPath,
+  `import { defineConfig } from 'vitest/config';\nimport rootConfig from '../vitest.config.ts';\n\nexport default defineConfig({\n  resolve: { alias: rootConfig.resolve?.alias },\n  test: { environment: 'node', include: ['.relay-pr-proof/broker-atomic-credential-pairing.test.mts'] },\n});\n`
+);
+
+run(process.execPath, [vitestEntry, 'run', '--config', configPath, '--reporter=verbose'], targetDir);
+
+const observation =
+  arm === 'base'
+    ? {
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'bug',
+        signature: 'cross_wired_credential_pair_and_probe_abort',
+        details:
+          'A relay agent\'s own RELAY_BROKER_API_KEY (env) got paired with a different broker\'s URL resolved from connection.json, and the isNativeHarness capability probe\'s rejection propagated instead of degrading, aborting the whole attach.',
+      }
+    : {
+        version: 1,
+        caseId: CASE_ID,
+        arm,
+        outcome: 'fixed',
+        signature: 'atomic_credential_pair_and_probe_degrades',
+        details:
+          'URL and API key now resolve from the same source once the URL comes from env or the connection file (an explicit --api-key still overrides, and an explicit --broker-url still discovers its key normally). isNativeHarness degrades to false on any probe failure instead of aborting the attach.',
+      };
+
+await writeFile(resultPath, `${JSON.stringify(observation, null, 2)}\n`);

--- a/tests/relayflows/cases/1382-broker-atomic-credential-pairing/run.mjs
+++ b/tests/relayflows/cases/1382-broker-atomic-credential-pairing/run.mjs
@@ -71,7 +71,7 @@ const observation =
         outcome: 'bug',
         signature: 'cross_wired_credential_pair_and_probe_abort',
         details:
-          'A relay agent\'s own RELAY_BROKER_API_KEY (env) got paired with a different broker\'s URL resolved from connection.json, and the isNativeHarness capability probe\'s rejection propagated instead of degrading, aborting the whole attach.',
+          "A relay agent's own RELAY_BROKER_API_KEY (env) got paired with a different broker's URL resolved from connection.json, and the isNativeHarness capability probe's rejection propagated instead of degrading, aborting the whole attach.",
       }
     : {
         version: 1,


### PR DESCRIPTION
## Summary

A relay agent's own `RELAY_BROKER_API_KEY` (env, its own broker's credential) could get paired with a *different* broker's URL resolved from `connection.json` (e.g. `agent-relay node agent attach <name>` against another repo's broker), since `resolveBrokerConnection` picked the URL and key independently from explicit/env/file sources instead of as a pair. The mismatched pair 401s and, because `isNativeHarness`'s capability probe let that rejection propagate, aborted the whole attach before the non-native fallback path ever ran.

Fixes #1382. Chief's orgchart tool has a manual `RELAY_BROKER_API_KEY`/`RELAY_BROKER_URL` env-unset workaround for this that can be deleted once this merges.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing completed

Added regression tests to `broker-connection.test.ts` (atomic pairing, explicit-override cases) and `attach-native.test.ts` (`isNativeHarness` degrades instead of throwing). Updated one existing test (`falls through to env API key when --api-key is blank/whitespace`) whose fixture happened to encode the exact cross-wiring bug as "expected" — its intent (blank explicit key falls through to env) is preserved, just with an env URL added so env is genuinely the active tier.

Verified locally:
- `packages/cli`: 23/23 tests passing in the two touched files.
- Typecheck: identical pre-existing error count with and without this change (confirmed via `git stash`/`git checkout` diff) — all remaining errors are unrelated workspace-package module resolution from running bare `tsc` outside the monorepo build order.
- Lint: 0 errors on all four touched files.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1382-broker-atomic-credential-pairing` <!-- relay-pr-proof:case -->

Verified both arms locally by checking out the pre-fix source against the probe: base observes the cross-wired pair and the probe-abort exactly as described above; head observes the atomic pair and the probe degrading to `false`.

## Screenshots

N/A — CLI/library fix, no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXsTUKG2oXAfj6dmW838mG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

