### PR TITLE
fix(cloud): carry RelayFlow launch budgets

### DIFF
--- a/.agentworkforce/trajectories/active/traj_ckbfhqbr1ews/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_ckbfhqbr1ews/trajectory.json
@@ -1,0 +1,70 @@
+{
+  "id": "traj_ckbfhqbr1ews",
+  "version": 1,
+  "task": {
+    "title": "Take over AgentWorkforce/relay PR #1712: validate review threads and failing checks, fix minimally, verify, and report"
+  },
+  "status": "active",
+  "startedAt": "2026-09-09T12:01:59.118Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T12:02:07.770Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_rn82ied9ot5c",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T12:02:07.770Z",
+      "events": [
+        {
+          "ts": 1788955327771,
+          "type": "decision",
+          "content": "Trim scanned timeout arguments before literal matching: Trim scanned timeout arguments before literal matching",
+          "raw": {
+            "question": "Trim scanned timeout arguments before literal matching",
+            "chosen": "Trim scanned timeout arguments before literal matching",
+            "alternatives": [],
+            "reasoning": "Masked comments and trailing whitespace are intentionally preserved as spaces, so untrimmed slices incorrectly omit valid inferred budgets."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788955328415,
+          "type": "decision",
+          "content": "Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved: Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved",
+          "raw": {
+            "question": "Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved",
+            "chosen": "Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved",
+            "alternatives": [],
+            "reasoning": "Existing checked-in workflows can declare 60-minute builder timeouts; preserving omitted metadata avoids breaking legacy requests."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788955329162,
+          "type": "decision",
+          "content": "Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace: Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace",
+          "raw": {
+            "question": "Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace",
+            "chosen": "Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace",
+            "alternatives": [],
+            "reasoning": "The runner has four independent 300-second child-command caps and isolated workspace builds must own their compiler dependency."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "16393cf7a05de1b8a8109e5b250a1c11cf4356ba",
+    "endRef": "16393cf7a05de1b8a8109e5b250a1c11cf4356ba"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_1w71a4z1me0z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_1w71a4z1me0z/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Send bounded RelayFlow launch budgets to Cloud
+
+> **Status:** ✅ Completed
+> **Task:** cloud#3463
+> **Confidence:** 90%
+> **Started:** September 9, 2026 at 03:26 AM
+> **Completed:** September 9, 2026 at 03:27 AM
+
+---
+
+## Summary
+
+Added bounded launchTimeoutMs metadata for cloud run and schedule, safe literal timeout inference for TypeScript and Python RelayFlows, CLI overrides, and compatibility tests; 123 focused tests and Cloud/CLI builds pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded
+- **Chose:** Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded
+- **Reasoning:** The client must never evaluate submitted TypeScript or Python. Masking comments and string bodies avoids common false positives; dynamic and ambiguous values require an explicit launchTimeoutMs. Explicit values are bounded from 30 seconds to 55 minutes, while inferred short workflow deadlines retain the legacy five-minute floor.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded: Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded

--- a/.agentworkforce/trajectories/completed/2026-09/traj_1w71a4z1me0z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_1w71a4z1me0z/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_1w71a4z1me0z",
+  "version": 1,
+  "task": {
+    "title": "Send bounded RelayFlow launch budgets to Cloud",
+    "source": {
+      "system": "plain",
+      "id": "cloud#3463"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T01:26:56.483Z",
+  "completedAt": "2026-09-09T01:27:11.074Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T01:27:04.240Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_m8s0lliirady",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T01:27:04.240Z",
+      "endedAt": "2026-09-09T01:27:11.074Z",
+      "events": [
+        {
+          "ts": 1788917224241,
+          "type": "decision",
+          "content": "Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded: Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded",
+          "raw": {
+            "question": "Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded",
+            "chosen": "Infer only literal script timeouts with a non-executing scanner and keep explicit overrides bounded",
+            "alternatives": [],
+            "reasoning": "The client must never evaluate submitted TypeScript or Python. Masking comments and string bodies avoids common false positives; dynamic and ambiguous values require an explicit launchTimeoutMs. Explicit values are bounded from 30 seconds to 55 minutes, while inferred short workflow deadlines retain the legacy five-minute floor."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added bounded launchTimeoutMs metadata for cloud run and schedule, safe literal timeout inference for TypeScript and Python RelayFlows, CLI overrides, and compatibility tests; 123 focused tests and Cloud/CLI builds pass.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "4306bb29be696ec84a4e3844f86fdc4a91584407",
+    "endRef": "4306bb29be696ec84a4e3844f86fdc4a91584407"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_b0mcm03aivor/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_b0mcm03aivor/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Fix PR 1712 parser correctness and linearity blockers
+
+> **Status:** ✅ Completed
+> **Task:** cloud#3463
+> **Confidence:** 90%
+> **Started:** September 9, 2026 at 03:24 PM
+> **Completed:** September 9, 2026 at 03:41 PM
+
+---
+
+## Summary
+
+Fixed PR 1712 timeout inference for expression arrows, computed methods, Unicode ASI labels, and multiline/inline Python defs; replaced quadratic arrow/lambda scope scans with near-linear sweeps; 362 Cloud and 76 CLI tests pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use interval scopes for expression-bodied arrows and Python lambdas
+- **Chose:** Use interval scopes for expression-bodied arrows and Python lambdas
+- **Reasoning:** A single delimiter sweep plus a single scope-application sweep preserves lexical shadowing while removing the repeated backward and suffix scans that caused quadratic scaling.
+
+### Resolve Python def scopes from matched parameter delimiters and indentation
+- **Chose:** Resolve Python def scopes from matched parameter delimiters and indentation
+- **Reasoning:** Balanced parentheses support multiline signatures, colon-aware handling supports one-line suites, and header indentation keeps the parameter scope active across the full function body.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use interval scopes for expression-bodied arrows and Python lambdas: Use interval scopes for expression-bodied arrows and Python lambdas
+- Resolve Python def scopes from matched parameter delimiters and indentation: Resolve Python def scopes from matched parameter delimiters and indentation

--- a/.agentworkforce/trajectories/completed/2026-09/traj_b0mcm03aivor/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_b0mcm03aivor/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_b0mcm03aivor",
+  "version": 1,
+  "task": {
+    "title": "Fix PR 1712 parser correctness and linearity blockers",
+    "source": {
+      "system": "plain",
+      "id": "cloud#3463"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T13:24:15.746Z",
+  "completedAt": "2026-09-09T13:41:34.152Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T13:40:39.099Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cqkdeyjyft0v",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T13:40:39.099Z",
+      "endedAt": "2026-09-09T13:41:34.152Z",
+      "events": [
+        {
+          "ts": 1788961239100,
+          "type": "decision",
+          "content": "Use interval scopes for expression-bodied arrows and Python lambdas: Use interval scopes for expression-bodied arrows and Python lambdas",
+          "raw": {
+            "question": "Use interval scopes for expression-bodied arrows and Python lambdas",
+            "chosen": "Use interval scopes for expression-bodied arrows and Python lambdas",
+            "alternatives": [],
+            "reasoning": "A single delimiter sweep plus a single scope-application sweep preserves lexical shadowing while removing the repeated backward and suffix scans that caused quadratic scaling."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788961239670,
+          "type": "decision",
+          "content": "Resolve Python def scopes from matched parameter delimiters and indentation: Resolve Python def scopes from matched parameter delimiters and indentation",
+          "raw": {
+            "question": "Resolve Python def scopes from matched parameter delimiters and indentation",
+            "chosen": "Resolve Python def scopes from matched parameter delimiters and indentation",
+            "alternatives": [],
+            "reasoning": "Balanced parentheses support multiline signatures, colon-aware handling supports one-line suites, and header indentation keeps the parameter scope active across the full function body."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed PR 1712 timeout inference for expression arrows, computed methods, Unicode ASI labels, and multiline/inline Python defs; replaced quadratic arrow/lambda scope scans with near-linear sweeps; 362 Cloud and 76 CLI tests pass.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "c70b83c75cb9d34161599eabd9edf60a237da15b",
+    "endRef": "c70b83c75cb9d34161599eabd9edf60a237da15b"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews.trace.json
@@ -1,0 +1,110 @@
+{
+  "version": "1.0.0",
+  "id": "23e9f558-b9d6-47d8-85e6-21c9a81dc0ab",
+  "timestamp": "2026-09-09T12:11:11.961Z",
+  "trajectory": "traj_ckbfhqbr1ews",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_ckbfhqbr1ews/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 70,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package-lock.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 13600,
+              "end_line": 13606,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cloud/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 73,
+              "end_line": 79,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cloud/src/workflow-timeout.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 15,
+              "end_line": 25,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cloud/src/workflow-timeout.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 355,
+              "end_line": 364,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1712-cloud-launch-timeout/case.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 13,
+              "revision": "28fbcb9f245fa9c594d428c604e69cd3be877668"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews/summary.md
@@ -1,0 +1,49 @@
+# Trajectory: Take over AgentWorkforce/relay PR #1712: validate review threads and failing checks, fix minimally, verify, and report
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** September 9, 2026 at 02:01 PM
+> **Completed:** September 9, 2026 at 02:11 PM
+
+---
+
+## Summary
+
+Closed PR #1712 review gaps: trimmed timeout literal slices, raised proof timeoutSeconds to 1500, declared TypeScript in the Cloud workspace and lockfile, added regression coverage, pushed 28fbcb9f2, and resolved all three review threads. Local Node 22 builds/tests/exact proof pass; GitHub proof first failed after Cloud remained pending and was rerun as infrastructure capacity evidence.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Trim scanned timeout arguments before literal matching
+- **Chose:** Trim scanned timeout arguments before literal matching
+- **Reasoning:** Masked comments and trailing whitespace are intentionally preserved as spaces, so untrimmed slices incorrectly omit valid inferred budgets.
+
+### Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved
+- **Chose:** Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved
+- **Reasoning:** Existing checked-in workflows can declare 60-minute builder timeouts; preserving omitted metadata avoids breaking legacy requests.
+
+### Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace
+- **Chose:** Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace
+- **Reasoning:** The runner has four independent 300-second child-command caps and isolated workspace builds must own their compiler dependency.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Trim scanned timeout arguments before literal matching: Trim scanned timeout arguments before literal matching
+- Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved: Keep explicit timeout validation strict while treating out-of-range inferred literals as unresolved
+- Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace: Raise PR proof case budget to 1500 seconds and declare TypeScript in the Cloud workspace
+- Validated three open review findings and fixed them minimally; local Node 22 exact-case proof is green, while GitHub RelayFlow proof first failed only after Cloud remained pending and was rerun as infrastructure evidence.
+
+---
+
+## Artifacts
+
+**Commits:** 28fbcb9f2
+**Files changed:** 6

--- a/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_ckbfhqbr1ews/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Take over AgentWorkforce/relay PR #1712: validate review threads and failing checks, fix minimally, verify, and report"
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-09-09T12:01:59.118Z",
+  "completedAt": "2026-09-09T12:11:11.784Z",
   "agents": [
     {
       "name": "default",
@@ -19,6 +20,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-09-09T12:02:07.770Z",
+      "endedAt": "2026-09-09T12:11:11.784Z",
       "events": [
         {
           "ts": 1788955327771,
@@ -55,16 +57,52 @@
             "reasoning": "The runner has four independent 300-second child-command caps and isolated workspace builds must own their compiler dependency."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1788955870676,
+          "type": "reflection",
+          "content": "Validated three open review findings and fixed them minimally; local Node 22 exact-case proof is green, while GitHub RelayFlow proof first failed only after Cloud remained pending and was rerun as infrastructure evidence.",
+          "raw": {
+            "focalPoints": [
+              "review-findings",
+              "proof-reliability",
+              "ci"
+            ],
+            "adjustments": "Reran the failed proof without changing source; report queue/infrastructure status separately from code verification",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-findings",
+            "focal:proof-reliability",
+            "focal:ci",
+            "confidence:0.9"
+          ]
         }
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Closed PR #1712 review gaps: trimmed timeout literal slices, raised proof timeoutSeconds to 1500, declared TypeScript in the Cloud workspace and lockfile, added regression coverage, pushed 28fbcb9f2, and resolved all three review threads. Local Node 22 builds/tests/exact proof pass; GitHub proof first failed after Cloud remained pending and was rerun as infrastructure capacity evidence.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "28fbcb9f2"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_ckbfhqbr1ews/trajectory.json",
+    "package-lock.json",
+    "packages/cloud/package.json",
+    "packages/cloud/src/workflow-timeout.test.ts",
+    "packages/cloud/src/workflow-timeout.ts",
+    "tests/relayflows/cases/1712-cloud-launch-timeout/case.json"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "16393cf7a05de1b8a8109e5b250a1c11cf4356ba",
-    "endRef": "16393cf7a05de1b8a8109e5b250a1c11cf4356ba"
+    "endRef": "28fbcb9f245fa9c594d428c604e69cd3be877668",
+    "traceId": "23e9f558-b9d6-47d8-85e6-21c9a81dc0ab"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_i7vwfnzs82ym/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_i7vwfnzs82ym/summary.md
@@ -1,0 +1,38 @@
+# Trajectory: Fix PR 1712 exact-head parser review findings
+
+> **Status:** ✅ Completed
+> **Task:** PR-1712
+> **Confidence:** 93%
+> **Started:** September 9, 2026 at 04:02 PM
+> **Completed:** September 9, 2026 at 04:34 PM
+
+---
+
+## Summary
+
+Closed PR 1712 parser review gaps with red-first regressions for nested expression scopes, Python annotated definitions and bindings, TypeScript expression/type boundaries, typed builders, and astral labels; verified Node 22 focused/full suites, builds, adversarial probes, and near-linear scaling.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Preserve structural scopes while overlaying expression scopes
+- **Chose:** Preserve structural scopes while overlaying expression scopes
+- **Reasoning:** Reparent direct nested brace scopes beneath synthetic arrow/lambda scopes so inner method/catch bindings and enclosing expression parameters both remain visible without per-position ancestor scans.
+
+### Replace broad Python assignment and lambda matching with statement/header-aware scans
+- **Chose:** Replace broad Python assignment and lambda matching with statement/header-aware scans
+- **Reasoning:** Anchored assignment targets exclude comparisons, keyword arguments, and defaults; structural colon discovery supports return annotations and colon-containing lambda defaults while retaining near-linear scans.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Preserve structural scopes while overlaying expression scopes: Preserve structural scopes while overlaying expression scopes
+- Replace broad Python assignment and lambda matching with statement/header-aware scans: Replace broad Python assignment and lambda matching with statement/header-aware scans
+- Red-first coverage now closes all independent review findings; Node 22 focused/full suites, build, probes, and scaling checks pass.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_i7vwfnzs82ym/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_i7vwfnzs82ym/trajectory.json
@@ -1,0 +1,93 @@
+{
+  "id": "traj_i7vwfnzs82ym",
+  "version": 1,
+  "task": {
+    "title": "Fix PR 1712 exact-head parser review findings",
+    "source": {
+      "system": "plain",
+      "id": "PR-1712"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T14:02:00.631Z",
+  "completedAt": "2026-09-09T14:34:26.932Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T14:19:16.090Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_6co1dgqpqzxl",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T14:19:16.090Z",
+      "endedAt": "2026-09-09T14:34:26.932Z",
+      "events": [
+        {
+          "ts": 1788963556091,
+          "type": "decision",
+          "content": "Preserve structural scopes while overlaying expression scopes: Preserve structural scopes while overlaying expression scopes",
+          "raw": {
+            "question": "Preserve structural scopes while overlaying expression scopes",
+            "chosen": "Preserve structural scopes while overlaying expression scopes",
+            "alternatives": [],
+            "reasoning": "Reparent direct nested brace scopes beneath synthetic arrow/lambda scopes so inner method/catch bindings and enclosing expression parameters both remain visible without per-position ancestor scans."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788963556632,
+          "type": "decision",
+          "content": "Replace broad Python assignment and lambda matching with statement/header-aware scans: Replace broad Python assignment and lambda matching with statement/header-aware scans",
+          "raw": {
+            "question": "Replace broad Python assignment and lambda matching with statement/header-aware scans",
+            "chosen": "Replace broad Python assignment and lambda matching with statement/header-aware scans",
+            "alternatives": [],
+            "reasoning": "Anchored assignment targets exclude comparisons, keyword arguments, and defaults; structural colon discovery supports return annotations and colon-containing lambda defaults while retaining near-linear scans."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788964466352,
+          "type": "reflection",
+          "content": "Red-first coverage now closes all independent review findings; Node 22 focused/full suites, build, probes, and scaling checks pass.",
+          "raw": {
+            "focalPoints": [
+              "scope preservation",
+              "Python binding precision",
+              "expression boundaries",
+              "Unicode",
+              "performance"
+            ],
+            "confidence": 0.93
+          },
+          "significance": "high",
+          "tags": [
+            "focal:scope preservation",
+            "focal:Python binding precision",
+            "focal:expression boundaries",
+            "focal:Unicode",
+            "focal:performance",
+            "confidence:0.93"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Closed PR 1712 parser review gaps with red-first regressions for nested expression scopes, Python annotated definitions and bindings, TypeScript expression/type boundaries, typed builders, and astral labels; verified Node 22 focused/full suites, builds, adversarial probes, and near-linear scaling.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "827b86e9b943afe27d01b886f26cf8c73fc7b3c1",
+    "endRef": "827b86e9b943afe27d01b886f26cf8c73fc7b3c1"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_j9kwhhairbh5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_j9kwhhairbh5/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix generic invoked root timeout inference
+
+> **Status:** ✅ Completed
+> **Task:** cloud#3463
+> **Confidence:** 95%
+> **Started:** September 9, 2026 at 04:16 AM
+> **Completed:** September 9, 2026 at 04:17 AM
+
+---
+
+## Summary
+
+Excluded generic invoked timeout roots; TypeScript and Python now infer only direct workflow chains or proven builder variables. Full Node 22 Cloud/CLI tests and builds pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables
+- **Chose:** Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables
+- **Reasoning:** Generic factory calls such as httpClient() and Python http_client() can expose timeout methods but are not RelayFlow builders; accepting them would reintroduce false launch metadata.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables: Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables
+- Generic invoked roots are now excluded in both TypeScript and Python; full Cloud and CLI suites, builds, format, and diff checks are passing.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_j9kwhhairbh5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_j9kwhhairbh5/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_j9kwhhairbh5",
+  "version": 1,
+  "task": {
+    "title": "Fix generic invoked root timeout inference",
+    "source": {
+      "system": "plain",
+      "id": "cloud#3463"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T02:16:06.088Z",
+  "completedAt": "2026-09-09T02:17:32.784Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T02:17:24.985Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_scjxlzt29mmj",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T02:17:24.985Z",
+      "endedAt": "2026-09-09T02:17:32.784Z",
+      "events": [
+        {
+          "ts": 1788920244986,
+          "type": "decision",
+          "content": "Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables: Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables",
+          "raw": {
+            "question": "Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables",
+            "chosen": "Require invoked timeout roots to be exactly workflow, while retaining proven assigned builder variables",
+            "alternatives": [],
+            "reasoning": "Generic factory calls such as httpClient() and Python http_client() can expose timeout methods but are not RelayFlow builders; accepting them would reintroduce false launch metadata."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788920245469,
+          "type": "reflection",
+          "content": "Generic invoked roots are now excluded in both TypeScript and Python; full Cloud and CLI suites, builds, format, and diff checks are passing.",
+          "raw": {
+            "focalPoints": [
+              "builder-identity",
+              "scanner",
+              "tests"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:builder-identity",
+            "focal:scanner",
+            "focal:tests",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Excluded generic invoked timeout roots; TypeScript and Python now infer only direct workflow chains or proven builder variables. Full Node 22 Cloud/CLI tests and builds pass.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "1f63d0ea6dcde2e4aa7844cfa62caa3449142876",
+    "endRef": "1f63d0ea6dcde2e4aa7844cfa62caa3449142876"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mpvsf8h7kbqz/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mpvsf8h7kbqz/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix Python continuation false workflow-timeout assignments
+
+> **Status:** ✅ Completed
+> **Task:** PR #1712
+> **Confidence:** 94%
+> **Started:** September 9, 2026 at 05:28 PM
+> **Completed:** September 9, 2026 at 05:28 PM
+
+---
+
+## Summary
+
+Fixed Python workflow timeout inference to ignore multiline call keyword arguments and function defaults while preserving real multiline assignments; added regression coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Guard Python declaration collection by precomputed delimiter depth
+- **Chose:** Guard Python declaration collection by precomputed delimiter depth
+- **Reasoning:** Call keyword arguments and multiline function defaults are not assignments; a one-pass depth guard preserves true statement-level multiline assignments while remaining linear.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Guard Python declaration collection by precomputed delimiter depth: Guard Python declaration collection by precomputed delimiter depth
+- Red-first tests exposed both false Python bindings; a single precomputed delimiter-depth guard fixed them while preserving multiline assignments. Focused workflow-timeout suite is green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mpvsf8h7kbqz/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mpvsf8h7kbqz/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_mpvsf8h7kbqz",
+  "version": 1,
+  "task": {
+    "title": "Fix Python continuation false workflow-timeout assignments",
+    "source": {
+      "system": "plain",
+      "id": "PR #1712"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T15:28:12.361Z",
+  "completedAt": "2026-09-09T15:28:28.816Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T15:28:16.498Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_txs2uput4eux",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T15:28:16.498Z",
+      "endedAt": "2026-09-09T15:28:28.816Z",
+      "events": [
+        {
+          "ts": 1788967696498,
+          "type": "decision",
+          "content": "Guard Python declaration collection by precomputed delimiter depth: Guard Python declaration collection by precomputed delimiter depth",
+          "raw": {
+            "question": "Guard Python declaration collection by precomputed delimiter depth",
+            "chosen": "Guard Python declaration collection by precomputed delimiter depth",
+            "alternatives": [],
+            "reasoning": "Call keyword arguments and multiline function defaults are not assignments; a one-pass depth guard preserves true statement-level multiline assignments while remaining linear."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788967708519,
+          "type": "reflection",
+          "content": "Red-first tests exposed both false Python bindings; a single precomputed delimiter-depth guard fixed them while preserving multiline assignments. Focused workflow-timeout suite is green.",
+          "raw": {
+            "focalPoints": [
+              "parser-context",
+              "linear-time",
+              "validation"
+            ],
+            "confidence": 0.92
+          },
+          "significance": "high",
+          "tags": [
+            "focal:parser-context",
+            "focal:linear-time",
+            "focal:validation",
+            "confidence:0.92"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed Python workflow timeout inference to ignore multiline call keyword arguments and function defaults while preserving real multiline assignments; added regression coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "64a2552fbb7e59f2d9a92460866f923cbbcae48b",
+    "endRef": "64a2552fbb7e59f2d9a92460866f923cbbcae48b"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_pisgowuqucrv/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_pisgowuqucrv/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix follow-up cloud timeout scanner defects
+
+> **Status:** ✅ Completed
+> **Task:** cloud#3463
+> **Confidence:** 95%
+> **Started:** September 9, 2026 at 04:03 AM
+> **Completed:** September 9, 2026 at 04:04 AM
+
+---
+
+## Summary
+
+Resolved follow-up scanner defects for bare workflow identifiers, regex after block statements, and mixed dynamic/literal timeout builders; Node 22 tests/build/lint/format checks pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata
+- **Chose:** Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata
+- **Reasoning:** Follow-up review identified remaining lexical and ambiguity false positives; direct calls and proven assigned builders remain inferable, while bare objects and runtime-dependent timeout sets remain omitted.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata: Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata
+- The follow-up scanner audit is resolved: direct workflow calls and proven assigned builders infer, bare identifiers and regex text do not, and dynamic/literal mixtures omit metadata.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_pisgowuqucrv/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_pisgowuqucrv/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_pisgowuqucrv",
+  "version": 1,
+  "task": {
+    "title": "Fix follow-up cloud timeout scanner defects",
+    "source": {
+      "system": "plain",
+      "id": "cloud#3463"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T02:03:01.950Z",
+  "completedAt": "2026-09-09T02:04:46.215Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T02:04:19.262Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_yq01o0fv8iwn",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T02:04:19.262Z",
+      "endedAt": "2026-09-09T02:04:46.215Z",
+      "events": [
+        {
+          "ts": 1788919459262,
+          "type": "decision",
+          "content": "Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata: Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata",
+          "raw": {
+            "question": "Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata",
+            "chosen": "Removed implicit workflow root, masked regex after block braces, and made mixed dynamic/literal builder timeouts omit metadata",
+            "alternatives": [],
+            "reasoning": "Follow-up review identified remaining lexical and ambiguity false positives; direct calls and proven assigned builders remain inferable, while bare objects and runtime-dependent timeout sets remain omitted."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788919485704,
+          "type": "reflection",
+          "content": "The follow-up scanner audit is resolved: direct workflow calls and proven assigned builders infer, bare identifiers and regex text do not, and dynamic/literal mixtures omit metadata.",
+          "raw": {
+            "focalPoints": [
+              "lexical-safety",
+              "ambiguity",
+              "compatibility"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:lexical-safety",
+            "focal:ambiguity",
+            "focal:compatibility",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Resolved follow-up scanner defects for bare workflow identifiers, regex after block statements, and mixed dynamic/literal timeout builders; Node 22 tests/build/lint/format checks pass.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "21f4238ff790c930bb6e5180e23a6a802f06f726",
+    "endRef": "21f4238ff790c930bb6e5180e23a6a802f06f726"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_r0b1b8ddrvg0/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_r0b1b8ddrvg0/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Implement cloud launch timeout review fixes
+
+> **Status:** ✅ Completed
+> **Task:** cloud#3463
+> **Confidence:** 90%
+> **Started:** September 9, 2026 at 03:35 AM
+> **Completed:** September 9, 2026 at 03:42 AM
+
+---
+
+## Summary
+
+Fixed cloud launch timeout review findings with safe lexical inference, RelayFlow builder filtering, strict CLI integers, and pre-auth bounds validation; Node 22 tests/builds pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation
+- **Chose:** Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation
+- **Reasoning:** The review found regex/object timeout false positives and late bounds errors; preserving omitted request bytes requires filtering only recognized RelayFlow builders while validating explicit values before auth or file reads.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation: Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation
+- Review fixes are implemented and verified on Node 22: lexical regex masking, builder-root filtering, strict CLI parsing, and pre-auth bounds validation all pass focused suites and builds.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_r0b1b8ddrvg0/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_r0b1b8ddrvg0/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_r0b1b8ddrvg0",
+  "version": 1,
+  "task": {
+    "title": "Implement cloud launch timeout review fixes",
+    "source": {
+      "system": "plain",
+      "id": "cloud#3463"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T01:35:13.379Z",
+  "completedAt": "2026-09-09T01:42:07.020Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T01:41:00.157Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_8lc6tmes5mgc",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T01:41:00.157Z",
+      "endedAt": "2026-09-09T01:42:07.020Z",
+      "events": [
+        {
+          "ts": 1788918060158,
+          "type": "decision",
+          "content": "Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation: Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation",
+          "raw": {
+            "question": "Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation",
+            "chosen": "Added a lexical regex masker and builder-root filter, plus strict CLI parsing and pre-auth explicit timeout validation",
+            "alternatives": [],
+            "reasoning": "The review found regex/object timeout false positives and late bounds errors; preserving omitted request bytes requires filtering only recognized RelayFlow builders while validating explicit values before auth or file reads."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788918126535,
+          "type": "reflection",
+          "content": "Review fixes are implemented and verified on Node 22: lexical regex masking, builder-root filtering, strict CLI parsing, and pre-auth bounds validation all pass focused suites and builds.",
+          "raw": {
+            "focalPoints": [
+              "scanner",
+              "validation",
+              "compatibility"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:scanner",
+            "focal:validation",
+            "focal:compatibility",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed cloud launch timeout review findings with safe lexical inference, RelayFlow builder filtering, strict CLI integers, and pre-auth bounds validation; Node 22 tests/builds pass.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "7e3eed71c7e8003bdda876462a8b99a94e95c6aa",
+    "endRef": "7e3eed71c7e8003bdda876462a8b99a94e95c6aa"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- `agent-relay cloud run` and `cloud schedule` now send a bounded sandbox/bootstrap budget, inferred safely from a script RelayFlow's literal `.timeout()` or set explicitly with `--launch-timeout-ms`.
 
 ## [11.10.4] - 2026-09-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13600,6 +13600,7 @@
       "devDependencies": {
         "@types/node": "^22.19.3",
         "@types/ssh2": "^1.15.5",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       },
       "engines": {

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -678,6 +678,23 @@ describe('registerCloudCommands', () => {
     );
   });
 
+  it('cloud run rejects a launch timeout with trailing non-numeric characters', async () => {
+    const { program } = createHarness();
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'agent-relay',
+        'cloud',
+        'run',
+        'workflow.ts',
+        '--launch-timeout-ms',
+        '900000junk',
+      ])
+    ).rejects.toThrow(/positive integer/);
+    expect(cloudMocks.runWorkflow).not.toHaveBeenCalled();
+  });
+
   it.each(['v1', 'v2'] as const)(
     'cloud run passes explicit %s with existing resume selectors',
     async (relayflowVersion) => {

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -629,6 +629,7 @@ describe('registerCloudCommands', () => {
     expect(optionNames).toContain('--start-from');
     expect(optionNames).toContain('--previous-run-id');
     expect(optionNames).toContain('--relayflow-version');
+    expect(optionNames).toContain('--launch-timeout-ms');
   });
 
   it('cloud run rejects a mistyped relayflow generation before submission', async () => {
@@ -655,6 +656,26 @@ describe('registerCloudCommands', () => {
     await program.parseAsync(['node', 'agent-relay', 'cloud', 'run', 'workflow.yaml']);
 
     expect(cloudMocks.runWorkflow.mock.calls[0][1]).not.toHaveProperty('relayflowVersion');
+  });
+
+  it('cloud run forwards an explicit bounded launch timeout', async () => {
+    const { program } = createHarness();
+    cloudMocks.runWorkflow.mockResolvedValueOnce({ runId: 'run-timeout', status: 'pending' });
+
+    await program.parseAsync([
+      'node',
+      'agent-relay',
+      'cloud',
+      'run',
+      'workflow.ts',
+      '--launch-timeout-ms',
+      '900000',
+    ]);
+
+    expect(cloudMocks.runWorkflow).toHaveBeenCalledWith(
+      'workflow.ts',
+      expect.objectContaining({ launchTimeoutMs: 900_000 })
+    );
   });
 
   it.each(['v1', 'v2'] as const)(
@@ -739,6 +760,8 @@ describe('registerCloudCommands', () => {
       'Hourly eval',
       '--relayflow-version',
       'v1',
+      '--launch-timeout-ms',
+      '900000',
       '--env',
       'AI_CLI_UPDATES_DRY_RUN=true',
       '--env',
@@ -751,6 +774,7 @@ describe('registerCloudCommands', () => {
         cron: '0 * * * *',
         name: 'Hourly eval',
         relayflowVersion: 'v1',
+        launchTimeoutMs: 900_000,
         envSecrets: {
           AI_CLI_UPDATES_DRY_RUN: 'true',
           AI_CLI_UPDATES_ONLY: 'codex',

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -110,8 +110,11 @@ function withDefaults(overrides: Partial<CloudDependencies> = {}): CloudDependen
 }
 
 function parsePositiveInteger(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError('Expected a positive integer.');
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new InvalidArgumentError('Expected a positive integer.');
   }
   return parsed;

--- a/packages/cli/src/cli/commands/cloud.ts
+++ b/packages/cli/src/cli/commands/cloud.ts
@@ -1063,6 +1063,11 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
     .option('--api-url <url>', 'Cloud API base URL')
     .option('--file-type <type>', 'Workflow type: yaml, ts, or py', parseWorkflowFileType)
     .option('--relayflow-version <version>', 'Relayflow engine generation: v1 or v2', parseRelayflowVersion)
+    .option(
+      '--launch-timeout-ms <milliseconds>',
+      'Bounded Cloud sandbox/bootstrap timeout (inferred from a literal script .timeout() when omitted)',
+      parsePositiveInteger
+    )
     .option('--sync-code', 'Upload the current working directory before running')
     .option('--no-sync-code', 'Skip uploading the current working directory')
     .option('--resume <runId>', 'Resume a previously failed cloud workflow run from where it left off')
@@ -1079,6 +1084,7 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
           apiUrl?: string;
           fileType?: WorkflowFileType;
           relayflowVersion?: RelayflowVersion;
+          launchTimeoutMs?: number;
           syncCode?: boolean;
           resume?: string;
           startFrom?: string;
@@ -1133,6 +1139,11 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
       'Relayflow engine generation for scheduled runs: v1 (v2 is not supported)',
       parseScheduleRelayflowVersion
     )
+    .option(
+      '--launch-timeout-ms <milliseconds>',
+      'Bounded Cloud sandbox/bootstrap timeout (inferred from a literal script .timeout() when omitted)',
+      parsePositiveInteger
+    )
     .option('--cron <expression>', 'Cron expression, for example "0 * * * *"')
     .option('--at <isoTimestamp>', 'One-time ISO timestamp, for example 2026-05-10T09:00:00Z')
     .option('--timezone <timezone>', 'IANA timezone for cron schedules', 'UTC')
@@ -1152,6 +1163,7 @@ export function registerCloudCommands(program: Command, overrides: Partial<Cloud
           apiUrl?: string;
           fileType?: WorkflowFileType;
           relayflowVersion?: 'v1';
+          launchTimeoutMs?: number;
           cron?: string;
           at?: string;
           timezone?: string;

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -73,6 +73,7 @@
   "devDependencies": {
     "@types/node": "^22.19.3",
     "@types/ssh2": "^1.15.5",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "publishConfig": {

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -191,6 +191,8 @@ export type RunWorkflowOptions = {
   apiUrl?: string;
   fileType?: WorkflowFileType;
   relayflowVersion?: RelayflowVersion;
+  /** Bounded outer Cloud sandbox/bootstrap budget. Literal script builder timeouts are inferred when omitted. */
+  launchTimeoutMs?: number;
   syncCode?: boolean;
   resume?: string;
   startFrom?: string;
@@ -247,6 +249,8 @@ export type ScheduleWorkflowOptions = {
   apiUrl?: string;
   fileType?: WorkflowFileType;
   relayflowVersion?: 'v1';
+  /** Bounded outer Cloud sandbox/bootstrap budget. Literal script builder timeouts are inferred when omitted. */
+  launchTimeoutMs?: number;
   name?: string;
   description?: string;
   cron?: string;

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -25,6 +25,33 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it('ignores timeout-shaped text in TypeScript regular expressions', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs(
+        'const pattern = /foo.timeout(600_000)/; if (ready) /workflow("fake").timeout(500_000)/;',
+        'ts'
+      )
+    ).toBeUndefined();
+  });
+
+  it('ignores a regular-expression timeout while inferring the real builder timeout', () => {
+    const source = 'const pattern = /foo.timeout(600_000)/; workflow("real").timeout(900_000).run();';
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('ignores timeout methods on unrelated objects', () => {
+    expect(inferWorkflowLaunchTimeoutMs('httpClient.timeout(600_000);', 'ts')).toBeUndefined();
+  });
+
+  it('supports the fluent and assigned RelayFlow builder shapes used by workflows', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs("const wf = workflow('real').description('demo').timeout(900_000);", 'ts')
+    ).toBe(900_000);
+    expect(inferWorkflowLaunchTimeoutMs("const wf = workflow('real'); wf.timeout(600_000);", 'ts')).toBe(
+      600_000
+    );
+  });
+
   it('reads Python literals while ignoring comments and string bodies', () => {
     const source = [
       '# workflow("comment").timeout(3_300_000)',

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -39,6 +39,27 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it('does not mistake a regex after a control paren containing a quoted close paren for code', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs('if (foo(")")) /workflow("fake").timeout(600_000)/;', 'ts')
+    ).toBeUndefined();
+  });
+
+  it('does not rescan a large slash-heavy source from the beginning for every slash', () => {
+    class NoRescanString extends String {
+      override replace(): never {
+        throw new Error('source.replace() indicates a whole-prefix rescan');
+      }
+
+      override slice(): never {
+        throw new Error('source.slice() indicates a whole-prefix rescan');
+      }
+    }
+
+    const source = new NoRescanString('/ '.repeat(100_000)) as unknown as string;
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
+  });
+
   it('ignores timeout methods on unrelated objects', () => {
     expect(
       inferWorkflowLaunchTimeoutMs(

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS,
+  MAX_WORKFLOW_LAUNCH_TIMEOUT_MS,
+  MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS,
+  inferWorkflowLaunchTimeoutMs,
+  resolveWorkflowLaunchTimeoutMs,
+} from './workflow-timeout.js';
+
+describe('workflow launch timeout inference', () => {
+  it('reads an underscored TypeScript builder timeout without executing the workflow', () => {
+    const source = "const result = await workflow('proof').timeout(3_300_000).run();";
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(3_300_000);
+  });
+
+  it('ignores timeout-shaped text in TypeScript comments, strings, and templates', () => {
+    const source = [
+      "// workflow('comment').timeout(3_300_000)",
+      "/* workflow('block').timeout(3_200_000) */",
+      'const quoted = ".timeout(3_100_000)";',
+      'const template = `.timeout(3_000_000)`;',
+      "workflow('real').timeout(900_000).run();",
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('reads Python literals while ignoring comments and string bodies', () => {
+    const source = [
+      '# workflow("comment").timeout(3_300_000)',
+      'description = """.timeout(3_200_000)"""',
+      'workflow("real").timeout(600_000).run()',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(600_000);
+  });
+
+  it('uses the legacy five-minute floor for shorter workflow deadlines', () => {
+    expect(inferWorkflowLaunchTimeoutMs("workflow('fast').timeout(1_000).run()", 'ts')).toBe(
+      DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS
+    );
+  });
+
+  it('does not guess dynamic timeout expressions', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs("workflow('dynamic').timeout(timeoutMs).run()", 'ts')
+    ).toBeUndefined();
+  });
+
+  it('requires an explicit override when distinct builder timeouts are present', () => {
+    const source = "workflow('a').timeout(600_000); workflow('b').timeout(900_000);";
+    expect(() => inferWorkflowLaunchTimeoutMs(source, 'ts')).toThrow(/multiple distinct/);
+    expect(resolveWorkflowLaunchTimeoutMs(source, 'ts', 1_200_000)).toBe(1_200_000);
+  });
+
+  it('rejects non-integer and oversized explicit budgets', () => {
+    expect(() => resolveWorkflowLaunchTimeoutMs('', 'ts', Number.NaN)).toThrow(/safe integer/);
+    expect(() =>
+      resolveWorkflowLaunchTimeoutMs('', 'ts', MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS - 1)
+    ).toThrow(/must be at least/);
+    expect(() => resolveWorkflowLaunchTimeoutMs('', 'ts', MAX_WORKFLOW_LAUNCH_TIMEOUT_MS + 1)).toThrow(
+      /must not exceed/
+    );
+  });
+});

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -15,6 +15,11 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(3_300_000);
   });
 
+  it('trims whitespace and masked comments around a TypeScript builder timeout literal', () => {
+    const source = "const result = await workflow('proof').timeout( /* budget */ 600_000 /* ms */ ).run();";
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(600_000);
+  });
+
   it('omits inference for the checked-in workflow timeout beyond the metadata limit', () => {
     const source = readFileSync(new URL('../../../workflows/verify-features.ts', import.meta.url), 'utf8');
     expect(source).toContain('.timeout(3_600_000)');

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -108,6 +108,21 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
   });
 
+  it('masks a regular expression after a labelled ASI break', () => {
+    const source =
+      'workflow("real").timeout(900_000); while (ready) { break label\n/workflow("fake").timeout(600_000)/.test(value); }';
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('keeps ASI regex masking through comments after break and continue', () => {
+    for (const keyword of ['break', 'continue']) {
+      const source =
+        `workflow("real").timeout(900_000); while (ready) { ${keyword} /* comment\n */ label\n` +
+        '/workflow("fake").timeout(600_000)/.test(value); }';
+      expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+    }
+  });
+
   it('does not let a shadowed non-builder identifier create an ambiguous timeout', () => {
     const source = [
       "const wf = workflow('real');",
@@ -127,6 +142,57 @@ describe('workflow launch timeout inference', () => {
       '  const workflow = fakeWorkflow;',
       '  workflow("fake").timeout(600_000);',
       '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not let a function parameter shadowing a builder create an ambiguous timeout', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'function run(wf) {',
+      '  wf.timeout(600_000);',
+      '}',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not let a function parameter shadowing workflow create an ambiguous timeout', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      'function run(workflow) {',
+      '  workflow("fake").timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('hoists var builder bindings to the surrounding function scope', () => {
+    const source = ['{', "  var wf = workflow('real');", '}', 'wf.timeout(900_000);'].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('tracks arrow-function parameters as lexical shadows', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'const run = (wf) => {',
+      '  wf.timeout(600_000);',
+      '};',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('keeps var shadows inside a function from changing the outer binding', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'function run() {',
+      '  {',
+      '    var wf = {};',
+      '  }',
+      '  wf.timeout(600_000);',
+      '}',
+      'wf.timeout(900_000);',
     ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -40,7 +40,12 @@ describe('workflow launch timeout inference', () => {
   });
 
   it('ignores timeout methods on unrelated objects', () => {
-    expect(inferWorkflowLaunchTimeoutMs('httpClient.timeout(600_000);', 'ts')).toBeUndefined();
+    expect(
+      inferWorkflowLaunchTimeoutMs(
+        'httpClient.timeout(600_000); httpClient().timeout(600_000); makeThing().timeout(600_000);',
+        'ts'
+      )
+    ).toBeUndefined();
   });
 
   it('does not treat a bare workflow object identifier as a builder', () => {
@@ -71,6 +76,10 @@ describe('workflow launch timeout inference', () => {
       'workflow("real").timeout(600_000).run()',
     ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(600_000);
+  });
+
+  it('ignores timeout methods on unrelated Python call expressions', () => {
+    expect(inferWorkflowLaunchTimeoutMs('http_client().timeout(600_000)', 'py')).toBeUndefined();
   });
 
   it('uses the legacy five-minute floor for shorter workflow deadlines', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -153,6 +153,27 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 
+  it('does not treat multiline Python call keyword arguments as assignments', () => {
+    const source = [
+      'from library import wf',
+      'register(',
+      '  wf=workflow("real"),',
+      ')',
+      'wf.timeout(900_000)',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBeUndefined();
+  });
+
+  it('does not treat multiline Python function defaults as assignments', () => {
+    const source = ['def build(', '  wf=workflow("fake"),', '):', '  pass', 'wf.timeout(900_000)'].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBeUndefined();
+  });
+
+  it('keeps multiline Python assignments as builder bindings', () => {
+    const source = ['wf = workflow(', '  "real",', '  option=other,', ')', 'wf.timeout(900_000)'].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
   it('does not let a shadowed non-builder identifier create an ambiguous timeout', () => {
     const source = [
       "const wf = workflow('real');",

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -60,6 +60,11 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
   });
 
+  it('resolves repeated fluent timeout calls without rescanning their call chain', () => {
+    const source = "workflow('root')" + '.timeout(600_000)'.repeat(12_000);
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(600_000);
+  });
+
   it('ignores timeout methods on unrelated objects', () => {
     expect(
       inferWorkflowLaunchTimeoutMs(
@@ -97,6 +102,13 @@ describe('workflow launch timeout inference', () => {
       'workflow("real").timeout(600_000).run()',
     ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(600_000);
+  });
+
+  it('keeps timeout-shaped text inside escaped Python triple-quoted delimiters masked', () => {
+    const doubleQuoted = String.raw`s = """abc \""" workflow("fake").timeout(600_000) still string"""`;
+    const singleQuoted = String.raw`s = '''abc \''' workflow("fake").timeout(600_000) still string'''`;
+    expect(inferWorkflowLaunchTimeoutMs(doubleQuoted, 'py')).toBeUndefined();
+    expect(inferWorkflowLaunchTimeoutMs(singleQuoted, 'py')).toBeUndefined();
   });
 
   it('ignores timeout methods on unrelated Python call expressions', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -167,6 +167,48 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it('tracks typed function parameters through return annotations', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      'function run(workflow: unknown): void {',
+      '  workflow("fake").timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('skips object types nested in typed function return annotations', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      'function run(workflow: unknown): Promise<{ ok: boolean }> {',
+      '  workflow("fake").timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('tracks typed arrow parameters through return annotations', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'const run = (wf: unknown): void => {',
+      '  wf.timeout(600_000);',
+      '};',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('tracks catch bindings as lexical shadows', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'try {} catch (wf) {',
+      '  wf.timeout(600_000);',
+      '}',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
   it('hoists var builder bindings to the surrounding function scope', () => {
     const source = ['{', "  var wf = workflow('real');", '}', 'wf.timeout(900_000);'].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
@@ -213,6 +255,25 @@ describe('workflow launch timeout inference', () => {
       'workflow("real").timeout(600_000).run()',
     ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(600_000);
+  });
+
+  it('tracks Python function parameters through indentation scopes', () => {
+    const source = [
+      "workflow('real').timeout(900_000)",
+      'def run(workflow):',
+      "    workflow('fake').timeout(600_000)",
+      "workflow('real').timeout(900_000)",
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
+  it('tracks Python lambda parameters through expression scope', () => {
+    const source = [
+      "workflow('real').timeout(900_000)",
+      "run = lambda workflow: workflow('fake').timeout(600_000)",
+      "workflow('real').timeout(900_000)",
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 
   it('keeps timeout-shaped text inside escaped Python triple-quoted delimiters masked', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -118,6 +118,9 @@ describe('workflow launch timeout inference', () => {
     `π: while (ready) { break π\n/workflow("fake").timeout(600_000)/.test(value); }`,
     String.raw`\u03c0: while (ready) { break \u03c0
 /workflow("fake").timeout(600_000)/.test(value); }`,
+    `𐐀: while (ready) { break 𐐀\n/workflow("fake").timeout(600_000)/.test(value); }`,
+    String.raw`\u{10400}: while (ready) { break \u{10400}
+/workflow("fake").timeout(600_000)/.test(value); }`,
   ])('masks a regular expression after a Unicode labelled ASI break', (statement) => {
     expect(inferWorkflowLaunchTimeoutMs(statement, 'ts')).toBeUndefined();
     const source = `workflow("real").timeout(900_000); ${statement}`;
@@ -227,10 +230,52 @@ describe('workflow launch timeout inference', () => {
   it.each([
     'const run = (workflow) => workflow("fake").timeout(600_000);',
     'const run = workflow => workflow("fake").timeout(600_000);',
+    'const run=workflow=>workflow("fake").timeout(600_000);',
     'const run = <T>(workflow: T): T => workflow("fake").timeout(600_000);',
   ])('tracks expression-bodied arrow parameters as lexical shadows: %s', (arrow) => {
     expect(inferWorkflowLaunchTimeoutMs(arrow, 'ts')).toBeUndefined();
     const source = [`workflow('real').timeout(900_000);`, arrow].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it.each([
+    `consume(workflow => workflow('fake').timeout(600_000), workflow('real').timeout(900_000));`,
+    `[workflow => workflow('fake').timeout(600_000), workflow('real').timeout(900_000)];`,
+    `ready ? workflow => workflow('fake').timeout(600_000) : workflow('real').timeout(900_000);`,
+  ])('ends expression-bodied arrow scope at its enclosing expression boundary: %s', (source) => {
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('keeps a conditional expression inside an arrow body in the arrow scope', () => {
+    const source = [
+      `const run=workflow=>ready`,
+      `  ? workflow('fake-a').timeout(600_000)`,
+      `  : workflow('fake-b').timeout(600_000);`,
+      `workflow('real').timeout(900_000);`,
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not treat a TypeScript function-type arrow as a value scope', () => {
+    const source =
+      `const runner: (workflow: unknown) => unknown = ` + `makeRunner(workflow('real').timeout(900_000));`;
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('reads parameters from an arrow whose return type contains a function type', () => {
+    const source = [
+      `workflow('real').timeout(900_000);`,
+      `const run = (workflow: unknown): (() => void) => workflow('fake').timeout(600_000);`,
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not borrow parameters from an earlier typed declaration for an arrow', () => {
+    const source = [
+      `declare function prior(): void;`,
+      `const run = (workflow) => workflow('fake').timeout(600_000);`,
+      `workflow('real').timeout(900_000);`,
+    ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
@@ -241,6 +286,28 @@ describe('workflow launch timeout inference', () => {
   ])('tracks computed method parameters as lexical shadows: %s', (method) => {
     expect(inferWorkflowLaunchTimeoutMs(method, 'ts')).toBeUndefined();
     const source = [`workflow('real').timeout(900_000);`, method].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('preserves a computed method parameter scope nested in an expression-bodied arrow', () => {
+    const nested =
+      `const make = () => ({ ` + `['run'](workflow: unknown) { workflow('fake').timeout(600_000); } ` + `});`;
+    expect(inferWorkflowLaunchTimeoutMs(nested, 'ts')).toBeUndefined();
+    expect(inferWorkflowLaunchTimeoutMs(`${nested}\nworkflow('real').timeout(900_000);`, 'ts')).toBe(900_000);
+  });
+
+  it('preserves catch and var shadows nested in an expression-bodied arrow', () => {
+    const source = [
+      `const wf = workflow('real');`,
+      `const make = () => class Runner {`,
+      `  run() {`,
+      `    try {} catch (workflow) { workflow('fake').timeout(600_000); }`,
+      `    { var wf = {}; }`,
+      `    wf.timeout(600_000);`,
+      `  }`,
+      `};`,
+      `wf.timeout(900_000);`,
+    ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
@@ -310,6 +377,15 @@ describe('workflow launch timeout inference', () => {
     );
   });
 
+  it('supports typed TypeScript builder declarations', () => {
+    for (const declaration of [
+      `const wf: WorkflowBuilder = workflow('real');`,
+      `const wf: WorkflowBuilder & { marker: () => void; } = workflow('real');`,
+    ]) {
+      expect(inferWorkflowLaunchTimeoutMs(`${declaration} wf.timeout(900_000);`, 'ts')).toBe(900_000);
+    }
+  });
+
   it('reads Python literals while ignoring comments and string bodies', () => {
     const source = [
       '# workflow("comment").timeout(3_300_000)',
@@ -342,6 +418,25 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 
+  it.each([
+    `def run(workflow) -> None:\n    workflow('fake').timeout(600_000)`,
+    `def run(\n    workflow,\n) -> dict[str, int]:\n    workflow('fake').timeout(600_000)`,
+    `def run(workflow) -> None: workflow('fake').timeout(600_000)`,
+    `def outer():\n    def run(workflow) -> None:\n        workflow('fake').timeout(600_000)`,
+  ])('tracks Python parameters in return-annotated definitions: %s', (definition) => {
+    expect(inferWorkflowLaunchTimeoutMs(definition, 'py')).toBeUndefined();
+    expect(inferWorkflowLaunchTimeoutMs(`${definition}\nworkflow('real').timeout(900_000)`, 'py')).toBe(
+      900_000
+    );
+  });
+
+  it('does not treat Python parameter annotations or defaults as bindings', () => {
+    const source = [`def run(value: workflow = workflow):`, `    workflow('real').timeout(900_000)`].join(
+      '\n'
+    );
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
   it('tracks Python parameters in a one-line function suite', () => {
     const definition = `def run(workflow): workflow('fake').timeout(600_000)`;
     expect(inferWorkflowLaunchTimeoutMs(definition, 'py')).toBeUndefined();
@@ -355,6 +450,33 @@ describe('workflow launch timeout inference', () => {
       "run = lambda workflow: workflow('fake').timeout(600_000)",
       "workflow('real').timeout(900_000)",
     ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
+  it.each([`fn = lambda wf={'x': 1}: wf.timeout(600_000)`, `fn = lambda wf=items[1:2]: wf.timeout(600_000)`])(
+    'tracks Python lambda parameters with colon-containing defaults: %s',
+    (lambda) => {
+      const source = [lambda, `wf = workflow('real')`, 'wf.timeout(900_000)'].join('\n');
+      expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+    }
+  );
+
+  it('ends a default lambda scope before the enclosing lambda body', () => {
+    const source =
+      `fn = lambda value=lambda workflow: workflow('fake').timeout(600_000): ` +
+      `workflow('real').timeout(900_000)`;
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
+  it.each([
+    `wf = workflow('real')\nif wf == other:\n    pass\nwf.timeout(900_000)`,
+    `wf = workflow('real')\nregister(wf=wf)\nwf.timeout(900_000)`,
+  ])('keeps Python builder bindings through non-assignment equals forms: %s', (source) => {
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
+  it('supports typed Python builder declarations', () => {
+    const source = `wf: WorkflowBuilder = workflow('real')\nwf.timeout(900_000)`;
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -226,10 +226,7 @@ describe('workflow launch timeout inference', () => {
   });
 
   it('hoists var declarations in a catch block to the enclosing function scope', () => {
-    const source = [
-      'try {} catch (e) { var wf = workflow(\'real\'); }',
-      'wf.timeout(900_000);',
-    ].join('\n');
+    const source = ["try {} catch (e) { var wf = workflow('real'); }", 'wf.timeout(900_000);'].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -187,6 +187,22 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it('tracks generic function parameters without executing TypeScript', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      "function run<T>(workflow: T): Promise<void> { workflow('fake').timeout(600_000); }",
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('tracks generic object-method parameters as lexical shadows', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      "const runner = { run<T>(workflow: T): void { workflow('fake').timeout(600_000); } };",
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
   it('tracks typed arrow parameters through return annotations', () => {
     const source = [
       "const wf = workflow('real');",

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 import {
   DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS,
@@ -12,6 +13,12 @@ describe('workflow launch timeout inference', () => {
   it('reads an underscored TypeScript builder timeout without executing the workflow', () => {
     const source = "const result = await workflow('proof').timeout(3_300_000).run();";
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(3_300_000);
+  });
+
+  it('omits inference for the checked-in workflow timeout beyond the metadata limit', () => {
+    const source = readFileSync(new URL('../../../workflows/verify-features.ts', import.meta.url), 'utf8');
+    expect(source).toContain('.timeout(3_600_000)');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
   });
 
   it('ignores timeout-shaped text in TypeScript comments, strings, and templates', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -136,23 +136,20 @@ describe('workflow launch timeout inference', () => {
     }
   });
 
-  it.each(['\u2028', '\u2029'])('keeps ASI regex masking after Unicode line terminator %j', (lineTerminator) => {
-    for (const keyword of ['break', 'continue', 'debugger']) {
-      const source =
-        `workflow("real").timeout(900_000); while (ready) { ${keyword}${lineTerminator}` +
-        '/workflow("fake").timeout(600_000)/.test(value); }';
-      expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  it.each(['\u2028', '\u2029'])(
+    'keeps ASI regex masking after Unicode line terminator %j',
+    (lineTerminator) => {
+      for (const keyword of ['break', 'continue', 'debugger']) {
+        const source =
+          `workflow("real").timeout(900_000); while (ready) { ${keyword}${lineTerminator}` +
+          '/workflow("fake").timeout(600_000)/.test(value); }';
+        expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+      }
     }
-  });
+  );
 
   it('does not treat multiline Python keyword arguments as assignments', () => {
-    const source = [
-      'wf = workflow(',
-      '  "real",',
-      '  option=other,',
-      ')',
-      'wf.timeout(900_000)',
-    ].join('\n');
+    const source = ['wf = workflow(', '  "real",', '  option=other,', ')', 'wf.timeout(900_000)'].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -114,6 +114,16 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it.each([
+    `π: while (ready) { break π\n/workflow("fake").timeout(600_000)/.test(value); }`,
+    String.raw`\u03c0: while (ready) { break \u03c0
+/workflow("fake").timeout(600_000)/.test(value); }`,
+  ])('masks a regular expression after a Unicode labelled ASI break', (statement) => {
+    expect(inferWorkflowLaunchTimeoutMs(statement, 'ts')).toBeUndefined();
+    const source = `workflow("real").timeout(900_000); ${statement}`;
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
   it('keeps ASI regex masking through comments after break and continue', () => {
     for (const keyword of ['break', 'continue']) {
       const source =
@@ -214,6 +224,26 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it.each([
+    'const run = (workflow) => workflow("fake").timeout(600_000);',
+    'const run = workflow => workflow("fake").timeout(600_000);',
+    'const run = <T>(workflow: T): T => workflow("fake").timeout(600_000);',
+  ])('tracks expression-bodied arrow parameters as lexical shadows: %s', (arrow) => {
+    expect(inferWorkflowLaunchTimeoutMs(arrow, 'ts')).toBeUndefined();
+    const source = [`workflow('real').timeout(900_000);`, arrow].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it.each([
+    `class Runner { ['run'](workflow: unknown) { workflow('fake').timeout(600_000); } }`,
+    `const runner = { ['run'](workflow: unknown) { workflow('fake').timeout(600_000); } };`,
+    `class Runner { [Symbol.iterator](workflow: unknown) { workflow('fake').timeout(600_000); } }`,
+  ])('tracks computed method parameters as lexical shadows: %s', (method) => {
+    expect(inferWorkflowLaunchTimeoutMs(method, 'ts')).toBeUndefined();
+    const source = [`workflow('real').timeout(900_000);`, method].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
   it('tracks catch bindings as lexical shadows', () => {
     const source = [
       "const wf = workflow('real');",
@@ -299,6 +329,26 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
   });
 
+  it('tracks Python parameters declared by a multiline function signature', () => {
+    const definition = [
+      'def run(',
+      '    workflow,',
+      '):',
+      '    pass',
+      `    workflow('fake').timeout(600_000)`,
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(definition, 'py')).toBeUndefined();
+    const source = [`workflow('real').timeout(900_000)`, definition].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
+  it('tracks Python parameters in a one-line function suite', () => {
+    const definition = `def run(workflow): workflow('fake').timeout(600_000)`;
+    expect(inferWorkflowLaunchTimeoutMs(definition, 'py')).toBeUndefined();
+    const source = [`workflow('real').timeout(900_000)`, definition].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
   it('tracks Python lambda parameters through expression scope', () => {
     const source = [
       "workflow('real').timeout(900_000)",
@@ -342,6 +392,34 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBeUndefined();
     expect(performance.now() - startedAt).toBeLessThan(2_000);
   });
+
+  it('keeps repeated single-parameter block arrows near-linear', () => {
+    const measure = (count: number): number => {
+      const source = `workflow('real').timeout(600_000);\n` + 'const f = value => {};\n'.repeat(count);
+      const startedAt = performance.now();
+      expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(600_000);
+      return performance.now() - startedAt;
+    };
+
+    measure(1_000);
+    const small = measure(4_000);
+    const large = measure(16_000);
+    expect(large / small).toBeLessThan(8);
+  }, 15_000);
+
+  it('keeps nested Python lambda scope discovery near-linear', () => {
+    const measure = (count: number): number => {
+      const source = 'run = ' + 'lambda value: '.repeat(count) + `workflow('real').timeout(600_000)`;
+      const startedAt = performance.now();
+      expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(600_000);
+      return performance.now() - startedAt;
+    };
+
+    measure(500);
+    const small = measure(2_000);
+    const large = measure(8_000);
+    expect(large / small).toBeLessThan(8);
+  }, 15_000);
 
   it('requires an explicit override when distinct builder timeouts are present', () => {
     const source = "workflow('a').timeout(600_000); workflow('b').timeout(900_000);";

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -67,6 +67,11 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
   });
 
+  it('does not rescan the suffix for repeated malformed timeout candidates', () => {
+    const source = "workflow('malformed').timeout(".repeat(8_000);
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
+  });
+
   it('resolves repeated fluent timeout calls without rescanning their call chain', () => {
     const source = "workflow('root')" + '.timeout(600_000)'.repeat(12_000);
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(600_000);

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -225,6 +225,25 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
   });
 
+  it('hoists var declarations in a catch block to the enclosing function scope', () => {
+    const source = [
+      'try {} catch (e) { var wf = workflow(\'real\'); }',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not treat a catch block as the var-hoist function scope', () => {
+    const source = [
+      "workflow('root').timeout(900_000);",
+      'function outer() {',
+      "  try {} catch (e) { var wf = workflow('inner'); }",
+      '  wf.timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(() => inferWorkflowLaunchTimeoutMs(source, 'ts')).toThrow(/multiple distinct/);
+  });
+
   it('hoists var builder bindings to the surrounding function scope', () => {
     const source = ['{', "  var wf = workflow('real');", '}', 'wf.timeout(900_000);'].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -103,6 +103,34 @@ describe('workflow launch timeout inference', () => {
     ).toBeUndefined();
   });
 
+  it.each(['break', 'continue', 'debugger'])('masks a regular expression after ASI keyword %s', (keyword) => {
+    const source = `while (ready) { ${keyword}\n/workflow("fake").timeout(600_000)/.test(value); }`;
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
+  });
+
+  it('does not let a shadowed non-builder identifier create an ambiguous timeout', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'wf.timeout(900_000);',
+      '{',
+      '  const wf = {};',
+      '  wf.timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('keeps scope-aware direct workflow calls from using a shadowed function', () => {
+    const source = [
+      "workflow('real').timeout(900_000);",
+      '{',
+      '  const workflow = fakeWorkflow;',
+      '  workflow("fake").timeout(600_000);',
+      '}',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
   it('supports the fluent and assigned RelayFlow builder shapes used by workflows', () => {
     expect(
       inferWorkflowLaunchTimeoutMs("const wf = workflow('real').description('demo').timeout(900_000);", 'ts')
@@ -147,6 +175,13 @@ describe('workflow launch timeout inference', () => {
   it('does not infer a literal when another builder timeout is dynamic', () => {
     const source = "workflow('dynamic').timeout(timeoutMs); workflow('literal').timeout(900_000);";
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
+  });
+
+  it('keeps malformed Python timeout candidates linear in their whitespace suffixes', () => {
+    const source = ('.timeout(' + '\t'.repeat(2_000)).repeat(2_000);
+    const startedAt = performance.now();
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBeUndefined();
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
   });
 
   it('requires an explicit override when distinct builder timeouts are present', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -136,6 +136,26 @@ describe('workflow launch timeout inference', () => {
     }
   });
 
+  it.each(['\u2028', '\u2029'])('keeps ASI regex masking after Unicode line terminator %j', (lineTerminator) => {
+    for (const keyword of ['break', 'continue', 'debugger']) {
+      const source =
+        `workflow("real").timeout(900_000); while (ready) { ${keyword}${lineTerminator}` +
+        '/workflow("fake").timeout(600_000)/.test(value); }';
+      expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+    }
+  });
+
+  it('does not treat multiline Python keyword arguments as assignments', () => {
+    const source = [
+      'wf = workflow(',
+      '  "real",',
+      '  option=other,',
+      ')',
+      'wf.timeout(900_000)',
+    ].join('\n');
+    expect(inferWorkflowLaunchTimeoutMs(source, 'py')).toBe(900_000);
+  });
+
   it('does not let a shadowed non-builder identifier create an ambiguous timeout', () => {
     const source = [
       "const wf = workflow('real');",
@@ -188,6 +208,17 @@ describe('workflow launch timeout inference', () => {
       '}',
     ].join('\n');
     expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBe(900_000);
+  });
+
+  it('does not treat identifiers inside TypeScript parameter types as runtime shadows', () => {
+    const source = [
+      "const wf = workflow('real');",
+      'function run(options: { wf: string }) {',
+      '  wf.timeout(600_000);',
+      '}',
+      'wf.timeout(900_000);',
+    ].join('\n');
+    expect(() => inferWorkflowLaunchTimeoutMs(source, 'ts')).toThrow(/multiple distinct/);
   });
 
   it('skips object types nested in typed function return annotations', () => {

--- a/packages/cloud/src/workflow-timeout.test.ts
+++ b/packages/cloud/src/workflow-timeout.test.ts
@@ -43,6 +43,18 @@ describe('workflow launch timeout inference', () => {
     expect(inferWorkflowLaunchTimeoutMs('httpClient.timeout(600_000);', 'ts')).toBeUndefined();
   });
 
+  it('does not treat a bare workflow object identifier as a builder', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs('const workflow = {}; workflow.timeout(600_000);', 'ts')
+    ).toBeUndefined();
+  });
+
+  it('masks a regular expression after a block statement', () => {
+    expect(
+      inferWorkflowLaunchTimeoutMs('if (ready) {} /workflow("fake").timeout(500_000)/;', 'ts')
+    ).toBeUndefined();
+  });
+
   it('supports the fluent and assigned RelayFlow builder shapes used by workflows', () => {
     expect(
       inferWorkflowLaunchTimeoutMs("const wf = workflow('real').description('demo').timeout(900_000);", 'ts')
@@ -71,6 +83,11 @@ describe('workflow launch timeout inference', () => {
     expect(
       inferWorkflowLaunchTimeoutMs("workflow('dynamic').timeout(timeoutMs).run()", 'ts')
     ).toBeUndefined();
+  });
+
+  it('does not infer a literal when another builder timeout is dynamic', () => {
+    const source = "workflow('dynamic').timeout(timeoutMs); workflow('literal').timeout(900_000);";
+    expect(inferWorkflowLaunchTimeoutMs(source, 'ts')).toBeUndefined();
   });
 
   it('requires an explicit override when distinct builder timeouts are present', () => {

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -25,6 +25,7 @@ const REGEX_KEYWORDS = new Set([
 ]);
 const ASI_LABEL_KEYWORDS = new Set(['break', 'continue']);
 const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
+const TYPESCRIPT_DECLARATION_KEYWORDS = ['const', 'let', 'var', 'function', 'class'] as const;
 const IDENTIFIER_PART = /[\p{ID_Continue}$\u200c\u200d]/u;
 
 type MaskedWorkflowSource = {
@@ -44,6 +45,13 @@ type ExpressionScope = { start: number; end: number; parameters: string };
 
 function isIdentifierPart(character: string | undefined): boolean {
   return character !== undefined && IDENTIFIER_PART.test(character);
+}
+
+function identifierCodePointAt(source: string, index: number): string | undefined {
+  const codePoint = source.codePointAt(index);
+  if (codePoint === undefined) return undefined;
+  const character = String.fromCodePoint(codePoint);
+  return isIdentifierPart(character) ? character : undefined;
 }
 
 function unicodeIdentifierEscapeLength(source: string, index: number): number {
@@ -295,6 +303,22 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       }
     }
 
+    const characterCode = source.charCodeAt(index);
+    if (fileType === 'ts' && characterCode >= 0xd800 && characterCode <= 0xdbff) {
+      const identifierCharacter = identifierCodePointAt(source, index);
+      if (identifierCharacter !== undefined && identifierCharacter.length > 1) {
+        output += identifierCharacter;
+        currentIdentifier += identifierCharacter;
+        previousSignificantCharacter = identifierCharacter;
+        closedControlParen = false;
+        for (let offset = 1; offset < identifierCharacter.length; offset += 1) {
+          scopeAt[index + offset] = scopeStack[scopeStack.length - 1];
+        }
+        index += identifierCharacter.length;
+        continue;
+      }
+    }
+
     if (fileType === 'ts' && character === '/' && next === '/') {
       output += '  ';
       index += 2;
@@ -465,6 +489,43 @@ function workflowInitializerAt(
   let cursor = end;
   while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
   if (fileType === 'ts') {
+    if (source[cursor] === ':') {
+      cursor += 1;
+      let delimiterDepth = 0;
+      let angleDepth = 0;
+      while (cursor < source.length) {
+        const character = source[cursor];
+        if (
+          delimiterDepth === 0 &&
+          angleDepth === 0 &&
+          TYPESCRIPT_DECLARATION_KEYWORDS.some(
+            (keyword) =>
+              source.startsWith(keyword, cursor) &&
+              !/[A-Za-z0-9_$]/.test(source[cursor - 1] ?? '') &&
+              /\s/.test(source[cursor + keyword.length] ?? '')
+          )
+        ) {
+          return false;
+        }
+        if (character === '(' || character === '[' || character === '{') delimiterDepth += 1;
+        else if (character === ')' || character === ']' || character === '}') {
+          delimiterDepth = Math.max(0, delimiterDepth - 1);
+        } else if (character === '<') angleDepth += 1;
+        else if (character === '>' && source[cursor - 1] !== '=') {
+          angleDepth = Math.max(0, angleDepth - 1);
+        } else if (
+          character === '=' &&
+          source[cursor + 1] !== '>' &&
+          delimiterDepth === 0 &&
+          angleDepth === 0
+        ) {
+          break;
+        } else if (character === ';' && delimiterDepth === 0 && angleDepth === 0) {
+          return false;
+        }
+        cursor += 1;
+      }
+    }
     if (source[cursor] !== '=') return false;
     cursor += 1;
     while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
@@ -561,7 +622,7 @@ function resolveExpressionScopeEnds(
   scopes: ExpressionScope[],
   fileType: Extract<WorkflowFileType, 'ts' | 'py'>
 ): void {
-  const active: Array<ExpressionScope & { depth: number }> = [];
+  const active: Array<ExpressionScope & { depth: number; conditionalDepth: number }> = [];
   let scopeIndex = 0;
   let delimiterDepth = 0;
 
@@ -572,8 +633,9 @@ function resolveExpressionScopeEnds(
   };
 
   for (let cursor = 0; cursor < source.length; cursor += 1) {
+    while (active.length > 0 && active[active.length - 1].end <= cursor) active.pop();
     while (scopeIndex < scopes.length && scopes[scopeIndex].start === cursor) {
-      active.push(Object.assign(scopes[scopeIndex], { depth: delimiterDepth }));
+      active.push(Object.assign(scopes[scopeIndex], { depth: delimiterDepth, conditionalDepth: 0 }));
       scopeIndex += 1;
     }
 
@@ -587,12 +649,36 @@ function resolveExpressionScopeEnds(
       delimiterDepth += 1;
       continue;
     }
-    if (character === ';' && active.length > 0) {
+    if ((character === ';' || character === ',') && active.length > 0) {
       closeAt(cursor);
       continue;
     }
-    if (fileType === 'py' && character === ',' && active.length > 0) {
-      closeAt(cursor);
+    if (
+      fileType === 'ts' &&
+      character === '?' &&
+      source[cursor + 1] !== '?' &&
+      source[cursor + 1] !== '.' &&
+      source[cursor - 1] !== '?' &&
+      active.length > 0 &&
+      active[active.length - 1].depth === delimiterDepth
+    ) {
+      active[active.length - 1].conditionalDepth += 1;
+      continue;
+    }
+    if (
+      fileType === 'ts' &&
+      character === ':' &&
+      active.length > 0 &&
+      active[active.length - 1].depth === delimiterDepth
+    ) {
+      while (active.length > 0 && active[active.length - 1].depth === delimiterDepth) {
+        const scope = active[active.length - 1];
+        if (scope.conditionalDepth > 0) {
+          scope.conditionalDepth -= 1;
+          break;
+        }
+        active.pop()!.end = cursor;
+      }
       continue;
     }
     if (fileType === 'py' && (character === '\n' || character === '\r') && delimiterDepth === 0) {
@@ -612,8 +698,10 @@ function applyExpressionScopes(
 ): void {
   if (scopes.length === 0) return;
 
-  const registered: Array<ExpressionScope & { scopeId: number }> = [];
-  const parentStack: Array<ExpressionScope & { scopeId: number }> = [];
+  const originalScopeAt = masked.scopeAt.slice();
+  const originalScopeParents = new Map(masked.scopeParents);
+  const registered: Array<ExpressionScope & { scopeId: number; baseScopeId: number }> = [];
+  const parentStack: Array<ExpressionScope & { scopeId: number; baseScopeId: number }> = [];
   let nextScopeId = 1;
   for (const scopeId of masked.scopeParents.keys()) nextScopeId = Math.max(nextScopeId, scopeId + 1);
 
@@ -622,17 +710,18 @@ function applyExpressionScopes(
       parentStack.pop();
     }
     const scopeId = nextScopeId++;
-    const parentScope = parentStack[parentStack.length - 1]?.scopeId ?? masked.scopeAt[scope.start] ?? 0;
+    const baseScopeId = originalScopeAt[scope.start] ?? 0;
+    const parentScope = parentStack[parentStack.length - 1]?.scopeId ?? baseScopeId;
     masked.scopeParents.set(scopeId, parentScope);
     functionScopes.add(scopeId);
     varScopes?.add(scopeId);
     addFunctionBinding(functionBindings, scopeId, scope.parameters);
-    const record = { ...scope, scopeId };
+    const record = { ...scope, scopeId, baseScopeId };
     registered.push(record);
     parentStack.push(record);
   }
 
-  const active: Array<ExpressionScope & { scopeId: number }> = [];
+  const active: Array<ExpressionScope & { scopeId: number; baseScopeId: number }> = [];
   let scopeIndex = 0;
   for (let cursor = 0; cursor < masked.source.length; cursor += 1) {
     while (active.length > 0 && active[active.length - 1].end <= cursor) active.pop();
@@ -640,8 +729,128 @@ function applyExpressionScopes(
       active.push(registered[scopeIndex]);
       scopeIndex += 1;
     }
-    if (active.length > 0) masked.scopeAt[cursor] = active[active.length - 1].scopeId;
+    if (active.length === 0) continue;
+    const expressionScope = active[active.length - 1];
+    const originalScopeId = originalScopeAt[cursor] ?? 0;
+    if (originalScopeId === expressionScope.baseScopeId) {
+      masked.scopeAt[cursor] = expressionScope.scopeId;
+      continue;
+    }
+    // Preserve nested block/method/catch scopes. Their top-level child is
+    // reparented under the expression scope so both the inner binding and the
+    // enclosing arrow/lambda parameters stay visible without rewriting the
+    // original scope id at every position.
+    if (originalScopeParents.get(originalScopeId) === expressionScope.baseScopeId) {
+      masked.scopeParents.set(originalScopeId, expressionScope.scopeId);
+    }
   }
+}
+
+function pythonHeaderColon(source: string, start: number): number | undefined {
+  let delimiterDepth = 0;
+  for (let cursor = start; cursor < source.length; cursor += 1) {
+    const character = source[cursor];
+    if (character === '(' || character === '[' || character === '{') {
+      delimiterDepth += 1;
+      continue;
+    }
+    if (character === ')' || character === ']' || character === '}') {
+      delimiterDepth = Math.max(0, delimiterDepth - 1);
+      continue;
+    }
+    if (character === ':' && delimiterDepth === 0) return cursor;
+    if (character === '\n' || character === '\r') {
+      const previous = previousNonWhitespace(source, cursor - 1);
+      if (delimiterDepth === 0 && source[previous] !== '\\') return undefined;
+      let nextLineToken = cursor + 1;
+      while (source[nextLineToken] === ' ' || source[nextLineToken] === '\t') nextLineToken += 1;
+      if (
+        source.startsWith('def ', nextLineToken) ||
+        (source.startsWith('async', nextLineToken) &&
+          /\s/.test(source[nextLineToken + 'async'.length] ?? '') &&
+          source.startsWith('def ', nextNonWhitespace(source, nextLineToken + 'async'.length)))
+      ) {
+        return undefined;
+      }
+      continue;
+    }
+    if (character === ';' && delimiterDepth === 0) return undefined;
+  }
+  return undefined;
+}
+
+function pythonParameterBindings(parameters: string): string {
+  const names: string[] = [];
+  let segmentStart = 0;
+  let delimiterDepth = 0;
+  const recordSegment = (end: number): void => {
+    const segment = parameters.slice(segmentStart, end).trim();
+    const match = segment.match(/^\*{0,2}\s*([A-Za-z_][A-Za-z0-9_]*)/);
+    if (match !== null) names.push(match[1]);
+  };
+
+  for (let cursor = 0; cursor < parameters.length; cursor += 1) {
+    const character = parameters[cursor];
+    if (character === '(' || character === '[' || character === '{') delimiterDepth += 1;
+    else if (character === ')' || character === ']' || character === '}') {
+      delimiterDepth = Math.max(0, delimiterDepth - 1);
+    } else if (character === ',' && delimiterDepth === 0) {
+      recordSegment(cursor);
+      segmentStart = cursor + 1;
+    }
+  }
+  recordSegment(parameters.length);
+  return names.join(',');
+}
+
+function collectPythonLambdaScopes(source: string): ExpressionScope[] {
+  const scopes: ExpressionScope[] = [];
+  const pending: Array<{ parametersStart: number; depth: number; nestedScopeIndexes: number[] }> = [];
+  let delimiterDepth = 0;
+
+  for (let cursor = 0; cursor < source.length; cursor += 1) {
+    if (
+      source.startsWith('lambda', cursor) &&
+      !isIdentifierPart(source[cursor - 1]) &&
+      !isIdentifierPart(source[cursor + 'lambda'.length])
+    ) {
+      pending.push({
+        parametersStart: cursor + 'lambda'.length,
+        depth: delimiterDepth,
+        nestedScopeIndexes: [],
+      });
+      cursor += 'lambda'.length - 1;
+      continue;
+    }
+
+    const character = source[cursor];
+    if (character === '(' || character === '[' || character === '{') {
+      delimiterDepth += 1;
+      continue;
+    }
+    if (character === ')' || character === ']' || character === '}') {
+      while (pending.length > 0 && pending[pending.length - 1].depth >= delimiterDepth) pending.pop();
+      delimiterDepth = Math.max(0, delimiterDepth - 1);
+      continue;
+    }
+    if (character === ':' && pending[pending.length - 1]?.depth === delimiterDepth) {
+      const lambda = pending.pop()!;
+      for (const nestedScopeIndex of lambda.nestedScopeIndexes) scopes[nestedScopeIndex].end = cursor;
+      const scopeIndex = scopes.length;
+      scopes.push({
+        start: nextNonWhitespace(source, cursor + 1),
+        end: source.length,
+        parameters: pythonParameterBindings(source.slice(lambda.parametersStart, cursor)),
+      });
+      pending[pending.length - 1]?.nestedScopeIndexes.push(scopeIndex);
+      continue;
+    }
+    if ((character === '\n' || character === '\r' || character === ';') && delimiterDepth === 0) {
+      pending.length = 0;
+    }
+  }
+
+  return scopes;
 }
 
 function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
@@ -686,8 +895,8 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
     const openParen = declarationMatch.index + declarationMatch[0].lastIndexOf('(');
     const closeParen = matchingCloseParens.get(openParen);
     if (closeParen === undefined) continue;
-    const colon = nextNonWhitespaceByIndex[closeParen + 1] ?? source.length;
-    if (source[colon] !== ':') continue;
+    const colon = pythonHeaderColon(source, nextNonWhitespaceByIndex[closeParen + 1] ?? source.length);
+    if (colon === undefined) continue;
     while (
       declarationLineIndex + 1 < lines.length &&
       lines[declarationLineIndex].end < declarationMatch.index
@@ -698,7 +907,7 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
       name: declarationMatch[1],
       colon,
       indent: lines[declarationLineIndex]?.indent ?? 0,
-      parameters: source.slice(openParen + 1, closeParen),
+      parameters: pythonParameterBindings(source.slice(openParen + 1, closeParen)),
     });
   }
 
@@ -750,13 +959,7 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
   // Python lambdas have expression scope rather than indentation scope. For
   // the static timeout scan, resolve all expression boundaries in one pass so
   // nested lambdas do not repeatedly rescan and rewrite the same suffix.
-  const lambdaScopes: ExpressionScope[] = [];
-  const lambdaPattern = /\blambda(?:\s+([^:\n]+))?:/g;
-  let lambdaMatch: RegExpExecArray | null;
-  while ((lambdaMatch = lambdaPattern.exec(source)) !== null) {
-    const bodyStart = nextNonWhitespace(source, lambdaMatch.index + lambdaMatch[0].length);
-    lambdaScopes.push({ start: bodyStart, end: source.length, parameters: lambdaMatch[1] ?? '' });
-  }
+  const lambdaScopes = collectPythonLambdaScopes(source);
   resolveExpressionScopeEnds(source, lambdaScopes, 'py');
   applyExpressionScopes(masked, lambdaScopes, functionScopes, functionBindings);
   return { functionScopes, functionBindings, varScopes: functionScopes };
@@ -825,25 +1028,70 @@ function collectFunctionScopes(
 
   const previousCloseParen = new Int32Array(source.length + 1);
   previousCloseParen.fill(-1);
+  const previousArrowBoundary = new Int32Array(source.length + 1);
+  previousArrowBoundary.fill(-1);
   let lastCloseParen = -1;
+  let lastArrowBoundary = -1;
   for (let cursor = 0; cursor < source.length; cursor += 1) {
     previousCloseParen[cursor] = lastCloseParen;
+    previousArrowBoundary[cursor] = lastArrowBoundary;
     if (source[cursor] === ')') lastCloseParen = cursor;
+    if (
+      source[cursor] === ';' ||
+      source[cursor] === '{' ||
+      source[cursor] === '}' ||
+      (source[cursor] === '=' && source[cursor + 1] !== '>')
+    ) {
+      lastArrowBoundary = cursor;
+    }
   }
   previousCloseParen[source.length] = lastCloseParen;
+  previousArrowBoundary[source.length] = lastArrowBoundary;
 
-  const arrowParameters = (arrowIndex: number): string => {
+  const arrowParameters = (
+    arrowIndex: number
+  ): { parameters: string; parameterOpen?: number; typePosition: boolean } => {
     const previous = previousNonWhitespace(source, arrowIndex - 1);
-    const parameterClose = source[previous] === ')' ? previous : previousCloseParen[arrowIndex];
-    if (parameterClose >= 0) {
+    const boundary = previousArrowBoundary[arrowIndex];
+    let parameterClose = previousCloseParen[arrowIndex];
+    let directCandidate: { parameters: string; parameterOpen: number } | undefined;
+    while (parameterClose > boundary) {
       const afterClose = nextNonWhitespace[parameterClose + 1] ?? source.length;
-      if (parameterClose === previous || source[afterClose] === ':') {
-        const parameterOpen = matchingOpenParens.get(parameterClose);
-        if (parameterOpen !== undefined) return source.slice(parameterOpen + 1, parameterClose);
+      const parameterOpen = matchingOpenParens.get(parameterClose);
+      if (parameterOpen !== undefined) {
+        if (source[afterClose] === ':' && afterClose < arrowIndex) {
+          const beforeOpen = previousNonWhitespace(source, parameterOpen - 1);
+          return {
+            parameters: source.slice(parameterOpen + 1, parameterClose),
+            parameterOpen,
+            typePosition: source[beforeOpen] === ':',
+          };
+        }
+        if (parameterClose === previous && directCandidate === undefined) {
+          directCandidate = {
+            parameters: source.slice(parameterOpen + 1, parameterClose),
+            parameterOpen,
+          };
+          const beforeOpen = previousNonWhitespace(source, parameterOpen - 1);
+          if (source[beforeOpen] !== ':' || !directCandidate.parameters.includes('=>')) {
+            return {
+              ...directCandidate,
+              typePosition: source[beforeOpen] === ':',
+            };
+          }
+        }
       }
+      parameterClose = previousCloseParen[parameterClose];
     }
-    const parameter = identifierBefore(source, previous + 1);
-    return parameter?.name ?? '';
+    if (directCandidate !== undefined) {
+      const beforeOpen = previousNonWhitespace(source, directCandidate.parameterOpen - 1);
+      return {
+        ...directCandidate,
+        typePosition: source[beforeOpen] === ':',
+      };
+    }
+    const parameter = identifierBefore(source, previous);
+    return { parameters: parameter?.name ?? '', typePosition: false };
   };
 
   // Track block and expression-bodied arrows. Expression bodies use compact
@@ -854,7 +1102,8 @@ function collectFunctionScopes(
   let arrowMatch: RegExpExecArray | null;
   while ((arrowMatch = arrowPattern.exec(source)) !== null) {
     const bodyStart = nextNonWhitespace[arrowMatch.index + arrowMatch[0].length] ?? source.length;
-    const parameters = arrowParameters(arrowMatch.index);
+    const { parameters, typePosition } = arrowParameters(arrowMatch.index);
+    if (typePosition) continue;
     if (source[bodyStart] === '{') {
       if (bodyStart + 1 >= source.length) continue;
       const scopeId = scopeAt[bodyStart + 1] ?? 0;
@@ -901,12 +1150,16 @@ export function inferWorkflowLaunchTimeoutMs(
   const declarationPattern =
     fileType === 'ts'
       ? /\b(const|let|var|function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g
-      : /\b([A-Za-z_][A-Za-z0-9_]*)\s*=/g;
+      : /(?:^|[;\n])[ \t]*([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=\n;]+)?=(?!=)/g;
   let declaration: RegExpExecArray | null;
   while ((declaration = declarationPattern.exec(source)) !== null) {
-    const scopeId = masked.scopeAt[declaration.index] ?? 0;
     const declarationKind = fileType === 'ts' ? declaration[1] : undefined;
     const declarationName = fileType === 'ts' ? declaration[2] : declaration[1];
+    const declarationNameIndex =
+      fileType === 'ts'
+        ? declaration.index + declaration[0].lastIndexOf(declarationName)
+        : declaration.index + declaration[0].indexOf(declarationName);
+    const scopeId = masked.scopeAt[declarationNameIndex] ?? 0;
     const bindingScope =
       declarationKind === 'var' ? nearestFunctionScope(scopeId, varScopes, masked.scopeParents) : scopeId;
     let scopeBindings = bindings.get(scopeId);

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -524,6 +524,7 @@ function addFunctionBinding(
 function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
   functionScopes: Set<number>;
   functionBindings: Map<number, Set<string>>;
+  varScopes: Set<number>;
 } {
   const { source, scopeAt, scopeParents } = masked;
   const functionScopes = new Set<number>();
@@ -613,7 +614,7 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
     }
     for (let cursor = bodyStart; cursor < bodyEnd; cursor += 1) scopeAt[cursor] = lambdaScope;
   }
-  return { functionScopes, functionBindings };
+  return { functionScopes, functionBindings, varScopes: functionScopes };
 }
 
 function collectFunctionScopes(
@@ -622,11 +623,13 @@ function collectFunctionScopes(
 ): {
   functionScopes: Set<number>;
   functionBindings: Map<number, Set<string>>;
+  varScopes: Set<number>;
 } {
   const { source, matchingOpenParens, matchingCloseParens, matchingCloseBraces, scopeAt, nextNonWhitespace } =
     masked;
   const functionScopes = new Set<number>();
   const functionBindings = new Map<number, Set<string>>();
+  const varScopes = new Set<number>();
 
   if (fileType === 'py') return collectPythonFunctionScopes(masked);
 
@@ -637,6 +640,7 @@ function collectFunctionScopes(
     if (bodyOpen === undefined || bodyOpen + 1 >= source.length) return;
     const scopeId = scopeAt[bodyOpen + 1] ?? 0;
     functionScopes.add(scopeId);
+    varScopes.add(scopeId);
     addFunctionBinding(functionBindings, scopeId, source.slice(parametersStart, parametersEnd));
   };
 
@@ -682,6 +686,7 @@ function collectFunctionScopes(
     if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) continue;
     const scopeId = scopeAt[bodyOpen + 1] ?? 0;
     functionScopes.add(scopeId);
+    varScopes.add(scopeId);
     let parameterClose = previousNonWhitespace(source, arrowMatch.index - 1);
     while (parameterClose >= 0 && source[parameterClose] !== ')') parameterClose -= 1;
     if (parameterClose >= 0) {
@@ -695,7 +700,7 @@ function collectFunctionScopes(
     }
   }
 
-  return { functionScopes, functionBindings };
+  return { functionScopes, functionBindings, varScopes };
 }
 
 function nearestFunctionScope(
@@ -723,7 +728,7 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const masked = maskNonCode(workflow, fileType);
   const source = masked.source;
-  const { functionScopes, functionBindings } = collectFunctionScopes(masked, fileType);
+  const { functionScopes, functionBindings, varScopes } = collectFunctionScopes(masked, fileType);
   const bindings = new Map<number, Map<string, WorkflowBinding>>();
   const declarationPattern =
     fileType === 'ts'
@@ -736,7 +741,7 @@ export function inferWorkflowLaunchTimeoutMs(
     const declarationName = fileType === 'ts' ? declaration[2] : declaration[1];
     const bindingScope =
       declarationKind === 'var'
-        ? nearestFunctionScope(scopeId, functionScopes, masked.scopeParents)
+        ? nearestFunctionScope(scopeId, varScopes, masked.scopeParents)
         : scopeId;
     let scopeBindings = bindings.get(scopeId);
     if (scopeBindings === undefined || bindingScope !== scopeId) {

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -640,12 +640,22 @@ function collectFunctionScopes(
     addFunctionBinding(functionBindings, scopeId, source.slice(parametersStart, parametersEnd));
   };
 
-  // Function declarations and expressions.
-  const functionPattern = /\bfunction\s*\*?\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\s*)?\(/g;
-  let functionMatch: RegExpExecArray | null;
-  while ((functionMatch = functionPattern.exec(source)) !== null) {
-    const openParen = functionMatch.index + functionMatch[0].lastIndexOf('(');
-    register(openParen, openParen + 1, matchingCloseParens.get(openParen) ?? openParen + 1);
+  // Any parenthesized construct with a block body is structurally a function
+  // or method unless its preceding token is a control-flow keyword. This also
+  // covers generic declarations/methods (`function f<T>(...) {}` and
+  // `method<T>(...) {}`) without trying to regex the type-parameter grammar.
+  const controlBlockKeywords = new Set(['if', 'while', 'for', 'switch', 'with', 'catch']);
+  for (const [openParen, closeParen] of matchingCloseParens) {
+    const previous = previousNonWhitespace(source, openParen - 1);
+    if (previous < 0) continue;
+    const precedingIdentifier = identifierBefore(source, previous);
+    const isGeneric = source[previous] === '>';
+    const isFunctionKeyword =
+      precedingIdentifier?.name === 'function' ||
+      (source[previous] === '*' && identifierBefore(source, previous - 1)?.name === 'function');
+    const isMethod = precedingIdentifier !== null && !controlBlockKeywords.has(precedingIdentifier.name);
+    if (!isGeneric && !isFunctionKeyword && !isMethod) continue;
+    register(openParen, openParen + 1, closeParen);
   }
 
   // Catch bindings have their own lexical scope, represented by the catch

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -245,14 +245,22 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const values = new Set<number>();
   let hasDynamicBuilderTimeout = false;
-  const timeoutPattern = /\.timeout\s*\(\s*([^)]*)\)/g;
+  const timeoutPattern = /\.timeout/g;
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
+    let argumentStart = match.index + match[0].length;
+    while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
+    if (source[argumentStart] !== '(') continue;
+    argumentStart += 1;
+    while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
+    const argumentEnd = source.indexOf(')', argumentStart);
+    if (argumentEnd < 0) continue;
+
     const root = timeoutRoot(source, match.index);
     if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {
       continue;
     }
-    const literal = match[1].match(/^[0-9](?:_?[0-9])*$/)?.[0];
+    const literal = source.slice(argumentStart, argumentEnd).match(/^[0-9](?:_?[0-9])*$/)?.[0];
     if (literal === undefined) {
       hasDynamicBuilderTimeout = true;
       continue;

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -12,6 +12,40 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let escaped = false;
   let lineComment = false;
   let blockComment = false;
+  let regexLiteral = false;
+  let regexCharacterClass = false;
+
+  const previousSignificantCharacter = (from: number): string | undefined => {
+    for (let cursor = from - 1; cursor >= 0; cursor -= 1) {
+      if (!/\s/.test(source[cursor])) return source[cursor];
+    }
+    return undefined;
+  };
+
+  // A slash starts a TypeScript regular-expression literal after an expression
+  // boundary (or after a keyword such as `return`). Division follows an
+  // expression and therefore remains visible code. This is intentionally
+  // conservative: masking a possible regex is safer than inferring a timeout
+  // from text inside it.
+  const startsRegexLiteral = (at: number): boolean => {
+    if (fileType !== 'ts') return false;
+    const previous = previousSignificantCharacter(at);
+    if (previous === undefined || /[([{:;,!?=+\-*%&|^~<>]/.test(previous)) return true;
+    if (previous === ')') {
+      let closeIndex = at - 1;
+      while (closeIndex >= 0 && /\s/.test(source[closeIndex])) closeIndex -= 1;
+      const openIndex = findMatchingOpenParen(source, closeIndex);
+      const control = openIndex === null ? null : identifierBefore(source, openIndex - 1)?.name;
+      if (control && new Set(['if', 'while', 'for', 'switch', 'catch', 'with']).has(control)) {
+        return true;
+      }
+    }
+    const prefix = source.slice(0, at).replace(/\s+$/, '');
+    const keyword = prefix.match(
+      /(?:^|[^\w$])(return|throw|case|delete|void|typeof|instanceof|in|of|yield|await|else|do)\s*$/
+    );
+    return keyword !== null;
+  };
 
   const mask = (character: string) => (character === '\n' || character === '\r' ? character : ' ');
 
@@ -19,6 +53,26 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     const character = source[index];
     const next = source[index + 1];
     const third = source[index + 2];
+
+    if (regexLiteral) {
+      output += mask(character);
+      if (character === '\\') {
+        if (next !== undefined) {
+          output += mask(next);
+          index += 2;
+        } else {
+          index += 1;
+        }
+        continue;
+      }
+      if (character === '[') regexCharacterClass = true;
+      if (character === ']' && regexCharacterClass) regexCharacterClass = false;
+      if (character === '/' && !regexCharacterClass) {
+        regexLiteral = false;
+      }
+      index += 1;
+      continue;
+    }
 
     if (lineComment) {
       output += mask(character);
@@ -74,6 +128,13 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       blockComment = true;
       continue;
     }
+    if (character === '/' && startsRegexLiteral(index)) {
+      output += ' ';
+      index += 1;
+      regexLiteral = true;
+      regexCharacterClass = false;
+      continue;
+    }
     if (fileType === 'py' && character === '#') {
       output += ' ';
       index += 1;
@@ -108,6 +169,57 @@ function validateLaunchTimeoutMs(value: number, source: string, minimum = 1): nu
   return value;
 }
 
+export function validateExplicitWorkflowLaunchTimeoutMs(explicit?: number): number | undefined {
+  if (explicit === undefined) return undefined;
+  return validateLaunchTimeoutMs(explicit, 'launchTimeoutMs', MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS);
+}
+
+function findMatchingOpenParen(source: string, closeIndex: number): number | null {
+  let depth = 0;
+  for (let index = closeIndex; index >= 0; index -= 1) {
+    if (source[index] === ')') depth += 1;
+    if (source[index] === '(') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return null;
+}
+
+function identifierBefore(source: string, end: number): { name: string; start: number } | null {
+  let cursor = end;
+  while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+  const finish = cursor + 1;
+  while (cursor >= 0 && /[A-Za-z0-9_$]/.test(source[cursor])) cursor -= 1;
+  if (cursor + 1 === finish) return null;
+  return { name: source.slice(cursor + 1, finish), start: cursor + 1 };
+}
+
+/**
+ * Return the root expression for a fluent call immediately before `.timeout`.
+ * The source has already had strings/comments/regex literals masked, so a
+ * small balanced-parenthesis walk is enough to distinguish `workflow(...).timeout`
+ * and a known workflow variable from `httpClient.timeout`.
+ */
+function timeoutRoot(source: string, timeoutDot: number): string | null {
+  let cursor = timeoutDot - 1;
+  while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+
+  while (cursor >= 0 && source[cursor] === ')') {
+    const open = findMatchingOpenParen(source, cursor);
+    if (open === null) return null;
+    const method = identifierBefore(source, open - 1);
+    if (method === null) return null;
+    cursor = method.start - 1;
+    while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+    if (cursor < 0 || source[cursor] !== '.') return method.name;
+    cursor -= 1;
+    while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+  }
+
+  return identifierBefore(source, cursor)?.name ?? null;
+}
+
 /**
  * Infer the outer Cloud launch budget from a literal RelayFlow builder timeout
  * without evaluating submitted workflow code. Dynamic expressions are left
@@ -120,10 +232,22 @@ export function inferWorkflowLaunchTimeoutMs(
   if (fileType === 'yaml') return undefined;
 
   const source = maskNonCode(workflow, fileType);
+  const builderNames = new Set<string>(['workflow']);
+  const assignmentPattern =
+    fileType === 'ts'
+      ? /\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:await\s+)?workflow\s*\(/g
+      : /\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*workflow\s*\(/g;
+  let assignment: RegExpExecArray | null;
+  while ((assignment = assignmentPattern.exec(source)) !== null) {
+    builderNames.add(assignment[1]);
+  }
+
   const values = new Set<number>();
   const timeoutPattern = /\.timeout\s*\(\s*([0-9](?:_?[0-9])*)\s*\)/g;
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
+    const root = timeoutRoot(source, match.index);
+    if (root === null || !builderNames.has(root)) continue;
     values.add(validateLaunchTimeoutMs(Number(match[1].replaceAll('_', '')), 'workflow .timeout()'));
   }
 
@@ -142,8 +266,6 @@ export function resolveWorkflowLaunchTimeoutMs(
   fileType: WorkflowFileType,
   explicit?: number
 ): number | undefined {
-  if (explicit !== undefined) {
-    return validateLaunchTimeoutMs(explicit, 'launchTimeoutMs', MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS);
-  }
+  if (explicit !== undefined) return validateExplicitWorkflowLaunchTimeoutMs(explicit);
   return inferWorkflowLaunchTimeoutMs(workflow, fileType);
 }

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -28,6 +28,10 @@ const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch',
 const TYPESCRIPT_DECLARATION_KEYWORDS = ['const', 'let', 'var', 'function', 'class'] as const;
 const IDENTIFIER_PART = /[\p{ID_Continue}$\u200c\u200d]/u;
 
+function isLineTerminator(character: string | undefined): boolean {
+  return character === '\n' || character === '\r' || character === '\u2028' || character === '\u2029';
+}
+
 type MaskedWorkflowSource = {
   source: string;
   matchingOpenParens: Map<number, number>;
@@ -78,7 +82,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let blockComment = false;
   let regexLiteral = false;
   let regexCharacterClass = false;
-  const mask = (character: string) => (character === '\n' || character === '\r' ? character : ' ');
+  const mask = (character: string) => (isLineTerminator(character) ? character : ' ');
   let previousSignificantCharacter: string | undefined;
   let currentIdentifier = '';
   let lastIdentifier: string | undefined;
@@ -133,7 +137,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     flushIdentifier();
     if (/\s/.test(character)) {
-      if (character === '\n' || character === '\r') recordLineBreak();
+      if (isLineTerminator(character)) recordLineBreak();
       return;
     }
 
@@ -239,7 +243,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     if (lineComment) {
       output += mask(character);
-      if (character === '\n' || character === '\r') {
+      if (isLineTerminator(character)) {
         recordLineBreak();
         lineComment = false;
       }
@@ -249,7 +253,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     if (blockComment) {
       output += mask(character);
-      if (character === '\n' || character === '\r') recordLineBreak();
+      if (isLineTerminator(character)) recordLineBreak();
       if (character === '*' && next === '/') {
         output += ' ';
         index += 2;
@@ -609,12 +613,37 @@ function addFunctionBinding(
     names = new Set();
     functionBindings.set(scopeId, names);
   }
-  // This is deliberately a conservative lexical scan. Marking names from a
-  // parameter's type/default/destructuring pattern as shadowed can omit an
-  // inference, but never turns unrelated code into a false builder timeout.
-  for (const parameter of parameters.matchAll(/[A-Za-z_$][A-Za-z0-9_$]*/g)) {
-    names.add(parameter[0]);
+  let segmentStart = 0;
+  let delimiterDepth = 0;
+  const recordSegment = (end: number): void => {
+    const declaration = parameters
+      .slice(segmentStart, end)
+      .match(/^\s*(?:\.\.\.\s*)?(?:[{[]\s*)?([A-Za-z_$][A-Za-z0-9_$]*)/);
+    if (declaration !== null) names.add(declaration[1]);
+  };
+  for (let cursor = 0; cursor < parameters.length; cursor += 1) {
+    const character = parameters[cursor];
+    if (character === '(' || character === '[' || character === '{') delimiterDepth += 1;
+    else if (character === ')' || character === ']' || character === '}') {
+      delimiterDepth = Math.max(0, delimiterDepth - 1);
+    } else if (character === ',' && delimiterDepth === 0) {
+      recordSegment(cursor);
+      segmentStart = cursor + 1;
+    }
   }
+  recordSegment(parameters.length);
+}
+
+function pythonDelimiterDepth(source: string): Uint32Array {
+  const depths = new Uint32Array(source.length);
+  let depth = 0;
+  for (let cursor = 0; cursor < source.length; cursor += 1) {
+    depths[cursor] = depth;
+    const character = source[cursor];
+    if (character === '(' || character === '[' || character === '{') depth += 1;
+    else if (character === ')' || character === ']' || character === '}') depth = Math.max(0, depth - 1);
+  }
+  return depths;
 }
 
 function resolveExpressionScopeEnds(
@@ -889,9 +918,11 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
     parameters: string;
   }> = [];
   const declarationPattern = /^[ \t]*(?:async[ \t]+)?def[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(/gm;
-  let declarationMatch: RegExpExecArray | null;
+  const declarationMatches = [...source.matchAll(declarationPattern)];
+  const delimiterDepth = declarationMatches.length > 0 ? pythonDelimiterDepth(source) : undefined;
   let declarationLineIndex = 0;
-  while ((declarationMatch = declarationPattern.exec(source)) !== null) {
+  for (const declarationMatch of declarationMatches) {
+    if (delimiterDepth?.[declarationMatch.index] !== 0) continue;
     const openParen = declarationMatch.index + declarationMatch[0].lastIndexOf('(');
     const closeParen = matchingCloseParens.get(openParen);
     if (closeParen === undefined) continue;

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -30,7 +30,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   const startsRegexLiteral = (at: number): boolean => {
     if (fileType !== 'ts') return false;
     const previous = previousSignificantCharacter(at);
-    if (previous === undefined || /[([{:;,!?=+\-*%&|^~<>]/.test(previous)) return true;
+    if (previous === undefined || /[([{:;,!?=+\-*%&|^~<>}]/.test(previous)) return true;
     if (previous === ')') {
       let closeIndex = at - 1;
       while (closeIndex >= 0 && /\s/.test(source[closeIndex])) closeIndex -= 1;
@@ -201,7 +201,7 @@ function identifierBefore(source: string, end: number): { name: string; start: n
  * small balanced-parenthesis walk is enough to distinguish `workflow(...).timeout`
  * and a known workflow variable from `httpClient.timeout`.
  */
-function timeoutRoot(source: string, timeoutDot: number): string | null {
+function timeoutRoot(source: string, timeoutDot: number): { name: string; invoked: boolean } | null {
   let cursor = timeoutDot - 1;
   while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
 
@@ -212,12 +212,13 @@ function timeoutRoot(source: string, timeoutDot: number): string | null {
     if (method === null) return null;
     cursor = method.start - 1;
     while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
-    if (cursor < 0 || source[cursor] !== '.') return method.name;
+    if (cursor < 0 || source[cursor] !== '.') return { name: method.name, invoked: true };
     cursor -= 1;
     while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
   }
 
-  return identifierBefore(source, cursor)?.name ?? null;
+  const identifier = identifierBefore(source, cursor);
+  return identifier ? { name: identifier.name, invoked: false } : null;
 }
 
 /**
@@ -232,7 +233,7 @@ export function inferWorkflowLaunchTimeoutMs(
   if (fileType === 'yaml') return undefined;
 
   const source = maskNonCode(workflow, fileType);
-  const builderNames = new Set<string>(['workflow']);
+  const builderNames = new Set<string>();
   const assignmentPattern =
     fileType === 'ts'
       ? /\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:await\s+)?workflow\s*\(/g
@@ -243,14 +244,24 @@ export function inferWorkflowLaunchTimeoutMs(
   }
 
   const values = new Set<number>();
-  const timeoutPattern = /\.timeout\s*\(\s*([0-9](?:_?[0-9])*)\s*\)/g;
+  let hasDynamicBuilderTimeout = false;
+  const timeoutPattern = /\.timeout\s*\(\s*([^)]*)\)/g;
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
     const root = timeoutRoot(source, match.index);
-    if (root === null || !builderNames.has(root)) continue;
-    values.add(validateLaunchTimeoutMs(Number(match[1].replaceAll('_', '')), 'workflow .timeout()'));
+    if (root === null || (!root.invoked && !builderNames.has(root.name))) continue;
+    const literal = match[1].match(/^[0-9](?:_?[0-9])*$/)?.[0];
+    if (literal === undefined) {
+      hasDynamicBuilderTimeout = true;
+      continue;
+    }
+    values.add(validateLaunchTimeoutMs(Number(literal.replaceAll('_', '')), 'workflow .timeout()'));
   }
 
+  // A literal and a dynamic builder timeout cannot be reconciled without
+  // evaluating user code. Leave the metadata omitted so callers can provide
+  // an explicit launchTimeoutMs override when they know the runtime value.
+  if (hasDynamicBuilderTimeout) return undefined;
   if (values.size === 0) return undefined;
   if (values.size > 1) {
     throw new Error(

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -30,6 +30,8 @@ type MaskedWorkflowSource = {
   source: string;
   matchingOpenParens: Map<number, number>;
   matchingCloseParens: Map<number, number>;
+  matchingOpenBraces: Map<number, number>;
+  matchingCloseBraces: Map<number, number>;
   scopeAt: Int32Array;
   scopeParents: Map<number, number>;
   nextNonWhitespace: Uint32Array;
@@ -58,8 +60,11 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let lineBreakAfterAsiLabel = false;
   const controlParenStack: boolean[] = [];
   const openParenStack: number[] = [];
+  const openBraceStack: number[] = [];
   const matchingOpenParens = new Map<number, number>();
   const matchingCloseParens = new Map<number, number>();
+  const matchingOpenBraces = new Map<number, number>();
+  const matchingCloseBraces = new Map<number, number>();
   const scopeAt = new Int32Array(source.length);
   const scopeParents = new Map<number, number>([[0, -1]]);
   const scopeStack = [0];
@@ -119,6 +124,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       return;
     }
     if (character === '{') {
+      openBraceStack.push(sourceIndex);
       const scopeId = nextScopeId++;
       scopeParents.set(scopeId, scopeStack[scopeStack.length - 1]);
       scopeStack.push(scopeId);
@@ -127,6 +133,11 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       return;
     }
     if (character === '}') {
+      const openBrace = openBraceStack.pop();
+      if (openBrace !== undefined) {
+        matchingOpenBraces.set(sourceIndex, openBrace);
+        matchingCloseBraces.set(openBrace, sourceIndex);
+      }
       if (scopeStack.length > 1) scopeStack.pop();
       lastIdentifier = undefined;
       closedControlParen = false;
@@ -304,6 +315,8 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     source: output,
     matchingOpenParens,
     matchingCloseParens,
+    matchingOpenBraces,
+    matchingCloseBraces,
     scopeAt,
     scopeParents,
     nextNonWhitespace,
@@ -439,6 +452,57 @@ function previousNonWhitespace(source: string, end: number): number {
   return cursor;
 }
 
+function nextNonWhitespace(source: string, start: number): number {
+  let cursor = start;
+  while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
+  return cursor;
+}
+
+function functionBodyOpen(
+  source: string,
+  closeParen: number,
+  nextNonWhitespaceByIndex: Uint32Array,
+  matchingCloseBraces: ReadonlyMap<number, number>
+): number | undefined {
+  let cursor = nextNonWhitespaceByIndex[closeParen + 1] ?? source.length;
+  if (source[cursor] === '{') return cursor;
+  // TypeScript permits a return annotation between the parameter list and
+  // body (`function f(x: T): Promise<void> { ... }`). If the annotation uses
+  // an object type, skip that balanced type literal and select the following
+  // body brace. Unterminated/ambiguous syntax is left unresolved.
+  if (source[cursor] !== ':') return undefined;
+  cursor = nextNonWhitespace(source, cursor + 1);
+  let angleDepth = 0;
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (character === '<') {
+      angleDepth += 1;
+      cursor += 1;
+      continue;
+    }
+    if (character === '>') {
+      angleDepth = Math.max(0, angleDepth - 1);
+      cursor += 1;
+      continue;
+    }
+    if (character !== '{') {
+      if (character === ';') return undefined;
+      cursor += 1;
+      continue;
+    }
+    const closeBrace = matchingCloseBraces.get(cursor);
+    if (closeBrace === undefined) return undefined;
+    if (angleDepth > 0) {
+      cursor = closeBrace + 1;
+      continue;
+    }
+    const afterBrace = nextNonWhitespace(source, closeBrace + 1);
+    if (source[afterBrace] === '{') return afterBrace;
+    return cursor;
+  }
+  return undefined;
+}
+
 function addFunctionBinding(
   functionBindings: Map<number, Set<string>>,
   scopeId: number,
@@ -457,19 +521,120 @@ function addFunctionBinding(
   }
 }
 
-function collectFunctionScopes(masked: MaskedWorkflowSource): {
+function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
   functionScopes: Set<number>;
   functionBindings: Map<number, Set<string>>;
 } {
-  const { source, matchingOpenParens, matchingCloseParens, scopeAt, nextNonWhitespace } = masked;
+  const { source, scopeAt, scopeParents } = masked;
   const functionScopes = new Set<number>();
   const functionBindings = new Map<number, Set<string>>();
+  const lines: Array<{ start: number; end: number; indent: number }> = [];
+  let lineStart = 0;
+  for (let cursor = 0; cursor <= source.length; cursor += 1) {
+    if (cursor !== source.length && source[cursor] !== '\n') continue;
+    let indent = 0;
+    while (lineStart + indent < cursor) {
+      const character = source[lineStart + indent];
+      if (character === ' ') indent += 1;
+      else if (character === '\t') indent += 4;
+      else break;
+    }
+    lines.push({ start: lineStart, end: cursor, indent });
+    lineStart = cursor + 1;
+  }
+
+  const pending: Array<{ indent: number; parameters: string }> = [];
+  const stack: Array<{ indent: number; scopeId: number }> = [];
+  let nextScopeId = 1;
+  for (const scopeId of scopeParents.keys()) nextScopeId = Math.max(nextScopeId, scopeId + 1);
+  for (const line of lines) {
+    const trimmed = source.slice(line.start + line.indent, line.end);
+    if (trimmed.trim() === '') continue;
+    while (stack.length > 0 && line.indent <= stack[stack.length - 1].indent) stack.pop();
+
+    while (pending.length > 0 && line.indent > pending[0].indent) {
+      const functionScope = nextScopeId++;
+      const parentScope = stack[stack.length - 1]?.scopeId ?? 0;
+      scopeParents.set(functionScope, parentScope);
+      functionScopes.add(functionScope);
+      addFunctionBinding(functionBindings, functionScope, pending.shift()!.parameters);
+      stack.push({ indent: line.indent, scopeId: functionScope });
+    }
+    pending.length = 0;
+
+    const scopeId = stack[stack.length - 1]?.scopeId ?? 0;
+    for (let cursor = line.start; cursor < line.end; cursor += 1) scopeAt[cursor] = scopeId;
+
+    const functionMatch = trimmed.match(
+      /^(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\((.*)\)\s*:\s*(?:#.*)?$/
+    );
+    if (functionMatch !== null) pending.push({ indent: line.indent, parameters: functionMatch[1] });
+  }
+
+  // Python lambdas have expression scope rather than indentation scope. For
+  // the static timeout scan, delimit their body at the first top-level
+  // separator on the source line; malformed expressions conservatively claim
+  // the remainder of that line.
+  const lambdaPattern = /\blambda\s+([^:\n]+):/g;
+  let lambdaMatch: RegExpExecArray | null;
+  while ((lambdaMatch = lambdaPattern.exec(source)) !== null) {
+    const bodyStart = nextNonWhitespace(source, lambdaMatch.index + lambdaMatch[0].length);
+    const parentScope = scopeAt[lambdaMatch.index] ?? 0;
+    const lambdaScope = nextScopeId++;
+    scopeParents.set(lambdaScope, parentScope);
+    functionScopes.add(lambdaScope);
+    addFunctionBinding(functionBindings, lambdaScope, lambdaMatch[1]);
+
+    let bodyEnd = source.indexOf('\n', bodyStart);
+    if (bodyEnd < 0) bodyEnd = source.length;
+    let parenDepth = 0;
+    let bracketDepth = 0;
+    let braceDepth = 0;
+    for (let cursor = bodyStart; cursor < bodyEnd; cursor += 1) {
+      const character = source[cursor];
+      if (character === '(') parenDepth += 1;
+      else if (character === ')') {
+        if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+          bodyEnd = cursor;
+          break;
+        }
+        parenDepth = Math.max(0, parenDepth - 1);
+      } else if (character === '[') bracketDepth += 1;
+      else if (character === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+      else if (character === '{') braceDepth += 1;
+      else if (character === '}') braceDepth = Math.max(0, braceDepth - 1);
+      else if (character === ',' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+        bodyEnd = cursor;
+        break;
+      } else if (character === ';' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+        bodyEnd = cursor;
+        break;
+      }
+    }
+    for (let cursor = bodyStart; cursor < bodyEnd; cursor += 1) scopeAt[cursor] = lambdaScope;
+  }
+  return { functionScopes, functionBindings };
+}
+
+function collectFunctionScopes(
+  masked: MaskedWorkflowSource,
+  fileType: Extract<WorkflowFileType, 'ts' | 'py'>
+): {
+  functionScopes: Set<number>;
+  functionBindings: Map<number, Set<string>>;
+} {
+  const { source, matchingOpenParens, matchingCloseParens, matchingCloseBraces, scopeAt, nextNonWhitespace } =
+    masked;
+  const functionScopes = new Set<number>();
+  const functionBindings = new Map<number, Set<string>>();
+
+  if (fileType === 'py') return collectPythonFunctionScopes(masked);
 
   const register = (openParen: number, parametersStart: number, parametersEnd: number): void => {
     const closeParen = matchingCloseParens.get(openParen);
     if (closeParen === undefined) return;
-    const bodyOpen = nextNonWhitespace[closeParen + 1] ?? source.length;
-    if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) return;
+    const bodyOpen = functionBodyOpen(source, closeParen, nextNonWhitespace, matchingCloseBraces);
+    if (bodyOpen === undefined || bodyOpen + 1 >= source.length) return;
     const scopeId = scopeAt[bodyOpen + 1] ?? 0;
     functionScopes.add(scopeId);
     addFunctionBinding(functionBindings, scopeId, source.slice(parametersStart, parametersEnd));
@@ -483,6 +648,21 @@ function collectFunctionScopes(masked: MaskedWorkflowSource): {
     register(openParen, openParen + 1, matchingCloseParens.get(openParen) ?? openParen + 1);
   }
 
+  // Catch bindings have their own lexical scope, represented by the catch
+  // block's brace scope in the masked source.
+  const catchPattern = /\bcatch\s*\(/g;
+  let catchMatch: RegExpExecArray | null;
+  while ((catchMatch = catchPattern.exec(source)) !== null) {
+    const openParen = catchMatch.index + catchMatch[0].lastIndexOf('(');
+    const closeParen = matchingCloseParens.get(openParen);
+    if (closeParen === undefined) continue;
+    const bodyOpen = nextNonWhitespace[closeParen + 1] ?? source.length;
+    if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) continue;
+    const scopeId = scopeAt[bodyOpen + 1] ?? 0;
+    functionScopes.add(scopeId);
+    addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, closeParen));
+  }
+
   // Block-bodied arrow functions. Expression-bodied arrows introduce no
   // lexical block that this scanner needs to model.
   const arrowPattern = /=>/g;
@@ -492,15 +672,15 @@ function collectFunctionScopes(masked: MaskedWorkflowSource): {
     if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) continue;
     const scopeId = scopeAt[bodyOpen + 1] ?? 0;
     functionScopes.add(scopeId);
-    const parameterEnd = previousNonWhitespace(source, arrowMatch.index - 1) + 1;
-    const parameterEndCharacter = parameterEnd - 1;
-    if (source[parameterEndCharacter] === ')') {
-      const openParen = matchingOpenParens.get(parameterEndCharacter);
+    let parameterClose = previousNonWhitespace(source, arrowMatch.index - 1);
+    while (parameterClose >= 0 && source[parameterClose] !== ')') parameterClose -= 1;
+    if (parameterClose >= 0) {
+      const openParen = matchingOpenParens.get(parameterClose);
       if (openParen !== undefined) {
-        addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, parameterEndCharacter));
+        addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, parameterClose));
       }
     } else {
-      const parameter = identifierBefore(source, parameterEnd);
+      const parameter = identifierBefore(source, previousNonWhitespace(source, arrowMatch.index - 1) + 1);
       if (parameter !== null) addFunctionBinding(functionBindings, scopeId, parameter.name);
     }
   }
@@ -533,7 +713,7 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const masked = maskNonCode(workflow, fileType);
   const source = masked.source;
-  const { functionScopes, functionBindings } = collectFunctionScopes(masked);
+  const { functionScopes, functionBindings } = collectFunctionScopes(masked, fileType);
   const bindings = new Map<number, Map<string, WorkflowBinding>>();
   const declarationPattern =
     fileType === 'ts'

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -1182,6 +1182,7 @@ export function inferWorkflowLaunchTimeoutMs(
     fileType === 'ts'
       ? /\b(const|let|var|function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g
       : /(?:^|[;\n])[ \t]*([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=\n;]+)?=(?!=)/g;
+  const pythonAssignmentDepth = fileType === 'py' ? pythonDelimiterDepth(source) : undefined;
   let declaration: RegExpExecArray | null;
   while ((declaration = declarationPattern.exec(source)) !== null) {
     const declarationKind = fileType === 'ts' ? declaration[1] : undefined;
@@ -1190,6 +1191,10 @@ export function inferWorkflowLaunchTimeoutMs(
       fileType === 'ts'
         ? declaration.index + declaration[0].lastIndexOf(declarationName)
         : declaration.index + declaration[0].indexOf(declarationName);
+    // A Python assignment nested inside delimiters is a keyword argument or
+    // function default, not a binding in the surrounding scope. Delimiter
+    // depth is precomputed once so this remains linear across all matches.
+    if (fileType === 'py' && pythonAssignmentDepth?.[declarationNameIndex] !== 0) continue;
     const scopeId = masked.scopeAt[declarationNameIndex] ?? 0;
     const bindingScope =
       declarationKind === 'var' ? nearestFunctionScope(scopeId, varScopes, masked.scopeParents) : scopeId;

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -23,6 +23,7 @@ const REGEX_KEYWORDS = new Set([
   'continue',
   'debugger',
 ]);
+const ASI_LABEL_KEYWORDS = new Set(['break', 'continue']);
 const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
 
 type MaskedWorkflowSource = {
@@ -52,6 +53,9 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let currentIdentifier = '';
   let lastIdentifier: string | undefined;
   let closedControlParen = false;
+  let asiKeywordPending: string | undefined;
+  let asiLabelCandidate = false;
+  let lineBreakAfterAsiLabel = false;
   const controlParenStack: boolean[] = [];
   const openParenStack: number[] = [];
   const matchingOpenParens = new Map<number, number>();
@@ -63,9 +67,26 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
   const flushIdentifier = () => {
     if (currentIdentifier) {
+      if (lastIdentifier !== undefined && ASI_LABEL_KEYWORDS.has(lastIdentifier)) {
+        asiLabelCandidate = true;
+      }
+      if (asiKeywordPending !== undefined) {
+        // `break label\n/regex/` is lexically a regex after the labelled
+        // statement. Keep the ASI context until the label's line terminator
+        // has been observed; a same-line slash remains ordinary code.
+        asiLabelCandidate = true;
+        asiKeywordPending = undefined;
+      }
       lastIdentifier = currentIdentifier;
       currentIdentifier = '';
     }
+  };
+
+  const recordLineBreak = () => {
+    if (lastIdentifier !== undefined && REGEX_KEYWORDS.has(lastIdentifier)) {
+      asiKeywordPending = lastIdentifier;
+    }
+    if (asiLabelCandidate) lineBreakAfterAsiLabel = true;
   };
 
   const appendCode = (character: string, sourceIndex: number) => {
@@ -78,7 +99,16 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     }
 
     flushIdentifier();
-    if (/\s/.test(character)) return;
+    if (/\s/.test(character)) {
+      if (character === '\n' || character === '\r') recordLineBreak();
+      return;
+    }
+
+    // Any non-whitespace token other than the slash handled by the caller
+    // ends the pending ASI/label context.
+    asiKeywordPending = undefined;
+    asiLabelCandidate = false;
+    lineBreakAfterAsiLabel = false;
 
     previousSignificantCharacter = character;
     if (character === '(') {
@@ -124,6 +154,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   // from text inside it.
   const startsRegexLiteral = (): boolean => {
     if (fileType !== 'ts') return false;
+    if (asiKeywordPending !== undefined || lineBreakAfterAsiLabel) return true;
     if (
       previousSignificantCharacter === undefined ||
       REGEX_BOUNDARY_CHARACTERS.test(previousSignificantCharacter)
@@ -155,6 +186,9 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       if (character === ']' && regexCharacterClass) regexCharacterClass = false;
       if (character === '/' && !regexCharacterClass) {
         regexLiteral = false;
+        asiKeywordPending = undefined;
+        asiLabelCandidate = false;
+        lineBreakAfterAsiLabel = false;
         previousSignificantCharacter = '/';
         currentIdentifier = '';
         lastIdentifier = undefined;
@@ -166,13 +200,17 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     if (lineComment) {
       output += mask(character);
-      if (character === '\n') lineComment = false;
+      if (character === '\n' || character === '\r') {
+        recordLineBreak();
+        lineComment = false;
+      }
       index += 1;
       continue;
     }
 
     if (blockComment) {
       output += mask(character);
+      if (character === '\n' || character === '\r') recordLineBreak();
       if (character === '*' && next === '/') {
         output += ' ';
         index += 2;
@@ -225,6 +263,9 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     }
     if (character === '/' && startsRegexLiteral()) {
       output += ' ';
+      asiKeywordPending = undefined;
+      asiLabelCandidate = false;
+      lineBreakAfterAsiLabel = false;
       index += 1;
       regexLiteral = true;
       regexCharacterClass = false;
@@ -392,6 +433,93 @@ function workflowInitializerAt(
   return source[cursor] === '(';
 }
 
+function previousNonWhitespace(source: string, end: number): number {
+  let cursor = end;
+  while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+  return cursor;
+}
+
+function addFunctionBinding(
+  functionBindings: Map<number, Set<string>>,
+  scopeId: number,
+  parameters: string
+): void {
+  let names = functionBindings.get(scopeId);
+  if (names === undefined) {
+    names = new Set();
+    functionBindings.set(scopeId, names);
+  }
+  // This is deliberately a conservative lexical scan. Marking names from a
+  // parameter's type/default/destructuring pattern as shadowed can omit an
+  // inference, but never turns unrelated code into a false builder timeout.
+  for (const parameter of parameters.matchAll(/[A-Za-z_$][A-Za-z0-9_$]*/g)) {
+    names.add(parameter[0]);
+  }
+}
+
+function collectFunctionScopes(masked: MaskedWorkflowSource): {
+  functionScopes: Set<number>;
+  functionBindings: Map<number, Set<string>>;
+} {
+  const { source, matchingOpenParens, matchingCloseParens, scopeAt, nextNonWhitespace } = masked;
+  const functionScopes = new Set<number>();
+  const functionBindings = new Map<number, Set<string>>();
+
+  const register = (openParen: number, parametersStart: number, parametersEnd: number): void => {
+    const closeParen = matchingCloseParens.get(openParen);
+    if (closeParen === undefined) return;
+    const bodyOpen = nextNonWhitespace[closeParen + 1] ?? source.length;
+    if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) return;
+    const scopeId = scopeAt[bodyOpen + 1] ?? 0;
+    functionScopes.add(scopeId);
+    addFunctionBinding(functionBindings, scopeId, source.slice(parametersStart, parametersEnd));
+  };
+
+  // Function declarations and expressions.
+  const functionPattern = /\bfunction\s*\*?\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\s*)?\(/g;
+  let functionMatch: RegExpExecArray | null;
+  while ((functionMatch = functionPattern.exec(source)) !== null) {
+    const openParen = functionMatch.index + functionMatch[0].lastIndexOf('(');
+    register(openParen, openParen + 1, matchingCloseParens.get(openParen) ?? openParen + 1);
+  }
+
+  // Block-bodied arrow functions. Expression-bodied arrows introduce no
+  // lexical block that this scanner needs to model.
+  const arrowPattern = /=>/g;
+  let arrowMatch: RegExpExecArray | null;
+  while ((arrowMatch = arrowPattern.exec(source)) !== null) {
+    const bodyOpen = nextNonWhitespace[arrowMatch.index + arrowMatch[0].length] ?? source.length;
+    if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) continue;
+    const scopeId = scopeAt[bodyOpen + 1] ?? 0;
+    functionScopes.add(scopeId);
+    const parameterEnd = previousNonWhitespace(source, arrowMatch.index - 1) + 1;
+    const parameterEndCharacter = parameterEnd - 1;
+    if (source[parameterEndCharacter] === ')') {
+      const openParen = matchingOpenParens.get(parameterEndCharacter);
+      if (openParen !== undefined) {
+        addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, parameterEndCharacter));
+      }
+    } else {
+      const parameter = identifierBefore(source, parameterEnd);
+      if (parameter !== null) addFunctionBinding(functionBindings, scopeId, parameter.name);
+    }
+  }
+
+  return { functionScopes, functionBindings };
+}
+
+function nearestFunctionScope(
+  scopeId: number,
+  functionScopes: ReadonlySet<number>,
+  scopeParents: ReadonlyMap<number, number>
+): number {
+  let currentScope = scopeId;
+  while (currentScope > 0 && !functionScopes.has(currentScope)) {
+    currentScope = scopeParents.get(currentScope) ?? 0;
+  }
+  return currentScope;
+}
+
 /**
  * Infer the outer Cloud launch budget from a literal RelayFlow builder timeout
  * without evaluating submitted workflow code. Dynamic expressions are left
@@ -405,21 +533,40 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const masked = maskNonCode(workflow, fileType);
   const source = masked.source;
+  const { functionScopes, functionBindings } = collectFunctionScopes(masked);
   const bindings = new Map<number, Map<string, WorkflowBinding>>();
   const declarationPattern =
     fileType === 'ts'
-      ? /\b(?:const|let|var|function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g
+      ? /\b(const|let|var|function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g
       : /\b([A-Za-z_][A-Za-z0-9_]*)\s*=/g;
   let declaration: RegExpExecArray | null;
   while ((declaration = declarationPattern.exec(source)) !== null) {
     const scopeId = masked.scopeAt[declaration.index] ?? 0;
+    const declarationKind = fileType === 'ts' ? declaration[1] : undefined;
+    const declarationName = fileType === 'ts' ? declaration[2] : declaration[1];
+    const bindingScope =
+      declarationKind === 'var'
+        ? nearestFunctionScope(scopeId, functionScopes, masked.scopeParents)
+        : scopeId;
+    let scopeBindings = bindings.get(scopeId);
+    if (scopeBindings === undefined || bindingScope !== scopeId) {
+      scopeBindings = bindings.get(bindingScope);
+    }
+    if (scopeBindings === undefined) {
+      scopeBindings = new Map();
+      bindings.set(bindingScope, scopeBindings);
+    }
+    const builder = workflowInitializerAt(source, declaration.index + declaration[0].length, fileType);
+    scopeBindings.set(declarationName, { builder });
+  }
+
+  for (const [scopeId, names] of functionBindings) {
     let scopeBindings = bindings.get(scopeId);
     if (scopeBindings === undefined) {
       scopeBindings = new Map();
       bindings.set(scopeId, scopeBindings);
     }
-    const builder = workflowInitializerAt(source, declaration.index + declaration[0].length, fileType);
-    scopeBindings.set(declaration[1], { builder });
+    for (const name of names) scopeBindings.set(name, { builder: false });
   }
 
   const values = new Set<number>();

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -1,0 +1,149 @@
+import type { WorkflowFileType } from './types.js';
+
+export const DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS = 5 * 60 * 1000;
+export const MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS = 30 * 1000;
+export const MAX_WORKFLOW_LAUNCH_TIMEOUT_MS = 55 * 60 * 1000;
+
+function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): string {
+  let output = '';
+  let index = 0;
+  let quote: "'" | '"' | '`' | null = null;
+  let triple = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  const mask = (character: string) => (character === '\n' || character === '\r' ? character : ' ');
+
+  while (index < source.length) {
+    const character = source[index];
+    const next = source[index + 1];
+    const third = source[index + 2];
+
+    if (lineComment) {
+      output += mask(character);
+      if (character === '\n') lineComment = false;
+      index += 1;
+      continue;
+    }
+
+    if (blockComment) {
+      output += mask(character);
+      if (character === '*' && next === '/') {
+        output += ' ';
+        index += 2;
+        blockComment = false;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      output += mask(character);
+      if (triple && character === quote && next === quote && third === quote) {
+        output += '  ';
+        index += 3;
+        quote = null;
+        triple = false;
+        escaped = false;
+        continue;
+      }
+      if (!triple) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === quote) {
+          quote = null;
+        }
+      }
+      index += 1;
+      continue;
+    }
+
+    if (fileType === 'ts' && character === '/' && next === '/') {
+      output += '  ';
+      index += 2;
+      lineComment = true;
+      continue;
+    }
+    if (fileType === 'ts' && character === '/' && next === '*') {
+      output += '  ';
+      index += 2;
+      blockComment = true;
+      continue;
+    }
+    if (fileType === 'py' && character === '#') {
+      output += ' ';
+      index += 1;
+      lineComment = true;
+      continue;
+    }
+    if (character === "'" || character === '"' || (fileType === 'ts' && character === '`')) {
+      triple = fileType === 'py' && next === character && third === character;
+      quote = character;
+      output += triple ? '   ' : ' ';
+      index += triple ? 3 : 1;
+      continue;
+    }
+
+    output += character;
+    index += 1;
+  }
+
+  return output;
+}
+
+function validateLaunchTimeoutMs(value: number, source: string, minimum = 1): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${source} must be a positive safe integer of milliseconds`);
+  }
+  if (value < minimum) {
+    throw new Error(`${source} must be at least ${minimum} milliseconds`);
+  }
+  if (value > MAX_WORKFLOW_LAUNCH_TIMEOUT_MS) {
+    throw new Error(`${source} must not exceed ${MAX_WORKFLOW_LAUNCH_TIMEOUT_MS} milliseconds`);
+  }
+  return value;
+}
+
+/**
+ * Infer the outer Cloud launch budget from a literal RelayFlow builder timeout
+ * without evaluating submitted workflow code. Dynamic expressions are left
+ * unresolved so callers can use the explicit launchTimeoutMs option instead.
+ */
+export function inferWorkflowLaunchTimeoutMs(
+  workflow: string,
+  fileType: WorkflowFileType
+): number | undefined {
+  if (fileType === 'yaml') return undefined;
+
+  const source = maskNonCode(workflow, fileType);
+  const values = new Set<number>();
+  const timeoutPattern = /\.timeout\s*\(\s*([0-9](?:_?[0-9])*)\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = timeoutPattern.exec(source)) !== null) {
+    values.add(validateLaunchTimeoutMs(Number(match[1].replaceAll('_', '')), 'workflow .timeout()'));
+  }
+
+  if (values.size === 0) return undefined;
+  if (values.size > 1) {
+    throw new Error(
+      'Workflow declares multiple distinct literal .timeout() values; pass launchTimeoutMs explicitly'
+    );
+  }
+  const inferred = values.values().next().value;
+  return inferred === undefined ? undefined : Math.max(DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS, inferred);
+}
+
+export function resolveWorkflowLaunchTimeoutMs(
+  workflow: string,
+  fileType: WorkflowFileType,
+  explicit?: number
+): number | undefined {
+  if (explicit !== undefined) {
+    return validateLaunchTimeoutMs(explicit, 'launchTimeoutMs', MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS);
+  }
+  return inferWorkflowLaunchTimeoutMs(workflow, fileType);
+}

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -4,6 +4,24 @@ export const DEFAULT_WORKFLOW_LAUNCH_TIMEOUT_MS = 5 * 60 * 1000;
 export const MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS = 30 * 1000;
 export const MAX_WORKFLOW_LAUNCH_TIMEOUT_MS = 55 * 60 * 1000;
 
+const REGEX_BOUNDARY_CHARACTERS = /[([{:;,!?=+\-*%&|^~<>}]/;
+const REGEX_KEYWORDS = new Set([
+  'return',
+  'throw',
+  'case',
+  'delete',
+  'void',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'yield',
+  'await',
+  'else',
+  'do',
+]);
+const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
+
 function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): string {
   let output = '';
   let index = 0;
@@ -14,12 +32,47 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let blockComment = false;
   let regexLiteral = false;
   let regexCharacterClass = false;
+  const mask = (character: string) => (character === '\n' || character === '\r' ? character : ' ');
+  let previousSignificantCharacter: string | undefined;
+  let currentIdentifier = '';
+  let lastIdentifier: string | undefined;
+  let closedControlParen = false;
+  const controlParenStack: boolean[] = [];
 
-  const previousSignificantCharacter = (from: number): string | undefined => {
-    for (let cursor = from - 1; cursor >= 0; cursor -= 1) {
-      if (!/\s/.test(source[cursor])) return source[cursor];
+  const flushIdentifier = () => {
+    if (currentIdentifier) {
+      lastIdentifier = currentIdentifier;
+      currentIdentifier = '';
     }
-    return undefined;
+  };
+
+  const appendCode = (character: string) => {
+    output += character;
+    if (/[A-Za-z0-9_$]/.test(character)) {
+      currentIdentifier += character;
+      previousSignificantCharacter = character;
+      closedControlParen = false;
+      return;
+    }
+
+    flushIdentifier();
+    if (/\s/.test(character)) return;
+
+    previousSignificantCharacter = character;
+    if (character === '(') {
+      controlParenStack.push(lastIdentifier !== undefined && CONTROL_PAREN_KEYWORDS.has(lastIdentifier));
+      lastIdentifier = undefined;
+      closedControlParen = false;
+      return;
+    }
+    if (character === ')') {
+      closedControlParen = controlParenStack.pop() ?? false;
+      lastIdentifier = undefined;
+      return;
+    }
+
+    lastIdentifier = undefined;
+    closedControlParen = false;
   };
 
   // A slash starts a TypeScript regular-expression literal after an expression
@@ -27,27 +80,17 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   // expression and therefore remains visible code. This is intentionally
   // conservative: masking a possible regex is safer than inferring a timeout
   // from text inside it.
-  const startsRegexLiteral = (at: number): boolean => {
+  const startsRegexLiteral = (): boolean => {
     if (fileType !== 'ts') return false;
-    const previous = previousSignificantCharacter(at);
-    if (previous === undefined || /[([{:;,!?=+\-*%&|^~<>}]/.test(previous)) return true;
-    if (previous === ')') {
-      let closeIndex = at - 1;
-      while (closeIndex >= 0 && /\s/.test(source[closeIndex])) closeIndex -= 1;
-      const openIndex = findMatchingOpenParen(source, closeIndex);
-      const control = openIndex === null ? null : identifierBefore(source, openIndex - 1)?.name;
-      if (control && new Set(['if', 'while', 'for', 'switch', 'catch', 'with']).has(control)) {
-        return true;
-      }
+    if (
+      previousSignificantCharacter === undefined ||
+      REGEX_BOUNDARY_CHARACTERS.test(previousSignificantCharacter)
+    ) {
+      return true;
     }
-    const prefix = source.slice(0, at).replace(/\s+$/, '');
-    const keyword = prefix.match(
-      /(?:^|[^\w$])(return|throw|case|delete|void|typeof|instanceof|in|of|yield|await|else|do)\s*$/
-    );
-    return keyword !== null;
+    if (previousSignificantCharacter === ')' && closedControlParen) return true;
+    return REGEX_KEYWORDS.has(currentIdentifier || lastIdentifier || '');
   };
-
-  const mask = (character: string) => (character === '\n' || character === '\r' ? character : ' ');
 
   while (index < source.length) {
     const character = source[index];
@@ -69,6 +112,10 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       if (character === ']' && regexCharacterClass) regexCharacterClass = false;
       if (character === '/' && !regexCharacterClass) {
         regexLiteral = false;
+        previousSignificantCharacter = '/';
+        currentIdentifier = '';
+        lastIdentifier = undefined;
+        closedControlParen = false;
       }
       index += 1;
       continue;
@@ -128,7 +175,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       blockComment = true;
       continue;
     }
-    if (character === '/' && startsRegexLiteral(index)) {
+    if (character === '/' && startsRegexLiteral()) {
       output += ' ';
       index += 1;
       regexLiteral = true;
@@ -145,11 +192,15 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       triple = fileType === 'py' && next === character && third === character;
       quote = character;
       output += triple ? '   ' : ' ';
+      previousSignificantCharacter = character;
+      currentIdentifier = '';
+      lastIdentifier = undefined;
+      closedControlParen = false;
       index += triple ? 3 : 1;
       continue;
     }
 
-    output += character;
+    appendCode(character);
     index += 1;
   }
 

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -332,7 +332,7 @@ export function inferWorkflowLaunchTimeoutMs(
   }
 
   const values = new Set<number>();
-  let hasDynamicBuilderTimeout = false;
+  let hasUnresolvedBuilderTimeout = false;
   const callRoots = new Map<number, WorkflowRoot | null>();
   const timeoutPattern = /\.timeout/g;
   let match: RegExpExecArray | null;
@@ -351,16 +351,23 @@ export function inferWorkflowLaunchTimeoutMs(
     }
     const literal = source.slice(argumentStart, argumentEnd).match(/^[0-9](?:_?[0-9])*$/)?.[0];
     if (literal === undefined) {
-      hasDynamicBuilderTimeout = true;
+      hasUnresolvedBuilderTimeout = true;
       continue;
     }
-    values.add(validateLaunchTimeoutMs(Number(literal.replaceAll('_', '')), 'workflow .timeout()'));
+    try {
+      values.add(validateLaunchTimeoutMs(Number(literal.replaceAll('_', '')), 'workflow .timeout()'));
+    } catch {
+      // A script literal outside the inferred metadata contract is still user
+      // code we cannot safely evaluate. Omit inference and let callers provide
+      // an explicit, strictly validated launchTimeoutMs instead.
+      hasUnresolvedBuilderTimeout = true;
+    }
   }
 
-  // A literal and a dynamic builder timeout cannot be reconciled without
+  // A dynamic or out-of-range builder timeout cannot be reconciled without
   // evaluating user code. Leave the metadata omitted so callers can provide
   // an explicit launchTimeoutMs override when they know the runtime value.
-  if (hasDynamicBuilderTimeout) return undefined;
+  if (hasUnresolvedBuilderTimeout) return undefined;
   if (values.size === 0) return undefined;
   if (values.size > 1) {
     throw new Error(

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -25,6 +25,7 @@ const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch',
 type MaskedWorkflowSource = {
   source: string;
   matchingOpenParens: Map<number, number>;
+  matchingCloseParens: Map<number, number>;
 };
 
 type WorkflowRoot = { name: string; invoked: boolean };
@@ -47,6 +48,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   const controlParenStack: boolean[] = [];
   const openParenStack: number[] = [];
   const matchingOpenParens = new Map<number, number>();
+  const matchingCloseParens = new Map<number, number>();
 
   const flushIdentifier = () => {
     if (currentIdentifier) {
@@ -77,7 +79,10 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     }
     if (character === ')') {
       const openParen = openParenStack.pop();
-      if (openParen !== undefined) matchingOpenParens.set(sourceIndex, openParen);
+      if (openParen !== undefined) {
+        matchingOpenParens.set(sourceIndex, openParen);
+        matchingCloseParens.set(openParen, sourceIndex);
+      }
       closedControlParen = controlParenStack.pop() ?? false;
       lastIdentifier = undefined;
       return;
@@ -222,7 +227,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     index += 1;
   }
 
-  return { source: output, matchingOpenParens };
+  return { source: output, matchingOpenParens, matchingCloseParens };
 }
 
 function validateLaunchTimeoutMs(value: number, source: string, minimum = 1): number {
@@ -340,10 +345,11 @@ export function inferWorkflowLaunchTimeoutMs(
     let argumentStart = match.index + match[0].length;
     while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
     if (source[argumentStart] !== '(') continue;
+    const argumentOpen = argumentStart;
     argumentStart += 1;
     while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
-    const argumentEnd = source.indexOf(')', argumentStart);
-    if (argumentEnd < 0) continue;
+    const argumentEnd = masked.matchingCloseParens.get(argumentOpen);
+    if (argumentEnd === undefined) continue;
 
     const root = timeoutRoot(source, match.index, masked.matchingOpenParens, callRoots);
     if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -249,7 +249,9 @@ export function inferWorkflowLaunchTimeoutMs(
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
     const root = timeoutRoot(source, match.index);
-    if (root === null || (!root.invoked && !builderNames.has(root.name))) continue;
+    if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {
+      continue;
+    }
     const literal = match[1].match(/^[0-9](?:_?[0-9])*$/)?.[0];
     if (literal === undefined) {
       hasDynamicBuilderTimeout = true;

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -25,6 +25,7 @@ const REGEX_KEYWORDS = new Set([
 ]);
 const ASI_LABEL_KEYWORDS = new Set(['break', 'continue']);
 const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
+const IDENTIFIER_PART = /[\p{ID_Continue}$\u200c\u200d]/u;
 
 type MaskedWorkflowSource = {
   source: string;
@@ -39,6 +40,25 @@ type MaskedWorkflowSource = {
 
 type WorkflowRoot = { name: string; invoked: boolean };
 type WorkflowBinding = { builder: boolean };
+type ExpressionScope = { start: number; end: number; parameters: string };
+
+function isIdentifierPart(character: string | undefined): boolean {
+  return character !== undefined && IDENTIFIER_PART.test(character);
+}
+
+function unicodeIdentifierEscapeLength(source: string, index: number): number {
+  if (source[index] !== '\\' || source[index + 1] !== 'u') return 0;
+  if (source[index + 2] === '{') {
+    let cursor = index + 3;
+    let digits = 0;
+    while (cursor < source.length && /[0-9A-Fa-f]/.test(source[cursor]) && digits < 6) {
+      cursor += 1;
+      digits += 1;
+    }
+    return digits > 0 && source[cursor] === '}' ? cursor - index + 1 : 0;
+  }
+  return /^[0-9A-Fa-f]{4}$/.test(source.slice(index + 2, index + 6)) ? 6 : 0;
+}
 
 function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): MaskedWorkflowSource {
   let output = '';
@@ -96,7 +116,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
   const appendCode = (character: string, sourceIndex: number) => {
     output += character;
-    if (/[A-Za-z0-9_$]/.test(character)) {
+    if (isIdentifierPart(character)) {
       currentIdentifier += character;
       previousSignificantCharacter = character;
       closedControlParen = false;
@@ -258,6 +278,21 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       }
       index += 1;
       continue;
+    }
+
+    if (fileType === 'ts' && character === '\\') {
+      const escapeLength = unicodeIdentifierEscapeLength(source, index);
+      if (escapeLength > 0) {
+        output += source.slice(index, index + escapeLength);
+        for (let offset = 1; offset < escapeLength; offset += 1) {
+          scopeAt[index + offset] = scopeStack[scopeStack.length - 1];
+        }
+        currentIdentifier += '_';
+        previousSignificantCharacter = '_';
+        closedControlParen = false;
+        index += escapeLength;
+        continue;
+      }
     }
 
     if (fileType === 'ts' && character === '/' && next === '/') {
@@ -521,12 +556,106 @@ function addFunctionBinding(
   }
 }
 
+function resolveExpressionScopeEnds(
+  source: string,
+  scopes: ExpressionScope[],
+  fileType: Extract<WorkflowFileType, 'ts' | 'py'>
+): void {
+  const active: Array<ExpressionScope & { depth: number }> = [];
+  let scopeIndex = 0;
+  let delimiterDepth = 0;
+
+  const closeAt = (position: number): void => {
+    while (active.length > 0 && active[active.length - 1].depth === delimiterDepth) {
+      active.pop()!.end = position;
+    }
+  };
+
+  for (let cursor = 0; cursor < source.length; cursor += 1) {
+    while (scopeIndex < scopes.length && scopes[scopeIndex].start === cursor) {
+      active.push(Object.assign(scopes[scopeIndex], { depth: delimiterDepth }));
+      scopeIndex += 1;
+    }
+
+    const character = source[cursor];
+    if (character === ')' || character === ']' || character === '}') {
+      closeAt(cursor);
+      delimiterDepth = Math.max(0, delimiterDepth - 1);
+      continue;
+    }
+    if (character === '(' || character === '[' || character === '{') {
+      delimiterDepth += 1;
+      continue;
+    }
+    if (character === ';' && active.length > 0) {
+      closeAt(cursor);
+      continue;
+    }
+    if (fileType === 'py' && character === ',' && active.length > 0) {
+      closeAt(cursor);
+      continue;
+    }
+    if (fileType === 'py' && (character === '\n' || character === '\r') && delimiterDepth === 0) {
+      closeAt(cursor);
+    }
+  }
+
+  while (active.length > 0) active.pop()!.end = source.length;
+}
+
+function applyExpressionScopes(
+  masked: MaskedWorkflowSource,
+  scopes: ExpressionScope[],
+  functionScopes: Set<number>,
+  functionBindings: Map<number, Set<string>>,
+  varScopes?: Set<number>
+): void {
+  if (scopes.length === 0) return;
+
+  const registered: Array<ExpressionScope & { scopeId: number }> = [];
+  const parentStack: Array<ExpressionScope & { scopeId: number }> = [];
+  let nextScopeId = 1;
+  for (const scopeId of masked.scopeParents.keys()) nextScopeId = Math.max(nextScopeId, scopeId + 1);
+
+  for (const scope of scopes) {
+    while (parentStack.length > 0 && parentStack[parentStack.length - 1].end <= scope.start) {
+      parentStack.pop();
+    }
+    const scopeId = nextScopeId++;
+    const parentScope = parentStack[parentStack.length - 1]?.scopeId ?? masked.scopeAt[scope.start] ?? 0;
+    masked.scopeParents.set(scopeId, parentScope);
+    functionScopes.add(scopeId);
+    varScopes?.add(scopeId);
+    addFunctionBinding(functionBindings, scopeId, scope.parameters);
+    const record = { ...scope, scopeId };
+    registered.push(record);
+    parentStack.push(record);
+  }
+
+  const active: Array<ExpressionScope & { scopeId: number }> = [];
+  let scopeIndex = 0;
+  for (let cursor = 0; cursor < masked.source.length; cursor += 1) {
+    while (active.length > 0 && active[active.length - 1].end <= cursor) active.pop();
+    while (scopeIndex < registered.length && registered[scopeIndex].start === cursor) {
+      active.push(registered[scopeIndex]);
+      scopeIndex += 1;
+    }
+    if (active.length > 0) masked.scopeAt[cursor] = active[active.length - 1].scopeId;
+  }
+}
+
 function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
   functionScopes: Set<number>;
   functionBindings: Map<number, Set<string>>;
   varScopes: Set<number>;
 } {
-  const { source, scopeAt, scopeParents } = masked;
+  const {
+    source,
+    scopeAt,
+    scopeParents,
+    matchingCloseParens,
+    nextNonWhitespace: nextNonWhitespaceByIndex,
+  } = masked;
   const functionScopes = new Set<number>();
   const functionBindings = new Map<number, Set<string>>();
   const lines: Array<{ start: number; end: number; indent: number }> = [];
@@ -544,76 +673,92 @@ function collectPythonFunctionScopes(masked: MaskedWorkflowSource): {
     lineStart = cursor + 1;
   }
 
-  const pending: Array<{ indent: number; parameters: string }> = [];
+  const declarations: Array<{
+    name: string;
+    colon: number;
+    indent: number;
+    parameters: string;
+  }> = [];
+  const declarationPattern = /^[ \t]*(?:async[ \t]+)?def[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(/gm;
+  let declarationMatch: RegExpExecArray | null;
+  let declarationLineIndex = 0;
+  while ((declarationMatch = declarationPattern.exec(source)) !== null) {
+    const openParen = declarationMatch.index + declarationMatch[0].lastIndexOf('(');
+    const closeParen = matchingCloseParens.get(openParen);
+    if (closeParen === undefined) continue;
+    const colon = nextNonWhitespaceByIndex[closeParen + 1] ?? source.length;
+    if (source[colon] !== ':') continue;
+    while (
+      declarationLineIndex + 1 < lines.length &&
+      lines[declarationLineIndex].end < declarationMatch.index
+    ) {
+      declarationLineIndex += 1;
+    }
+    declarations.push({
+      name: declarationMatch[1],
+      colon,
+      indent: lines[declarationLineIndex]?.indent ?? 0,
+      parameters: source.slice(openParen + 1, closeParen),
+    });
+  }
+
+  const pending: Array<{ indent: number; parameters: string; parentScope: number }> = [];
   const stack: Array<{ indent: number; scopeId: number }> = [];
   let nextScopeId = 1;
   for (const scopeId of scopeParents.keys()) nextScopeId = Math.max(nextScopeId, scopeId + 1);
+  let declarationIndex = 0;
   for (const line of lines) {
     const trimmed = source.slice(line.start + line.indent, line.end);
     if (trimmed.trim() === '') continue;
     while (stack.length > 0 && line.indent <= stack[stack.length - 1].indent) stack.pop();
 
     while (pending.length > 0 && line.indent > pending[0].indent) {
+      const definition = pending.shift()!;
       const functionScope = nextScopeId++;
-      const parentScope = stack[stack.length - 1]?.scopeId ?? 0;
-      scopeParents.set(functionScope, parentScope);
+      scopeParents.set(functionScope, definition.parentScope);
       functionScopes.add(functionScope);
-      addFunctionBinding(functionBindings, functionScope, pending.shift()!.parameters);
-      stack.push({ indent: line.indent, scopeId: functionScope });
+      addFunctionBinding(functionBindings, functionScope, definition.parameters);
+      stack.push({ indent: definition.indent, scopeId: functionScope });
     }
     pending.length = 0;
 
     const scopeId = stack[stack.length - 1]?.scopeId ?? 0;
     for (let cursor = line.start; cursor < line.end; cursor += 1) scopeAt[cursor] = scopeId;
 
-    const functionMatch = trimmed.match(
-      /^(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\((.*)\)\s*:\s*(?:#.*)?$/
-    );
-    if (functionMatch !== null) pending.push({ indent: line.indent, parameters: functionMatch[1] });
+    while (declarationIndex < declarations.length && declarations[declarationIndex].colon <= line.end) {
+      const definition = declarations[declarationIndex++];
+      addFunctionBinding(functionBindings, scopeId, definition.name);
+      const inlineBodyStart = nextNonWhitespaceByIndex[definition.colon + 1] ?? source.length;
+      if (inlineBodyStart < line.end) {
+        const functionScope = nextScopeId++;
+        scopeParents.set(functionScope, scopeId);
+        functionScopes.add(functionScope);
+        addFunctionBinding(functionBindings, functionScope, definition.parameters);
+        for (let cursor = inlineBodyStart; cursor < line.end; cursor += 1) {
+          scopeAt[cursor] = functionScope;
+        }
+      } else {
+        pending.push({
+          indent: definition.indent,
+          parameters: definition.parameters,
+          parentScope: scopeId,
+        });
+      }
+    }
   }
 
   // Python lambdas have expression scope rather than indentation scope. For
-  // the static timeout scan, delimit their body at the first top-level
-  // separator on the source line; malformed expressions conservatively claim
-  // the remainder of that line.
-  const lambdaPattern = /\blambda\s+([^:\n]+):/g;
+  // the static timeout scan, resolve all expression boundaries in one pass so
+  // nested lambdas do not repeatedly rescan and rewrite the same suffix.
+  const lambdaScopes: ExpressionScope[] = [];
+  const lambdaPattern = /\blambda(?:\s+([^:\n]+))?:/g;
   let lambdaMatch: RegExpExecArray | null;
   while ((lambdaMatch = lambdaPattern.exec(source)) !== null) {
     const bodyStart = nextNonWhitespace(source, lambdaMatch.index + lambdaMatch[0].length);
-    const parentScope = scopeAt[lambdaMatch.index] ?? 0;
-    const lambdaScope = nextScopeId++;
-    scopeParents.set(lambdaScope, parentScope);
-    functionScopes.add(lambdaScope);
-    addFunctionBinding(functionBindings, lambdaScope, lambdaMatch[1]);
-
-    let bodyEnd = source.indexOf('\n', bodyStart);
-    if (bodyEnd < 0) bodyEnd = source.length;
-    let parenDepth = 0;
-    let bracketDepth = 0;
-    let braceDepth = 0;
-    for (let cursor = bodyStart; cursor < bodyEnd; cursor += 1) {
-      const character = source[cursor];
-      if (character === '(') parenDepth += 1;
-      else if (character === ')') {
-        if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
-          bodyEnd = cursor;
-          break;
-        }
-        parenDepth = Math.max(0, parenDepth - 1);
-      } else if (character === '[') bracketDepth += 1;
-      else if (character === ']') bracketDepth = Math.max(0, bracketDepth - 1);
-      else if (character === '{') braceDepth += 1;
-      else if (character === '}') braceDepth = Math.max(0, braceDepth - 1);
-      else if (character === ',' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
-        bodyEnd = cursor;
-        break;
-      } else if (character === ';' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
-        bodyEnd = cursor;
-        break;
-      }
-    }
-    for (let cursor = bodyStart; cursor < bodyEnd; cursor += 1) scopeAt[cursor] = lambdaScope;
+    lambdaScopes.push({ start: bodyStart, end: source.length, parameters: lambdaMatch[1] ?? '' });
   }
+  resolveExpressionScopeEnds(source, lambdaScopes, 'py');
+  applyExpressionScopes(masked, lambdaScopes, functionScopes, functionBindings);
   return { functionScopes, functionBindings, varScopes: functionScopes };
 }
 
@@ -645,20 +790,21 @@ function collectFunctionScopes(
   };
 
   // Any parenthesized construct with a block body is structurally a function
-  // or method unless its preceding token is a control-flow keyword. This also
-  // covers generic declarations/methods (`function f<T>(...) {}` and
-  // `method<T>(...) {}`) without trying to regex the type-parameter grammar.
+  // or method unless its preceding token is a control-flow keyword. Register
+  // the structural shape instead of requiring an identifier immediately before
+  // `(` so computed and quoted class/object methods are covered as well.
   const controlBlockKeywords = new Set(['if', 'while', 'for', 'switch', 'with', 'catch']);
   for (const [openParen, closeParen] of matchingCloseParens) {
     const previous = previousNonWhitespace(source, openParen - 1);
     if (previous < 0) continue;
     const precedingIdentifier = identifierBefore(source, previous);
-    const isGeneric = source[previous] === '>';
-    const isFunctionKeyword =
-      precedingIdentifier?.name === 'function' ||
-      (source[previous] === '*' && identifierBefore(source, previous - 1)?.name === 'function');
-    const isMethod = precedingIdentifier !== null && !controlBlockKeywords.has(precedingIdentifier.name);
-    if (!isGeneric && !isFunctionKeyword && !isMethod) continue;
+    if (precedingIdentifier !== null && controlBlockKeywords.has(precedingIdentifier.name)) continue;
+    if (
+      precedingIdentifier?.name === 'await' &&
+      identifierBefore(source, precedingIdentifier.start - 1)?.name === 'for'
+    ) {
+      continue;
+    }
     register(openParen, openParen + 1, closeParen);
   }
 
@@ -677,28 +823,50 @@ function collectFunctionScopes(
     addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, closeParen));
   }
 
-  // Block-bodied arrow functions. Expression-bodied arrows introduce no
-  // lexical block that this scanner needs to model.
+  const previousCloseParen = new Int32Array(source.length + 1);
+  previousCloseParen.fill(-1);
+  let lastCloseParen = -1;
+  for (let cursor = 0; cursor < source.length; cursor += 1) {
+    previousCloseParen[cursor] = lastCloseParen;
+    if (source[cursor] === ')') lastCloseParen = cursor;
+  }
+  previousCloseParen[source.length] = lastCloseParen;
+
+  const arrowParameters = (arrowIndex: number): string => {
+    const previous = previousNonWhitespace(source, arrowIndex - 1);
+    const parameterClose = source[previous] === ')' ? previous : previousCloseParen[arrowIndex];
+    if (parameterClose >= 0) {
+      const afterClose = nextNonWhitespace[parameterClose + 1] ?? source.length;
+      if (parameterClose === previous || source[afterClose] === ':') {
+        const parameterOpen = matchingOpenParens.get(parameterClose);
+        if (parameterOpen !== undefined) return source.slice(parameterOpen + 1, parameterClose);
+      }
+    }
+    const parameter = identifierBefore(source, previous + 1);
+    return parameter?.name ?? '';
+  };
+
+  // Track block and expression-bodied arrows. Expression bodies use compact
+  // interval scopes applied in one sweep, avoiding repeated suffix rewrites for
+  // nested arrows while preserving their parameter bindings.
+  const expressionArrowScopes: ExpressionScope[] = [];
   const arrowPattern = /=>/g;
   let arrowMatch: RegExpExecArray | null;
   while ((arrowMatch = arrowPattern.exec(source)) !== null) {
-    const bodyOpen = nextNonWhitespace[arrowMatch.index + arrowMatch[0].length] ?? source.length;
-    if (source[bodyOpen] !== '{' || bodyOpen + 1 >= source.length) continue;
-    const scopeId = scopeAt[bodyOpen + 1] ?? 0;
-    functionScopes.add(scopeId);
-    varScopes.add(scopeId);
-    let parameterClose = previousNonWhitespace(source, arrowMatch.index - 1);
-    while (parameterClose >= 0 && source[parameterClose] !== ')') parameterClose -= 1;
-    if (parameterClose >= 0) {
-      const openParen = matchingOpenParens.get(parameterClose);
-      if (openParen !== undefined) {
-        addFunctionBinding(functionBindings, scopeId, source.slice(openParen + 1, parameterClose));
-      }
+    const bodyStart = nextNonWhitespace[arrowMatch.index + arrowMatch[0].length] ?? source.length;
+    const parameters = arrowParameters(arrowMatch.index);
+    if (source[bodyStart] === '{') {
+      if (bodyStart + 1 >= source.length) continue;
+      const scopeId = scopeAt[bodyStart + 1] ?? 0;
+      functionScopes.add(scopeId);
+      varScopes.add(scopeId);
+      addFunctionBinding(functionBindings, scopeId, parameters);
     } else {
-      const parameter = identifierBefore(source, previousNonWhitespace(source, arrowMatch.index - 1) + 1);
-      if (parameter !== null) addFunctionBinding(functionBindings, scopeId, parameter.name);
+      expressionArrowScopes.push({ start: bodyStart, end: source.length, parameters });
     }
   }
+  resolveExpressionScopeEnds(source, expressionArrowScopes, 'ts');
+  applyExpressionScopes(masked, expressionArrowScopes, functionScopes, functionBindings, varScopes);
 
   return { functionScopes, functionBindings, varScopes };
 }

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -22,7 +22,14 @@ const REGEX_KEYWORDS = new Set([
 ]);
 const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
 
-function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): string {
+type MaskedWorkflowSource = {
+  source: string;
+  matchingOpenParens: Map<number, number>;
+};
+
+type WorkflowRoot = { name: string; invoked: boolean };
+
+function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): MaskedWorkflowSource {
   let output = '';
   let index = 0;
   let quote: "'" | '"' | '`' | null = null;
@@ -38,6 +45,8 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   let lastIdentifier: string | undefined;
   let closedControlParen = false;
   const controlParenStack: boolean[] = [];
+  const openParenStack: number[] = [];
+  const matchingOpenParens = new Map<number, number>();
 
   const flushIdentifier = () => {
     if (currentIdentifier) {
@@ -46,7 +55,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     }
   };
 
-  const appendCode = (character: string) => {
+  const appendCode = (character: string, sourceIndex: number) => {
     output += character;
     if (/[A-Za-z0-9_$]/.test(character)) {
       currentIdentifier += character;
@@ -60,12 +69,15 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     previousSignificantCharacter = character;
     if (character === '(') {
+      openParenStack.push(sourceIndex);
       controlParenStack.push(lastIdentifier !== undefined && CONTROL_PAREN_KEYWORDS.has(lastIdentifier));
       lastIdentifier = undefined;
       closedControlParen = false;
       return;
     }
     if (character === ')') {
+      const openParen = openParenStack.pop();
+      if (openParen !== undefined) matchingOpenParens.set(sourceIndex, openParen);
       closedControlParen = controlParenStack.pop() ?? false;
       lastIdentifier = undefined;
       return;
@@ -142,15 +154,20 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
 
     if (quote) {
       output += mask(character);
-      if (triple && character === quote && next === quote && third === quote) {
-        output += '  ';
-        index += 3;
-        quote = null;
-        triple = false;
-        escaped = false;
-        continue;
-      }
-      if (!triple) {
+      if (triple) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === quote && next === quote && third === quote) {
+          output += '  ';
+          index += 3;
+          quote = null;
+          triple = false;
+          escaped = false;
+          continue;
+        }
+      } else {
         if (escaped) {
           escaped = false;
         } else if (character === '\\') {
@@ -192,6 +209,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       triple = fileType === 'py' && next === character && third === character;
       quote = character;
       output += triple ? '   ' : ' ';
+      escaped = false;
       previousSignificantCharacter = character;
       currentIdentifier = '';
       lastIdentifier = undefined;
@@ -200,11 +218,11 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
       continue;
     }
 
-    appendCode(character);
+    appendCode(character, index);
     index += 1;
   }
 
-  return output;
+  return { source: output, matchingOpenParens };
 }
 
 function validateLaunchTimeoutMs(value: number, source: string, minimum = 1): number {
@@ -225,18 +243,6 @@ export function validateExplicitWorkflowLaunchTimeoutMs(explicit?: number): numb
   return validateLaunchTimeoutMs(explicit, 'launchTimeoutMs', MIN_EXPLICIT_WORKFLOW_LAUNCH_TIMEOUT_MS);
 }
 
-function findMatchingOpenParen(source: string, closeIndex: number): number | null {
-  let depth = 0;
-  for (let index = closeIndex; index >= 0; index -= 1) {
-    if (source[index] === ')') depth += 1;
-    if (source[index] === '(') {
-      depth -= 1;
-      if (depth === 0) return index;
-    }
-  }
-  return null;
-}
-
 function identifierBefore(source: string, end: number): { name: string; start: number } | null {
   let cursor = end;
   while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
@@ -248,24 +254,54 @@ function identifierBefore(source: string, end: number): { name: string; start: n
 
 /**
  * Return the root expression for a fluent call immediately before `.timeout`.
- * The source has already had strings/comments/regex literals masked, so a
- * small balanced-parenthesis walk is enough to distinguish `workflow(...).timeout`
- * and a known workflow variable from `httpClient.timeout`.
+ * The source has already had strings/comments/regex literals masked, and the
+ * lexer has recorded balanced parentheses, so resolving a fluent call shares
+ * structural work across repeated `.timeout()` candidates.
  */
-function timeoutRoot(source: string, timeoutDot: number): { name: string; invoked: boolean } | null {
+function timeoutRoot(
+  source: string,
+  timeoutDot: number,
+  matchingOpenParens: ReadonlyMap<number, number>,
+  callRoots: Map<number, WorkflowRoot | null>
+): WorkflowRoot | null {
   let cursor = timeoutDot - 1;
   while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
 
-  while (cursor >= 0 && source[cursor] === ')') {
-    const open = findMatchingOpenParen(source, cursor);
-    if (open === null) return null;
-    const method = identifierBefore(source, open - 1);
-    if (method === null) return null;
-    cursor = method.start - 1;
-    while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
-    if (cursor < 0 || source[cursor] !== '.') return { name: method.name, invoked: true };
-    cursor -= 1;
-    while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+  if (cursor >= 0 && source[cursor] === ')') {
+    const pendingCalls: number[] = [];
+    let root: WorkflowRoot | null = null;
+    while (cursor >= 0 && source[cursor] === ')') {
+      if (callRoots.has(cursor)) {
+        root = callRoots.get(cursor) ?? null;
+        break;
+      }
+      const open = matchingOpenParens.get(cursor);
+      if (open === undefined) {
+        root = null;
+        break;
+      }
+      pendingCalls.push(cursor);
+      const method = identifierBefore(source, open - 1);
+      if (method === null) {
+        root = null;
+        break;
+      }
+      cursor = method.start - 1;
+      while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+      if (cursor < 0 || source[cursor] !== '.') {
+        root = { name: method.name, invoked: true };
+        break;
+      }
+      cursor -= 1;
+      while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+    }
+
+    if (root === null && pendingCalls.length > 0 && (cursor < 0 || source[cursor] !== ')')) {
+      const identifier = identifierBefore(source, cursor);
+      root = identifier ? { name: identifier.name, invoked: false } : null;
+    }
+    for (const pendingCall of pendingCalls) callRoots.set(pendingCall, root);
+    return root;
   }
 
   const identifier = identifierBefore(source, cursor);
@@ -283,7 +319,8 @@ export function inferWorkflowLaunchTimeoutMs(
 ): number | undefined {
   if (fileType === 'yaml') return undefined;
 
-  const source = maskNonCode(workflow, fileType);
+  const masked = maskNonCode(workflow, fileType);
+  const source = masked.source;
   const builderNames = new Set<string>();
   const assignmentPattern =
     fileType === 'ts'
@@ -296,6 +333,7 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const values = new Set<number>();
   let hasDynamicBuilderTimeout = false;
+  const callRoots = new Map<number, WorkflowRoot | null>();
   const timeoutPattern = /\.timeout/g;
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
@@ -307,7 +345,7 @@ export function inferWorkflowLaunchTimeoutMs(
     const argumentEnd = source.indexOf(')', argumentStart);
     if (argumentEnd < 0) continue;
 
-    const root = timeoutRoot(source, match.index);
+    const root = timeoutRoot(source, match.index, masked.matchingOpenParens, callRoots);
     if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {
       continue;
     }

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -740,9 +740,7 @@ export function inferWorkflowLaunchTimeoutMs(
     const declarationKind = fileType === 'ts' ? declaration[1] : undefined;
     const declarationName = fileType === 'ts' ? declaration[2] : declaration[1];
     const bindingScope =
-      declarationKind === 'var'
-        ? nearestFunctionScope(scopeId, varScopes, masked.scopeParents)
-        : scopeId;
+      declarationKind === 'var' ? nearestFunctionScope(scopeId, varScopes, masked.scopeParents) : scopeId;
     let scopeBindings = bindings.get(scopeId);
     if (scopeBindings === undefined || bindingScope !== scopeId) {
       scopeBindings = bindings.get(bindingScope);

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -19,6 +19,9 @@ const REGEX_KEYWORDS = new Set([
   'await',
   'else',
   'do',
+  'break',
+  'continue',
+  'debugger',
 ]);
 const CONTROL_PAREN_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
 
@@ -26,9 +29,13 @@ type MaskedWorkflowSource = {
   source: string;
   matchingOpenParens: Map<number, number>;
   matchingCloseParens: Map<number, number>;
+  scopeAt: Int32Array;
+  scopeParents: Map<number, number>;
+  nextNonWhitespace: Uint32Array;
 };
 
 type WorkflowRoot = { name: string; invoked: boolean };
+type WorkflowBinding = { builder: boolean };
 
 function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 'py'>): MaskedWorkflowSource {
   let output = '';
@@ -49,6 +56,10 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
   const openParenStack: number[] = [];
   const matchingOpenParens = new Map<number, number>();
   const matchingCloseParens = new Map<number, number>();
+  const scopeAt = new Int32Array(source.length);
+  const scopeParents = new Map<number, number>([[0, -1]]);
+  const scopeStack = [0];
+  let nextScopeId = 1;
 
   const flushIdentifier = () => {
     if (currentIdentifier) {
@@ -73,6 +84,20 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     if (character === '(') {
       openParenStack.push(sourceIndex);
       controlParenStack.push(lastIdentifier !== undefined && CONTROL_PAREN_KEYWORDS.has(lastIdentifier));
+      lastIdentifier = undefined;
+      closedControlParen = false;
+      return;
+    }
+    if (character === '{') {
+      const scopeId = nextScopeId++;
+      scopeParents.set(scopeId, scopeStack[scopeStack.length - 1]);
+      scopeStack.push(scopeId);
+      lastIdentifier = undefined;
+      closedControlParen = false;
+      return;
+    }
+    if (character === '}') {
+      if (scopeStack.length > 1) scopeStack.pop();
       lastIdentifier = undefined;
       closedControlParen = false;
       return;
@@ -113,6 +138,7 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     const character = source[index];
     const next = source[index + 1];
     const third = source[index + 2];
+    scopeAt[index] = scopeStack[scopeStack.length - 1];
 
     if (regexLiteral) {
       output += mask(character);
@@ -227,7 +253,20 @@ function maskNonCode(source: string, fileType: Extract<WorkflowFileType, 'ts' | 
     index += 1;
   }
 
-  return { source: output, matchingOpenParens, matchingCloseParens };
+  const nextNonWhitespace = new Uint32Array(output.length + 1);
+  nextNonWhitespace[output.length] = output.length;
+  for (let cursor = output.length - 1; cursor >= 0; cursor -= 1) {
+    nextNonWhitespace[cursor] = /\s/.test(output[cursor]) ? nextNonWhitespace[cursor + 1] : cursor;
+  }
+
+  return {
+    source: output,
+    matchingOpenParens,
+    matchingCloseParens,
+    scopeAt,
+    scopeParents,
+    nextNonWhitespace,
+  };
 }
 
 function validateLaunchTimeoutMs(value: number, source: string, minimum = 1): number {
@@ -313,6 +352,46 @@ function timeoutRoot(
   return identifier ? { name: identifier.name, invoked: false } : null;
 }
 
+function bindingAt(
+  name: string,
+  scopeId: number,
+  bindings: ReadonlyMap<number, ReadonlyMap<string, WorkflowBinding>>,
+  scopeParents: ReadonlyMap<number, number>
+): WorkflowBinding | null {
+  let currentScope = scopeId;
+  while (currentScope >= 0) {
+    const scopeBindings = bindings.get(currentScope);
+    const binding = scopeBindings?.get(name);
+    if (binding !== undefined) return binding;
+    currentScope = scopeParents.get(currentScope) ?? -1;
+  }
+  return null;
+}
+
+function workflowInitializerAt(
+  source: string,
+  end: number,
+  fileType: Extract<WorkflowFileType, 'ts' | 'py'>
+): boolean {
+  let cursor = end;
+  while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
+  if (fileType === 'ts') {
+    if (source[cursor] !== '=') return false;
+    cursor += 1;
+    while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
+    if (source.startsWith('await', cursor) && !/[A-Za-z0-9_$]/.test(source[cursor + 5] ?? '')) {
+      cursor += 5;
+      while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
+    }
+  }
+  if (!source.startsWith('workflow', cursor)) return false;
+  const afterName = source[cursor + 'workflow'.length] ?? '';
+  if (/[A-Za-z0-9_$]/.test(afterName)) return false;
+  cursor += 'workflow'.length;
+  while (cursor < source.length && /\s/.test(source[cursor])) cursor += 1;
+  return source[cursor] === '(';
+}
+
 /**
  * Infer the outer Cloud launch budget from a literal RelayFlow builder timeout
  * without evaluating submitted workflow code. Dynamic expressions are left
@@ -326,14 +405,21 @@ export function inferWorkflowLaunchTimeoutMs(
 
   const masked = maskNonCode(workflow, fileType);
   const source = masked.source;
-  const builderNames = new Set<string>();
-  const assignmentPattern =
+  const bindings = new Map<number, Map<string, WorkflowBinding>>();
+  const declarationPattern =
     fileType === 'ts'
-      ? /\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:await\s+)?workflow\s*\(/g
-      : /\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*workflow\s*\(/g;
-  let assignment: RegExpExecArray | null;
-  while ((assignment = assignmentPattern.exec(source)) !== null) {
-    builderNames.add(assignment[1]);
+      ? /\b(?:const|let|var|function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g
+      : /\b([A-Za-z_][A-Za-z0-9_]*)\s*=/g;
+  let declaration: RegExpExecArray | null;
+  while ((declaration = declarationPattern.exec(source)) !== null) {
+    const scopeId = masked.scopeAt[declaration.index] ?? 0;
+    let scopeBindings = bindings.get(scopeId);
+    if (scopeBindings === undefined) {
+      scopeBindings = new Map();
+      bindings.set(scopeId, scopeBindings);
+    }
+    const builder = workflowInitializerAt(source, declaration.index + declaration[0].length, fileType);
+    scopeBindings.set(declaration[1], { builder });
   }
 
   const values = new Set<number>();
@@ -342,17 +428,20 @@ export function inferWorkflowLaunchTimeoutMs(
   const timeoutPattern = /\.timeout/g;
   let match: RegExpExecArray | null;
   while ((match = timeoutPattern.exec(source)) !== null) {
-    let argumentStart = match.index + match[0].length;
-    while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
-    if (source[argumentStart] !== '(') continue;
-    const argumentOpen = argumentStart;
-    argumentStart += 1;
-    while (argumentStart < source.length && /\s/.test(source[argumentStart])) argumentStart += 1;
+    const afterTimeout = masked.nextNonWhitespace[match.index + match[0].length] ?? source.length;
+    if (source[afterTimeout] !== '(') continue;
+    const argumentOpen = afterTimeout;
+    const argumentStart = masked.nextNonWhitespace[argumentOpen + 1] ?? source.length;
     const argumentEnd = masked.matchingCloseParens.get(argumentOpen);
     if (argumentEnd === undefined) continue;
 
     const root = timeoutRoot(source, match.index, masked.matchingOpenParens, callRoots);
-    if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {
+    if (root === null) continue;
+    const scopeId = masked.scopeAt[match.index] ?? 0;
+    const binding = bindingAt(root.name, scopeId, bindings, masked.scopeParents);
+    if (root.invoked) {
+      if (root.name !== 'workflow' || binding !== null) continue;
+    } else if (binding?.builder !== true) {
       continue;
     }
     const literal = source

--- a/packages/cloud/src/workflow-timeout.ts
+++ b/packages/cloud/src/workflow-timeout.ts
@@ -355,7 +355,10 @@ export function inferWorkflowLaunchTimeoutMs(
     if (root === null || (root.invoked ? root.name !== 'workflow' : !builderNames.has(root.name))) {
       continue;
     }
-    const literal = source.slice(argumentStart, argumentEnd).match(/^[0-9](?:_?[0-9])*$/)?.[0];
+    const literal = source
+      .slice(argumentStart, argumentEnd)
+      .trim()
+      .match(/^[0-9](?:_?[0-9])*$/)?.[0];
     if (literal === undefined) {
       hasUnresolvedBuilderTimeout = true;
       continue;

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -145,6 +145,15 @@ describe('relayflow version request contract', () => {
     expect(JSON.parse(bodies[0])).toMatchObject({ launchTimeoutMs: 900_000 });
   });
 
+  it('omits launch timeout metadata when literal and dynamic builders are mixed', async () => {
+    const bodies = captureRunBodies();
+    const workflow = "workflow('dynamic').timeout(timeoutMs); workflow('literal').timeout(900_000);";
+
+    await runWorkflow(workflow, { fileType: 'ts', syncCode: false });
+
+    expect(JSON.parse(bodies[0])).toEqual({ workflow, fileType: 'ts' });
+  });
+
   it('rejects an invalid explicit timeout before authentication, filesystem, or network access', async () => {
     await expect(
       runWorkflow('missing-workflow.ts', {

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -132,6 +132,15 @@ describe('relayflow version request contract', () => {
     });
   });
 
+  it('preserves the omitted run request when a literal script timeout exceeds the metadata limit', async () => {
+    const bodies = captureRunBodies();
+    const workflow = "const result = await workflow('verify').timeout(3_600_000).run();";
+
+    await runWorkflow(workflow, { fileType: 'ts', syncCode: false });
+
+    expect(bodies).toEqual([JSON.stringify({ workflow, fileType: 'ts' })]);
+  });
+
   it('uses the explicit launch timeout when script configuration is dynamic', async () => {
     const bodies = captureRunBodies();
     const workflow = "const result = await workflow('proof').timeout(timeoutMs).run();";
@@ -908,6 +917,36 @@ describe('workflow schedules', () => {
       }),
     ]);
     expect(scheduleBodyBytes[0]).not.toContain('relayflowVersion');
+  });
+
+  it('preserves the omitted schedule request when a literal script timeout exceeds the metadata limit', async () => {
+    const workflow = "const result = await workflow('verify').timeout(3_600_000).run();";
+    const workflowPath = path.join(tmpRoot, 'workflow.ts');
+    await writeFile(workflowPath, workflow);
+    const scheduleBodyBytes: string[] = [];
+    authorizedApiFetchMock.mockImplementation(async (_auth, requestPath, init) => {
+      expect(requestPath).toBe('/api/v1/workflows/schedules');
+      scheduleBodyBytes.push(String(init?.body));
+      return {
+        auth: { accessToken: 'token' },
+        response: new Response(JSON.stringify({ schedule: scheduleRecord() }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      };
+    });
+
+    await scheduleWorkflow(workflowPath, { cron: '0 * * * *' });
+
+    expect(scheduleBodyBytes).toEqual([
+      JSON.stringify({
+        name: 'workflow.ts',
+        schedule_type: 'cron',
+        timezone: 'UTC',
+        workflowRequest: { workflow, fileType: 'ts' },
+        cron_expression: '0 * * * *',
+      }),
+    ]);
   });
 
   it('rejects unsupported v2 schedules before authentication, filesystem, or network access', async () => {

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -119,6 +119,32 @@ describe('relayflow version request contract', () => {
     });
   });
 
+  it('submits a statically inferred script launch timeout as authenticated request metadata', async () => {
+    const bodies = captureRunBodies();
+    const workflow = "const result = await workflow('proof').timeout(3_300_000).run();";
+
+    await runWorkflow(workflow, { fileType: 'ts', syncCode: false });
+
+    expect(JSON.parse(bodies[0])).toEqual({
+      workflow,
+      fileType: 'ts',
+      launchTimeoutMs: 3_300_000,
+    });
+  });
+
+  it('uses the explicit launch timeout when script configuration is dynamic', async () => {
+    const bodies = captureRunBodies();
+    const workflow = "const result = await workflow('proof').timeout(timeoutMs).run();";
+
+    await runWorkflow(workflow, {
+      fileType: 'ts',
+      syncCode: false,
+      launchTimeoutMs: 900_000,
+    });
+
+    expect(JSON.parse(bodies[0])).toMatchObject({ launchTimeoutMs: 900_000 });
+  });
+
   it('rejects an unknown run selector before authentication, filesystem, or network access', async () => {
     await expect(
       runWorkflow('missing-workflow.yaml', {
@@ -789,6 +815,7 @@ describe('workflow schedules', () => {
       cron: '0 * * * *',
       name: 'Hourly eval',
       relayflowVersion: 'v1',
+      launchTimeoutMs: 900_000,
       envSecrets: {
         AI_CLI_UPDATES_DRY_RUN: 'true',
         AI_CLI_UPDATES_ONLY: 'codex',
@@ -804,6 +831,7 @@ describe('workflow schedules', () => {
       workflowRequest: {
         fileType: 'yaml',
         relayflowVersion: 'v1',
+        launchTimeoutMs: 900_000,
         envSecrets: {
           AI_CLI_UPDATES_DRY_RUN: 'true',
           AI_CLI_UPDATES_ONLY: 'codex',

--- a/packages/cloud/src/workflows.test.ts
+++ b/packages/cloud/src/workflows.test.ts
@@ -145,6 +145,19 @@ describe('relayflow version request contract', () => {
     expect(JSON.parse(bodies[0])).toMatchObject({ launchTimeoutMs: 900_000 });
   });
 
+  it('rejects an invalid explicit timeout before authentication, filesystem, or network access', async () => {
+    await expect(
+      runWorkflow('missing-workflow.ts', {
+        fileType: 'ts',
+        syncCode: false,
+        launchTimeoutMs: 1,
+      })
+    ).rejects.toThrow('launchTimeoutMs must be at least');
+
+    expect(ensureAuthenticatedMock).not.toHaveBeenCalled();
+    expect(authorizedApiFetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects an unknown run selector before authentication, filesystem, or network access', async () => {
     await expect(
       runWorkflow('missing-workflow.yaml', {
@@ -965,6 +978,18 @@ describe('workflow schedules', () => {
     await expect(scheduleWorkflow('workflow.yaml', {})).rejects.toThrow(
       'Provide exactly one of --cron or --at.'
     );
+  });
+
+  it('rejects an invalid schedule timeout before authentication, filesystem, or network access', async () => {
+    await expect(
+      scheduleWorkflow('missing-workflow.ts', {
+        cron: '0 * * * *',
+        launchTimeoutMs: 55 * 60 * 1000 + 1,
+      })
+    ).rejects.toThrow('launchTimeoutMs must not exceed');
+
+    expect(ensureAuthenticatedMock).not.toHaveBeenCalled();
+    expect(authorizedApiFetchMock).not.toHaveBeenCalled();
   });
 
   it('rejects invalid one-time schedule timestamps with a clear error', async () => {

--- a/packages/cloud/src/workflows.ts
+++ b/packages/cloud/src/workflows.ts
@@ -21,7 +21,10 @@ import {
   type PathSubmission,
 } from './types.js';
 import { inferWorkflowFileType, parseWorkflowPaths, shouldSyncCodeByDefault } from './workflow-paths.js';
-import { resolveWorkflowLaunchTimeoutMs } from './workflow-timeout.js';
+import {
+  resolveWorkflowLaunchTimeoutMs,
+  validateExplicitWorkflowLaunchTimeoutMs,
+} from './workflow-timeout.js';
 
 // Re-exported so consumers (cloud package barrel, workflows tests) keep
 // importing these from './workflows.js' after the parsers moved out.
@@ -248,6 +251,7 @@ export async function runWorkflow(
   options: RunWorkflowOptions = {}
 ): Promise<RunWorkflowResponse> {
   validateRelayflowVersion(options.relayflowVersion);
+  validateExplicitWorkflowLaunchTimeoutMs(options.launchTimeoutMs);
   const apiUrl = options.apiUrl ?? defaultApiUrl();
   const api = await workflowApiClient(apiUrl);
   const input = await resolveWorkflowInput(workflowArg, options.fileType);
@@ -462,6 +466,7 @@ export async function scheduleWorkflow(
   options: ScheduleWorkflowOptions = {}
 ): Promise<WorkflowSchedule> {
   validateScheduleRelayflowVersion(options.relayflowVersion);
+  validateExplicitWorkflowLaunchTimeoutMs(options.launchTimeoutMs);
   const hasCron = typeof options.cron === 'string' && options.cron.trim().length > 0;
   const hasAt = typeof options.at === 'string' && options.at.trim().length > 0;
   if (hasCron === hasAt) {

--- a/packages/cloud/src/workflows.ts
+++ b/packages/cloud/src/workflows.ts
@@ -21,6 +21,7 @@ import {
   type PathSubmission,
 } from './types.js';
 import { inferWorkflowFileType, parseWorkflowPaths, shouldSyncCodeByDefault } from './workflow-paths.js';
+import { resolveWorkflowLaunchTimeoutMs } from './workflow-timeout.js';
 
 // Re-exported so consumers (cloud package barrel, workflows tests) keep
 // importing these from './workflows.js' after the parsers moved out.
@@ -263,6 +264,14 @@ export async function runWorkflow(
     workflow: input.workflow,
     fileType: input.fileType,
   };
+  const launchTimeoutMs = resolveWorkflowLaunchTimeoutMs(
+    input.workflow,
+    input.fileType,
+    options.launchTimeoutMs
+  );
+  if (launchTimeoutMs !== undefined) {
+    requestBody.launchTimeoutMs = launchTimeoutMs;
+  }
   if (options.relayflowVersion !== undefined) {
     requestBody.relayflowVersion = options.relayflowVersion;
   }
@@ -469,6 +478,11 @@ export async function scheduleWorkflow(
     console.error('Validating workflow...');
     validateYamlWorkflow(input.workflow);
   }
+  const launchTimeoutMs = resolveWorkflowLaunchTimeoutMs(
+    input.workflow,
+    input.fileType,
+    options.launchTimeoutMs
+  );
 
   const requestBody: Record<string, unknown> = {
     name: options.name?.trim() || path.basename(workflowArg),
@@ -477,6 +491,7 @@ export async function scheduleWorkflow(
     workflowRequest: {
       workflow: input.workflow,
       fileType: input.fileType,
+      ...(launchTimeoutMs === undefined ? {} : { launchTimeoutMs }),
       ...(options.relayflowVersion === undefined ? {} : { relayflowVersion: options.relayflowVersion }),
       ...(input.sourceFileType ? { sourceFileType: input.sourceFileType } : {}),
       ...(options.envSecrets && Object.keys(options.envSecrets).length > 0

--- a/tests/relayflows/cases/1712-cloud-launch-timeout/case.json
+++ b/tests/relayflows/cases/1712-cloud-launch-timeout/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1712-cloud-launch-timeout",
+  "kind": "bugfix",
+  "title": "Forward explicit Cloud workflow launch budgets through the public client",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1712-cloud-launch-timeout/run.mjs"]
+  },
+  "requirements": [],
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "launch_timeout_not_forwarded"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "launch_timeout_forwarded"
+    }
+  }
+}

--- a/tests/relayflows/cases/1712-cloud-launch-timeout/case.json
+++ b/tests/relayflows/cases/1712-cloud-launch-timeout/case.json
@@ -7,7 +7,7 @@
     "command": ["node", "tests/relayflows/cases/1712-cloud-launch-timeout/run.mjs"]
   },
   "requirements": [],
-  "timeoutSeconds": 900,
+  "timeoutSeconds": 1500,
   "expected": {
     "base": {
       "outcome": "bug",

--- a/tests/relayflows/cases/1712-cloud-launch-timeout/run.mjs
+++ b/tests/relayflows/cases/1712-cloud-launch-timeout/run.mjs
@@ -1,0 +1,251 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1712-cloud-launch-timeout';
+const LAUNCH_TIMEOUT_MS = 900_000;
+const COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = path.resolve(requiredValue('RELAY_PR_PROOF_RESULT_PATH'));
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+  timeout: COMMAND_TIMEOUT_MS,
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probePath = path.join(targetDir, 'packages/cloud/dist/.relayflow-1712-launch-timeout.test.mjs');
+const probeConfigPath = path.join(targetDir, '.relayflow-1712-launch-timeout.vitest.config.mjs');
+const probeObservationPath = path.join(targetDir, '.relayflow-1712-launch-timeout-observation.json');
+
+const probeSource = String.raw`import { test, vi } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+
+const mocks = vi.hoisted(() => ({
+  ensureAuthenticated: vi.fn(),
+  authorizedApiFetch: vi.fn(),
+}));
+
+vi.mock('./auth.js', () => ({
+  ensureAuthenticated: (...args) => mocks.ensureAuthenticated(...args),
+  authorizedApiFetch: (...args) => mocks.authorizedApiFetch(...args),
+}));
+
+import { runWorkflow, scheduleWorkflow } from './index.js';
+
+const workflow = [
+  'version: "1.0"',
+  'name: launch-timeout-proof',
+  'swarm:',
+  '  pattern: dag',
+  'agents: []',
+  'workflows: []',
+].join('\n');
+
+test('observes explicit launch timeout forwarding on the compiled public client', async () => {
+  const observationPath = process.env.RELAY_PR1712_OBSERVATION_PATH;
+  if (!observationPath) throw new Error('Missing RELAY_PR1712_OBSERVATION_PATH.');
+
+  const auth = { accessToken: 'relayflow-proof-access' };
+  const schedule = {
+    id: 'schedule-launch-timeout-proof',
+    relaycronScheduleId: 'relaycron-launch-timeout-proof',
+    userId: 'user-launch-timeout-proof',
+    workspaceId: 'workspace-launch-timeout-proof',
+    organizationId: 'organization-launch-timeout-proof',
+    name: 'launch-timeout-proof',
+    description: null,
+    scheduleType: 'once',
+    cronExpression: null,
+    scheduledAt: '2099-01-01T00:00:00.000Z',
+    timezone: 'UTC',
+    status: 'active',
+    lastTriggeredRunId: null,
+    lastTriggeredAt: null,
+    createdAt: '2098-01-01T00:00:00.000Z',
+    updatedAt: '2098-01-01T00:00:00.000Z',
+  };
+  const requests = [];
+  mocks.ensureAuthenticated.mockResolvedValue(auth);
+  mocks.authorizedApiFetch.mockImplementation(async (_auth, requestPath, init) => {
+    requests.push({ requestPath, body: JSON.parse(String(init?.body ?? '{}')) });
+    if (requestPath === '/api/v1/workflows/run') {
+      return { auth, response: Response.json({ runId: 'run-launch-timeout-proof', status: 'queued' }) };
+    }
+    if (requestPath === '/api/v1/workflows/schedules') {
+      return { auth, response: Response.json({ schedule }) };
+    }
+    throw new Error('Unexpected Cloud request path: ' + requestPath);
+  });
+
+  await runWorkflow(workflow, {
+    apiUrl: 'https://relayflow.invalid',
+    fileType: 'yaml',
+    syncCode: false,
+    launchTimeoutMs: ${LAUNCH_TIMEOUT_MS},
+  });
+  await scheduleWorkflow(workflow, {
+    apiUrl: 'https://relayflow.invalid',
+    fileType: 'yaml',
+    at: '2099-01-01T00:00:00.000Z',
+    launchTimeoutMs: ${LAUNCH_TIMEOUT_MS},
+  });
+
+  const runRequest = requests.find(({ requestPath }) => requestPath === '/api/v1/workflows/run');
+  const scheduleRequest = requests.find(({ requestPath }) => requestPath === '/api/v1/workflows/schedules');
+  await writeFile(
+    observationPath,
+    JSON.stringify({
+      runLaunchTimeoutMs: runRequest?.body?.launchTimeoutMs ?? null,
+      scheduleLaunchTimeoutMs: scheduleRequest?.body?.workflowRequest?.launchTimeoutMs ?? null,
+    }),
+    'utf8'
+  );
+});
+`;
+
+const probeConfigSource = `export default {
+  test: {
+    environment: 'node',
+    include: ['packages/cloud/dist/.relayflow-1712-launch-timeout.test.mjs'],
+    setupFiles: [],
+  },
+};\n`;
+
+try {
+  run(
+    'npm',
+    ['ci', '--ignore-scripts', '--workspace', 'packages/cloud', '--include-workspace-root=false'],
+    targetDir,
+    'Cloud workspace dependency installation'
+  );
+  run('npm', ['run', 'build:config'], targetDir, 'configuration package build');
+  run('npm', ['run', 'build:cloud'], targetDir, 'Cloud package build');
+
+  await writeGeneratedFile(probePath, probeSource);
+  await writeGeneratedFile(probeConfigPath, probeConfigSource);
+  run(
+    'npm',
+    ['exec', '--', 'vitest', 'run', '--config', path.relative(targetDir, probeConfigPath)],
+    targetDir,
+    'Compiled Cloud public API launch-timeout probe',
+    {
+      CLOUD_API_KEY: '',
+      RELAY_PR1712_OBSERVATION_PATH: probeObservationPath,
+    }
+  );
+
+  const observation = JSON.parse(await readFile(probeObservationPath, 'utf8'));
+  console.log('RelayFlow proof observation:', JSON.stringify(observation));
+  const baseObserved =
+    observation.runLaunchTimeoutMs === null && observation.scheduleLaunchTimeoutMs === null;
+  const headObserved =
+    observation.runLaunchTimeoutMs === LAUNCH_TIMEOUT_MS &&
+    observation.scheduleLaunchTimeoutMs === LAUNCH_TIMEOUT_MS;
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'launch_timeout_not_forwarded';
+    details =
+      'The compiled base Cloud public client accepted explicit launchTimeoutMs options but omitted the budget from both run and schedule request bodies.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'launch_timeout_forwarded';
+    details =
+      'The compiled head Cloud public client forwarded the explicit 900000ms launch budget for both run and schedule requests; the inline YAML was validated but never executed as untrusted workflow source.';
+  } else {
+    throw new Error(`Unexpected launch-timeout observation: ${JSON.stringify(observation)}.`);
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+} finally {
+  await rm(probePath, { force: true });
+  await rm(probeConfigPath, { force: true });
+  await rm(probeObservationPath, { force: true });
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+async function writeGeneratedFile(targetPath, source) {
+  try {
+    const existing = await lstat(targetPath);
+    if (!existing.isFile()) {
+      throw new Error(`Refusing to replace non-regular generated file ${targetPath}.`);
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+
+  const temporaryPath = `${targetPath}.tmp-${process.pid}`;
+  const handle = await open(temporaryPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(source, 'utf8');
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(temporaryPath, targetPath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+function run(command, args, cwd, label, extraEnv = {}) {
+  const completed = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...extraEnv },
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: COMMAND_TIMEOUT_MS,
+  });
+  if (completed.error) throw new Error(`${label} could not start: ${completed.error.message}`);
+  if (completed.status !== 0) {
+    throw new Error(
+      `${label} failed with ${
+        completed.signal ? `signal ${completed.signal}` : `exit code ${completed.status ?? 'unknown'}`
+      }.`
+    );
+  }
+}


### PR DESCRIPTION
`cloud run` and `cloud schedule` now send an optional bounded sandbox/bootstrap budget through `launchTimeoutMs`. The CLI accepts an explicit `--launch-timeout-ms`, or infers a literal timeout from a recognized TypeScript/Python RelayFlow builder without executing submitted code. Dynamic, out-of-range, conflicting, or otherwise unproven inferred values leave the legacy request bytes intact. Explicit overrides remain strictly validated before authentication or submission.

The scanner respects lexical bindings, including nested object/array destructuring, renamed/rest bindings, arrow/method parameters, and TypeScript constructor properties. Property keys, type annotations, and default-value expressions do not introduce bindings. Mixed Python builder assignments and timeout-bearing comprehensions conservatively omit inference instead of borrowing an unproven outer or later binding. Horizontal whitespace and scope-index construction are batched to keep large malformed inputs linear with coverage enabled.

Companion to AgentWorkforce/cloud#3464. The repair composes current main with the existing PR history without rewriting published commits.

Validation on `3ad04ae246b7e1bdedcdc8e3ca6d3a784809c616`:

- Targeted Cloud/CLI tests: 588 passed across 22 files, including byte-for-byte run/schedule omission regressions.
- Official parser V8 coverage: 126 tests passed; 96.39% lines, 87.25% branches, 100% functions. The existing malformed-Python two-second assertion is unchanged and passes.
- Full `npm run typecheck`, Prettier, and `git diff --check`: passed.
- Six new review reproductions failed before the second repair and pass after; explicit overrides pass throughout. The 51-case binding matrix also passes with the corrected ambiguity-omission contract.
- Broader CLI suite: 1,506 passed, 20 skipped, two failures. Both failures reproduce on unchanged main: the Reflex structured-log assertion expects the old text format, and the SDK client test expects no base URL but observes the canonical URL. These unrelated files were not changed.

Fresh GitHub CI and hosted proof remain required. The earlier repaired-head proof attempts stopped before Cloud launch because GitHub retained an old PR base snapshot; a same-base refresh corrected the diff to 29 files and exactly the declared case. No successful hosted proof or merge-ready status is claimed here.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1712-cloud-launch-timeout` <!-- relay-pr-proof:case -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow submission metadata and adds complex static parsing of untrusted TS/Python; behavior is conservative when inference is uncertain, but wrong inference could still affect Cloud bootstrap timeouts.
> 
> **Overview**
> **Cloud run/schedule** now attach an optional bounded sandbox/bootstrap budget as `launchTimeoutMs` on API requests. The CLI adds `--launch-timeout-ms` for `cloud run` and `cloud schedule`, with stricter positive-integer parsing (no trailing junk).
> 
> When the flag is omitted, a new **non-executing static scanner** (`workflow-timeout.ts`) may infer the budget from a **single, unambiguous literal** `.timeout(...)` on a recognized TypeScript/Python RelayFlow builder (`workflow(...)` or a proven assigned builder). Comments, strings, regex literals, lexical shadowing, and many edge cases are handled conservatively: dynamic values, conflicting literals, out-of-range inferred literals, loops/comprehensions, and mixed builder assignments **omit** the field so legacy request bodies stay unchanged. Explicit overrides are validated (30s–55m) **before** auth/network; inferred short deadlines keep a **5-minute floor**.
> 
> Coverage includes a large `workflow-timeout.test.ts` suite, Cloud/CLI workflow tests, changelog, Cloud workspace TypeScript devDependency, and a RelayFlow proof case for forwarding explicit budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697a4661305fb8a9d78b3f4f18fc22f54159bf20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->