### PR TITLE
[DISPOSABLE DEMO ghsub-0908-implementation] GitHub subscriptions

### DIFF
--- a/ghsub-demo-fixtures/ghsub-0908-implementation.txt
+++ b/ghsub-demo-fixtures/ghsub-0908-implementation.txt
@@ -1,0 +1,2 @@
+Disposable subscription demo fixture ghsub-0908-implementation
+Review this line for a real thread event.


### PR DESCRIPTION
Owned fixture for GitHub subscription validation. Only a disposable base branch may receive a fixture merge. No product changes or main merge. Run: ghsub-0908-implementation.