### PR TITLE
fix(cli): harden standalone Cloud workflow runtime

### DIFF
--- a/.agentworkforce/trajectories/active/traj_94islbdz6537/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_94islbdz6537/trajectory.json
@@ -1,0 +1,70 @@
+{
+  "id": "traj_94islbdz6537",
+  "version": 1,
+  "task": {
+    "title": "Fix standalone Bun Agent Relay workflow execution"
+  },
+  "status": "active",
+  "startedAt": "2026-09-09T19:18:44.987Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T19:32:00.507Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_xtkrtvxqoa6z",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T19:32:00.507Z",
+      "events": [
+        {
+          "ts": 1788982320508,
+          "type": "decision",
+          "content": "Use a shared compiled-Bun workflow runtime helper: Use a shared compiled-Bun workflow runtime helper",
+          "raw": {
+            "question": "Use a shared compiled-Bun workflow runtime helper",
+            "chosen": "Use a shared compiled-Bun workflow runtime helper",
+            "alternatives": [],
+            "reasoning": "Compiled Bun process.execPath is the standalone binary; local workflow, detached monitor, and Cloud assignment children need a real Node executable and project-relative relayflows resolution."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788982321367,
+          "type": "decision",
+          "content": "Resolve relayflows with Node execFile from the real workflow directory in compiled mode: Resolve relayflows with Node execFile from the real workflow directory in compiled mode",
+          "raw": {
+            "question": "Resolve relayflows with Node execFile from the real workflow directory in compiled mode",
+            "chosen": "Resolve relayflows with Node execFile from the real workflow directory in compiled mode",
+            "alternatives": [],
+            "reasoning": "Bun's createRequire remains tied to the sealed compiled image, so project dependency resolution must run through Node with argv arrays."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788982321965,
+          "type": "reflection",
+          "content": "The shared helper now covers command selection, dependency resolution, missing-runtime diagnostics, local monitor supervision, Cloud assignment execution, and a real compiled-Bun smoke.",
+          "raw": {
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "4306bb29be696ec84a4e3844f86fdc4a91584407",
+    "endRef": "4306bb29be696ec84a4e3844f86fdc4a91584407"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_3ebvptahg9cl/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_3ebvptahg9cl/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Tighten PR 1727 proof signature
+
+> **Status:** ✅ Completed
+> **Confidence:** 98%
+> **Started:** September 10, 2026 at 12:22 AM
+> **Completed:** September 10, 2026 at 12:22 AM
+
+---
+
+## Summary
+
+Narrowed the RelayFlow base signature to the exact missing __bundled-workflow command and validated the proof contract.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Require the base command name in every accepted failure form
+- **Chose:** Require the base command name in every accepted failure form
+- **Reasoning:** A broad unknown-command alternative could misclassify rejection of a nested argument as the expected missing internal entrypoint bug.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Require the base command name in every accepted failure form: Require the base command name in every accepted failure form

--- a/.agentworkforce/trajectories/completed/2026-09/traj_3ebvptahg9cl/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_3ebvptahg9cl/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_3ebvptahg9cl",
+  "version": 1,
+  "task": {
+    "title": "Tighten PR 1727 proof signature"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T22:22:57.646Z",
+  "completedAt": "2026-09-09T22:22:58.770Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T22:22:58.215Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cmaivc3al9dg",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T22:22:58.215Z",
+      "endedAt": "2026-09-09T22:22:58.770Z",
+      "events": [
+        {
+          "ts": 1788992578216,
+          "type": "decision",
+          "content": "Require the base command name in every accepted failure form: Require the base command name in every accepted failure form",
+          "raw": {
+            "question": "Require the base command name in every accepted failure form",
+            "chosen": "Require the base command name in every accepted failure form",
+            "alternatives": [],
+            "reasoning": "A broad unknown-command alternative could misclassify rejection of a nested argument as the expected missing internal entrypoint bug."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Narrowed the RelayFlow base signature to the exact missing __bundled-workflow command and validated the proof contract.",
+    "approach": "Standard approach",
+    "confidence": 0.98
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "68b5e53abcad1d59fa2b81d236e89fac575292bb",
+    "endRef": "68b5e53abcad1d59fa2b81d236e89fac575292bb"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537.trace.json
@@ -1,0 +1,280 @@
+{
+  "version": "1.0.0",
+  "id": "288e2de0-78e2-4db9-9be6-b87cb46d78a9",
+  "timestamp": "2026-09-09T19:36:45.074Z",
+  "trajectory": "traj_94islbdz6537",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_94islbdz6537/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 70,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/package-validation.yml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 356,
+              "end_line": 361,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 5,
+              "end_line": 15,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/cloud-worker.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 3,
+              "end_line": 8,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 19,
+              "end_line": 29,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 36,
+              "end_line": 50,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 53,
+              "end_line": 70,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 157,
+              "end_line": 163,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 240,
+              "end_line": 250,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/cloud.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 395,
+              "end_line": 408,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 411,
+              "end_line": 426,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 472,
+              "end_line": 480,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 484,
+              "end_line": 495,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 520,
+              "end_line": 578,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/local-workflow.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 4,
+              "end_line": 14,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 183,
+              "end_line": 255,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/local-workflow.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 3,
+              "end_line": 17,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 50,
+              "end_line": 60,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 67,
+              "end_line": 82,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 96,
+              "end_line": 106,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 266,
+              "end_line": 280,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 293,
+              "end_line": 319,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 346,
+              "end_line": 358,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            },
+            {
+              "start_line": 396,
+              "end_line": 402,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/workflow-runtime.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 108,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/workflow-runtime.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 115,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/standalone-workflow.bun.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 39,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/ci-standalone-workflow-smoke.sh",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 42,
+              "revision": "df9cd939b35114428c64028e15a634304186ff00"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537/summary.md
@@ -1,0 +1,44 @@
+# Trajectory: Fix standalone Bun Agent Relay workflow execution
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** September 9, 2026 at 09:18 PM
+> **Completed:** September 9, 2026 at 09:36 PM
+
+---
+
+## Summary
+
+Added shared compiled-Bun workflow runtime selection, Node-based project-relative relayflows resolution, local monitor and Cloud worker fixes, focused tests, and CI standalone workflow smoke.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use a shared compiled-Bun workflow runtime helper
+- **Chose:** Use a shared compiled-Bun workflow runtime helper
+- **Reasoning:** Compiled Bun process.execPath is the standalone binary; local workflow, detached monitor, and Cloud assignment children need a real Node executable and project-relative relayflows resolution.
+
+### Resolve relayflows with Node execFile from the real workflow directory in compiled mode
+- **Chose:** Resolve relayflows with Node execFile from the real workflow directory in compiled mode
+- **Reasoning:** Bun's createRequire remains tied to the sealed compiled image, so project dependency resolution must run through Node with argv arrays.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use a shared compiled-Bun workflow runtime helper: Use a shared compiled-Bun workflow runtime helper
+- Resolve relayflows with Node execFile from the real workflow directory in compiled mode: Resolve relayflows with Node execFile from the real workflow directory in compiled mode
+- The shared helper now covers command selection, dependency resolution, missing-runtime diagnostics, local monitor supervision, Cloud assignment execution, and a real compiled-Bun smoke.
+
+---
+
+## Artifacts
+
+**Commits:** df9cd939b
+**Files changed:** 11

--- a/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_94islbdz6537/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Fix standalone Bun Agent Relay workflow execution"
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-09-09T19:18:44.987Z",
+  "completedAt": "2026-09-09T19:36:45.006Z",
   "agents": [
     {
       "name": "default",
@@ -19,6 +20,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-09-09T19:32:00.507Z",
+      "endedAt": "2026-09-09T19:36:45.006Z",
       "events": [
         {
           "ts": 1788982320508,
@@ -59,12 +61,32 @@
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Added shared compiled-Bun workflow runtime selection, Node-based project-relative relayflows resolution, local monitor and Cloud worker fixes, focused tests, and CI standalone workflow smoke.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [
+    "df9cd939b"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_94islbdz6537/trajectory.json",
+    ".github/workflows/package-validation.yml",
+    "CHANGELOG.md",
+    "packages/cli/src/cli/commands/cloud-worker.ts",
+    "packages/cli/src/cli/commands/cloud.test.ts",
+    "packages/cli/src/cli/commands/local-workflow.test.ts",
+    "packages/cli/src/cli/commands/local-workflow.ts",
+    "packages/cli/src/cli/lib/workflow-runtime.test.ts",
+    "packages/cli/src/cli/lib/workflow-runtime.ts",
+    "packages/cli/src/cli/standalone-workflow.bun.test.ts",
+    "scripts/ci-standalone-workflow-smoke.sh"
+  ],
   "projectId": "AgentWorkforce/relay",
   "tags": [],
   "_trace": {
     "startRef": "4306bb29be696ec84a4e3844f86fdc4a91584407",
-    "endRef": "4306bb29be696ec84a4e3844f86fdc4a91584407"
+    "endRef": "df9cd939b35114428c64028e15a634304186ff00",
+    "traceId": "288e2de0-78e2-4db9-9be6-b87cb46d78a9"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon.trace.json
@@ -1,0 +1,242 @@
+{
+  "version": "1.0.0",
+  "id": "f3223490-05f3-4aaa-87a0-c409fce65ee1",
+  "timestamp": "2026-09-09T20:58:12.303Z",
+  "trajectory": "traj_b1ugp5gx4jon",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_b1ugp5gx4jon/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 74,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 9,
+              "end_line": 15,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package-lock.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 13566,
+              "end_line": 13572,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 51,
+              "end_line": 57,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/cloud-worker.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 21,
+              "end_line": 27,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 241,
+              "end_line": 265,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 293,
+              "end_line": 306,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 313,
+              "end_line": 319,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/cloud.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 344,
+              "end_line": 394,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 565,
+              "end_line": 641,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/local-workflow.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 7,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 153,
+              "end_line": 180,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/commands/local-workflow.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 405,
+              "end_line": 434,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/index.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 13,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            },
+            {
+              "start_line": 24,
+              "end_line": 35,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/bundled-workflow-runner.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 79,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/src/cli/lib/workflow-runtime.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 54,
+              "end_line": 75,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/ci-standalone-workflow-smoke.sh",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 40,
+              "end_line": 70,
+              "revision": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon/summary.md
@@ -1,0 +1,45 @@
+# Trajectory: Fix standalone Cloud workflow runtime blockers
+
+> **Status:** ✅ Completed
+> **Task:** standalone-workflow-fix3-luna-0909
+> **Confidence:** 88%
+> **Started:** September 9, 2026 at 10:57 PM
+> **Completed:** September 9, 2026 at 10:58 PM
+
+---
+
+## Summary
+
+Hardened standalone Bun Cloud workflow execution, daemon restart re-entry, and detached monitor error handling with focused tests and compiled smoke coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules
+- **Chose:** Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules
+- **Reasoning:** Compiled Bun cannot expose its virtual package files to a Node child, while the bundled core can execute archive-only deterministic and agent workflows.
+
+### Omit Bun's virtual argv[1] during compiled daemon re-entry
+- **Chose:** Omit Bun's virtual argv[1] during compiled daemon re-entry
+- **Reasoning:** The compiled binary already supplies its virtual entrypoint and parses the first user argument as the command.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules: Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules
+- Omit Bun's virtual argv[1] during compiled daemon re-entry: Omit Bun's virtual argv[1] during compiled daemon re-entry
+- All three fresh-review blockers are covered by focused unit tests and real compiled-Bun smoke paths; remaining risk is limited to relayflows runtime behavior beyond the deterministic smoke workflow.
+
+---
+
+## Artifacts
+
+**Commits:** 87eb6c0e4
+**Files changed:** 12

--- a/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_b1ugp5gx4jon/trajectory.json
@@ -1,0 +1,97 @@
+{
+  "id": "traj_b1ugp5gx4jon",
+  "version": 1,
+  "task": {
+    "title": "Fix standalone Cloud workflow runtime blockers",
+    "source": {
+      "system": "plain",
+      "id": "standalone-workflow-fix3-luna-0909"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T20:57:33.851Z",
+  "completedAt": "2026-09-09T20:58:12.193Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T20:57:40.017Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_v135sloglqs4",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T20:57:40.017Z",
+      "endedAt": "2026-09-09T20:58:12.193Z",
+      "events": [
+        {
+          "ts": 1788987460018,
+          "type": "decision",
+          "content": "Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules: Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules",
+          "raw": {
+            "question": "Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules",
+            "chosen": "Use the standalone binary's bundled @relayflows/core runner when Cloud archives have no node_modules",
+            "alternatives": [],
+            "reasoning": "Compiled Bun cannot expose its virtual package files to a Node child, while the bundled core can execute archive-only deterministic and agent workflows."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788987460783,
+          "type": "decision",
+          "content": "Omit Bun's virtual argv[1] during compiled daemon re-entry: Omit Bun's virtual argv[1] during compiled daemon re-entry",
+          "raw": {
+            "question": "Omit Bun's virtual argv[1] during compiled daemon re-entry",
+            "chosen": "Omit Bun's virtual argv[1] during compiled daemon re-entry",
+            "alternatives": [],
+            "reasoning": "The compiled binary already supplies its virtual entrypoint and parses the first user argument as the command."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788987461549,
+          "type": "reflection",
+          "content": "All three fresh-review blockers are covered by focused unit tests and real compiled-Bun smoke paths; remaining risk is limited to relayflows runtime behavior beyond the deterministic smoke workflow.",
+          "raw": {
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.86"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Hardened standalone Bun Cloud workflow execution, daemon restart re-entry, and detached monitor error handling with focused tests and compiled smoke coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  },
+  "commits": [
+    "87eb6c0e4"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_b1ugp5gx4jon/trajectory.json",
+    "CHANGELOG.md",
+    "package-lock.json",
+    "packages/cli/package.json",
+    "packages/cli/src/cli/commands/cloud-worker.ts",
+    "packages/cli/src/cli/commands/cloud.test.ts",
+    "packages/cli/src/cli/commands/local-workflow.test.ts",
+    "packages/cli/src/cli/commands/local-workflow.ts",
+    "packages/cli/src/cli/index.ts",
+    "packages/cli/src/cli/lib/bundled-workflow-runner.ts",
+    "packages/cli/src/cli/lib/workflow-runtime.ts",
+    "scripts/ci-standalone-workflow-smoke.sh"
+  ],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "4ae7e86a9a895e311bf2d5aeba9166cd04e70f32",
+    "endRef": "87eb6c0e41e8ceb6a8e6411bfe45a70d785d7709",
+    "traceId": "f3223490-05f3-4aaa-87a0-c409fce65ee1"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mm38cfan4q76/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mm38cfan4q76/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Address PR 1727 review feedback
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** September 10, 2026 at 12:19 AM
+> **Completed:** September 10, 2026 at 12:19 AM
+
+---
+
+## Summary
+
+Serialized standalone workflow monitor startup failures, made metadata atomic writes collision-resistant, corrected child executable diagnostics, and isolated runtime tests from ambient configuration; 94 focused tests and CLI build pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Serialize detached monitor startup before recording running state
+- **Chose:** Serialize detached monitor startup before recording running state
+- **Reasoning:** ChildProcess reports ENOENT asynchronously; awaiting the first spawn/error outcome and persisting the error first prevents the normal running write from masking a failed monitor. Unique atomic temp names also prevent same-process metadata writes from colliding.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Serialize detached monitor startup before recording running state: Serialize detached monitor startup before recording running state

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mm38cfan4q76/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mm38cfan4q76/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_mm38cfan4q76",
+  "version": 1,
+  "task": {
+    "title": "Address PR 1727 review feedback"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T22:19:32.152Z",
+  "completedAt": "2026-09-09T22:19:42.161Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T22:19:32.686Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_s5487d0ld5s9",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T22:19:32.686Z",
+      "endedAt": "2026-09-09T22:19:42.161Z",
+      "events": [
+        {
+          "ts": 1788992372687,
+          "type": "decision",
+          "content": "Serialize detached monitor startup before recording running state: Serialize detached monitor startup before recording running state",
+          "raw": {
+            "question": "Serialize detached monitor startup before recording running state",
+            "chosen": "Serialize detached monitor startup before recording running state",
+            "alternatives": [],
+            "reasoning": "ChildProcess reports ENOENT asynchronously; awaiting the first spawn/error outcome and persisting the error first prevents the normal running write from masking a failed monitor. Unique atomic temp names also prevent same-process metadata writes from colliding."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Serialized standalone workflow monitor startup failures, made metadata atomic writes collision-resistant, corrected child executable diagnostics, and isolated runtime tests from ambient configuration; 94 focused tests and CLI build pass.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "15dae8e61845c03509645ddbf8ff40cc756382a3",
+    "endRef": "15dae8e61845c03509645ddbf8ff40cc756382a3"
+  }
+}

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -356,3 +356,6 @@ jobs:
           AGENT_RELAY_STARTUP_DEBUG: 1
           RELAY_WORKSPACE_KEY: ${{ secrets.RELAY_CI_WORKSPACE_KEY }}
         run: bash scripts/ci-standalone-smoke.sh "$STANDALONE_CLI" "$STANDALONE_BROKER"
+
+      - name: Smoke standalone workflow execution
+        run: bash scripts/ci-standalone-workflow-smoke.sh "$STANDALONE_CLI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Standalone Bun workflow runs now execute relayflows and detached monitors with a real Node.js runtime resolved from the workflow project.
+- Standalone Bun workflow runs now use a real Node.js runtime when available, with bundled relayflows execution for Cloud archives that omit node_modules; daemon restarts and monitor failures now remain actionable.
 
 ## [11.10.4] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Standalone Bun workflow runs now execute relayflows and detached monitors with a real Node.js runtime resolved from the workflow project.
 
 ## [11.10.4] - 2026-09-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13566,6 +13566,7 @@
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@relayfile/client": "^0.10.27",
         "@relayflows/cli": "1.0.1",
+        "@relayflows/core": "1.0.1",
         "@xterm/headless": "^6.0.0",
         "commander": "^12.1.0",
         "dotenv": "^17.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "@agent-relay/sdk": "11.10.4",
     "@agent-relay/session": "11.10.4",
     "@agent-relay/utils": "11.10.4",
+    "@relayflows/core": "1.0.1",
     "@modelcontextprotocol/sdk": "^1.23.0",
     "@relayfile/client": "^0.10.27",
     "@relayflows/cli": "1.0.1",

--- a/packages/cli/src/cli/commands/cloud-worker.ts
+++ b/packages/cli/src/cli/commands/cloud-worker.ts
@@ -21,6 +21,7 @@ import {
 import { defaultExit } from '../lib/exit.js';
 import {
   describeWorkflowChildError,
+  isCompiledBunWorkflowRuntime,
   resolveRelayflowsCliEntrypoint,
   workflowNodeExecutable,
 } from '../lib/workflow-runtime.js';
@@ -240,12 +241,25 @@ export function createDefaultAssignmentRunner(deps: CloudWorkerDependencies): Ex
       const workflowPath = path.join(runDir, safeFileName(payload.workflowFileName));
       await writeSecretFile(workflowPath, payload.workflow);
 
-      const relayflowsCli = await (deps.resolveRelayflowsCliEntrypoint
-        ? deps.resolveRelayflowsCliEntrypoint(workflowPath)
-        : resolveRelayflowsCliEntrypoint(workflowPath, deps));
+      let command = workflowNodeExecutable(deps);
+      let args: string[];
+      try {
+        const relayflowsCli = await (deps.resolveRelayflowsCliEntrypoint
+          ? deps.resolveRelayflowsCliEntrypoint(workflowPath)
+          : resolveRelayflowsCliEntrypoint(workflowPath, deps));
+        args = relayflowsArgs(relayflowsCli, workflowPath, payload);
+      } catch (error) {
+        // Cloud code archives intentionally omit node_modules. A compiled Bun
+        // worker still has relayflows core embedded in its binary, so fall
+        // back to the bundled runner when Node cannot resolve the package from
+        // the extracted assignment directory.
+        if (!isCompiledBunWorkflowRuntime(deps)) throw error;
+        command = deps.execPath ?? process.execPath;
+        args = ['__bundled-workflow', ...relayflowsArgs('', workflowPath, payload).slice(1)];
+      }
       const result = await runChild({
-        command: workflowNodeExecutable(deps),
-        args: relayflowsArgs(relayflowsCli, workflowPath, payload),
+        command,
+        args,
         cwd: runDir,
         env: buildWorkerRuntimeEnv(payload, deps),
         deps,
@@ -279,8 +293,14 @@ async function startDaemon(input: {
   const logPath = path.join(stateDir, `${input.worker.workerId}.log`);
   const logFd = fs.openSync(logPath, 'a');
   let child: ChildProcess;
+  // Node needs the real CLI entrypoint as argv[1]. Bun standalone binaries
+  // already inject their virtual `/$bunfs/...` entrypoint and treat the first
+  // user argument as the command; passing that virtual path again makes the
+  // restarted binary parse it as an unknown command.
   const args = [
-    process.argv[1] ?? 'agent-relay',
+    ...(isCompiledBunWorkflowRuntime(input.deps)
+      ? []
+      : [input.deps.cliScript ?? process.argv[1] ?? 'agent-relay']),
     'cloud',
     'worker',
     'start',
@@ -293,7 +313,7 @@ async function startDaemon(input: {
   ];
 
   try {
-    child = input.deps.spawnProcess(process.execPath, args, {
+    child = input.deps.spawnProcess(input.deps.execPath ?? process.execPath, args, {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       env: input.deps.env,

--- a/packages/cli/src/cli/commands/cloud-worker.ts
+++ b/packages/cli/src/cli/commands/cloud-worker.ts
@@ -3,7 +3,6 @@ import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { createRequire } from 'node:module';
 import { Command, Option } from 'commander';
 import { extract } from 'tar';
 
@@ -20,6 +19,11 @@ import {
 } from '@agent-relay/cloud';
 
 import { defaultExit } from '../lib/exit.js';
+import {
+  describeWorkflowChildError,
+  resolveRelayflowsCliEntrypoint,
+  workflowNodeExecutable,
+} from '../lib/workflow-runtime.js';
 
 type ExitFn = (code: number) => never;
 
@@ -32,13 +36,15 @@ export interface CloudWorkerDependencies {
   now: () => Date;
   cwd: () => string;
   fetchImpl: typeof fetch;
-  resolveRelayflowsCliEntrypoint: () => string;
+  resolveRelayflowsCliEntrypoint?: (workflowPath: string) => string | Promise<string>;
+  argv?: readonly string[];
+  execPath?: string;
+  cliScript?: string;
+  execFile?: typeof import('node:child_process').execFile;
 }
 
-const nodeRequire = createRequire(import.meta.url);
-
 function withDefaults(overrides: Partial<CloudWorkerDependencies> = {}): CloudWorkerDependencies {
-  return {
+  const deps: CloudWorkerDependencies = {
     log: (...args: unknown[]) => console.log(...args),
     error: (...args: unknown[]) => console.error(...args),
     exit: defaultExit,
@@ -47,9 +53,18 @@ function withDefaults(overrides: Partial<CloudWorkerDependencies> = {}): CloudWo
     now: () => new Date(),
     cwd: () => process.cwd(),
     fetchImpl: fetch,
-    resolveRelayflowsCliEntrypoint: () => nodeRequire.resolve('@relayflows/cli'),
+    resolveRelayflowsCliEntrypoint: async () => '',
+    execFile: undefined,
+    argv: process.argv,
+    execPath: process.execPath,
+    cliScript: process.argv[1] ?? '',
     ...overrides,
   };
+  if (!overrides.resolveRelayflowsCliEntrypoint) {
+    deps.resolveRelayflowsCliEntrypoint = (workflowPath) =>
+      resolveRelayflowsCliEntrypoint(workflowPath, deps);
+  }
+  return deps;
 }
 
 function safeFileName(value: string): string {
@@ -142,7 +157,7 @@ async function runChild(input: {
 
     child.on('error', (error) => {
       input.signal.removeEventListener('abort', stop);
-      reject(error);
+      reject(describeWorkflowChildError(error, input.command));
     });
 
     child.on('exit', (code, signal) => {
@@ -225,9 +240,11 @@ export function createDefaultAssignmentRunner(deps: CloudWorkerDependencies): Ex
       const workflowPath = path.join(runDir, safeFileName(payload.workflowFileName));
       await writeSecretFile(workflowPath, payload.workflow);
 
-      const relayflowsCli = deps.resolveRelayflowsCliEntrypoint();
+      const relayflowsCli = await (deps.resolveRelayflowsCliEntrypoint
+        ? deps.resolveRelayflowsCliEntrypoint(workflowPath)
+        : resolveRelayflowsCliEntrypoint(workflowPath, deps));
       const result = await runChild({
-        command: process.execPath,
+        command: workflowNodeExecutable(deps),
         args: relayflowsArgs(relayflowsCli, workflowPath, payload),
         cwd: runDir,
         env: buildWorkerRuntimeEnv(payload, deps),

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -395,6 +395,14 @@ describe('registerCloudCommands', () => {
         registeredAt: '2026-06-13T00:00:00.000Z',
         updatedAt: '2026-06-13T00:00:00.000Z',
       };
+      const execFile = vi.fn(
+        (
+          _command: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null, stdout: string, stderr: string) => void
+        ) => callback(null, '/project/node_modules/@relayflows/cli/dist/cli.js\n', '')
+      );
       const runner = createDefaultAssignmentRunner({
         log: vi.fn(),
         error: vi.fn(),
@@ -403,12 +411,16 @@ describe('registerCloudCommands', () => {
           AGENT_RELAY_HOME: tmpHome,
           AGENT_RELAY_WORKER_KEEP_RUN_DIR: '1',
           BASE_ENV: 'kept',
+          AGENT_RELAY_NODE: ' /opt/node/bin/node ',
         },
+        argv: ['bun', '/$bunfs/root/cli/index.js'],
+        cliScript: '/$bunfs/root/cli/index.js',
+        execPath: '/tmp/agent-relay',
         spawnProcess,
         now: () => new Date('2026-06-13T00:00:00.000Z'),
         cwd: () => tmpHome,
         fetchImpl: vi.fn() as never,
-        resolveRelayflowsCliEntrypoint: () => '/opt/relayflows/dist/cli.js',
+        execFile: execFile as never,
       });
 
       await runner({
@@ -460,9 +472,9 @@ describe('registerCloudCommands', () => {
       expect(spawnCalls).toHaveLength(1);
       const call = spawnCalls[0]!;
       const workflowPath = path.join(tmpHome, 'cloud-workers', 'runs', 'run_relayflows', 'workflow.yaml');
-      expect(call.command).toBe(process.execPath);
+      expect(call.command).toBe('/opt/node/bin/node');
       expect(call.args).toEqual([
-        '/opt/relayflows/dist/cli.js',
+        '/project/node_modules/@relayflows/cli/dist/cli.js',
         'run',
         workflowPath,
         '--resume',
@@ -472,6 +484,12 @@ describe('registerCloudCommands', () => {
         '--previous-run-id',
         'run_cache',
       ]);
+      expect(execFile).toHaveBeenCalledWith(
+        '/opt/node/bin/node',
+        expect.arrayContaining(['@relayflows/cli', path.dirname(workflowPath)]),
+        expect.objectContaining({ cwd: path.dirname(workflowPath) }),
+        expect.any(Function)
+      );
       expect(call.cwd).toBe(path.dirname(workflowPath));
       expect(call.env).toMatchObject({
         BASE_ENV: 'kept',
@@ -500,6 +518,59 @@ describe('registerCloudCommands', () => {
     } finally {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
+  });
+
+  it('keeps normal Node relayflows resolution anchored to the installed CLI for an external assignment', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-worker-external-'));
+    const child = new EventEmitter() as EventEmitter & { killed: boolean; kill: () => void };
+    child.killed = false;
+    child.kill = vi.fn();
+    const spawnProcess = vi.fn(() => {
+      queueMicrotask(() => child.emit('exit', 0, null));
+      return child;
+    }) as never;
+    const runner = createDefaultAssignmentRunner({
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn() as never,
+      env: {
+        AGENT_RELAY_HOME: tmpHome,
+        AGENT_RELAY_WORKER_KEEP_RUN_DIR: '1',
+      },
+      spawnProcess,
+      now: () => new Date('2026-06-13T00:00:00.000Z'),
+      cwd: () => tmpHome,
+      fetchImpl: vi.fn() as never,
+      argv: ['node', '/repo/packages/cli/dist/cli/index.js'],
+      execPath: process.execPath,
+      cliScript: '/repo/packages/cli/dist/cli/index.js',
+    });
+
+    await runner({
+      assignment: { runId: 'run_external' } as never,
+      payload: {
+        runId: 'run_external',
+        workspaceId: 'rw_1',
+        relayWorkspaceId: 'rw_relay',
+        relaycastApiKey: 'rk_live_secret',
+        relayfileUrl: 'https://relayfile.test',
+        relayfileToken: 'relayfile_secret',
+        workflow: 'version: "1.0"\nworkflows: []\n',
+        fileType: 'yaml',
+        sourceFileType: 'yaml',
+        workflowFileName: 'workflow.yaml',
+      },
+      worker: { workerId: 'wrk_1' } as never,
+      signal: new AbortController().signal,
+    });
+
+    const workflowPath = path.join(tmpHome, 'cloud-workers', 'runs', 'run_external', 'workflow.yaml');
+    expect(spawnProcess).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.stringMatching(/node_modules[\\/]@relayflows[\\/]cli/), 'run', workflowPath],
+      expect.objectContaining({ cwd: path.dirname(workflowPath) })
+    );
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
   it('prints the canonical cloud session as JSON without interactive login', async () => {

--- a/packages/cli/src/cli/commands/cloud.test.ts
+++ b/packages/cli/src/cli/commands/cloud.test.ts
@@ -344,6 +344,51 @@ describe('registerCloudCommands', () => {
     );
   });
 
+  it('restarts a compiled Bun daemon without passing its virtual argv entrypoint', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-worker-daemon-'));
+    const worker = {
+      baseUrl: 'https://cloud.test',
+      workerId: 'wrk_daemon',
+      workerToken: 'ocl_wrk_secret',
+      name: 'demo',
+      heartbeatIntervalMs: 30_000,
+      registeredAt: '2026-06-13T00:00:00.000Z',
+      updatedAt: '2026-06-13T00:00:00.000Z',
+    };
+    cloudMocks.resolveCloudWorkerRecord.mockReturnValueOnce(worker);
+    const child = { pid: 4242, unref: vi.fn() };
+    const spawnProcess = vi.fn(() => child) as never;
+
+    try {
+      const { program } = createHarness({
+        env: { AGENT_RELAY_HOME: tmpHome },
+        argv: ['bun', '/$bunfs/root/cli/index.js'],
+        cliScript: '/$bunfs/root/cli/index.js',
+        execPath: '/tmp/agent-relay',
+        spawnProcess,
+      });
+      await program.parseAsync(['cloud', 'worker', 'start', '--daemon'], { from: 'user' });
+
+      expect(spawnProcess).toHaveBeenCalledWith(
+        '/tmp/agent-relay',
+        [
+          'cloud',
+          'worker',
+          'start',
+          '--worker-id',
+          'wrk_daemon',
+          '--base-url',
+          'https://cloud.test',
+          '--foreground-child',
+        ],
+        expect.objectContaining({ detached: true })
+      );
+      expect(spawnProcess.mock.calls[0]?.[1]).not.toContain('/$bunfs/root/cli/index.js');
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   it('materializes Cloud assignments into relayflows args and child env without persisting secrets', async () => {
     const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-worker-relayflows-'));
     const spawnCalls: Array<{
@@ -515,6 +560,77 @@ describe('registerCloudCommands', () => {
       expect(persisted).not.toContain('sk-secret');
       expect(persisted).not.toContain('relayfile_secret');
       expect(persisted).not.toContain('rk_live_secret');
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('runs a compiled Cloud assignment with the bundled workflow runner when the archive has no node_modules', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-worker-bundled-'));
+    const child = new EventEmitter() as EventEmitter & { killed: boolean; kill: () => void };
+    child.killed = false;
+    child.kill = vi.fn();
+    const spawnProcess = vi.fn(() => {
+      queueMicrotask(() => child.emit('exit', 0, null));
+      return child;
+    }) as never;
+    const execFile = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) =>
+        callback(
+          Object.assign(new Error('Cannot find module @relayflows/cli'), { code: 'MODULE_NOT_FOUND' }),
+          '',
+          ''
+        )
+    );
+
+    try {
+      const runner = createDefaultAssignmentRunner({
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn() as never,
+        env: { AGENT_RELAY_HOME: tmpHome, AGENT_RELAY_WORKER_KEEP_RUN_DIR: '1' },
+        argv: ['bun', '/$bunfs/root/cli/index.js'],
+        cliScript: '/$bunfs/root/cli/index.js',
+        execPath: '/tmp/agent-relay',
+        spawnProcess,
+        now: () => new Date('2026-06-13T00:00:00.000Z'),
+        cwd: () => tmpHome,
+        fetchImpl: vi.fn() as never,
+        execFile: execFile as never,
+      });
+
+      await runner({
+        assignment: { runId: 'run_bundled' } as never,
+        payload: {
+          runId: 'run_bundled',
+          workspaceId: 'rw_1',
+          relayWorkspaceId: 'rw_relay',
+          relaycastApiKey: 'rk_live_secret',
+          relayfileUrl: 'https://relayfile.test',
+          relayfileToken: 'relayfile_secret',
+          workflow: 'version: "1.0"\nworkflows: []\n',
+          fileType: 'yaml',
+          sourceFileType: 'yaml',
+          workflowFileName: 'workflow.yaml',
+        },
+        worker: { workerId: 'wrk_1' } as never,
+        signal: new AbortController().signal,
+      });
+
+      expect(spawnProcess).toHaveBeenCalledWith(
+        '/tmp/agent-relay',
+        [
+          '__bundled-workflow',
+          'run',
+          path.join(tmpHome, 'cloud-workers', 'runs', 'run_bundled', 'workflow.yaml'),
+        ],
+        expect.objectContaining({ cwd: path.join(tmpHome, 'cloud-workers', 'runs', 'run_bundled') })
+      );
     } finally {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }

--- a/packages/cli/src/cli/commands/local-workflow.test.ts
+++ b/packages/cli/src/cli/commands/local-workflow.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { EventEmitter } from 'node:events';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -150,6 +151,28 @@ describe('registerLocalWorkflowCommands', () => {
 
     await program.parseAsync(['sync', 'local_test123'], { from: 'user' });
     expect(logs).toContain('Local workflow ran in this checkout; no patch sync is required.');
+  });
+
+  it('records actionable guidance when the detached monitor cannot start Node', async () => {
+    const monitor = new EventEmitter() as EventEmitter & { pid: number; unref: () => void };
+    monitor.pid = 4242;
+    monitor.unref = vi.fn();
+    const spawnProcess = vi.fn(() => monitor) as never;
+    const { program, tmpRoot, errors } = createHarness({
+      spawnProcess,
+      argv: ['bun', '/$bunfs/root/cli/index.js'],
+      cliScript: '/$bunfs/root/cli/index.js',
+      execPath: '/tmp/agent-relay',
+    });
+    fs.writeFileSync(path.join(tmpRoot, 'workflow.js'), 'console.log("workflow");\n', 'utf-8');
+
+    await program.parseAsync(['run', 'workflow.js'], { from: 'user' });
+    monitor.emit('error', new Error('spawn node ENOENT'));
+
+    const record = await waitForRunStatus(tmpRoot, 'local_test123', 'failed');
+    expect(record.status).toBe('failed');
+    expect(record.error).toMatch(/Node.js executable.*AGENT_RELAY_NODE/);
+    expect(errors.join('\n')).toMatch(/Node.js executable.*AGENT_RELAY_NODE/);
   });
 
   it.each([

--- a/packages/cli/src/cli/commands/local-workflow.test.ts
+++ b/packages/cli/src/cli/commands/local-workflow.test.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { registerLocalWorkflowCommands, type LocalWorkflowDependencies } from './local-workflow.js';
+import {
+  registerLocalWorkflowCommands,
+  resolveLocalWorkflowCommand,
+  type LocalWorkflowDependencies,
+} from './local-workflow.js';
 
 vi.mock('../telemetry/index.js', () => ({
   track: vi.fn(),
@@ -178,5 +182,74 @@ describe('registerLocalWorkflowCommands', () => {
     expect(record.command).toBe(process.execPath);
     expect(record.args).toEqual([relayflowsCliPath, 'run', workflowPath]);
     expect(record.status).toBe('running');
+  });
+
+  it('uses a real Node child and resolves relayflows from the workflow project in compiled Bun mode', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'local-workflow-runtime-'));
+    tmpRoots.push(tmpRoot);
+    const workflowPath = path.join(tmpRoot, 'workflow.yaml');
+    fs.writeFileSync(workflowPath, 'version: "1.0"\n', 'utf-8');
+    const execFile = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => callback(null, '/project/node_modules/@relayflows/cli/dist/cli.js\n', '')
+    );
+
+    const command = await resolveLocalWorkflowCommand(workflowPath, 'yaml', {
+      ...({} as LocalWorkflowDependencies),
+      argv: ['bun', '/$bunfs/root/cli/index.js'],
+      cliScript: '/$bunfs/root/cli/index.js',
+      execPath: '/tmp/agent-relay',
+      env: { AGENT_RELAY_NODE: ' /opt/node/bin/node ' },
+      execFile: execFile as never,
+    });
+
+    expect(command).toEqual({
+      command: '/opt/node/bin/node',
+      args: ['/project/node_modules/@relayflows/cli/dist/cli.js', 'run', workflowPath],
+    });
+    expect(execFile).toHaveBeenCalledWith(
+      '/opt/node/bin/node',
+      expect.arrayContaining(['@relayflows/cli', tmpRoot]),
+      expect.objectContaining({ cwd: tmpRoot }),
+      expect.any(Function)
+    );
+  });
+
+  it('keeps normal Node relayflows resolution anchored to the installed CLI for an external workflow', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'local-workflow-external-'));
+    tmpRoots.push(tmpRoot);
+    const workflowPath = path.join(tmpRoot, 'workflow.yaml');
+    fs.writeFileSync(workflowPath, 'version: "1.0"\nworkflows: []\n', 'utf-8');
+    const spawnProcess = vi.fn(() => ({
+      pid: 42,
+      unref: vi.fn(),
+    })) as unknown as LocalWorkflowDependencies['spawnProcess'];
+    const program = new Command();
+    program.exitOverride();
+    registerLocalWorkflowCommands(program, {
+      cwd: () => tmpRoot,
+      env: { ...process.env },
+      spawnProcess,
+      randomRunId: () => 'local_external',
+      sleep: async () => undefined,
+      log: vi.fn(),
+    });
+
+    await program.parseAsync(['run', workflowPath], { from: 'user' });
+
+    expect(spawnProcess.mock.calls[0]?.[0]).toBe(process.execPath);
+    const record = JSON.parse(
+      fs.readFileSync(path.join(tmpRoot, '.agentworkforce/relay/local-runs/local_external/run.json'), 'utf-8')
+    ) as { command: string; args: string[] };
+    expect(record.command).toBe(process.execPath);
+    expect(record.args).toEqual([
+      expect.stringMatching(/node_modules[\\/]@relayflows[\\/]cli/),
+      'run',
+      workflowPath,
+    ]);
   });
 });

--- a/packages/cli/src/cli/commands/local-workflow.test.ts
+++ b/packages/cli/src/cli/commands/local-workflow.test.ts
@@ -157,7 +157,10 @@ describe('registerLocalWorkflowCommands', () => {
     const monitor = new EventEmitter() as EventEmitter & { pid: number; unref: () => void };
     monitor.pid = 4242;
     monitor.unref = vi.fn();
-    const spawnProcess = vi.fn(() => monitor) as never;
+    const spawnProcess = vi.fn(() => {
+      queueMicrotask(() => monitor.emit('error', new Error('spawn node ENOENT')));
+      return monitor;
+    }) as never;
     const { program, tmpRoot, errors } = createHarness({
       spawnProcess,
       argv: ['bun', '/$bunfs/root/cli/index.js'],
@@ -167,10 +170,12 @@ describe('registerLocalWorkflowCommands', () => {
     fs.writeFileSync(path.join(tmpRoot, 'workflow.js'), 'console.log("workflow");\n', 'utf-8');
 
     await program.parseAsync(['run', 'workflow.js'], { from: 'user' });
-    monitor.emit('error', new Error('spawn node ENOENT'));
 
-    const record = await waitForRunStatus(tmpRoot, 'local_test123', 'failed');
+    const record = JSON.parse(
+      fs.readFileSync(path.join(tmpRoot, '.agentworkforce/relay/local-runs/local_test123/run.json'), 'utf-8')
+    ) as Record<string, unknown>;
     expect(record.status).toBe('failed');
+    expect(record.monitorPid).toBeUndefined();
     expect(record.error).toMatch(/Node.js executable.*AGENT_RELAY_NODE/);
     expect(errors.join('\n')).toMatch(/Node.js executable.*AGENT_RELAY_NODE/);
   });

--- a/packages/cli/src/cli/commands/local-workflow.ts
+++ b/packages/cli/src/cli/commands/local-workflow.ts
@@ -3,11 +3,15 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { spawn as spawnProcess, type ChildProcess } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { createRequire } from 'node:module';
 import { Command, InvalidArgumentError } from 'commander';
 
 import { defaultExit } from '../lib/exit.js';
 import { errorClassName } from '../lib/telemetry-helpers.js';
+import {
+  describeWorkflowChildError,
+  resolveRelayflowsCliEntrypoint,
+  workflowNodeExecutable,
+} from '../lib/workflow-runtime.js';
 import { track } from '../telemetry/index.js';
 
 type ExitFn = (code: number) => never;
@@ -46,7 +50,11 @@ export interface LocalWorkflowDependencies {
   cwd: () => string;
   env: NodeJS.ProcessEnv;
   spawnProcess: typeof spawnProcess;
-  resolveRelayflowsCliEntrypoint: () => string;
+  resolveRelayflowsCliEntrypoint?: (workflowPath: string) => string | Promise<string>;
+  argv?: readonly string[];
+  execPath?: string;
+  cliScript?: string;
+  execFile?: typeof import('node:child_process').execFile;
   randomRunId: () => string;
   now: () => Date;
   sleep: (ms: number) => Promise<void>;
@@ -59,14 +67,16 @@ export interface LocalWorkflowDependencies {
 
 const RUN_ID_RE = /^local_[A-Za-z0-9][A-Za-z0-9_-]{0,80}$/;
 const TERMINAL_STATUSES = new Set<LocalWorkflowRunStatus>(['completed', 'failed']);
-const nodeRequire = createRequire(import.meta.url);
-
 function withDefaults(overrides: Partial<LocalWorkflowDependencies> = {}): LocalWorkflowDependencies {
-  return {
+  const deps: LocalWorkflowDependencies = {
     cwd: () => process.cwd(),
     env: process.env,
     spawnProcess,
-    resolveRelayflowsCliEntrypoint: () => nodeRequire.resolve('@relayflows/cli'),
+    resolveRelayflowsCliEntrypoint: async () => '',
+    execFile: undefined,
+    argv: process.argv,
+    execPath: process.execPath,
+    cliScript: process.argv[1] ?? '',
     randomRunId: () =>
       `local_${new Date().toISOString().replace(/[-:.TZ]/g, '')}_${randomBytes(4).toString('hex')}`,
     now: () => new Date(),
@@ -86,6 +96,11 @@ function withDefaults(overrides: Partial<LocalWorkflowDependencies> = {}): Local
     exit: defaultExit,
     ...overrides,
   };
+  if (!overrides.resolveRelayflowsCliEntrypoint) {
+    deps.resolveRelayflowsCliEntrypoint = (workflowPath) =>
+      resolveRelayflowsCliEntrypoint(workflowPath, deps);
+  }
+  return deps;
 }
 
 function parsePositiveInteger(value: string): number {
@@ -251,11 +266,15 @@ process.on('SIGTERM', () => stopChild('SIGTERM'));
 process.on('SIGINT', () => stopChild('SIGINT'));
 
 child.on('error', (error) => {
-  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  const detail = error instanceof Error ? error.stack || error.message : String(error);
+  const message = /\\bENOENT\\b|spawn .* not found|not found/i.test(detail)
+    ? detail + ' A Node.js executable is required for standalone workflow execution; install Node.js or set AGENT_RELAY_NODE to its path.'
+    : detail;
+  console.error(message);
   writeRecord({
     status: 'failed',
     exitCode: 1,
-    error: error instanceof Error ? error.message : String(error),
+    error: message,
     finishedAt: new Date().toISOString(),
   });
   process.exit(1);
@@ -274,17 +293,27 @@ child.on('exit', (code, signal) => {
 `;
 }
 
-async function resolveLocalWorkflowCommand(
+export async function resolveLocalWorkflowCommand(
   workflowPath: string,
   fileType: LocalWorkflowFileType,
   deps: LocalWorkflowDependencies
 ): Promise<{ command: string; args: string[] }> {
+  const node = workflowNodeExecutable(deps);
   if (fileType === 'yaml' || fileType === 'ts' || fileType === 'py') {
-    return { command: process.execPath, args: [deps.resolveRelayflowsCliEntrypoint(), 'run', workflowPath] };
+    return {
+      command: node,
+      args: [
+        deps.resolveRelayflowsCliEntrypoint
+          ? await deps.resolveRelayflowsCliEntrypoint(workflowPath)
+          : await resolveRelayflowsCliEntrypoint(workflowPath, deps),
+        'run',
+        workflowPath,
+      ],
+    };
   }
 
   if (fileType === 'js') {
-    return { command: process.execPath, args: [workflowPath] };
+    return { command: node, args: [workflowPath] };
   }
 
   return { command: deps.env.SHELL?.trim() || '/bin/sh', args: [workflowPath] };
@@ -317,7 +346,13 @@ async function runLocalWorkflow(
   const runDir = runDirFor(cwd, runId);
   await fsp.mkdir(runDir, { recursive: true });
 
-  const { command, args } = await resolveLocalWorkflowCommand(workflowPath, fileType, deps);
+  let command: string;
+  let args: string[];
+  try {
+    ({ command, args } = await resolveLocalWorkflowCommand(workflowPath, fileType, deps));
+  } catch (error) {
+    throw describeWorkflowChildError(error, workflowPath);
+  }
   const now = deps.now().toISOString();
   const logPath = path.join(runDir, 'workflow.log');
   const metadataPath = path.join(runDir, 'run.json');
@@ -361,7 +396,7 @@ async function runLocalWorkflow(
   const logFd = fs.openSync(logPath, 'a');
   let monitor: ChildProcess;
   try {
-    monitor = deps.spawnProcess(process.execPath, [runnerPath], {
+    monitor = deps.spawnProcess(workflowNodeExecutable(deps), [runnerPath], {
       cwd,
       detached: true,
       stdio: ['ignore', logFd, logFd],

--- a/packages/cli/src/cli/commands/local-workflow.ts
+++ b/packages/cli/src/cli/commands/local-workflow.ts
@@ -405,6 +405,30 @@ async function runLocalWorkflow(
   } finally {
     fs.closeSync(logFd);
   }
+
+  // A detached child can fail after spawn returns (for example when Node is
+  // missing on a Bun standalone install). Always consume that event so Node
+  // does not report a raw unhandled `spawn ... ENOENT`, and persist guidance
+  // where `workflow logs` can surface it later.
+  if (typeof monitor.on === 'function') {
+    monitor.on('error', (error) => {
+      const message = describeWorkflowChildError(error, workflowNodeExecutable(deps)).message;
+      deps.error(message);
+      void readRunRecord(cwd, runId)
+        .catch(() => record)
+        .then((current) =>
+          writeJsonAtomic(metadataPath, {
+            ...current,
+            status: 'failed',
+            exitCode: 1,
+            error: message,
+            finishedAt: deps.now().toISOString(),
+            updatedAt: deps.now().toISOString(),
+          })
+        )
+        .catch(() => undefined);
+    });
+  }
   monitor.unref();
 
   const current = await readRunRecord(cwd, runId).catch(() => record);

--- a/packages/cli/src/cli/commands/local-workflow.ts
+++ b/packages/cli/src/cli/commands/local-workflow.ts
@@ -175,7 +175,7 @@ function runDirFor(cwd: string, runId: string): string {
 }
 
 async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
-  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  const tmpPath = `${filePath}.tmp-${process.pid}-${randomBytes(6).toString('hex')}`;
   await fsp.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
   await fsp.rename(tmpPath, filePath);
 }
@@ -351,7 +351,7 @@ async function runLocalWorkflow(
   try {
     ({ command, args } = await resolveLocalWorkflowCommand(workflowPath, fileType, deps));
   } catch (error) {
-    throw describeWorkflowChildError(error, workflowPath);
+    throw describeWorkflowChildError(error, workflowNodeExecutable(deps));
   }
   const now = deps.now().toISOString();
   const logPath = path.join(runDir, 'workflow.log');
@@ -406,30 +406,60 @@ async function runLocalWorkflow(
     fs.closeSync(logFd);
   }
 
-  // A detached child can fail after spawn returns (for example when Node is
-  // missing on a Bun standalone install). Always consume that event so Node
-  // does not report a raw unhandled `spawn ... ENOENT`, and persist guidance
-  // where `workflow logs` can surface it later.
+  // A detached child reports initial spawn failures asynchronously. Wait for
+  // either `spawn` or the fully persisted `error` before marking the run
+  // active, otherwise the normal running write can overwrite the failure.
+  let settleStartup: ((record: LocalWorkflowRunRecord | null) => void) | undefined;
+  let startupSettled = false;
+  const startup =
+    typeof monitor.once === 'function'
+      ? new Promise<LocalWorkflowRunRecord | null>((resolve) => {
+          settleStartup = resolve;
+          monitor.once('spawn', () => {
+            if (startupSettled) return;
+            startupSettled = true;
+            resolve(null);
+          });
+        })
+      : Promise.resolve(null);
+
   if (typeof monitor.on === 'function') {
     monitor.on('error', (error) => {
       const message = describeWorkflowChildError(error, workflowNodeExecutable(deps)).message;
       deps.error(message);
       void readRunRecord(cwd, runId)
         .catch(() => record)
-        .then((current) =>
-          writeJsonAtomic(metadataPath, {
+        .then(async (current) => {
+          const failed: LocalWorkflowRunRecord = {
             ...current,
             status: 'failed',
             exitCode: 1,
             error: message,
             finishedAt: deps.now().toISOString(),
             updatedAt: deps.now().toISOString(),
-          })
-        )
-        .catch(() => undefined);
+          };
+          await writeJsonAtomic(metadataPath, failed);
+          return failed;
+        })
+        .catch(() => ({
+          ...record,
+          status: 'failed' as const,
+          exitCode: 1,
+          error: message,
+          finishedAt: deps.now().toISOString(),
+          updatedAt: deps.now().toISOString(),
+        }))
+        .then((failed) => {
+          if (startupSettled) return;
+          startupSettled = true;
+          settleStartup?.(failed);
+        });
     });
   }
   monitor.unref();
+
+  const startupFailure = await startup;
+  if (startupFailure) return startupFailure;
 
   const current = await readRunRecord(cwd, runId).catch(() => record);
   const next: LocalWorkflowRunRecord = {

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { runAiSdkSidecarMain } from '@agent-relay/harnesses';
 
 import { runCli } from './bootstrap.js';
+import { runBundledWorkflowCli } from './lib/bundled-workflow-runner.js';
 import { describeError } from './lib/describe-error.js';
 import { exitAfterFlush } from './lib/flush-stdio.js';
 
@@ -23,7 +24,12 @@ function isEntrypoint(): boolean {
 }
 
 if (isEntrypoint()) {
-  const main = process.argv[2] === '__ai-sdk-sidecar' ? runAiSdkSidecarMain(process.argv.slice(3)) : runCli();
+  const main =
+    process.argv[2] === '__ai-sdk-sidecar'
+      ? runAiSdkSidecarMain(process.argv.slice(3))
+      : process.argv[2] === '__bundled-workflow'
+        ? runBundledWorkflowCli(process.argv.slice(3))
+        : runCli();
   main.catch(async (err) => {
     // Commander will have already printed a helpful message for parse errors.
     // For other top-level failures, surface them to stderr and exit non-zero.

--- a/packages/cli/src/cli/lib/bundled-workflow-runner.ts
+++ b/packages/cli/src/cli/lib/bundled-workflow-runner.ts
@@ -1,0 +1,79 @@
+import path from 'node:path';
+
+import { runScriptWorkflow, runWorkflow } from '@relayflows/core';
+
+type WorkflowOptions = {
+  workflow?: string;
+  dryRun?: boolean;
+  resume?: string;
+  startFrom?: string;
+  previousRunId?: string;
+};
+
+function parseRunOptions(args: readonly string[]): { filePath: string; options: WorkflowOptions } {
+  if (args[0] !== 'run' || !args[1]) {
+    throw new Error('Expected bundled workflow invocation: run <file>');
+  }
+
+  const options: WorkflowOptions = {};
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--workflow' || arg === '-w') {
+      options.workflow = args[++index];
+    } else if (arg === '--resume') {
+      options.resume = args[++index];
+    } else if (arg === '--start-from') {
+      options.startFrom = args[++index];
+    } else if (arg === '--previous-run-id') {
+      options.previousRunId = args[++index];
+    } else {
+      throw new Error(`Unknown bundled workflow option: ${arg}`);
+    }
+  }
+
+  return { filePath: path.resolve(args[1]), options };
+}
+
+function logWorkflowEvent(event: { type: string; stepName?: string; error?: string }): void {
+  if (event.type === 'broker:event') return;
+  const prefix = event.type.startsWith('run:') ? '[run]' : '[step]';
+  const name = event.stepName ? `${event.stepName} ` : '';
+  const status = event.type.split(':')[1] ?? event.type;
+  const detail = event.error ? `: ${event.error}` : '';
+  console.log(`${prefix} ${name}${status}${detail}`);
+}
+
+/** Run a Cloud workflow with the relayflows core bundled into the standalone binary. */
+export async function runBundledWorkflowCli(args: readonly string[]): Promise<void> {
+  const { filePath, options } = parseRunOptions(args);
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (ext === '.yaml' || ext === '.yml') {
+    const result = await runWorkflow(filePath, {
+      workflow: options.workflow,
+      dryRun: options.dryRun,
+      resume: options.resume,
+      startFrom: options.startFrom,
+      previousRunId: options.previousRunId,
+      onEvent: logWorkflowEvent,
+    });
+    if (options.dryRun) return;
+    if ('status' in result && result.status === 'completed') return;
+    const detail = 'error' in result && result.error ? `: ${result.error}` : '';
+    throw new Error(`Workflow failed${detail}`);
+  }
+
+  if (ext === '.ts' || ext === '.tsx' || ext === '.py') {
+    await runScriptWorkflow(filePath, {
+      dryRun: options.dryRun,
+      resume: options.resume,
+      startFrom: options.startFrom,
+      previousRunId: options.previousRunId,
+    });
+    return;
+  }
+
+  throw new Error(`Unsupported file type: ${ext}. Use .yaml, .yml, .ts, or .py`);
+}

--- a/packages/cli/src/cli/lib/workflow-runtime.test.ts
+++ b/packages/cli/src/cli/lib/workflow-runtime.test.ts
@@ -8,7 +8,7 @@ import {
 } from './workflow-runtime.js';
 
 const compiled = {
-  env: { ...process.env },
+  env: {} as NodeJS.ProcessEnv,
   argv: ['bun', '/$bunfs/root/cli/index.js'],
   execPath: '/tmp/agent-relay',
   cliScript: '/$bunfs/root/cli/index.js',

--- a/packages/cli/src/cli/lib/workflow-runtime.test.ts
+++ b/packages/cli/src/cli/lib/workflow-runtime.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  describeWorkflowChildError,
+  isCompiledBunWorkflowRuntime,
+  resolveRelayflowsCliEntrypoint,
+  workflowNodeExecutable,
+} from './workflow-runtime.js';
+
+const compiled = {
+  env: { ...process.env },
+  argv: ['bun', '/$bunfs/root/cli/index.js'],
+  execPath: '/tmp/agent-relay',
+  cliScript: '/$bunfs/root/cli/index.js',
+};
+
+describe('workflow runtime selection', () => {
+  it('detects the compiled Bun argv signature', () => {
+    expect(isCompiledBunWorkflowRuntime(compiled)).toBe(true);
+    expect(
+      isCompiledBunWorkflowRuntime({
+        ...compiled,
+        argv: ['node', '/$bunfs/root/cli/index.js'],
+      })
+    ).toBe(false);
+    expect(
+      isCompiledBunWorkflowRuntime({
+        ...compiled,
+        cliScript: '/workspace/packages/cli/dist/cli/index.js',
+      })
+    ).toBe(false);
+  });
+
+  it('uses the configured Node executable for compiled Bun and process.execPath otherwise', () => {
+    expect(workflowNodeExecutable(compiled)).toBe('node');
+    expect(workflowNodeExecutable({ ...compiled, env: { AGENT_RELAY_NODE: ' /opt/node/bin/node ' } })).toBe(
+      '/opt/node/bin/node'
+    );
+    expect(
+      workflowNodeExecutable({
+        env: {},
+        argv: ['node', '/workspace/cli.js'],
+        execPath: '/opt/node/bin/node',
+        cliScript: '/workspace/cli.js',
+      })
+    ).toBe('/opt/node/bin/node');
+  });
+
+  it('keeps normal Node resolution anchored to the installed CLI package', async () => {
+    await expect(
+      resolveRelayflowsCliEntrypoint('/tmp/workflow-without-node-modules.yaml', {
+        env: {},
+        argv: ['node', '/repo/packages/cli/dist/cli/index.js'],
+        execPath: '/opt/node/bin/node',
+        cliScript: '/repo/packages/cli/dist/cli/index.js',
+      })
+    ).resolves.toMatch(/node_modules[\\/]@relayflows[\\/]cli/);
+  });
+
+  it('resolves project dependencies from the workflow path', async () => {
+    const execFile = vi.fn((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(new Error('Cannot find module @relayflows/cli'), { code: 'MODULE_NOT_FOUND' }),
+        '',
+        ''
+      );
+    });
+    await expect(
+      resolveRelayflowsCliEntrypoint('/tmp/no-workflow.yaml', {
+        ...compiled,
+        execFile: execFile as never,
+      })
+    ).rejects.toThrow(
+      /Cannot resolve @relayflows\/cli from \/tmp\/no-workflow\.yaml.*Install @relayflows\/cli.*Cause:/s
+    );
+  });
+
+  it('asks Node to resolve from the real workflow directory in compiled mode', async () => {
+    const execFile = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(null, '/project/node_modules/@relayflows/cli/dist/cli.js\n', '');
+      }
+    );
+    const entrypoint = await resolveRelayflowsCliEntrypoint('/project/workflow.yaml', {
+      ...compiled,
+      execFile: execFile as never,
+    });
+
+    expect(entrypoint).toBe('/project/node_modules/@relayflows/cli/dist/cli.js');
+    expect(execFile).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining(['@relayflows/cli', '/project']),
+      expect.objectContaining({ cwd: '/project' }),
+      expect.any(Function)
+    );
+  });
+
+  it('makes missing executable failures actionable', () => {
+    expect(describeWorkflowChildError(new Error('spawn node ENOENT'), 'node').message).toMatch(
+      /Node\.js executable.*AGENT_RELAY_NODE/
+    );
+  });
+});

--- a/packages/cli/src/cli/lib/workflow-runtime.ts
+++ b/packages/cli/src/cli/lib/workflow-runtime.ts
@@ -1,0 +1,115 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { execFile as nodeExecFile } from 'node:child_process';
+
+import { isBundledBunEntrypointPath } from './agent-relay-mcp-command.js';
+
+const nodeRequire = createRequire(import.meta.url);
+
+export type WorkflowRuntimeDependencies = {
+  env: NodeJS.ProcessEnv;
+  argv?: readonly string[];
+  execPath?: string;
+  cliScript?: string;
+  execFile?: typeof nodeExecFile;
+};
+
+/** The argv shape emitted by a `bun build --compile` standalone binary. */
+export function isCompiledBunWorkflowRuntime(deps: WorkflowRuntimeDependencies): boolean {
+  return (
+    (deps.argv ?? process.argv)[0] === 'bun' &&
+    isBundledBunEntrypointPath(deps.cliScript ?? process.argv[1] ?? '')
+  );
+}
+
+/**
+ * Return the executable that should run a user workflow or generated monitor.
+ *
+ * A compiled Bun executable cannot execute a Node script by re-entering itself:
+ * `process.execPath` is the standalone binary. Use an operator-selected Node
+ * executable or PATH's `node` in that case. Regular Node and non-compiled
+ * installs retain their existing process executable.
+ */
+export function workflowNodeExecutable(deps: WorkflowRuntimeDependencies): string {
+  if (!isCompiledBunWorkflowRuntime(deps)) {
+    return deps.execPath ?? process.execPath;
+  }
+  return deps.env.AGENT_RELAY_NODE?.trim() || 'node';
+}
+
+/**
+ * Resolve relayflows from the directory containing the real workflow file.
+ * This is essential for standalone binaries, whose bundled dependencies live
+ * in a sealed `/$bunfs` image and cannot resolve the user's project install.
+ */
+export async function resolveRelayflowsCliEntrypoint(
+  workflowPath: string,
+  deps: WorkflowRuntimeDependencies
+): Promise<string> {
+  const resolvedWorkflowPath = path.resolve(workflowPath);
+  try {
+    if (!isCompiledBunWorkflowRuntime(deps)) {
+      return nodeRequire.resolve('@relayflows/cli');
+    }
+
+    const execFile = deps.execFile ?? nodeExecFile;
+    const node = workflowNodeExecutable(deps);
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        node,
+        [
+          '-e',
+          'process.stdout.write(require.resolve(process.argv[1], { paths: [process.argv[2]] }))',
+          '@relayflows/cli',
+          path.dirname(resolvedWorkflowPath),
+        ],
+        {
+          cwd: path.dirname(resolvedWorkflowPath),
+          env: deps.env,
+          windowsHide: true,
+        },
+        (error, output, stderr) => {
+          if (error) {
+            reject({ error, stderr });
+            return;
+          }
+          resolve(output);
+        }
+      );
+    });
+    const entrypoint = stdout.trim();
+    if (!entrypoint) {
+      throw new Error(`Node did not return a path for @relayflows/cli from ${resolvedWorkflowPath}`);
+    }
+    return entrypoint;
+  } catch (error) {
+    const childError =
+      error && typeof error === 'object' && 'error' in error ? (error as { error: unknown }).error : error;
+    const detail = childError instanceof Error ? childError.message : String(childError);
+    if (/\bENOENT\b|spawn .* not found|not found/i.test(detail)) {
+      throw describeWorkflowChildError(childError, workflowNodeExecutable(deps));
+    }
+    throw new Error(
+      `Cannot resolve @relayflows/cli from ${resolvedWorkflowPath}. ` +
+        'Install @relayflows/cli in the workflow project (for example, npm install @relayflows/cli). ' +
+        `Cause: ${detail}${
+          error && typeof error === 'object' && 'stderr' in error
+            ? ` ${(error as { stderr?: unknown }).stderr ?? ''}`.trim()
+            : ''
+        }`,
+      { cause: error }
+    );
+  }
+}
+
+/** Add a useful hint when a child executable cannot be started. */
+export function describeWorkflowChildError(error: unknown, command: string): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (/\bENOENT\b|spawn .* not found|not found/i.test(detail)) {
+    return new Error(
+      `Unable to start workflow child ${command}: ${detail}. ` +
+        'A Node.js executable is required for standalone workflow execution; install Node.js or set AGENT_RELAY_NODE to its path.'
+    );
+  }
+  return error instanceof Error ? error : new Error(detail);
+}

--- a/packages/cli/src/cli/lib/workflow-runtime.ts
+++ b/packages/cli/src/cli/lib/workflow-runtime.ts
@@ -54,14 +54,22 @@ export async function resolveRelayflowsCliEntrypoint(
 
     const execFile = deps.execFile ?? nodeExecFile;
     const node = workflowNodeExecutable(deps);
+    const cliScript = deps.cliScript ?? process.argv[1] ?? '';
+    const installedCliPath =
+      cliScript && !isBundledBunEntrypointPath(cliScript) ? path.dirname(path.resolve(cliScript)) : undefined;
+    const resolutionPaths = [
+      path.dirname(resolvedWorkflowPath),
+      ...(installedCliPath ? [installedCliPath] : []),
+    ];
     const stdout = await new Promise<string>((resolve, reject) => {
       execFile(
         node,
         [
           '-e',
-          'process.stdout.write(require.resolve(process.argv[1], { paths: [process.argv[2]] }))',
+          'const paths = process.argv[3] ? JSON.parse(process.argv[3]) : [process.argv[2]]; process.stdout.write(require.resolve(process.argv[1], { paths }))',
           '@relayflows/cli',
           path.dirname(resolvedWorkflowPath),
+          JSON.stringify(resolutionPaths),
         ],
         {
           cwd: path.dirname(resolvedWorkflowPath),

--- a/packages/cli/src/cli/standalone-workflow.bun.test.ts
+++ b/packages/cli/src/cli/standalone-workflow.bun.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const cliDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(cliDir, '../../../..');
+const distEntrypoint = path.resolve(cliDir, '../../dist/cli/index.js');
+const smokeScript = path.join(repoRoot, 'scripts/ci-standalone-workflow-smoke.sh');
+const bunAvailable = spawnSync('bun', ['--version'], { stdio: 'ignore' }).status === 0;
+
+describe.skipIf(!bunAvailable || !existsSync(distEntrypoint))('compiled Bun workflow regression', () => {
+  it('runs a no-allocation workflow to terminal logs and completed status', () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'agent-relay-bun-workflow-test-'));
+    const binary = path.join(tempRoot, 'agent-relay');
+    try {
+      execFileSync(
+        'bun',
+        [
+          'build',
+          '--compile',
+          '--external=better-sqlite3',
+          '--external=node-pty',
+          '--external=cpu-features',
+          distEntrypoint,
+          '--outfile',
+          binary,
+        ],
+        { cwd: repoRoot, stdio: 'pipe' }
+      );
+      execFileSync('bash', [smokeScript, binary], { cwd: repoRoot, stdio: 'pipe' });
+      expect(existsSync(binary)).toBe(true);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/scripts/ci-standalone-workflow-smoke.sh
+++ b/scripts/ci-standalone-workflow-smoke.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+STANDALONE_CLI="${1:?usage: $0 /path/to/agent-relay-standalone}"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agent-relay-workflow-smoke.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/node_modules/@relayflows/cli/dist"
+cat > "$TMP_ROOT/node_modules/@relayflows/cli/package.json" <<'JSON'
+{"name":"@relayflows/cli","version":"0.0.0-smoke","type":"module","exports":"./dist/cli.js"}
+JSON
+cat > "$TMP_ROOT/node_modules/@relayflows/cli/dist/cli.js" <<'JS'
+console.log(`no-allocation workflow completed: ${process.argv.slice(2).join(' ')}`);
+JS
+cat > "$TMP_ROOT/workflow.yaml" <<'YAML'
+version: "1.0"
+workflows: []
+YAML
+
+run_output="$(cd "$TMP_ROOT" && AGENT_RELAY_TELEMETRY_DISABLED=1 "$STANDALONE_CLI" node workflow run workflow.yaml)"
+printf '%s\n' "$run_output"
+run_id="$(printf '%s\n' "$run_output" | sed -n 's/^Run created: //p')"
+if [ -z "$run_id" ]; then
+  echo "ERROR: standalone workflow smoke did not create a run" >&2
+  exit 1
+fi
+
+logs_output="$(cd "$TMP_ROOT" && AGENT_RELAY_TELEMETRY_DISABLED=1 "$STANDALONE_CLI" node workflow logs "$run_id" --follow --poll-interval 1)"
+printf '%s\n' "$logs_output"
+if ! printf '%s\n' "$logs_output" | grep -q 'no-allocation workflow completed'; then
+  echo "ERROR: standalone workflow smoke did not surface terminal logs" >&2
+  exit 1
+fi
+
+status_output="$(cd "$TMP_ROOT" && AGENT_RELAY_TELEMETRY_DISABLED=1 "$STANDALONE_CLI" node workflow logs "$run_id" --json)"
+printf '%s\n' "$status_output"
+if ! printf '%s\n' "$status_output" | grep -q '"status": "completed"'; then
+  echo "ERROR: standalone workflow smoke did not reach completed status" >&2
+  exit 1
+fi
+
+echo "Standalone workflow smoke passed"

--- a/scripts/ci-standalone-workflow-smoke.sh
+++ b/scripts/ci-standalone-workflow-smoke.sh
@@ -40,3 +40,31 @@ if ! printf '%s\n' "$status_output" | grep -q '"status": "completed"'; then
 fi
 
 echo "Standalone workflow smoke passed"
+
+# Cloud worker archives intentionally omit node_modules. Exercise the
+# standalone binary's bundled relayflows-core path from a project with no
+# dependency tree at all, which is the Cloud assignment shape.
+BUNDLED_ROOT="$TMP_ROOT/bundled-cloud"
+mkdir -p "$BUNDLED_ROOT"
+cat > "$BUNDLED_ROOT/workflow.yaml" <<'YAML'
+version: "1.0"
+name: "standalone-cloud-smoke"
+swarm:
+  pattern: sequential
+agents: []
+workflows:
+  - name: smoke
+    steps:
+      - name: noop
+        type: deterministic
+        command: "printf bundled-workflow-ok"
+YAML
+
+bundled_output="$(cd "$BUNDLED_ROOT" && AGENT_RELAY_TELEMETRY_DISABLED=1 "$STANDALONE_CLI" __bundled-workflow run workflow.yaml)"
+printf '%s\n' "$bundled_output"
+if ! printf '%s\n' "$bundled_output" | grep -q 'Workflow completed successfully'; then
+  echo "ERROR: standalone bundled workflow smoke did not complete" >&2
+  exit 1
+fi
+
+echo "Standalone bundled Cloud workflow smoke passed"

--- a/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/case.json
+++ b/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1727-standalone-cloud-workflow-runtime",
+  "kind": "bugfix",
+  "title": "Run Cloud workflow assignments from standalone archives without node_modules",
+  "requirements": [],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "standalone_cloud_archive_lacks_bundled_workflow_runtime"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "standalone_cloud_archive_runs_bundled_workflow_runtime"
+    }
+  }
+}

--- a/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/run.mjs
+++ b/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/run.mjs
@@ -1,0 +1,183 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { access, lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1727-standalone-cloud-workflow-runtime';
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1727-'));
+const runtimeDir = path.join(probeDir, 'cloud-archive');
+const binaryPath = path.join(probeDir, 'agent-relay');
+const workflowPath = path.join(runtimeDir, 'workflow.yaml');
+
+try {
+  run('npm', ['ci', '--ignore-scripts'], targetDir, 'workspace dependency installation');
+  run('npm', ['run', 'build:core'], targetDir, 'candidate CLI build');
+  run(
+    'bun',
+    [
+      'build',
+      '--compile',
+      '--minify',
+      '--define',
+      'process.env.AGENT_RELAY_VERSION="relayflow-proof"',
+      '--external',
+      'better-sqlite3',
+      '--external',
+      'cpu-features',
+      '--external',
+      'node-pty',
+      path.join(targetDir, 'packages/cli/dist/cli/index.js'),
+      '--outfile',
+      binaryPath,
+    ],
+    targetDir,
+    'standalone candidate compilation'
+  );
+  await access(binaryPath, fsConstants.R_OK | fsConstants.X_OK);
+
+  await mkdir(runtimeDir, { mode: 0o700 });
+  await writeFile(
+    workflowPath,
+    [
+      'version: "1.0"',
+      'name: "standalone-cloud-proof"',
+      'swarm:',
+      '  pattern: sequential',
+      'agents: []',
+      'workflows:',
+      '  - name: proof',
+      '    steps:',
+      '      - name: noop',
+      '        type: deterministic',
+      '        command: "printf bundled-workflow-ok"',
+      '',
+    ].join('\n'),
+    { encoding: 'utf8', mode: 0o600 }
+  );
+  try {
+    await lstat(path.join(runtimeDir, 'node_modules'));
+    throw new Error('The Cloud archive probe must not contain node_modules.');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+
+  const observed = spawnSync(binaryPath, ['__bundled-workflow', 'run', workflowPath, '--dry-run'], {
+    cwd: runtimeDir,
+    env: {
+      PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
+      HOME: runtimeDir,
+      TMPDIR: runtimeDir,
+      NO_COLOR: '1',
+      AGENT_RELAY_TELEMETRY_DISABLED: '1',
+      AGENT_RELAY_WORKFLOW_DISABLE_RELAYCAST: '1',
+      RELAY_CLOUD_PROVISIONING_DONE: '1',
+    },
+    encoding: 'utf8',
+    timeout: 60_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  const output = `${observed.stdout ?? ''}\n${observed.stderr ?? ''}`;
+  const baseObserved =
+    observed.status !== 0 && /unknown command ['"]?__bundled-workflow|error: unknown command/i.test(output);
+  const headObserved =
+    observed.status === 0 && output.includes('Dry Run: proof') && output.includes('Validation: PASS');
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'standalone_cloud_archive_lacks_bundled_workflow_runtime';
+    details =
+      'The exact-base compiled standalone rejected the internal bundled-workflow entrypoint from a dependency-free Cloud archive.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'standalone_cloud_archive_runs_bundled_workflow_runtime';
+    details =
+      'The exact-head compiled standalone loaded the bundled RelayFlow runtime from a dependency-free Cloud archive and validated its workflow plan.';
+  } else {
+    throw new Error(
+      `Unexpected standalone Cloud runtime observation: ${JSON.stringify({
+        arm,
+        status: observed.status,
+        signal: observed.signal,
+        errorCode: observed.error?.code ?? null,
+        outputTail: output.slice(-2_000),
+      })}.`
+    );
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+} finally {
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+function run(command, args, cwd, label) {
+  try {
+    execFileSync(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10 * 60 * 1000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (error) {
+    const stderr = Buffer.isBuffer(error?.stderr)
+      ? error.stderr.toString('utf8')
+      : String(error?.stderr ?? '');
+    const stdout = Buffer.isBuffer(error?.stdout)
+      ? error.stdout.toString('utf8')
+      : String(error?.stdout ?? '');
+    throw new Error(`${label} failed: ${`${stdout}\n${stderr}`.slice(-4_000)}`);
+  }
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}

--- a/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/run.mjs
+++ b/tests/relayflows/cases/1727-standalone-cloud-workflow-runtime/run.mjs
@@ -105,7 +105,7 @@ try {
   });
   const output = `${observed.stdout ?? ''}\n${observed.stderr ?? ''}`;
   const baseObserved =
-    observed.status !== 0 && /unknown command ['"]?__bundled-workflow|error: unknown command/i.test(output);
+    observed.status !== 0 && /unknown command(?:\s+|:\s*)['"]?__bundled-workflow\b/i.test(output);
   const headObserved =
     observed.status === 0 && output.includes('Dry Run: proof') && output.includes('Validation: PASS');
 


### PR DESCRIPTION
Fixes standalone Bun workflow execution across both local and Cloud paths.

- omit Bun virtual argv entrypoints when restarting Cloud workers
- use a bundled relayflows-core runner when Cloud archives omit node_modules
- persist actionable diagnostics when the required Node child cannot start
- serialize monitor startup before recording a run active, with collision-resistant metadata writes
- add focused unit coverage and a compiled dependency-free Cloud workflow smoke

## RelayFlow Proof
- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1727-standalone-cloud-workflow-runtime` <!-- relay-pr-proof:case -->

Exact-SHA local red/green proof:
- base `4306bb29be696ec84a4e3844f86fdc4a91584407` reproduced `standalone_cloud_archive_lacks_bundled_workflow_runtime`
- head `b445d0edd7f8bdeddfb1caa60852f3e85f5dc338` produced `standalone_cloud_archive_runs_bundled_workflow_runtime`
- both arms compiled a standalone Bun binary; the head ran `__bundled-workflow --dry-run` from a dependency-free archive with no credentials

Additional proof:
- 94 focused CLI tests passed
- CLI TypeScript build passed
- compiled Bun standalone smoke passed with an explicit Node 22 runtime
- dependency-free bundled Cloud workflow passed
- fresh independent Luna review: PASS, no blockers

Fresh review feedback on monitor serialization, diagnostic accuracy, and ambient test isolation was addressed in `b445d0edd7f8bdeddfb1caa60852f3e85f5dc338`.

No release or deployment is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Cloud worker execution, process spawning, and CLI entry routing; behavior changes are covered by focused tests and smoke/proof harnesses, but runtime edge cases outside the smoke workflow remain possible.
> 
> **Overview**
> Fixes **standalone Bun** workflow execution for local runs and Cloud worker assignments by routing child processes through a shared **workflow runtime** instead of always using `process.execPath`.
> 
> Compiled binaries now spawn a real **Node** child (via `AGENT_RELAY_NODE` or `node`) and resolve `@relayflows/cli` from the workflow project. When Cloud archives have no `node_modules`, the worker falls back to an internal **`__bundled-workflow`** entrypoint backed by **`@relayflows/core`**. Cloud worker **daemon restarts** no longer pass Bun’s virtual `argv[1]` path, which previously broke re-entry.
> 
> Local workflow runs **await detached monitor spawn/error** before marking a run active, use **collision-resistant** atomic metadata writes, and surface clearer errors when Node is missing. **CI** adds standalone workflow smoke; a **RelayFlow** proof case validates the bundled path with a tightened base signature for `__bundled-workflow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b445d0edd7f8bdeddfb1caa60852f3e85f5dc338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->