### PR TITLE
ci: isolate Ubuntu toolchain installs from unrelated apt feeds

### DIFF
--- a/.github/workflows/relayflow-pr-proof-broker.yml
+++ b/.github/workflows/relayflow-pr-proof-broker.yml
@@ -52,8 +52,12 @@ jobs:
 
       - name: Install musl tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools util-linux
+          # These toolchains come from Ubuntu; unrelated runner feeds must not
+          # break their index refresh (for example a stale Chrome Packages.gz).
+          test -f /etc/apt/sources.list.d/ubuntu.sources
+          CI_APT_SOURCE_OPTIONS=(-o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources -o Dir::Etc::sourceparts=-)
+          sudo apt-get "${CI_APT_SOURCE_OPTIONS[@]}" update
+          sudo apt-get "${CI_APT_SOURCE_OPTIONS[@]}" install -y musl-tools util-linux
 
       - name: Build exact static broker
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -86,8 +86,12 @@ jobs:
       - name: Install cross-compilation tools
         if: matrix.packages
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.packages }}
+          # These toolchains come from Ubuntu; unrelated runner feeds must not
+          # break their index refresh (for example a stale Chrome Packages.gz).
+          test -f /etc/apt/sources.list.d/ubuntu.sources
+          CI_APT_SOURCE_OPTIONS=(-o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources -o Dir::Etc::sourceparts=-)
+          sudo apt-get "${CI_APT_SOURCE_OPTIONS[@]}" update
+          sudo apt-get "${CI_APT_SOURCE_OPTIONS[@]}" install -y ${{ matrix.packages }}
       - name: Cross-compile agent-relay-broker
         run: cargo check --target ${{ matrix.target }} --bin agent-relay-broker
         env:


### PR DESCRIPTION
## Summary

Broker proof and ARM64 cross-compilation jobs fail before compilation when the runner's unrelated Google Chrome apt feed has an inconsistent index. On September 9, its Release advertised SHA256 `233e56de…`, while Packages.gz returned `bc1428ab…`; repeated CI runs and a direct read reproduced the mismatch.

Restrict these two Ubuntu toolchain installs to the runner's Ubuntu sources file. Update and install use the same source selection, and missing source configuration fails closed. Package signature/checksum verification remains enabled. This unblocks the tooling dependency for #1708 without changing broker behavior or the trusted proof isolation boundary.

## Test Plan

- [x] Reproduced the external checksum mismatch in CI and with a direct Release/Packages.gz comparison.
- [x] Prettier and diff checks pass.
- [ ] PR-head Linux broker validation and ARM64 cross-compilation pass on GitHub's Ubuntu runner.

The `pull_request_target` broker producer runs trusted base workflow code; it can continue hitting the old apt-feed failure until this workflow repair lands. The separate `pull_request` validation job exercises this PR's workflow. No merge or production release has been performed.

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to how apt sources are selected on GitHub Ubuntu runners; no application, auth, or release behavior changes.
> 
> **Overview**
> **CI apt installs for Ubuntu toolchain packages are restricted to the runner’s official Ubuntu sources**, so `apt-get update` no longer pulls indexes from unrelated feeds (e.g. a broken Google Chrome `Packages.gz` checksum) that were failing jobs before Rust ever built.
> 
> In **RelayFlow PR proof broker** (`Install musl tools`) and **rust-ci** (`Install cross-compilation tools` on the ARM64 matrix), plain `sudo apt-get update` / `install` are replaced with options that point apt only at `/etc/apt/sources.list.d/ubuntu.sources` and disable `sourceparts`. A **`test -f`** on that file fails the step if the expected Ubuntu layout is missing. Signature/checksum behavior is unchanged; broker proof isolation and compile steps are untouched.
> 
> Other workflows that still call unrestricted `apt-get` are out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8438bdffbbd2b03259b02ebbba78931ff09f35fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->