### PR TITLE
fix(broker): retry Relaycast workspace busy startup admission

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_q7a7m644yvsi/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_q7a7m644yvsi/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Retry transient Relaycast workspace_busy admission failures
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** September 10, 2026 at 12:33 AM
+> **Completed:** September 10, 2026 at 12:42 AM
+
+---
+
+## Summary
+
+Added bounded Relaycast workspace_busy startup/admission retry with diagnostics-preserving exhaustion tests, unrelated-429 terminal coverage, explicit fail-closed session boundary documentation, and a patch changelog entry.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Retry only the exact HTTP 429 workspace_busy admission code
+- **Chose:** Retry only the exact HTTP 429 workspace_busy admission code
+- **Reasoning:** Generic 429s may represent credential or quota policy and must remain terminal; RelayError 8.0.0 does not retain Retry-After, so the existing bounded 200ms/400ms startup backoff is the safest available fallback.
+
+### Keep complete startup handshake fail-closed after admission retry exhaustion
+- **Chose:** Keep complete startup handshake fail-closed after admission retry exhaustion
+- **Reasoning:** Replaying startup would repeat unkeyed workspace and agent registration POSTs and could create duplicate or orphaned identities.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Retry only the exact HTTP 429 workspace_busy admission code: Retry only the exact HTTP 429 workspace_busy admission code
+- Keep complete startup handshake fail-closed after admission retry exhaustion: Keep complete startup handshake fail-closed after admission retry exhaustion
+- The broker now retries exact workspace_busy admission failures at the request boundary, while preserving terminal behavior for unrelated 429s and complete-handshake replay safety. Focused, full broker library tests and clippy are green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_q7a7m644yvsi/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_q7a7m644yvsi/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_q7a7m644yvsi",
+  "version": 1,
+  "task": {
+    "title": "Retry transient Relaycast workspace_busy admission failures"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T22:33:18.944Z",
+  "completedAt": "2026-09-09T22:42:11.347Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T22:42:04.687Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_73p4he5ty41v",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T22:42:04.687Z",
+      "endedAt": "2026-09-09T22:42:11.347Z",
+      "events": [
+        {
+          "ts": 1788993724688,
+          "type": "decision",
+          "content": "Retry only the exact HTTP 429 workspace_busy admission code: Retry only the exact HTTP 429 workspace_busy admission code",
+          "raw": {
+            "question": "Retry only the exact HTTP 429 workspace_busy admission code",
+            "chosen": "Retry only the exact HTTP 429 workspace_busy admission code",
+            "alternatives": [],
+            "reasoning": "Generic 429s may represent credential or quota policy and must remain terminal; RelayError 8.0.0 does not retain Retry-After, so the existing bounded 200ms/400ms startup backoff is the safest available fallback."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788993726731,
+          "type": "decision",
+          "content": "Keep complete startup handshake fail-closed after admission retry exhaustion: Keep complete startup handshake fail-closed after admission retry exhaustion",
+          "raw": {
+            "question": "Keep complete startup handshake fail-closed after admission retry exhaustion",
+            "chosen": "Keep complete startup handshake fail-closed after admission retry exhaustion",
+            "alternatives": [],
+            "reasoning": "Replaying startup would repeat unkeyed workspace and agent registration POSTs and could create duplicate or orphaned identities."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788993728782,
+          "type": "reflection",
+          "content": "The broker now retries exact workspace_busy admission failures at the request boundary, while preserving terminal behavior for unrelated 429s and complete-handshake replay safety. Focused, full broker library tests and clippy are green.",
+          "raw": {
+            "confidence": 0.92
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.92"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added bounded Relaycast workspace_busy startup/admission retry with diagnostics-preserving exhaustion tests, unrelated-429 terminal coverage, explicit fail-closed session boundary documentation, and a patch changelog entry.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "4306bb29be696ec84a4e3844f86fdc4a91584407",
+    "endRef": "4306bb29be696ec84a4e3844f86fdc4a91584407"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_zylcy1hl0sus/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_zylcy1hl0sus/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Add RelayFlow proof for workspace_busy startup admission
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** September 10, 2026 at 12:57 AM
+> **Completed:** September 10, 2026 at 12:57 AM
+
+---
+
+## Summary
+
+Added workspace-busy-startup-retry-429 RelayFlow proof covering baseline failure, head retry success, unrelated 429 terminal behavior, bounded exhaustion, and no whole-handshake replay.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server
+- **Chose:** Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server
+- **Reasoning:** This gives deterministic base/head evidence for exact 429 workspace_busy behavior while checking unrelated 429 terminal handling and bounded request-scoped exhaustion without replaying registration.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server: Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server
+- The cleanroom proof distinguishes the pre-fix terminal 429 from the retrying head and confirms unrelated throttles remain terminal; both compiled binaries passed their intended arm.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_zylcy1hl0sus/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_zylcy1hl0sus/trajectory.json
@@ -1,0 +1,73 @@
+{
+  "id": "traj_zylcy1hl0sus",
+  "version": 1,
+  "task": {
+    "title": "Add RelayFlow proof for workspace_busy startup admission"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T22:57:20.071Z",
+  "completedAt": "2026-09-09T22:57:35.297Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T22:57:31.069Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_rsah9jnq4u84",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T22:57:31.069Z",
+      "endedAt": "2026-09-09T22:57:35.297Z",
+      "events": [
+        {
+          "ts": 1788994651070,
+          "type": "decision",
+          "content": "Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server: Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server",
+          "raw": {
+            "question": "Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server",
+            "chosen": "Used a dedicated real-broker RelayFlow case with an ephemeral HTTP admission server",
+            "alternatives": [],
+            "reasoning": "This gives deterministic base/head evidence for exact 429 workspace_busy behavior while checking unrelated 429 terminal handling and bounded request-scoped exhaustion without replaying registration."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788994653138,
+          "type": "reflection",
+          "content": "The cleanroom proof distinguishes the pre-fix terminal 429 from the retrying head and confirms unrelated throttles remain terminal; both compiled binaries passed their intended arm.",
+          "raw": {
+            "focalPoints": [
+              "base-head proof",
+              "request bounds",
+              "diagnostics"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:base-head proof",
+            "focal:request bounds",
+            "focal:diagnostics",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added workspace-busy-startup-retry-429 RelayFlow proof covering baseline failure, head retry success, unrelated 429 terminal behavior, bounded exhaustion, and no whole-handshake replay.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "8f1f4059716d1a9aad91eaa18f33c4dceadd454a",
+    "endRef": "8f1f4059716d1a9aad91eaa18f33c4dceadd454a"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `agent-relay node up` now retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal.
 
 ## [11.10.4] - 2026-09-08
 

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -901,6 +901,20 @@ fn is_rate_limited(err: &anyhow::Error) -> bool {
     auth_http_status(err).is_some_and(|status| status == StatusCode::TOO_MANY_REQUESTS)
 }
 
+/// `connect_relay` uses this to keep an exhausted workspace admission retry
+/// distinct from a handshake timeout. The complete startup operation must not
+/// be replayed after admission has exhausted its own bounded request retries:
+/// it contains unkeyed workspace and agent-registration POSTs.
+pub(crate) fn is_workspace_busy_anyhow(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<AuthHttpError>().is_some_and(|error| {
+        error.status == StatusCode::TOO_MANY_REQUESTS
+            && error
+                .code
+                .as_deref()
+                .is_some_and(|code| code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE))
+    })
+}
+
 fn auth_http_status(err: &anyhow::Error) -> Option<StatusCode> {
     err.downcast_ref::<AuthHttpError>()
         .map(|e| e.status)
@@ -932,11 +946,19 @@ const RELAYCAST_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// a single upstream 503 exits the broker process with code 1. Publish run
 /// 34099838274 lost three jobs to exactly that.
 const TRANSIENT_STARTUP_RETRY_BACKOFFS_MS: [u64; 2] = [200, 400];
+/// Relaycast returns this admission code while a workspace is being
+/// provisioned or resumed by another request. Unlike a generic 429, this is
+/// a bounded, server-side busy signal and is safe to replay for startup.
+/// `RelayError` does not retain the response's `Retry-After` header, so the
+/// broker uses the bounded backoff above when the SDK cannot expose it.
+const WORKSPACE_BUSY_CODE: &str = "workspace_busy";
 
-/// The server-side statuses worth replaying: 500, 502, 503, 504. A 501 is a
+/// The server-side failures worth replaying: 500, 502, 503, 504, plus the
+/// narrowly-scoped 429 `workspace_busy` admission response. A 501 is a
 /// contract mismatch rather than a transient and is deliberately excluded, as
-/// are transport errors — a timed-out `POST /v1/agents` may already have
-/// created the agent, and re-sending it is the AR-448 duplicate shape.
+/// are unrelated 429s and transport errors — a timed-out `POST /v1/agents` may
+/// already have created the agent, and re-sending it is the AR-448 duplicate
+/// shape.
 fn is_transient_server_error(error: &RelayError) -> bool {
     matches!(
         error,
@@ -944,6 +966,17 @@ fn is_transient_server_error(error: &RelayError) -> bool {
             status: 500 | 502 | 503 | 504,
             ..
         }
+    ) || is_workspace_busy_error(error)
+}
+
+fn is_workspace_busy_error(error: &RelayError) -> bool {
+    matches!(
+        error,
+        RelayError::Api {
+            code,
+            status: 429,
+            ..
+        } if code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE)
     )
 }
 
@@ -1535,10 +1568,10 @@ mod tests {
 
     use super::{
         hash_identity_key, is_agent_token_invalid, is_agent_token_invalid_anyhow,
-        is_agent_token_invalid_code, reclaim_legacy_identity, relay_error_to_anyhow,
-        relay_request_with_timeout, resolve_relaycast_base_url, retry_transient_relay_error,
-        stable_node_identity_key, AuthClient, AuthHttpError, CredentialCache,
-        AGENT_TOKEN_INVALID_CODE, DEFAULT_RELAYCAST_BASE_URL,
+        is_agent_token_invalid_code, is_workspace_busy_error, reclaim_legacy_identity,
+        relay_error_to_anyhow, relay_request_with_timeout, resolve_relaycast_base_url,
+        retry_transient_relay_error, stable_node_identity_key, AuthClient, AuthHttpError,
+        CredentialCache, AGENT_TOKEN_INVALID_CODE, DEFAULT_RELAYCAST_BASE_URL,
     };
     use relaycast::RelayError;
 
@@ -2074,6 +2107,88 @@ mod tests {
             }
             other => panic!("expected a terminal API error, got {other}"),
         }
+    }
+
+    #[tokio::test]
+    async fn workspace_busy_is_retried_until_admission_clears() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let result = retry_transient_relay_error("admitting a workspace", || {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if attempt == 0 {
+                    return Err::<_, _>(RelayError::api(
+                        "workspace_busy",
+                        "workspace admission is busy",
+                        429,
+                    ));
+                }
+                Ok::<_, RelayError>("admitted")
+            }
+        })
+        .await
+        .expect("workspace_busy should be replayed once");
+
+        assert_eq!(result, "admitted");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn workspace_busy_retry_budget_is_bounded_and_preserves_diagnostics() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let error = retry_transient_relay_error::<(), _, _>("admitting a workspace", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err(RelayError::api(
+                    "workspace_busy",
+                    "workspace admission is busy",
+                    429,
+                ))
+            }
+        })
+        .await
+        .expect_err("a persistent workspace_busy must eventually be terminal");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        match error {
+            RelayError::Api {
+                code,
+                status,
+                attempts,
+                ..
+            } => {
+                assert_eq!(code, "workspace_busy");
+                assert_eq!(status, 429);
+                assert_eq!(attempts, 3);
+            }
+            other => panic!("expected a terminal API error, got {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unrelated_rate_limit_is_terminal_without_replay() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let error = retry_transient_relay_error("admitting a workspace", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<(), _>(RelayError::api(
+                    "registration_rate_limited",
+                    "registration rate limit exceeded",
+                    429,
+                ))
+            }
+        })
+        .await
+        .expect_err("an unrelated 429 must not be replayed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!is_workspace_busy_error(&error));
+        assert!(matches!(error, RelayError::Api { status: 429, .. }));
     }
 
     /// The retry budget is bounded, and the terminal error still carries the

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -370,6 +370,7 @@ impl AuthClient {
             let preferred_name = requested_name;
             let mut memberships = Vec::with_capacity(sources.len());
             let mut auth_rejections = Vec::new();
+            let mut workspace_busy_rejection: Option<anyhow::Error> = None;
 
             for source in sources {
                 let Some(api_key) = normalize_workspace_key(&source.api_key) else {
@@ -394,6 +395,14 @@ impl AuthClient {
                         session.credentials.workspace_alias = source.workspace_alias.clone();
                         memberships.push(session);
                     }
+                    Err(error) if is_workspace_busy_anyhow(&error) => {
+                        // Keep the typed terminal admission error available if
+                        // every configured membership fails. A generic
+                        // rate-limit summary would erase the server code,
+                        // request id, and cumulative attempts that connect_relay
+                        // needs to report accurately.
+                        workspace_busy_rejection.get_or_insert(error);
+                    }
                     Err(error) if is_auth_rejection(&error) => {
                         auth_rejections
                             .push(source.workspace_id.unwrap_or_else(|| "env".to_string()));
@@ -413,6 +422,11 @@ impl AuthClient {
             }
 
             if memberships.is_empty() {
+                if let Some(error) = workspace_busy_rejection {
+                    return Err(error).context(
+                        "all configured multi-workspace memberships were rejected; workspace admission remained busy",
+                    );
+                }
                 anyhow::bail!(
                     "all configured multi-workspace memberships were rejected ({})",
                     auth_rejections.join(", ")
@@ -581,6 +595,16 @@ impl AuthClient {
                         default_workspace_id: Some(session.credentials.workspace_id.clone()),
                         memberships: vec![session],
                     });
+                }
+                Err(error) if is_workspace_busy_anyhow(&error) => {
+                    // RELAY_API_KEY is a join hint, not permission to mint a
+                    // replacement workspace. Preserve the exhausted typed
+                    // admission response instead of falling through to fresh
+                    // workspace creation.
+                    return Err(error).context(format!(
+                        "failed registering agent with {} workspace key; workspace admission remained busy",
+                        candidate.source
+                    ));
                 }
                 Err(error) if is_auth_rejection(&error) => {
                     if candidate.explicit_join {
@@ -2266,6 +2290,103 @@ mod tests {
         // SAFETY: test-only, serialized by RELAY_ENV_MUTEX via clear_relay_env.
         unsafe {
             std::env::remove_var("AGENT_RELAY_WORKSPACE_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn exhausted_workspace_busy_does_not_mint_replacement_workspace() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("RELAY_API_KEY", "rk_live_busy");
+        }
+        let register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_busy");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("x-request-id", "workspace-busy-374")
+                .body(
+                    r#"{"ok":false,"error":{"code":"workspace_busy","message":"Workspace write capacity is busy"}}"#,
+                );
+        });
+        let workspace = server.mock(|when, then| {
+            when.method(POST).path("/v1/workspaces");
+            then.status(500);
+        });
+
+        let error = AuthClient::new(Some(server.base_url()))
+            .startup_session(Some("lead"))
+            .await
+            .expect_err("exhausted workspace_busy must remain terminal");
+        let message = format!("{error:#}");
+        for marker in [
+            "workspace_busy",
+            "429 Too Many Requests",
+            "Workspace write capacity is busy",
+            "request_id: workspace-busy-374",
+            "attempts: 3",
+        ] {
+            assert!(message.contains(marker), "missing {marker}: {message}");
+        }
+        register.assert_hits(3);
+        workspace.assert_hits(0);
+
+        unsafe {
+            std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_workspace_selection_preserves_workspace_busy_diagnostics() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var(
+                "RELAY_WORKSPACES_JSON",
+                r#"[{"workspace_id":"ws_busy","api_key":"rk_live_busy"},{"workspace_id":"ws_auth","api_key":"rk_live_auth"}]"#,
+            );
+        }
+        let busy_register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_busy");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("x-request-id", "multi-workspace-busy-374")
+                .body(
+                    r#"{"ok":false,"error":{"code":"workspace_busy","message":"Workspace write capacity is busy"}}"#,
+                );
+        });
+        let auth_register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_auth");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"unauthorized","message":"unauthorized"}}"#);
+        });
+
+        let error = AuthClient::new(Some(server.base_url()))
+            .startup_session_set(Some("lead"))
+            .await
+            .expect_err("a busy membership must remain diagnosable when all fail");
+        let message = format!("{error:#}");
+        for marker in [
+            "workspace_busy",
+            "429 Too Many Requests",
+            "Workspace write capacity is busy",
+            "request_id: multi-workspace-busy-374",
+            "attempts: 3",
+        ] {
+            assert!(message.contains(marker), "missing {marker}: {message}");
+        }
+        busy_register.assert_hits(3);
+        auth_register.assert_hits(1);
+
+        unsafe {
+            std::env::remove_var("RELAY_WORKSPACES_JSON");
         }
     }
 

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -9,8 +9,8 @@ pub(crate) use crate::snippets::{
     configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token,
 };
 pub(crate) use auth::{
-    agent_identity_key, identity_key_fingerprint, reclaim_legacy_identity,
-    stable_node_identity_key, AuthClient,
+    agent_identity_key, identity_key_fingerprint, is_workspace_busy_anyhow,
+    reclaim_legacy_identity, stable_node_identity_key, AuthClient,
 };
 // `is_agent_token_invalid`, `is_agent_token_invalid_anyhow`,
 // `is_agent_token_invalid_code`, and `AGENT_TOKEN_INVALID_CODE` are declared

--- a/crates/broker/src/runtime/session.rs
+++ b/crates/broker/src/runtime/session.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::relaycast::is_workspace_busy_anyhow;
 
 /// Shared Relaycast connection state used by run_init and run_wrap.
 #[derive(Clone)]
@@ -313,14 +314,18 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
     // timeout: a returned error is a definite server response, and replaying
     // `startup_session_set_with_options` would re-run workspace creation and
     // agent registration from scratch — risking duplicate Relaycast resources —
-    // so returned errors surface immediately (preserving the pre-retry
-    // behavior). The residual for a timeout retry is narrow (the backend both
-    // completed the request AND failed to answer within the deadline); the
-    // per-attempt deadline is scaled by the configured workspace count so a
-    // healthy multi-workspace startup, which registers each membership serially,
-    // is not cut off mid-flight. The final attempt is shortened to whatever
-    // remains of HANDSHAKE_TOTAL_TIMEOUT so membership scaling and environment
-    // overrides cannot move exhaustion past the SDK startup deadline.
+    // so returned errors surface immediately. AuthClient retries only the
+    // narrowly safe 429 `workspace_busy` admission response (and transient
+    // 5xx responses) at the individual request boundary. If that bounded
+    // admission retry is exhausted, this loop deliberately does not replay the
+    // complete startup operation. The residual for a timeout retry is narrow
+    // (the backend both completed the request AND failed to answer within the
+    // deadline); the per-attempt deadline is scaled by the configured workspace
+    // count so a healthy multi-workspace startup, which registers each
+    // membership serially, is not cut off mid-flight. The final attempt is
+    // shortened to whatever remains of HANDSHAKE_TOTAL_TIMEOUT so membership
+    // scaling and environment overrides cannot move exhaustion past the SDK
+    // startup deadline.
     let membership_count = configured_membership_count();
     let attempt_timeout = handshake_attempt_timeout().saturating_mul(membership_count);
     let max_attempts = handshake_max_attempts();
@@ -362,7 +367,20 @@ pub(crate) async fn connect_relay(opts: RelaySessionOptions<'_>) -> Result<Relay
             {
                 // Success, or a definite failure from the backend: return
                 // immediately in both cases (never replay a returned error).
+                // AuthClient has already exhausted its safe, request-scoped
+                // workspace_busy retries; replaying the whole handshake here
+                // would repeat unkeyed POSTs. Keep this explicit in the
+                // startup boundary so future handshake retry changes cannot
+                // accidentally widen that admission retry.
                 Ok(result) => {
+                    if let Err(error) = &result {
+                        if is_workspace_busy_anyhow(error) {
+                            tracing::error!(
+                                error = %error,
+                                "workspace admission remained busy after bounded startup retries; refusing to replay the complete handshake"
+                            );
+                        }
+                    }
                     break result.context("failed to initialize relaycast session")?;
                 }
                 Err(_elapsed) => {

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/case.json
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "workspace-busy-startup-retry-429",
+  "kind": "bugfix",
+  "title": "Retry only Relaycast workspace_busy startup admission responses",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "startup_429_workspace_busy_not_retried"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "startup_429_workspace_busy_retried_safely"
+    }
+  }
+}

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
@@ -110,15 +110,20 @@ try {
   const baseObserved =
     arm === 'base' &&
     success.registrationCount === 1 &&
+    !success.timedOut &&
     !success.stderr.includes(HANDSHAKE_MARKER) &&
     success.stderr.includes('status: 429') &&
     success.stderr.includes(BUSY_CODE) &&
     success.stderr.includes('attempts: 1') &&
     unrelated.registrationCount === 1 &&
+    !unrelated.timedOut &&
     !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
     unrelated.stderr.includes(UNRELATED_CODE) &&
     exhaustion.registrationCount === 1 &&
+    !exhaustion.timedOut &&
     !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    exhaustion.stderr.includes('status: 429') &&
+    exhaustion.stderr.includes('workspace admission is busy') &&
     exhaustion.stderr.includes('attempts: 1');
   const headObserved =
     arm === 'head' &&
@@ -126,11 +131,15 @@ try {
     success.stderr.includes(HANDSHAKE_MARKER) &&
     !success.timedOut &&
     unrelated.registrationCount === 1 &&
+    !unrelated.timedOut &&
     !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
     unrelated.stderr.includes(UNRELATED_CODE) &&
     exhaustion.registrationCount === 3 &&
+    !exhaustion.timedOut &&
     !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
     exhaustion.stderr.includes(BUSY_CODE) &&
+    exhaustion.stderr.includes('status: 429') &&
+    exhaustion.stderr.includes('workspace admission is busy') &&
     exhaustion.stderr.includes('attempts: 3');
   let outcome;
   let signature;

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
@@ -1,0 +1,317 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = 'workspace-busy-startup-retry-429';
+const INSTANCE_NAME = 'relayflow-workspace-busy-429';
+const HANDSHAKE_MARKER = 'connect_relay completed';
+const BUSY_CODE = 'workspace_busy';
+const UNRELATED_CODE = 'registration_rate_limited';
+const REQUEST_ID = 'relayflow-workspace-busy-429-request';
+const STARTUP_WINDOW_MS = 60_000;
+
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+if (!isWithin(harnessDir, fileURLToPath(import.meta.url))) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-workspace-busy-429-'));
+const serverPath = path.join(probeDir, 'relaycast-admission-probe.mjs');
+const serverSource = String.raw`import http from 'node:http';
+const mode = process.argv[2];
+let registrationCount = 0;
+const server = http.createServer((request, response) => {
+  if (request.method === 'GET' && request.url === '/observations') {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ registrationCount }));
+    return;
+  }
+  if (request.method !== 'POST' || request.url !== '/v1/agents') {
+    response.writeHead(404, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: false, error: { code: 'not_found', message: 'no route' } }));
+    return;
+  }
+  registrationCount += 1;
+  const attempt = registrationCount;
+  request.resume();
+  request.once('end', () => {
+    const workspaceBusy = mode === 'busy-success' || mode === 'busy-exhaustion';
+    const shouldReject =
+      mode === 'unrelated-429' ||
+      (workspaceBusy && (mode === 'busy-exhaustion' || attempt === 1));
+    if (shouldReject) {
+      const code = mode === 'unrelated-429' ? '${UNRELATED_CODE}' : '${BUSY_CODE}';
+      response.writeHead(429, {
+        'content-type': 'application/json',
+        'retry-after': '0',
+        'x-request-id': '${REQUEST_ID}',
+      });
+      response.end(JSON.stringify({
+        ok: false,
+        error: {
+          code,
+          message: code === '${BUSY_CODE}' ? 'workspace admission is busy' : 'registration rate limit exceeded',
+        },
+      }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      ok: true,
+      data: {
+        id: 'a_relayflow_workspace_busy_429',
+        workspace_id: 'ws_relayflow_workspace_busy_429',
+        name: '${INSTANCE_NAME}',
+        token: 'at_live_relayflow_workspace_busy_429',
+        status: 'online',
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    }));
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a TCP address.');
+  process.stdout.write(JSON.stringify({ port: address.port }) + '\n');
+});
+process.once('SIGTERM', () => server.close(() => process.exit(0)));
+`;
+
+const observations = {};
+try {
+  await writeFile(serverPath, serverSource, { encoding: 'utf8', mode: 0o600 });
+  for (const mode of ['busy-success', 'unrelated-429', 'busy-exhaustion']) {
+    observations[mode] = await runScenario(mode);
+  }
+  const success = observations['busy-success'];
+  const unrelated = observations['unrelated-429'];
+  const exhaustion = observations['busy-exhaustion'];
+  const baseObserved =
+    arm === 'base' &&
+    success.registrationCount === 1 &&
+    !success.stderr.includes(HANDSHAKE_MARKER) &&
+    success.stderr.includes('status: 429') &&
+    success.stderr.includes(BUSY_CODE) &&
+    success.stderr.includes('attempts: 1') &&
+    unrelated.registrationCount === 1 &&
+    !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
+    unrelated.stderr.includes(UNRELATED_CODE) &&
+    exhaustion.registrationCount === 1 &&
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    exhaustion.stderr.includes('attempts: 1');
+  const headObserved =
+    arm === 'head' &&
+    success.registrationCount === 2 &&
+    success.stderr.includes(HANDSHAKE_MARKER) &&
+    !success.timedOut &&
+    unrelated.registrationCount === 1 &&
+    !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
+    unrelated.stderr.includes(UNRELATED_CODE) &&
+    exhaustion.registrationCount === 3 &&
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    exhaustion.stderr.includes(BUSY_CODE) &&
+    exhaustion.stderr.includes('attempts: 3');
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'startup_429_workspace_busy_not_retried';
+    details =
+      'The base broker treated the exact 429 workspace_busy admission response as terminal; unrelated 429s were terminal and no startup replay occurred.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'startup_429_workspace_busy_retried_safely';
+    details =
+      'The head broker retried workspace_busy once to complete startup, kept an unrelated 429 terminal, and exhausted workspace_busy at three request attempts without replaying the complete handshake.';
+  } else {
+    throw new Error(
+      `Unexpected workspace admission observations: ${JSON.stringify(summarize(observations))}`
+    );
+  }
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+} finally {
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+async function runScenario(mode) {
+  const server = spawn(process.execPath, [serverPath, mode], {
+    cwd: probeDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  try {
+    const { port, stderr: serverStderr } = await waitForServerReady(server);
+    const observed = await runBrokerStartup({
+      binaryPath,
+      cwd: probeDir,
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        HOME: probeDir,
+        TMPDIR: probeDir,
+        NO_COLOR: '1',
+        RELAYCAST_BASE_URL: `http://127.0.0.1:${port}`,
+        AGENT_RELAY_WORKSPACE_KEY: 'rk_relayflow_workspace_busy_429',
+        AGENT_RELAY_STARTUP_DEBUG: '1',
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+      },
+    });
+    const { registrationCount } = await readObservations(port);
+    return { ...observed, registrationCount, serverStderr };
+  } finally {
+    if (server.exitCode === null) {
+      server.kill('SIGTERM');
+      await Promise.race([
+        new Promise((resolve) => server.once('exit', resolve)),
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+      ]);
+      if (server.exitCode === null) server.kill('SIGKILL');
+    }
+  }
+}
+
+function runBrokerStartup({ binaryPath, cwd, env }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binaryPath, ['init', '--instance-name', INSTANCE_NAME, '--channels', 'general'], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      resolve({ ...result, stdout, stderr });
+    };
+    const timer = setTimeout(() => finish({ status: null, signal: null, timedOut: true }), STARTUP_WINDOW_MS);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.includes(HANDSHAKE_MARKER)) finish({ timedOut: false });
+    });
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`compiled broker probe could not start: ${error.message}`));
+    });
+    child.once('exit', (status, signal) => finish({ status, signal, timedOut: false }));
+  });
+}
+
+async function waitForServerReady(server) {
+  let stdout = '';
+  let stderr = '';
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Relaycast probe did not start: ${stderr || stdout || 'timeout'}`)),
+      10_000
+    );
+    server.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      const line = stdout.split('\n').find(Boolean);
+      if (!line) return;
+      try {
+        const parsed = JSON.parse(line);
+        clearTimeout(timer);
+        resolve({ ...parsed, stderr });
+      } catch {
+        // Wait for a complete JSON line.
+      }
+    });
+    server.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    server.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    server.once('exit', (code, signal) => {
+      if (code !== null || signal !== null) {
+        clearTimeout(timer);
+        reject(new Error(`Relaycast probe exited before ready: ${code ?? signal}`));
+      }
+    });
+  });
+}
+
+async function readObservations(port) {
+  const response = await fetch(`http://127.0.0.1:${port}/observations`);
+  if (!response.ok) throw new Error(`Observation endpoint returned HTTP ${response.status}.`);
+  const value = await response.json();
+  if (!Number.isInteger(value.registrationCount)) {
+    throw new Error('Observation endpoint returned an invalid registration count.');
+  }
+  return value;
+}
+
+function summarize(values) {
+  return Object.fromEntries(
+    Object.entries(values).map(([name, value]) => [
+      name,
+      {
+        registrationCount: value.registrationCount,
+        timedOut: value.timedOut,
+        status: value.status,
+        stdout: value.stdout.slice(-1_000),
+        stderr: value.stderr.slice(-2_000),
+      },
+    ])
+  );
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+async function requiredExecutable(name) {
+  const candidate = path.resolve(requiredValue(name));
+  try {
+    await access(candidate, fsConstants.R_OK | fsConstants.X_OK);
+  } catch {
+    throw new Error(`${name} must name a readable executable file.`);
+  }
+  return candidate;
+}
+function isWithin(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}


### PR DESCRIPTION
## Summary

Retry the narrowly transient Relaycast HTTP 429 `workspace_busy` response during broker startup/admission.

Only the exact `workspace_busy` code is retried. Unrelated 429 responses remain terminal. Exhaustion preserves Relaycast diagnostics, and the complete startup handshake remains fail-closed so unkeyed workspace or agent-registration POSTs are not replayed.

Fixes #1728. Related to #1715; this PR does not close #1715 because that issue covers worker `/api/spawn` preregistration and HTTP 503 `database_overloaded`.

## Test plan

- [x] Exact workspace-busy retry succeeds after one transient response
- [x] Persistent workspace-busy exhausts at three request attempts
- [x] Unrelated 429 remains terminal after one attempt
- [x] Complete startup handshake is not replayed
- [x] Full broker library: 1,063 passed, 4 ignored
- [x] Clippy with warnings denied
- [x] Rust formatting and diff checks
- [x] Exact RelayFlow base/head case and proof-contract suite

## RelayFlow proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `workspace-busy-startup-retry-429` <!-- relay-pr-proof:case -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

