### PR TITLE
ci(pr-proof): retain Cloud startup failure diagnostics

### DIFF
--- a/scripts/pr-proof/run-cloud.mjs
+++ b/scripts/pr-proof/run-cloud.mjs
@@ -20,6 +20,9 @@ const MAX_LIVE_OUTPUT_BYTES = 256 * 1024;
 const DEFAULT_COMMAND_TIMEOUT_MS = 2 * 60_000;
 const PREPARED_RUN_ID_MARKER = 'AGENT_RELAY_CLOUD_PREPARED_RUN_ID=';
 const RUN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const MAX_TERMINAL_DIAGNOSTIC_BYTES = 32 * 1024;
+const LIVE_CREDENTIAL =
+  /(rk_live_|rjt_live_|at_live_|nt_live_|ot_live_|cld_at_|rth_at_|ocl_node_enr_|br_)([A-Za-z0-9_%-]+(?:\.[A-Za-z0-9_%-]+)*)/g;
 
 function run(command, args, options = {}) {
   return runBoundedProcess(command, args, {
@@ -59,6 +62,56 @@ function statusFrom(payload) {
     if (typeof candidate === 'string') return candidate.toLowerCase();
   }
   throw new Error('Cloud status response did not contain a status');
+}
+
+function diagnosticString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Keep terminal Cloud failures useful even when the orchestrator never wrote
+ * runner.log. The status route already removes its callback credential; this
+ * additionally whitelists only lifecycle diagnostics, bounds them, and masks
+ * both the dispatcher's exact credential and known Relay credential shapes.
+ */
+export function terminalStatusDiagnostic(payload, secrets = []) {
+  const failure =
+    payload.failure && typeof payload.failure === 'object' && !Array.isArray(payload.failure)
+      ? payload.failure
+      : null;
+  const causeChain = Array.isArray(failure?.causeChain)
+    ? failure.causeChain.map(diagnosticString).filter(Boolean).slice(0, 20)
+    : undefined;
+  const evidence = {
+    runId: diagnosticString(payload.runId),
+    status: diagnosticString(payload.status),
+    sandboxId: diagnosticString(payload.sandboxId),
+    error: diagnosticString(payload.error),
+    ...(failure
+      ? {
+          failure: {
+            phase: diagnosticString(failure.phase),
+            code: diagnosticString(failure.code),
+            message: diagnosticString(failure.message),
+            causeChain,
+            dispatchType: diagnosticString(failure.dispatchType),
+            sandboxId: diagnosticString(failure.sandboxId),
+            occurredAt: diagnosticString(failure.occurredAt),
+          },
+        }
+      : {}),
+  };
+
+  let diagnostic = JSON.stringify(evidence, null, 2);
+  for (const secret of secrets) {
+    if (typeof secret === 'string' && secret.length >= 8) {
+      diagnostic = diagnostic.split(secret).join('[REDACTED_DECLARED_SECRET]');
+    }
+  }
+  diagnostic = diagnostic.replace(LIVE_CREDENTIAL, (_match, prefix, body) =>
+    body.length <= 8 ? `${prefix}\u2026` : `${prefix}\u2026${body.slice(-4)}`
+  );
+  return diagnostic.slice(0, MAX_TERMINAL_DIAGNOSTIC_BYTES);
 }
 
 function requiredCredential(env, name) {
@@ -244,6 +297,7 @@ export async function main() {
 
     const deadline = Date.now() + timeoutMs;
     let terminalStatus = null;
+    let terminalPayload = null;
     while (Date.now() < deadline) {
       await delay(pollMs);
       const statusResult = await runTracked(cli, ['cloud', 'status', runId, '--json'], {
@@ -258,10 +312,12 @@ export async function main() {
         console.warn(`Cloud status poll failed (${statusResult.exitCode}); retrying`);
         continue;
       }
-      const status = statusFrom(parseJsonOutput(statusResult.stdout, 'Cloud status'));
+      const statusPayload = parseJsonOutput(statusResult.stdout, 'Cloud status');
+      const status = statusFrom(statusPayload);
       console.log(`Cloud RelayFlow status: ${status}`);
       if (TERMINAL_SUCCESS.has(status) || TERMINAL_FAILURE.has(status)) {
         terminalStatus = status;
+        terminalPayload = statusPayload;
         terminal = true;
         break;
       }
@@ -278,9 +334,13 @@ export async function main() {
       quiet: true,
       timeoutMs: commandTimeoutMs,
     });
-    await writeFile(logsPath, logs.stdout + logs.stderr);
+    const terminalDiagnostic = terminalPayload
+      ? `\nCloud terminal status:\n${terminalStatusDiagnostic(terminalPayload, [process.env.CLOUD_API_KEY])}\n`
+      : '';
+    await writeFile(logsPath, logs.stdout + logs.stderr + terminalDiagnostic);
     if (logs.stdout) process.stdout.write(logs.stdout);
     if (logs.stderr) process.stderr.write(logs.stderr);
+    if (terminalDiagnostic) process.stderr.write(terminalDiagnostic);
     if (logs.timedOut) throw new Error(`Cloud log retrieval timed out for run ${runId}`);
     if (logs.exitCode !== 0) throw new Error(`Cloud log retrieval failed with exit ${logs.exitCode}`);
 

--- a/scripts/pr-proof/run-cloud.mjs
+++ b/scripts/pr-proof/run-cloud.mjs
@@ -21,8 +21,13 @@ const DEFAULT_COMMAND_TIMEOUT_MS = 2 * 60_000;
 const PREPARED_RUN_ID_MARKER = 'AGENT_RELAY_CLOUD_PREPARED_RUN_ID=';
 const RUN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const MAX_TERMINAL_DIAGNOSTIC_BYTES = 32 * 1024;
+// This action-facing script runs before any repository dependency install.
+// Keep the credential matcher local and dependency-free so importing the
+// runner cannot depend on workspace package resolution.
 const LIVE_CREDENTIAL =
-  /(rk_live_|rjt_live_|at_live_|nt_live_|ot_live_|cld_at_|rth_at_|ocl_node_enr_|br_)([A-Za-z0-9_%-]+(?:\.[A-Za-z0-9_%-]+)*)/g;
+  /(github_pat_|ghp_|gho_|ghu_|ghs_|ghr_|rk_live_|rjt_live_|at_live_|nt_live_|ot_live_|cld_at_|rth_at_|ocl_node_enr_|br_)([A-Za-z0-9_%-]+(?:\.[A-Za-z0-9_%-]+)*)/g;
+const LIVE_CREDENTIAL_PREFIX =
+  /^(?:github_pat_|ghp_|gho_|ghu_|ghs_|ghr_|rk_live_|rjt_live_|at_live_|nt_live_|ot_live_|cld_at_|rth_at_|ocl_node_enr_|br_)/;
 
 function run(command, args, options = {}) {
   return runBoundedProcess(command, args, {
@@ -57,15 +62,81 @@ function parseJsonOutput(output, label) {
   }
 }
 
-function statusFrom(payload) {
-  for (const candidate of [payload.status, payload.run?.status, payload.workflowRun?.status]) {
-    if (typeof candidate === 'string') return candidate.toLowerCase();
+function statusPayloadFrom(payload) {
+  for (const candidate of [payload, payload?.run, payload?.workflowRun]) {
+    if (
+      candidate &&
+      typeof candidate === 'object' &&
+      !Array.isArray(candidate) &&
+      typeof candidate.status === 'string'
+    ) {
+      return candidate;
+    }
   }
   throw new Error('Cloud status response did not contain a status');
 }
 
-function diagnosticString(value) {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+function statusFrom(payload) {
+  return statusPayloadFrom(payload).status.toLowerCase();
+}
+
+function truncateUtf8(value, maxBytes = 1_024) {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length <= maxBytes) return value;
+  const contentLimit = Math.max(0, maxBytes - Buffer.byteLength('…'));
+  let end = contentLimit;
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
+  return `${bytes.subarray(0, end).toString('utf8')}…`;
+}
+
+function diagnosticString(value, declaredSecrets = []) {
+  return typeof value === 'string' && value.trim()
+    ? truncateUtf8(redactTerminalDiagnostic(value.trim(), declaredSecrets))
+    : undefined;
+}
+
+function redactTerminalDiagnostic(value, declaredSecrets) {
+  // Remove complete declared values before credential matching. Otherwise a
+  // credential-looking substring can be replaced first and leave the wrapper
+  // around it exposed. Incidental short substrings inside a larger credential
+  // stay intact for whole-credential masking; a declaration that begins at
+  // the credential boundary is authoritative only when it names a known
+  // credential prefix.
+  let redacted = value;
+  for (const secret of declaredSecrets) {
+    const credentialRanges = [...redacted.matchAll(LIVE_CREDENTIAL)].map((match) => ({
+      start: Number(match.index),
+      end: Number(match.index) + match[0].length,
+    }));
+    const replacementRanges = [];
+    let searchFrom = 0;
+    while (searchFrom <= redacted.length - secret.length) {
+      const start = redacted.indexOf(secret, searchFrom);
+      if (start < 0) break;
+      const end = start + secret.length;
+      const containingCredential = credentialRanges.find((range) => start >= range.start && end <= range.end);
+      if (
+        containingCredential &&
+        (start !== containingCredential.start || !LIVE_CREDENTIAL_PREFIX.test(secret))
+      ) {
+        searchFrom = end;
+        continue;
+      }
+      replacementRanges.push(containingCredential ?? { start, end });
+      searchFrom = end;
+    }
+    let cursor = 0;
+    let replacement = '';
+    for (const range of replacementRanges.sort((left, right) => left.start - right.start)) {
+      if (range.start < cursor) continue;
+      replacement += `${redacted.slice(cursor, range.start)}[REDACTED_DECLARED_SECRET]`;
+      cursor = range.end;
+    }
+    if (replacementRanges.length > 0) redacted = replacement + redacted.slice(cursor);
+  }
+  return redacted.replace(LIVE_CREDENTIAL, (_match, prefix, body) =>
+    body.length <= 8 ? `${prefix}\u2026` : `${prefix}\u2026${body.slice(-4)}`
+  );
 }
 
 /**
@@ -75,43 +146,57 @@ function diagnosticString(value) {
  * both the dispatcher's exact credential and known Relay credential shapes.
  */
 export function terminalStatusDiagnostic(payload, secrets = []) {
+  const statusPayload = statusPayloadFrom(payload);
+  const declaredSecrets = [...new Set(secrets.filter((secret) => typeof secret === 'string' && secret))].sort(
+    (left, right) => right.length - left.length
+  );
   const failure =
-    payload.failure && typeof payload.failure === 'object' && !Array.isArray(payload.failure)
-      ? payload.failure
+    statusPayload.failure &&
+    typeof statusPayload.failure === 'object' &&
+    !Array.isArray(statusPayload.failure)
+      ? statusPayload.failure
       : null;
   const causeChain = Array.isArray(failure?.causeChain)
-    ? failure.causeChain.map(diagnosticString).filter(Boolean).slice(0, 20)
+    ? failure.causeChain
+        .map((value) => diagnosticString(value, declaredSecrets))
+        .filter(Boolean)
+        .slice(0, 20)
     : undefined;
   const evidence = {
-    runId: diagnosticString(payload.runId),
-    status: diagnosticString(payload.status),
-    sandboxId: diagnosticString(payload.sandboxId),
-    error: diagnosticString(payload.error),
+    runId: diagnosticString(statusPayload.runId ?? payload.runId, declaredSecrets),
+    status: diagnosticString(statusPayload.status, declaredSecrets),
+    sandboxId: diagnosticString(statusPayload.sandboxId, declaredSecrets),
+    error: diagnosticString(statusPayload.error, declaredSecrets),
     ...(failure
       ? {
           failure: {
-            phase: diagnosticString(failure.phase),
-            code: diagnosticString(failure.code),
-            message: diagnosticString(failure.message),
+            phase: diagnosticString(failure.phase, declaredSecrets),
+            code: diagnosticString(failure.code, declaredSecrets),
+            message: diagnosticString(failure.message, declaredSecrets),
             causeChain,
-            dispatchType: diagnosticString(failure.dispatchType),
-            sandboxId: diagnosticString(failure.sandboxId),
-            occurredAt: diagnosticString(failure.occurredAt),
+            dispatchType: diagnosticString(failure.dispatchType, declaredSecrets),
+            sandboxId: diagnosticString(failure.sandboxId, declaredSecrets),
+            occurredAt: diagnosticString(failure.occurredAt, declaredSecrets),
           },
         }
       : {}),
   };
 
-  let diagnostic = JSON.stringify(evidence, null, 2);
-  for (const secret of secrets) {
-    if (typeof secret === 'string' && secret.length >= 8) {
-      diagnostic = diagnostic.split(secret).join('[REDACTED_DECLARED_SECRET]');
-    }
-  }
-  diagnostic = diagnostic.replace(LIVE_CREDENTIAL, (_match, prefix, body) =>
-    body.length <= 8 ? `${prefix}\u2026` : `${prefix}\u2026${body.slice(-4)}`
+  const diagnostic = JSON.stringify(evidence, null, 2);
+  if (Buffer.byteLength(diagnostic, 'utf8') <= MAX_TERMINAL_DIAGNOSTIC_BYTES) return diagnostic;
+  const fallback = JSON.stringify(
+    {
+      runId: evidence.runId,
+      status: evidence.status,
+      error: '[TERMINAL DIAGNOSTIC OMITTED: exceeded 32768 byte evidence limit]',
+    },
+    null,
+    2
   );
-  return diagnostic.slice(0, MAX_TERMINAL_DIAGNOSTIC_BYTES);
+  if (Buffer.byteLength(fallback, 'utf8') <= MAX_TERMINAL_DIAGNOSTIC_BYTES) return fallback;
+  return JSON.stringify({
+    error: '[TERMINAL DIAGNOSTIC OMITTED: exceeded 32768 byte evidence limit]',
+  });
 }
 
 function requiredCredential(env, name) {
@@ -335,7 +420,7 @@ export async function main() {
       timeoutMs: commandTimeoutMs,
     });
     const terminalDiagnostic = terminalPayload
-      ? `\nCloud terminal status:\n${terminalStatusDiagnostic(terminalPayload, [process.env.CLOUD_API_KEY])}\n`
+      ? `\nCloud terminal status:\n${terminalStatusDiagnostic(terminalPayload, [auth.cliEnv.CLOUD_API_KEY])}\n`
       : '';
     await writeFile(logsPath, logs.stdout + logs.stderr + terminalDiagnostic);
     if (logs.stdout) process.stdout.write(logs.stdout);

--- a/scripts/pr-proof/run-cloud.mjs
+++ b/scripts/pr-proof/run-cloud.mjs
@@ -63,17 +63,28 @@ function parseJsonOutput(output, label) {
 }
 
 function statusPayloadFrom(payload) {
-  for (const candidate of [payload, payload?.run, payload?.workflowRun]) {
-    if (
-      candidate &&
-      typeof candidate === 'object' &&
-      !Array.isArray(candidate) &&
-      typeof candidate.status === 'string'
-    ) {
-      return candidate;
-    }
+  const candidates = [payload, payload?.run, payload?.workflowRun].filter(
+    (candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate)
+  );
+  const primary = candidates.find((candidate) => typeof candidate.status === 'string');
+  if (!primary) throw new Error('Cloud status response did not contain a status');
+  // Some Cloud responses duplicate `status` at the wrapper level while
+  // nesting the detailed failure (phase/code/message/causeChain) under
+  // `run`/`workflowRun` instead of the wrapper itself. Preferring the first
+  // candidate with a `status` string then silently drops that detail. Merge
+  // in whichever candidate actually carries a `failure` object, without
+  // overriding one the primary already has.
+  if (primary.failure === undefined) {
+    const failureSource = candidates.find(
+      (candidate) =>
+        candidate !== primary &&
+        candidate.failure &&
+        typeof candidate.failure === 'object' &&
+        !Array.isArray(candidate.failure)
+    );
+    if (failureSource) return { ...primary, failure: failureSource.failure };
   }
-  throw new Error('Cloud status response did not contain a status');
+  return primary;
 }
 
 function statusFrom(payload) {
@@ -114,15 +125,31 @@ function redactTerminalDiagnostic(value, declaredSecrets) {
       const start = redacted.indexOf(secret, searchFrom);
       if (start < 0) break;
       const end = start + secret.length;
-      const containingCredential = credentialRanges.find((range) => start >= range.start && end <= range.end);
-      if (
-        containingCredential &&
-        (start !== containingCredential.start || !LIVE_CREDENTIAL_PREFIX.test(secret))
-      ) {
-        searchFrom = end;
+      const overlappingCredential = credentialRanges.find((range) => start < range.end && end > range.start);
+      if (overlappingCredential) {
+        const fullyContained = start >= overlappingCredential.start && end <= overlappingCredential.end;
+        const atBoundary = start === overlappingCredential.start && LIVE_CREDENTIAL_PREFIX.test(secret);
+        if (fullyContained && !atBoundary) {
+          // An incidental short match fully inside a larger credential, away
+          // from its boundary: leave it for the whole-credential regex pass
+          // below instead of fragmenting the credential here.
+          searchFrom = end;
+          continue;
+        }
+        // Either the declared secret IS the credential's recognized prefix,
+        // or it only partially overlaps the credential (e.g. starts before
+        // it and ends partway through). A partial replacement in either case
+        // would strip the credential's prefix while leaving its tail intact
+        // and unrecognizable to the final regex pass, so redact the
+        // credential's FULL span instead of just the secret's own span.
+        replacementRanges.push({
+          start: Math.min(start, overlappingCredential.start),
+          end: Math.max(end, overlappingCredential.end),
+        });
+        searchFrom = Math.max(end, overlappingCredential.end);
         continue;
       }
-      replacementRanges.push(containingCredential ?? { start, end });
+      replacementRanges.push({ start, end });
       searchFrom = end;
     }
     let cursor = 0;

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -48,6 +48,7 @@ import {
   createPreparedRunProgressParser,
   createCliApiKeyEnvironment,
   preparedRunIdFromOutput,
+  terminalStatusDiagnostic,
 } from '../../scripts/pr-proof/run-cloud.mjs';
 // @ts-expect-error JavaScript module intentionally has no declaration file.
 import {
@@ -1715,6 +1716,46 @@ describe('trusted dispatcher source contract', () => {
     expect(source).toContain("requiredCredential(env, 'CLOUD_API_KEY')");
     expect(source).not.toContain("path.join(authDir, 'cloud-auth.json')");
     expect(source).not.toContain('CLOUD_API_REFRESH_TOKEN=');
+  });
+
+  it('retains bounded terminal lifecycle evidence while redacting credentials', () => {
+    const declaredSecret = 'cloud-proof-api-key-secret';
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        runId: 'run-1',
+        status: 'failed',
+        sandboxId: null,
+        workflow: 'must not be copied',
+        error: `bootstrap failed with ${declaredSecret}`,
+        failure: {
+          phase: 'launch',
+          code: 'sandbox_provision_failed',
+          message: 'provider rejected br_supersecretcredential',
+          causeChain: ['first cause', 'second cause'],
+          dispatchType: 'sandbox',
+          sandboxId: null,
+          occurredAt: '2026-09-05T23:06:20.000Z',
+          ignored: 'must not be copied',
+        },
+      },
+      [declaredSecret]
+    );
+
+    expect(JSON.parse(diagnostic)).toEqual({
+      runId: 'run-1',
+      status: 'failed',
+      error: 'bootstrap failed with [REDACTED_DECLARED_SECRET]',
+      failure: {
+        phase: 'launch',
+        code: 'sandbox_provision_failed',
+        message: 'provider rejected br_\u2026tial',
+        causeChain: ['first cause', 'second cause'],
+        dispatchType: 'sandbox',
+        occurredAt: '2026-09-05T23:06:20.000Z',
+      },
+    });
+    expect(diagnostic).not.toContain('cloud-proof-api-key-secret');
+    expect(diagnostic).not.toContain('must not be copied');
   });
 
   it('emits the prepared Cloud run id before upload and final submission', async () => {

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1824,6 +1824,55 @@ describe('trusted dispatcher source contract', () => {
     expect(diagnostic).not.toContain('short');
   });
 
+  it('merges a nested failure into a wrapper that already carries its own status', () => {
+    // A response can duplicate `status` at the wrapper level while nesting
+    // the detailed failure under `run`/`workflowRun` instead of the wrapper
+    // itself. Preferring the first candidate with a `status` string must not
+    // silently drop that nested detail.
+    const diagnostic = terminalStatusDiagnostic({
+      status: 'failed',
+      run: {
+        status: 'failed',
+        failure: { phase: 'launch', code: 'workflow_launch_failed', message: 'boom' },
+      },
+    });
+
+    expect(JSON.parse(diagnostic)).toMatchObject({
+      status: 'failed',
+      failure: { phase: 'launch', code: 'workflow_launch_failed', message: 'boom' },
+    });
+  });
+
+  it('does not let a nested candidate override a failure the wrapper already has', () => {
+    const diagnostic = terminalStatusDiagnostic({
+      status: 'failed',
+      failure: { message: 'wrapper failure' },
+      run: { status: 'failed', failure: { message: 'nested failure' } },
+    });
+
+    expect(JSON.parse(diagnostic)).toMatchObject({
+      status: 'failed',
+      failure: { message: 'wrapper failure' },
+    });
+  });
+
+  it('redacts the full credential when a declared secret only partially overlaps it', () => {
+    // A declared secret that starts before a live credential and ends partway
+    // through it must not strip the credential's prefix while leaving its
+    // tail behind — that tail would no longer match the whole-credential
+    // regex pass and would leak.
+    const declaredSecret = 'prefix-before-ghp_0123456789ab';
+    const diagnostic = terminalStatusDiagnostic(
+      { status: 'failed', error: `token ${declaredSecret}cdefghijklmnop trailer` },
+      [declaredSecret]
+    );
+
+    expect(diagnostic).not.toContain(declaredSecret);
+    expect(diagnostic).not.toContain('ghp_0123456789ab');
+    expect(diagnostic).not.toContain('cdefghijklmnop');
+    expect(diagnostic).toContain('[REDACTED_DECLARED_SECRET]');
+  });
+
   it('fully redacts a declared secret that is itself credential-shaped', () => {
     const declaredCredential = 'ghp_0123456789abcdefghijklmnop';
     const diagnostic = terminalStatusDiagnostic(

--- a/tests/fixtures/pr-proof-contract.test.ts
+++ b/tests/fixtures/pr-proof-contract.test.ts
@@ -1718,6 +1718,25 @@ describe('trusted dispatcher source contract', () => {
     expect(source).not.toContain('CLOUD_API_REFRESH_TOKEN=');
   });
 
+  it('keeps the pre-install Cloud runner importable without workspace packages', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'relay-pr-proof-cloud-import-'));
+    try {
+      await copyFile('scripts/pr-proof/run-cloud.mjs', path.join(root, 'run-cloud.mjs'));
+      await copyFile('scripts/pr-proof/process-runner.mjs', path.join(root, 'process-runner.mjs'));
+      execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '--eval',
+          `await import(${JSON.stringify(pathToFileURL(path.join(root, 'run-cloud.mjs')).href)})`,
+        ],
+        { cwd: root, stdio: 'pipe' }
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('retains bounded terminal lifecycle evidence while redacting credentials', () => {
     const declaredSecret = 'cloud-proof-api-key-secret';
     const diagnostic = terminalStatusDiagnostic(
@@ -1756,6 +1775,219 @@ describe('trusted dispatcher source contract', () => {
     });
     expect(diagnostic).not.toContain('cloud-proof-api-key-secret');
     expect(diagnostic).not.toContain('must not be copied');
+  });
+
+  it('extracts nested terminal payloads and redacts every declared and GitHub credential shape', () => {
+    const prefixes = [
+      'ghp_',
+      'gho_',
+      'ghu_',
+      'ghs_',
+      'ghr_',
+      'github_pat_',
+      'rk_live_',
+      'rjt_live_',
+      'at_live_',
+      'nt_live_',
+      'ot_live_',
+      'cld_at_',
+      'rth_at_',
+      'ocl_node_enr_',
+      'br_',
+    ];
+    const credentials = prefixes.flatMap((prefix) => [
+      `${prefix}0123456789abcdefghijklmnop`,
+      `${prefix}short`,
+    ]);
+    const declaredSecret = 'declared-cloud-proof-secret';
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        workflowRun: {
+          runId: 'run-nested',
+          status: 'failed',
+          error: `no ${credentials.join(' ')} declared=${declaredSecret}`,
+          failure: { message: `nested failure ${declaredSecret}` },
+        },
+      },
+      [declaredSecret]
+    );
+    const parsed = JSON.parse(diagnostic);
+    expect(parsed).toMatchObject({
+      runId: 'run-nested',
+      status: 'failed',
+      failure: { message: 'nested failure [REDACTED_DECLARED_SECRET]' },
+    });
+    expect(diagnostic).not.toContain(declaredSecret);
+    for (const credential of credentials) expect(diagnostic).not.toContain(credential);
+    expect(diagnostic).not.toContain('0123456789abcdefghijklmnop');
+    expect(diagnostic).not.toContain('defghijklmnop');
+    expect(diagnostic).not.toContain('short');
+  });
+
+  it('fully redacts a declared secret that is itself credential-shaped', () => {
+    const declaredCredential = 'ghp_0123456789abcdefghijklmnop';
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        runId: declaredCredential,
+        status: 'failed',
+        failure: { message: `provider rejected ${declaredCredential}` },
+      },
+      [declaredCredential]
+    );
+
+    expect(JSON.parse(diagnostic)).toEqual({
+      runId: '[REDACTED_DECLARED_SECRET]',
+      status: 'failed',
+      failure: { message: 'provider rejected [REDACTED_DECLARED_SECRET]' },
+    });
+    expect(diagnostic).not.toContain('ghp_');
+    expect(diagnostic).not.toContain('mnop');
+  });
+
+  it('fully redacts a declared credential followed by another credential-compatible character', () => {
+    const declaredCredential = 'ghp_0123456789abcdefghijklmnop';
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        status: 'failed',
+        error: `provider rejected ${declaredCredential}X`,
+      },
+      [declaredCredential]
+    );
+
+    expect(diagnostic).toContain('[REDACTED_DECLARED_SECRET]');
+    expect(diagnostic).not.toContain(declaredCredential);
+    expect(diagnostic).not.toContain(`${declaredCredential.slice(-4)}X`);
+    expect(diagnostic).not.toContain('ghp_');
+  });
+
+  it('redacts the whole credential when a declared secret is only its recognized prefix', () => {
+    const declaredPrefix = 'ghp_abc';
+    const diagnostic = terminalStatusDiagnostic(
+      { status: 'failed', error: `provider rejected ${declaredPrefix}defghijklmnopqrstuvwxyz` },
+      [declaredPrefix]
+    );
+
+    expect(JSON.parse(diagnostic).error).toBe('provider rejected [REDACTED_DECLARED_SECRET]');
+    expect(diagnostic).not.toContain('ghp_');
+    expect(diagnostic).not.toContain('defghijklmnopqrstuvwxyz');
+  });
+
+  it('redacts an eight-character declared credential body with a compatible suffix', () => {
+    const declaredCredential = 'ghp_12345678';
+    const diagnostic = terminalStatusDiagnostic({ status: 'failed', error: `${declaredCredential}X` }, [
+      declaredCredential,
+    ]);
+
+    expect(diagnostic).toContain('[REDACTED_DECLARED_SECRET]');
+    expect(diagnostic).not.toContain('ghp_');
+    expect(diagnostic).not.toContain('5678X');
+  });
+
+  it('does not classify an arbitrary one-character declaration as a credential containment match', () => {
+    const diagnostic = terminalStatusDiagnostic({ status: 'failed', error: 'ghp_xxxxxxxxxxxx1234' }, ['x']);
+
+    expect(diagnostic).toContain('ghp_…1234');
+    expect(diagnostic).not.toContain('[REDACTED_DECLARED_SECRET]');
+  });
+
+  it('redacts declared credentials before JSON escaping diagnostic fields', () => {
+    const declaredCredential = 'cloud"\\line\nsecret';
+    const diagnostic = terminalStatusDiagnostic(
+      { status: 'failed', error: `before ${declaredCredential} after` },
+      [declaredCredential]
+    );
+
+    expect(JSON.parse(diagnostic).error).toBe('before [REDACTED_DECLARED_SECRET] after');
+    expect(diagnostic).not.toContain('cloud');
+    expect(diagnostic).not.toContain('secret');
+  });
+
+  it('redacts an escaped declared value that begins with a recognized credential prefix', () => {
+    const declaredCredential = 'ghp_abc"\\line\nsecret';
+    const diagnostic = terminalStatusDiagnostic(
+      { status: 'failed', error: `before ${declaredCredential} after` },
+      [declaredCredential]
+    );
+
+    expect(JSON.parse(diagnostic).error).toBe('before [REDACTED_DECLARED_SECRET] after');
+    expect(diagnostic).not.toContain('ghp_');
+    expect(diagnostic).not.toContain('secret');
+  });
+
+  it('redacts a complete declared secret that contains a credential-shaped substring', () => {
+    const declaredCredential = 'wrapper-ghp_0123456789abcdefghijklmnop-tail';
+    const diagnostic = terminalStatusDiagnostic(
+      { status: 'failed', error: `before ${declaredCredential} after` },
+      [declaredCredential]
+    );
+
+    expect(JSON.parse(diagnostic).error).toBe('before [REDACTED_DECLARED_SECRET] after');
+    expect(diagnostic).not.toContain('wrapper');
+    expect(diagnostic).not.toContain('ghp_');
+    expect(diagnostic).not.toContain('tail');
+  });
+
+  it('masks a credential-shaped diagnostic that is only a prefix of a declared secret', () => {
+    const declaredCredential = 'ghp_abc"\\line\nsecret';
+    const diagnostic = terminalStatusDiagnostic({ status: 'failed', error: 'provider returned ghp_abc' }, [
+      declaredCredential,
+    ]);
+
+    expect(JSON.parse(diagnostic).error).toBe('provider returned ghp_\u2026');
+    expect(diagnostic).not.toContain('ghp_abc');
+  });
+
+  it('redacts secret-bearing fallback fields after oversized diagnostics are omitted', () => {
+    const secret = 'overflow-run-id-secret';
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        run: {
+          runId: `run-${secret}`,
+          status: 'failed',
+          failure: { causeChain: Array.from({ length: 20 }, () => '"\\'.repeat(2_000)) },
+        },
+      },
+      [secret]
+    );
+    expect(JSON.parse(diagnostic)).toEqual({
+      runId: 'run-[REDACTED_DECLARED_SECRET]',
+      status: 'failed',
+      error: '[TERMINAL DIAGNOSTIC OMITTED: exceeded 32768 byte evidence limit]',
+    });
+    expect(diagnostic).not.toContain(secret);
+    expect(Buffer.byteLength(diagnostic, 'utf8')).toBeLessThanOrEqual(32 * 1024);
+  });
+
+  it('redacts short secrets before serialization without rewriting JSON keys', () => {
+    const diagnostic = terminalStatusDiagnostic(
+      {
+        runId: 'a'.repeat(1_024),
+        status: 'a'.repeat(1_024),
+        failure: { causeChain: Array.from({ length: 20 }, () => 'x'.repeat(2_000)) },
+      },
+      ['a']
+    );
+
+    const parsed = JSON.parse(diagnostic);
+    expect(Object.keys(parsed)).toEqual(['runId', 'status', 'failure']);
+    expect(parsed.runId).toContain('[REDACTED_DECLARED_SECRET]');
+    expect(parsed.status).toContain('[REDACTED_DECLARED_SECRET]');
+    expect(parsed.failure.causeChain).toHaveLength(20);
+    expect(diagnostic).not.toContain('"f[REDACTED_DECLARED_SECRET]ilure"');
+    expect(Buffer.byteLength(diagnostic, 'utf8')).toBeLessThanOrEqual(32 * 1024);
+  });
+
+  it('always returns valid UTF-8 JSON inside the terminal diagnostic byte limit', () => {
+    const diagnostic = terminalStatusDiagnostic({
+      run: {
+        runId: 'run-large',
+        status: 'failed',
+        error: '💥'.repeat(30_000),
+        failure: { causeChain: Array.from({ length: 20 }, () => 'é'.repeat(4_000)) },
+      },
+    });
+    expect(() => JSON.parse(diagnostic)).not.toThrow();
+    expect(Buffer.byteLength(diagnostic, 'utf8')).toBeLessThanOrEqual(32 * 1024);
   });
 
   it('emits the prepared Cloud run id before upload and final submission', async () => {


### PR DESCRIPTION
A Cloud proof can fail before its runner writes any logs, leaving CI with only `Cloud RelayFlow finished with status failed`. The latest #1665 run followed that path: its Cloud status carried a Relaycast 503 during workspace-key repair, but the dispatcher discarded the error and uploaded an empty log.

Preserve the terminal status's failure phase, code, message, cause chain, and sandbox/run identity in both CI output and the uploaded log. Output is allowlisted, redacted, and bounded to valid UTF-8 JSON within 32 KiB. The dispatcher remains dependency-free and uses only trusted base code; failures still fail the proof. This extracts the reviewed diagnostic implementation from #1665 so that PR does not have to land before its own startup failures become readable.

Validation: all 22 trusted-dispatcher tests pass, including nested payloads, credential redaction, byte bounds, and import before npm install. The full fixture run passes 102 tests with six skips and one process-timeout fixture failure; that same failure reproduces on untouched main on this host (`descendantPid` remains zero within its 100 ms startup budget). Formatting and diff checks pass.

Failure evidence: https://github.com/AgentWorkforce/relay/actions/runs/34098681770

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->
