### PR TITLE
fix(broker): retry overloaded worker preregistration safely

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd.trace.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.0.0",
+  "id": "2f7178f0-a2ba-4c9a-ad4a-7102fb547dbe",
+  "timestamp": "2026-09-10T18:07:12.764Z",
+  "trajectory": "traj_shd42liwvlpd",
+  "files": [
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 9,
+              "end_line": 15,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "crates/broker/src/cli_mcp_args.rs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 4,
+              "end_line": 11,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            },
+            {
+              "start_line": 172,
+              "end_line": 186,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            },
+            {
+              "start_line": 632,
+              "end_line": 638,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            },
+            {
+              "start_line": 670,
+              "end_line": 682,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/relayflows/cases/1715-spawn-overload/run.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 140,
+              "end_line": 159,
+              "revision": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd/summary.md
@@ -1,0 +1,40 @@
+# Trajectory: Finish Relay PR #1730 overload retries and mcp-args proof
+
+> **Status:** ✅ Completed
+> **Task:** relay-1730-1715
+> **Confidence:** 90%
+> **Started:** September 10, 2026 at 08:01 PM
+> **Completed:** September 10, 2026 at 08:07 PM
+
+---
+
+## Summary
+
+Extended the broker-owned bounded Relaycast registration retry path to cli mcp-args --register, corrected the base proof marker contract, updated the changelog, and validated full broker tests plus exact base-red/head-green proof at bde1d4257d7a95484f4e3bcb86f0e3eb95124022.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Extended the broker-owned bounded registration retry helper into mcp-args --register
+- **Chose:** Extended the broker-owned bounded registration retry helper into mcp-args --register
+- **Reasoning:** The fresh Cloud proof showed the outer RelayFlow executor retried three times while each inner mcp-args registration reported attempts:1; the existing helper already owns typed 503 classification, bounded backoff, diagnostics, and takeover-safe registration.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Extended the broker-owned bounded registration retry helper into mcp-args --register: Extended the broker-owned bounded registration retry helper into mcp-args --register
+- Broker spawn is green at head and red at base; Cloud mcp-args was a separate uncovered call site and now shares the same bounded retry path. Full broker tests pass.
+
+---
+
+## Artifacts
+
+**Commits:** bde1d4257
+**Files changed:** 3

--- a/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_shd42liwvlpd/trajectory.json
@@ -1,0 +1,76 @@
+{
+  "id": "traj_shd42liwvlpd",
+  "version": 1,
+  "task": {
+    "title": "Finish Relay PR #1730 overload retries and mcp-args proof",
+    "source": {
+      "system": "plain",
+      "id": "relay-1730-1715"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T18:01:46.070Z",
+  "completedAt": "2026-09-10T18:07:12.675Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T18:05:54.505Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_j655wk1uhsl5",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T18:05:54.505Z",
+      "endedAt": "2026-09-10T18:07:12.675Z",
+      "events": [
+        {
+          "ts": 1789063554506,
+          "type": "decision",
+          "content": "Extended the broker-owned bounded registration retry helper into mcp-args --register: Extended the broker-owned bounded registration retry helper into mcp-args --register",
+          "raw": {
+            "question": "Extended the broker-owned bounded registration retry helper into mcp-args --register",
+            "chosen": "Extended the broker-owned bounded registration retry helper into mcp-args --register",
+            "alternatives": [],
+            "reasoning": "The fresh Cloud proof showed the outer RelayFlow executor retried three times while each inner mcp-args registration reported attempts:1; the existing helper already owns typed 503 classification, bounded backoff, diagnostics, and takeover-safe registration."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789063556526,
+          "type": "reflection",
+          "content": "Broker spawn is green at head and red at base; Cloud mcp-args was a separate uncovered call site and now shares the same bounded retry path. Full broker tests pass.",
+          "raw": {
+            "confidence": 0.88
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.88"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Extended the broker-owned bounded Relaycast registration retry path to cli mcp-args --register, corrected the base proof marker contract, updated the changelog, and validated full broker tests plus exact base-red/head-green proof at bde1d4257d7a95484f4e3bcb86f0e3eb95124022.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "bde1d4257"
+  ],
+  "filesChanged": [
+    "CHANGELOG.md",
+    "crates/broker/src/cli_mcp_args.rs",
+    "tests/relayflows/cases/1715-spawn-overload/run.mjs"
+  ],
+  "projectId": "AgentWorkforce/relay",
+  "tags": [],
+  "_trace": {
+    "startRef": "be109f9f94e641d35a842024418440b8b0a7ae3d",
+    "endRef": "bde1d4257d7a95484f4e3bcb86f0e3eb95124022",
+    "traceId": "2f7178f0-a2ba-4c9a-ad4a-7102fb547dbe"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Broker worker spawns now retry transient Relaycast registration overloads and only fall back to local headless task-exit workers when Relaycast messaging is explicitly disabled.
 
 ## [11.10.4] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Broker worker spawns now retry transient Relaycast registration overloads and only fall back to local headless task-exit workers when Relaycast messaging is explicitly disabled.
+- Broker worker spawns and `mcp-args --register` now retry transient Relaycast registration overloads; spawns only fall back to local headless task-exit workers when Relaycast messaging is explicitly disabled.
 
 ## [11.10.4] - 2026-09-08
 

--- a/crates/broker/src/cli_mcp_args.rs
+++ b/crates/broker/src/cli_mcp_args.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use crate::relaycast::{
-    configure_agent_relay_mcp_with_token, RelaycastHttpClient, RelaycastRegistrationError,
+    configure_agent_relay_mcp_with_token, retry_agent_registration, RegRetryOutcome,
+    RelaycastHttpClient, RelaycastRegistrationError,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -171,12 +172,15 @@ async fn register_agent_token_for_mcp_args_with_timeout(
 
     let agent_token = match tokio::time::timeout(
         timeout,
-        client.register_agent_token(agent_name, Some(&cli_lower)),
+        retry_agent_registration(&client, agent_name, Some(&cli_lower)),
     )
     .await
     {
         Ok(Ok(token)) => token,
-        Ok(Err(error)) => return Err(map_register_agent_token_error(error)),
+        Ok(Err(RegRetryOutcome::RetryableExhausted(error)))
+        | Ok(Err(RegRetryOutcome::Fatal(error))) => {
+            return Err(map_register_agent_token_error(error));
+        }
         Err(error) => bail!("register timed out after {timeout:?}: {error}"),
     };
 
@@ -628,7 +632,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_surfaces_terminal_sdk_diagnostics_without_replaying_an_unsafe_post() {
+    async fn register_retries_transient_overload_before_surface_terminal_diagnostics() {
         let _env = EnvGuard::all();
         std::env::remove_var("RELAY_API_KEY");
         std::env::remove_var("RELAY_BASE_URL");
@@ -666,14 +670,13 @@ mod tests {
             "registration_backend_overloaded",
             "deterministic registration failure",
             "request_id: mcp-args-374",
-            "attempts: 1",
+            "attempts: 3",
         ] {
             assert!(message.contains(marker), "missing {marker}: {message}");
         }
-        // Registration is an unkeyed POST. Retrying an ambiguous 503 could
-        // duplicate a committed agent registration, so the SDK must not replay
-        // it even when the server advertised Retry-After.
-        register_mock.assert_hits(1);
+        // The broker-owned retry budget handles the typed transient overload;
+        // the terminal diagnostic must report the total broker attempts.
+        register_mock.assert_hits(3);
     }
 
     #[tokio::test]

--- a/crates/broker/src/listen_api.rs
+++ b/crates/broker/src/listen_api.rs
@@ -434,7 +434,7 @@ fn configured_broker_api_key() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-fn listen_api_router_with_auth(
+pub(crate) fn listen_api_router_with_auth(
     config: ListenApiConfig,
     broker_api_key: Option<String>,
 ) -> axum::Router {

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -1515,8 +1515,9 @@ fn registration_attempt_count(error: &RelaycastRegistrationError) -> u32 {
 /// errors. The delay is deliberately bounded: the SDK does not expose the
 /// `Retry-After` header on 503 errors, so use the documented short retry
 /// budget rather than sleeping on an untrusted/unbounded server value. For
-/// SDK errors that do carry a retry-after duration (429 cooldowns), honor it
-/// up to the same five-second per-sleep cap.
+/// SDK errors that do carry a retry-after duration are capped at one second;
+/// 429 cooldowns are returned immediately because the SDK blocks the name
+/// locally and another attempt cannot issue a POST until that cooldown ends.
 pub async fn retry_agent_registration(
     http: &RelaycastHttpClient,
     name: &str,

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -1522,14 +1522,13 @@ pub async fn retry_agent_registration(
     name: &str,
     cli: Option<&str>,
 ) -> Result<String, RegRetryOutcome> {
-    let registration = http.registration.as_ref().as_ref().ok_or_else(|| {
-        RegRetryOutcome::Fatal(RelaycastRegistrationError::Transport {
-            agent_name: name.to_string(),
-            detail: "SDK relay client not initialized".to_string(),
-        })
-    })?;
     const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_millis(200), Duration::from_millis(400)];
-    const MAX_RETRY_AFTER: u64 = 5;
+    // This loop runs inside the serialized broker runtime actor. Keep any
+    // server-advertised cooldown on the same short scale as the fixed
+    // backoffs; the SDK also blocks the name locally after a 429, so sleeping
+    // for the full cooldown here would stall unrelated broker work and still
+    // produce no further POST.
+    const MAX_RETRY_AFTER: Duration = Duration::from_secs(1);
 
     let mut total_attempts: u32 = 0;
     for retry_delay in RETRY_BACKOFFS
@@ -1538,7 +1537,7 @@ pub async fn retry_agent_registration(
         .map(Some)
         .chain(std::iter::once(None))
     {
-        match registration.register_agent_token(name, cli).await {
+        match http.register_agent_token(name, cli).await {
             Ok(token) => return Ok(token),
             Err(error) => {
                 total_attempts = total_attempts.saturating_add(registration_attempt_count(&error));
@@ -1546,8 +1545,16 @@ pub async fn retry_agent_registration(
                     || is_transient_registration_api_error(&error);
                 if retryable {
                     if let Some(delay) = retry_delay {
+                        // A 429 installs an SDK-side cooldown. Do not issue
+                        // futile retries that only return `Blocked` while
+                        // consuming the bounded attempt budget.
+                        if http.registration_block_remaining(name).is_some() {
+                            return Err(RegRetryOutcome::RetryableExhausted(
+                                with_registration_attempts(error, total_attempts),
+                            ));
+                        }
                         let delay = registration_retry_after_secs(&error)
-                            .map(|seconds| Duration::from_secs(seconds.min(MAX_RETRY_AFTER)))
+                            .map(|seconds| Duration::from_secs(seconds).min(MAX_RETRY_AFTER))
                             .unwrap_or(delay);
                         tokio::time::sleep(delay).await;
                         continue;
@@ -1764,6 +1771,69 @@ mod tests {
             .expect("database overload should be retried");
         assert_eq!(token, "at_live_worker_a");
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn rate_limited_registration_does_not_burn_retries_during_sdk_cooldown() {
+        #[derive(Clone)]
+        struct RegistrationState(Arc<AtomicUsize>);
+
+        async fn rate_limited(
+            State(state): State<RegistrationState>,
+        ) -> (StatusCode, Json<serde_json::Value>) {
+            state.0.fetch_add(1, Ordering::SeqCst);
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(json!({
+                    "ok": false,
+                    "error": {
+                        "code": "rate_limited",
+                        "message": "registration rate limited"
+                    }
+                })),
+            )
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind registration probe");
+        let address = listener.local_addr().expect("registration probe address");
+        let server_attempts = attempts.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route("/v1/agents", post(rate_limited))
+                    .with_state(RegistrationState(server_attempts)),
+            )
+            .await
+            .expect("registration probe server");
+        });
+
+        let client = RelaycastHttpClient::new(
+            Some(format!("http://{address}")),
+            "rk_live_test",
+            "broker",
+            "codex",
+        );
+        let result =
+            super::retry_agent_registration(&client, "worker-rate-limited", Some("codex")).await;
+        assert!(matches!(
+            result,
+            Err(
+                relaycast::AgentRegistrationRetryOutcome::RetryableExhausted(
+                    AgentRegistrationError::RateLimited { .. }
+                )
+            )
+        ));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "SDK cooldown must not cause futile retry POSTs"
+        );
 
         server.abort();
     }

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -6,12 +6,12 @@ use std::{
 
 use anyhow::{Context, Result};
 use relaycast::{
-    agent::DmOptions, format_registration_error,
-    retry_agent_registration as sdk_retry_agent_registration, ActionDefinition, ActionInvocation,
-    AgentClient, AgentIdentityRecoveryResponse, AgentRegistrationClient, AgentRegistrationError,
-    AgentRegistrationRetryOutcome, CompleteInvocationRequest, CreateObserverTokenRequest,
-    EmitSessionEventRequest, MessageListQuery, ObserverToken, RegisterActionRequest, RelayCast,
-    RelayCastOptions, RelayError, ReleaseAgentRequest, TakeOverAgentRequest, UpdateAgentRequest,
+    agent::DmOptions, format_registration_error, registration_is_retryable, ActionDefinition,
+    ActionInvocation, AgentClient, AgentIdentityRecoveryResponse, AgentRegistrationClient,
+    AgentRegistrationError, AgentRegistrationRetryOutcome, CompleteInvocationRequest,
+    CreateObserverTokenRequest, EmitSessionEventRequest, MessageListQuery, ObserverToken,
+    RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
+    TakeOverAgentRequest, UpdateAgentRequest,
 };
 use serde_json::Value;
 
@@ -49,8 +49,6 @@ pub struct RelaycastHttpClient {
 
 pub type RelaycastRegistrationError = AgentRegistrationError;
 pub type RegRetryOutcome = AgentRegistrationRetryOutcome;
-#[cfg(test)]
-pub(crate) use relaycast::registration_is_retryable;
 pub(crate) use relaycast::registration_retry_after_secs;
 
 /// Why the broker is asking `register_agent_token` for a token.
@@ -1442,7 +1440,83 @@ pub fn format_worker_preregistration_error(
     format_registration_error(name, error).replace("register agent", "pre-register worker")
 }
 
-/// Attempt to register an agent token with up to 3 retries for transient errors.
+/// The Relaycast SDK currently classifies only rate limits and transport
+/// failures as retryable registration errors. A registration `POST` is not
+/// retried by the SDK's HTTP layer because it is unkeyed, so a transient
+/// `database_overloaded` 503 otherwise reaches the broker as `Fatal` after one
+/// request. Keep the broker's retry budget small and explicit for that typed
+/// control-plane failure.
+fn is_transient_registration_api_error(error: &RelaycastRegistrationError) -> bool {
+    // Relaycast's 503 contract covers `database_overloaded` and deployments
+    // that use a different transient code with `Retry-After`. The SDK drops
+    // that header while converting the response to `AgentRegistrationError`,
+    // so status 503 is the only stable signal available here. Auth failures
+    // (401/403) and contract/conflict responses remain terminal.
+    matches!(error, RelaycastRegistrationError::Api { status: 503, .. })
+}
+
+/// Keep the terminal registration diagnostics truthful after broker-owned
+/// retries. The SDK includes the number of HTTP attempts in the opaque API
+/// detail string; each call here represents one POST because unkeyed agent
+/// registration is not retried by the SDK itself.
+fn with_registration_attempts(
+    error: RelaycastRegistrationError,
+    total_attempts: u32,
+) -> RelaycastRegistrationError {
+    match error {
+        RelaycastRegistrationError::Api {
+            agent_name,
+            status,
+            detail,
+        } => RelaycastRegistrationError::Api {
+            agent_name,
+            status,
+            detail: restamp_registration_attempts(detail, total_attempts),
+        },
+        other => other,
+    }
+}
+
+fn restamp_registration_attempts(detail: String, total_attempts: u32) -> String {
+    let marker = "; attempts: ";
+    let Some(start) = detail.find(marker) else {
+        return format!("{detail}; attempts: {total_attempts}");
+    };
+    let value_start = start + marker.len();
+    let value_end = detail[value_start..]
+        .find([';', ')'])
+        .map_or(detail.len(), |offset| value_start + offset);
+    format!(
+        "{}{}{}",
+        &detail[..value_start],
+        total_attempts,
+        &detail[value_end..]
+    )
+}
+
+fn registration_attempt_count(error: &RelaycastRegistrationError) -> u32 {
+    let RelaycastRegistrationError::Api { detail, .. } = error else {
+        return 1;
+    };
+    let marker = "; attempts: ";
+    let Some(start) = detail.find(marker) else {
+        return 1;
+    };
+    let value_start = start + marker.len();
+    detail[value_start..]
+        .split([';', ')'])
+        .next()
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|attempts| *attempts > 0)
+        .unwrap_or(1)
+}
+
+/// Attempt to register an agent token with up to 3 retries for transient
+/// errors. The delay is deliberately bounded: the SDK does not expose the
+/// `Retry-After` header on 503 errors, so use the documented short retry
+/// budget rather than sleeping on an untrusted/unbounded server value. For
+/// SDK errors that do carry a retry-after duration (429 cooldowns), honor it
+/// up to the same five-second per-sleep cap.
 pub async fn retry_agent_registration(
     http: &RelaycastHttpClient,
     name: &str,
@@ -1454,7 +1528,42 @@ pub async fn retry_agent_registration(
             detail: "SDK relay client not initialized".to_string(),
         })
     })?;
-    sdk_retry_agent_registration(registration, name, cli).await
+    const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_millis(200), Duration::from_millis(400)];
+    const MAX_RETRY_AFTER: u64 = 5;
+
+    let mut total_attempts: u32 = 0;
+    for retry_delay in RETRY_BACKOFFS
+        .iter()
+        .copied()
+        .map(Some)
+        .chain(std::iter::once(None))
+    {
+        match registration.register_agent_token(name, cli).await {
+            Ok(token) => return Ok(token),
+            Err(error) => {
+                total_attempts = total_attempts.saturating_add(registration_attempt_count(&error));
+                let retryable = registration_is_retryable(&error)
+                    || is_transient_registration_api_error(&error);
+                if retryable {
+                    if let Some(delay) = retry_delay {
+                        let delay = registration_retry_after_secs(&error)
+                            .map(|seconds| Duration::from_secs(seconds.min(MAX_RETRY_AFTER)))
+                            .unwrap_or(delay);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(RegRetryOutcome::RetryableExhausted(
+                        with_registration_attempts(error, total_attempts),
+                    ));
+                }
+                return Err(RegRetryOutcome::Fatal(with_registration_attempts(
+                    error,
+                    total_attempts,
+                )));
+            }
+        }
+    }
+    unreachable!("the bounded registration retry loop always returns")
 }
 
 /// The declared fields alone, trimmed, with blanks omitted.
@@ -1511,20 +1620,28 @@ fn registration_metadata_error(agent_name: &str, error: RelayError) -> Relaycast
 
 #[cfg(test)]
 mod tests {
+    use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
     use httpmock::{
         Method::{GET, PATCH, POST},
         MockServer,
     };
     use relaycast::AgentRegistrationError;
     use serde_json::json;
-    use std::time::Duration;
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use crate::{fleet_wire::AgentRegistrationMetadata, ids::ChannelName};
 
     use super::{
-        format_worker_preregistration_error, registration_is_retryable,
-        registration_retry_after_secs, ImpersonationAwareRegistrationError, MessageInjectionMode,
-        RecipientReachability, RegisterIntent, RelaycastHttpClient,
+        format_worker_preregistration_error, is_transient_registration_api_error,
+        registration_is_retryable, registration_retry_after_secs, restamp_registration_attempts,
+        ImpersonationAwareRegistrationError, MessageInjectionMode, RecipientReachability,
+        RegisterIntent, RelaycastHttpClient,
     };
 
     fn seeded_http_client(base_url: &str) -> RelaycastHttpClient {
@@ -1547,6 +1664,108 @@ mod tests {
         };
         assert!(registration_is_retryable(&error));
         assert_eq!(registration_retry_after_secs(&error), Some(60));
+    }
+
+    #[test]
+    fn database_overloaded_registration_is_transient_but_auth_failures_are_not() {
+        let overloaded = AgentRegistrationError::Api {
+            agent_name: "worker-a".to_string(),
+            status: 503,
+            detail: "The database is temporarily overloaded. (code: database_overloaded; attempts: 1; request_id: req-1)".to_string(),
+        };
+        assert!(is_transient_registration_api_error(&overloaded));
+
+        let retry_after_503 = AgentRegistrationError::Api {
+            agent_name: "worker-a".to_string(),
+            status: 503,
+            detail: "service unavailable (code: temporarily_unavailable; attempts: 1)".to_string(),
+        };
+        assert!(is_transient_registration_api_error(&retry_after_503));
+
+        let unauthorized = AgentRegistrationError::Api {
+            agent_name: "worker-a".to_string(),
+            status: 401,
+            detail: "unauthorized (code: invalid_key; attempts: 1)".to_string(),
+        };
+        assert!(!is_transient_registration_api_error(&unauthorized));
+    }
+
+    #[test]
+    fn registration_attempt_diagnostics_are_restamped_without_losing_request_id() {
+        let detail =
+            "overloaded (code: database_overloaded; attempts: 1; request_id: req-1)".to_string();
+        let restamped = restamp_registration_attempts(detail, 3);
+        assert!(restamped.contains("attempts: 3"));
+        assert!(restamped.contains("request_id: req-1"));
+    }
+
+    #[tokio::test]
+    async fn worker_registration_retries_database_overloaded_then_succeeds() {
+        #[derive(Clone)]
+        struct RegistrationState(Arc<AtomicUsize>);
+
+        async fn register_agent(
+            State(state): State<RegistrationState>,
+        ) -> (StatusCode, Json<serde_json::Value>) {
+            let attempt = state.0.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({
+                        "ok": false,
+                        "error": {
+                            "code": "database_overloaded",
+                            "message": "The database is temporarily overloaded."
+                        }
+                    })),
+                );
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "data": {
+                        "id": "agent_worker_a",
+                        "workspace_id": "ws_test",
+                        "name": "worker-a",
+                        "status": "online",
+                        "created_at": "2026-09-10T00:00:00.000Z",
+                        "token": "at_live_worker_a"
+                    }
+                })),
+            )
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind registration probe");
+        let address = listener.local_addr().expect("registration probe address");
+        let server_attempts = attempts.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route("/v1/agents", post(register_agent))
+                    .with_state(RegistrationState(server_attempts)),
+            )
+            .await
+            .expect("registration probe server");
+        });
+
+        let client = RelaycastHttpClient::new(
+            Some(format!("http://{address}")),
+            "rk_live_test",
+            "broker",
+            "codex",
+        );
+        let token = super::retry_agent_registration(&client, "worker-a", Some("codex"))
+            .await
+            .expect("database overload should be retried");
+        assert_eq!(token, "at_live_worker_a");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        server.abort();
     }
 
     #[test]

--- a/crates/broker/src/relaycast/ws.rs
+++ b/crates/broker/src/relaycast/ws.rs
@@ -1455,6 +1455,14 @@ fn is_transient_registration_api_error(error: &RelaycastRegistrationError) -> bo
     matches!(error, RelaycastRegistrationError::Api { status: 503, .. })
 }
 
+fn registration_client_unavailable(error: &RelaycastRegistrationError) -> bool {
+    matches!(
+        error,
+        RelaycastRegistrationError::Transport { detail, .. }
+            if detail == "SDK relay client not initialized"
+    )
+}
+
 /// Keep the terminal registration diagnostics truthful after broker-owned
 /// retries. The SDK includes the number of HTTP attempts in the opaque API
 /// detail string; each call here represents one POST because unkeyed agent
@@ -1542,6 +1550,16 @@ pub async fn retry_agent_registration(
             Ok(token) => return Ok(token),
             Err(error) => {
                 total_attempts = total_attempts.saturating_add(registration_attempt_count(&error));
+                // A missing SDK client is a configuration/authentication
+                // failure, not a transient transport outage. In particular,
+                // do not let the Transport variant reach the retryable
+                // classifier and delay a fail-closed spawn.
+                if registration_client_unavailable(&error) {
+                    return Err(RegRetryOutcome::Fatal(with_registration_attempts(
+                        error,
+                        total_attempts,
+                    )));
+                }
                 let retryable = registration_is_retryable(&error)
                     || is_transient_registration_api_error(&error);
                 if retryable {
@@ -1837,6 +1855,25 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn uninitialized_registration_fails_closed_without_retry_delay() {
+        let mut client = RelaycastHttpClient::new(None, "rk_live_test", "broker", "codex");
+        client.registration = Arc::new(None);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            super::retry_agent_registration(&client, "worker-uninitialized", Some("codex")),
+        )
+        .await
+        .expect("missing SDK client must fail without retry sleeps");
+        assert!(matches!(
+            result,
+            Err(relaycast::AgentRegistrationRetryOutcome::Fatal(
+                AgentRegistrationError::Transport { detail, .. }
+            )) if detail == "SDK relay client not initialized"
+        ));
     }
 
     #[test]

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -37,6 +37,19 @@ fn set_model_write_timeout(timeout_ms: Option<u64>) -> Duration {
         .unwrap_or(DEFAULT_SET_MODEL_TIMEOUT)
 }
 
+/// A missing preregistration token is safe only for an explicitly local,
+/// one-shot worker. Interactive and PTY workers need Relaycast identity for
+/// inbound delivery; silently starting either without it would report a
+/// process that cannot receive messages. `skip_relay_prompt` is the API's
+/// explicit declaration that the worker does not need Relaycast tools.
+pub(crate) fn can_spawn_without_preregistration(
+    spec: &AgentSpec,
+    exit_after_task: bool,
+    skip_relay_prompt: bool,
+) -> bool {
+    matches!(spec.runtime, AgentRuntime::Headless) && exit_after_task && skip_relay_prompt
+}
+
 /// Resolve the named recipient whose presence accompanies an HTTP send.
 /// Normalize at this boundary so direct runtime requests cannot publish to a
 /// trimmed target while observing a whitespace-padded agent name.
@@ -492,6 +505,14 @@ impl BrokerRuntime {
                                 Err(RegRetryOutcome::RetryableExhausted(error)) => {
                                     let message =
                                         format_worker_preregistration_error(&name, &error);
+                                    if !can_spawn_without_preregistration(
+                                        &spec,
+                                        exit_after_task,
+                                        skip_relay_prompt,
+                                    ) {
+                                        let _ = reply.send(Err(message));
+                                        return;
+                                    }
                                     tracing::warn!(
                                         worker = %name,
                                         error = %error,

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -3676,10 +3676,11 @@ async fn api_spawn_retries_overload_and_only_safe_mode_falls_back() {
     });
 
     let (worker_event_tx, _worker_event_rx) = mpsc::channel(16);
+    let worker_logs_dir = tempfile::tempdir().expect("worker logs dir");
     let workers = WorkerRegistry::new(
         worker_event_tx,
         Vec::new(),
-        PathBuf::from("/tmp/agent-relay-broker-tests"),
+        worker_logs_dir.path().to_path_buf(),
         Instant::now(),
     );
     let mut fixture =

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -35,7 +35,7 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use super::api::recipient_name_for_reachability;
+use super::api::{can_spawn_without_preregistration, recipient_name_for_reachability};
 use super::{
     apply_exit_after_task_instruction, build_agent_state_transition_event,
     build_http_api_spawn_spec, build_thread_infos, channels_from_csv,
@@ -3597,6 +3597,45 @@ fn preregistration_error_message_does_not_invent_retry_after_for_transport_error
     };
     let message = format_worker_preregistration_error("Foobar", &error);
     assert!(!message.contains("retry after"));
+}
+
+#[test]
+fn preregistration_fallback_is_limited_to_local_headless_task_exit() {
+    let headless = build_http_api_spawn_spec(
+        WorkerName::new("worker-a"),
+        "opencode".to_string(),
+        Some("headless".to_string()),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("headless spec");
+    assert!(can_spawn_without_preregistration(&headless, true, true));
+    assert!(!can_spawn_without_preregistration(&headless, false, true));
+    assert!(!can_spawn_without_preregistration(&headless, true, false));
+
+    let pty = build_http_api_spawn_spec(
+        WorkerName::new("worker-b"),
+        "codex".to_string(),
+        Some("pty".to_string()),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("pty spec");
+    assert!(!can_spawn_without_preregistration(&pty, true, true));
 }
 
 #[test]

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -11,12 +11,14 @@ use crate::ids::{
     AgentId, ChannelName, DeliveryId, EventId, MessageTarget, WorkerName, WorkspaceAlias,
     WorkspaceId,
 };
+use crate::listen_api::{listen_api_router_with_auth, ListenApiConfig, ListenApiRequest};
 use crate::node_control::{FleetControlCommand, FleetDeliveryBook};
 use crate::protocol::{
     AgentSpec, BrokerEvent, DeliveryReadAckStatus, HarnessReleasePolicy, HeadlessHarnessConfig,
     HeadlessHarnessDriver, MessageInjectionMode, NativeHarnessConfig, ProtocolEnvelope,
     RelayDelivery, ResolvedHarnessConfig,
 };
+use crate::replay_buffer::{ReplayBuffer, DEFAULT_REPLAY_CAPACITY};
 use crate::telemetry::TelemetryClient;
 use crate::worker::{
     spawn_worker_writer, AgentWorkState, WorkerEvent, WorkerHandle, WorkerRegistry,
@@ -31,8 +33,10 @@ use crate::{
         },
     },
 };
+use axum::{body::to_bytes, body::Body, http::Request};
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
+use tower::ServiceExt;
 use uuid::Uuid;
 
 use super::api::{can_spawn_without_preregistration, recipient_name_for_reachability};
@@ -199,6 +203,7 @@ async fn cleanup_worker_registry(mut registry: WorkerRegistry) {
 
 struct WorkerEventRuntimeFixture {
     runtime: BrokerRuntime,
+    api_tx: mpsc::Sender<ListenApiRequest>,
     fleet_control_rx: mpsc::Receiver<FleetControlCommand>,
     _sdk_out_rx: mpsc::Receiver<ProtocolEnvelope<Value>>,
     _temp_dir: tempfile::TempDir,
@@ -207,6 +212,14 @@ struct WorkerEventRuntimeFixture {
 fn worker_event_runtime_fixture(
     workers: WorkerRegistry,
     pending_deliveries: HashMap<DeliveryId, PendingDelivery>,
+) -> WorkerEventRuntimeFixture {
+    worker_event_runtime_fixture_with_relay(workers, pending_deliveries, None)
+}
+
+fn worker_event_runtime_fixture_with_relay(
+    workers: WorkerRegistry,
+    pending_deliveries: HashMap<DeliveryId, PendingDelivery>,
+    relay_base_url: Option<String>,
 ) -> WorkerEventRuntimeFixture {
     let temp_dir = tempfile::tempdir().expect("runtime fixture temp dir");
     let paths = RuntimePaths {
@@ -217,7 +230,8 @@ fn worker_event_runtime_fixture(
         dedup: temp_dir.path().join("dedup.json"),
         _lock: None,
     };
-    let default_workspace = test_relay_workspace("ws_demo", Some("demo"));
+    let default_workspace =
+        test_relay_workspace_with_base_url("ws_demo", Some("demo"), relay_base_url.as_deref());
     let default_workspace_id = Some(default_workspace.workspace_id.clone());
     let workspace_lookup = HashMap::from([(
         default_workspace.workspace_id.clone(),
@@ -226,7 +240,7 @@ fn worker_event_runtime_fixture(
     let self_names = default_workspace.self_names.clone();
     let ws_control_tx = default_workspace.ws_control_tx.clone();
     let relaycast_http = default_workspace.http_client.clone();
-    let (_api_tx, api_rx) = mpsc::channel(4);
+    let (api_tx, api_rx) = mpsc::channel(4);
     let (_ws_inbound_tx, ws_inbound_rx) = mpsc::channel(4);
     let (fleet_control_tx, fleet_control_rx) = mpsc::channel(16);
     let (_fleet_event_tx, fleet_event_rx) = mpsc::channel(4);
@@ -312,6 +326,7 @@ fn worker_event_runtime_fixture(
 
     WorkerEventRuntimeFixture {
         runtime,
+        api_tx,
         fleet_control_rx,
         _sdk_out_rx: sdk_out_rx,
         _temp_dir: temp_dir,
@@ -3638,6 +3653,173 @@ fn preregistration_fallback_is_limited_to_local_headless_task_exit() {
     assert!(!can_spawn_without_preregistration(&pty, true, true));
 }
 
+/// Exercise the complete `/api/spawn` path around node-registration failure:
+/// the real router emits a spawn request, the runtime answers the
+/// node-control registration with an error, and Relaycast stays at a
+/// persistent typed 503. Only an explicitly local/headless/task-exit request
+/// reaches `WorkerRegistry::spawn`; the PTY request fails closed.
+#[tokio::test]
+async fn api_spawn_retries_overload_and_only_safe_mode_falls_back() {
+    use httpmock::{Method::POST, MockServer};
+
+    let server = MockServer::start();
+    let registration = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents");
+        then.status(503).json_body(json!({
+            "ok": false,
+            "error": {
+                "code": "database_overloaded",
+                "message": "The database is temporarily overloaded.",
+                "request_id": "req-overload"
+            }
+        }));
+    });
+
+    let (worker_event_tx, _worker_event_rx) = mpsc::channel(16);
+    let workers = WorkerRegistry::new(
+        worker_event_tx,
+        Vec::new(),
+        PathBuf::from("/tmp/agent-relay-broker-tests"),
+        Instant::now(),
+    );
+    let mut fixture =
+        worker_event_runtime_fixture_with_relay(workers, HashMap::new(), Some(server.base_url()));
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel(8);
+    let router = listen_api_router_with_auth(
+        ListenApiConfig {
+            tx: fixture.api_tx.clone(),
+            events_tx,
+            replay_buffer: ReplayBuffer::new(DEFAULT_REPLAY_CAPACITY),
+            workspace_key: None,
+            relay_base_url: Some(server.base_url()),
+            memberships: Vec::new(),
+            default_workspace_id: Some(WorkspaceId::new("ws_demo")),
+            node_id: "node_test".to_string(),
+            node_name: "test-node".to_string(),
+            node_token: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            persist: false,
+        },
+        None,
+    );
+    let spawn_request = |body: Value| {
+        Request::builder()
+            .method("POST")
+            .uri("/api/spawn")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).expect("spawn body")))
+            .expect("spawn request")
+    };
+
+    let unsafe_response = tokio::spawn(router.clone().oneshot(spawn_request(json!({
+        "name": "unsafe-overload-worker",
+        "cli": "codex",
+        "transport": "pty"
+    }))));
+    let unsafe_api_request = fixture
+        .runtime
+        .api_rx
+        .recv()
+        .await
+        .expect("unsafe API request");
+    let mut unsafe_runtime = Box::pin(fixture.runtime.handle_api_request(unsafe_api_request));
+    let unsafe_command = tokio::select! {
+        command = fixture.fleet_control_rx.recv() => command.expect("unsafe node registration command"),
+        _ = &mut unsafe_runtime => panic!("runtime must wait for node registration reply"),
+    };
+    let FleetControlCommand::RegisterAgent { reply, .. } = unsafe_command else {
+        panic!("spawn should use node-control agent.register");
+    };
+    reply
+        .send(Err("node_agent_registration_unavailable".to_string()))
+        .expect("unsafe registration reply");
+    unsafe_runtime.await;
+
+    let unsafe_response = unsafe_response
+        .await
+        .expect("unsafe router task")
+        .expect("unsafe router response");
+    assert_eq!(
+        unsafe_response.status(),
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let unsafe_body = to_bytes(unsafe_response.into_body(), usize::MAX)
+        .await
+        .expect("unsafe response body");
+    let unsafe_json: Value = serde_json::from_slice(&unsafe_body).expect("unsafe JSON");
+    let unsafe_error = unsafe_json["error"].as_str().expect("unsafe error");
+    assert!(unsafe_error.contains("503"));
+    assert!(unsafe_error.contains("database_overloaded"));
+    assert!(unsafe_error.contains("attempts: 3"));
+    assert!(fixture.runtime.workers.workers.is_empty());
+
+    let safe_response = tokio::spawn(router.oneshot(spawn_request(json!({
+        "name": "safe-overload-worker",
+        "cli": "codex",
+        "transport": "headless",
+        "spawnMode": "task_exit",
+        "skipRelayPrompt": true,
+        "task": "run the local task",
+        "harnessConfig": {
+            "runtime": "native",
+            "command": "cat",
+            "sessionId": "session-safe"
+        }
+    }))));
+    let safe_api_request = fixture
+        .runtime
+        .api_rx
+        .recv()
+        .await
+        .expect("safe API request");
+    let mut safe_runtime = Box::pin(fixture.runtime.handle_api_request(safe_api_request));
+    let safe_command = tokio::select! {
+        command = fixture.fleet_control_rx.recv() => command.expect("safe node registration command"),
+        _ = &mut safe_runtime => panic!("runtime must wait for node registration reply"),
+    };
+    let FleetControlCommand::RegisterAgent { reply, .. } = safe_command else {
+        panic!("safe spawn should use node-control agent.register");
+    };
+    reply
+        .send(Err("node_agent_registration_unavailable".to_string()))
+        .expect("safe registration reply");
+    safe_runtime.await;
+
+    let safe_response = safe_response
+        .await
+        .expect("safe router task")
+        .expect("safe router response");
+    assert_eq!(safe_response.status(), axum::http::StatusCode::OK);
+    let safe_body = to_bytes(safe_response.into_body(), usize::MAX)
+        .await
+        .expect("safe response body");
+    let safe_json: Value = serde_json::from_slice(&safe_body).expect("safe JSON");
+    assert_eq!(safe_json["success"], true);
+    assert_eq!(safe_json["runtime"], "headless");
+    assert_eq!(safe_json["pre_registered"], false);
+    assert_eq!(safe_json["sessionId"], "session-safe");
+    assert!(
+        safe_json["pid"].as_u64().is_some(),
+        "must report the live process PID"
+    );
+    let warning = safe_json["warning"].as_str().expect("safe warning");
+    assert!(warning.contains("503"));
+    assert!(warning.contains("database_overloaded"));
+    assert!(warning.contains("attempts: 3"));
+    assert!(fixture.runtime.workers.has_worker("safe-overload-worker"));
+    assert_eq!(
+        registration.hits(),
+        6,
+        "each spawn gets the full bounded retry budget"
+    );
+
+    fixture
+        .runtime
+        .workers
+        .release("safe-overload-worker")
+        .await
+        .expect("clean up local fallback worker");
+}
+
 #[test]
 fn injection_format_preserved() {
     let rendered = format_injection("alice", "evt_1", "hello", "bob");
@@ -5243,6 +5425,14 @@ fn model_flag_injected_with_other_args() {
 // ---------------------------------------------------------------------------
 
 fn test_relay_workspace(workspace_id: &str, workspace_alias: Option<&str>) -> RelayWorkspace {
+    test_relay_workspace_with_base_url(workspace_id, workspace_alias, None)
+}
+
+fn test_relay_workspace_with_base_url(
+    workspace_id: &str,
+    workspace_alias: Option<&str>,
+    relay_base_url: Option<&str>,
+) -> RelayWorkspace {
     let (ws_control_tx, _ws_control_rx) = mpsc::channel::<WsControl>(1);
     RelayWorkspace {
         workspace_id: WorkspaceId::from(workspace_id.to_string()),
@@ -5252,7 +5442,12 @@ fn test_relay_workspace(workspace_id: &str, workspace_alias: Option<&str>) -> Re
         self_agent_id: AgentId::from("agent_broker".to_string()),
         self_names: HashSet::from(["broker".to_string()]),
         self_agent_ids: HashSet::from([AgentId::from("agent_broker".to_string())]),
-        http_client: RelaycastHttpClient::new(None, "rk_live_test", "broker", "codex"),
+        http_client: RelaycastHttpClient::new(
+            relay_base_url.map(ToOwned::to_owned),
+            "rk_live_test",
+            "broker",
+            "codex",
+        ),
         ws_control_tx,
     }
 }

--- a/tests/relayflows/cases/1715-spawn-overload/case.json
+++ b/tests/relayflows/cases/1715-spawn-overload/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1715-spawn-overload",
+  "kind": "bugfix",
+  "title": "Retry overloaded worker registration and keep spawn fallback safe",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1715-spawn-overload/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "spawn_503_not_retried_and_safe_fallback_missing"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "spawn_503_retried_and_safe_fallback_is_live"
+    }
+  }
+}

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -140,18 +140,20 @@ try {
   }, 'safe task-exit cleanup');
   const registrationTimestamps = [...relay.workerRegistrationTimestamps];
   const retryScheduleBounded = retryScheduleIsBounded(registrationTimestamps);
-  const markers = (text, attempts) =>
+  // The pre-fix SDK reports one POST by omission (no attempts marker), while
+  // the broker-owned retry path restamps the terminal detail with the total.
+  const markers = (text, attempts, requireAttempts = true) =>
     text.includes(`(${ERROR_STATUS})`) &&
     text.includes(ERROR_CODE) &&
     text.includes(REQUEST_ID) &&
-    text.includes(`attempts: ${attempts}`);
+    (!requireAttempts || text.includes(`attempts: ${attempts}`));
 
   const baseObserved =
     arm === 'base' &&
     unsafe.status === 500 &&
     safe.status === 500 &&
-    markers(unsafeError, 1) &&
-    markers(typeof safe.body?.error === 'string' ? safe.body.error : '', 1) &&
+    markers(unsafeError, 1, false) &&
+    markers(typeof safe.body?.error === 'string' ? safe.body.error : '', 1, false) &&
     unsafeNoWorker === true &&
     safeNoWorker === true &&
     safeTaskExitCleaned === true &&

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -16,6 +16,7 @@ const ERROR_STATUS = 503;
 const REQUEST_ID = 'relayflow-1715-request';
 const RETRY_AFTER_SECONDS = 1;
 const RETRY_BACKOFFS_MS = [200, 400];
+const RETRY_DELAY_TOLERANCE_MS = 250;
 const RETRY_DEADLINE_MS = 2_000;
 const UNSAFE_AGENT = 'relayflow-1715-unsafe';
 const SAFE_AGENT = 'relayflow-1715-safe';
@@ -407,7 +408,12 @@ function retryScheduleIsBounded(timestamps) {
     if (elapsed > RETRY_DEADLINE_MS) return false;
     for (let retry = 0; retry < RETRY_BACKOFFS_MS.length; retry += 1) {
       const delta = timestamps[start + retry + 1] - timestamps[start + retry];
-      if (delta < RETRY_BACKOFFS_MS[retry] - 50) return false;
+      if (
+        delta < RETRY_BACKOFFS_MS[retry] - 50 ||
+        delta > RETRY_BACKOFFS_MS[retry] + RETRY_DELAY_TOLERANCE_MS
+      ) {
+        return false;
+      }
     }
   }
   return true;

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -200,10 +200,7 @@ try {
 } finally {
   if (broker && broker.exitCode === null) {
     broker.kill('SIGTERM');
-    await Promise.race([
-      onceExit(broker),
-      new Promise((resolve) => setTimeout(resolve, 5_000)),
-    ]);
+    await Promise.race([onceExit(broker), new Promise((resolve) => setTimeout(resolve, 5_000))]);
     if (broker.exitCode === null) broker.kill('SIGKILL');
   }
   await relay?.close();
@@ -227,10 +224,15 @@ async function startRelayProbe() {
     if (request.method === 'POST' && pathname === '/v1/agents') {
       if (body?.name !== BROKER_NAME) {
         state.workerRegistrations += 1;
-        sendJson(response, ERROR_STATUS, {
-          ok: false,
-          error: { code: ERROR_CODE, message: ERROR_MESSAGE },
-        }, { 'x-request-id': REQUEST_ID });
+        sendJson(
+          response,
+          ERROR_STATUS,
+          {
+            ok: false,
+            error: { code: ERROR_CODE, message: ERROR_MESSAGE },
+          },
+          { 'x-request-id': REQUEST_ID }
+        );
         return;
       }
       sendJson(response, 200, {
@@ -359,5 +361,8 @@ async function requiredExecutable(name) {
 
 function isWithin(directory, candidate) {
   const relative = path.relative(directory, candidate);
-  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
 }

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -14,6 +14,9 @@ const ERROR_CODE = 'database_overloaded';
 const ERROR_MESSAGE = 'The database is temporarily overloaded. request_id: relayflow-1715-request';
 const ERROR_STATUS = 503;
 const REQUEST_ID = 'relayflow-1715-request';
+const RETRY_AFTER_SECONDS = 1;
+const RETRY_BACKOFFS_MS = [200, 400];
+const RETRY_DEADLINE_MS = 2_000;
 const UNSAFE_AGENT = 'relayflow-1715-unsafe';
 const SAFE_AGENT = 'relayflow-1715-safe';
 
@@ -134,6 +137,8 @@ try {
     const agents = (await api('GET', '/api/spawned')).body?.agents ?? [];
     return agents.every((agent) => agent?.name !== SAFE_AGENT);
   }, 'safe task-exit cleanup');
+  const registrationTimestamps = [...relay.workerRegistrationTimestamps];
+  const retryScheduleBounded = retryScheduleIsBounded(registrationTimestamps);
   const markers = (text, attempts) =>
     text.includes(`(${ERROR_STATUS})`) &&
     text.includes(ERROR_CODE) &&
@@ -149,6 +154,7 @@ try {
     unsafeNoWorker === true &&
     safeNoWorker === true &&
     safeTaskExitCleaned === true &&
+    retryScheduleBounded === false &&
     relay.workerRegistrations === 2 &&
     !safe.body?.success;
   const headObserved =
@@ -165,6 +171,7 @@ try {
     Number.isInteger(safeWorkerPid) &&
     safeWorkerPid > 0 &&
     safeTaskExitCleaned === true &&
+    retryScheduleBounded === true &&
     relay.workerRegistrations === 6;
 
   let outcome;
@@ -177,7 +184,7 @@ try {
   } else if (headObserved) {
     outcome = 'fixed';
     signature = 'spawn_503_retried_and_safe_fallback_is_live';
-    details = `Head sent three bounded HTTP registration attempts for each spawn (${relay.workerRegistrations} total), kept unsafe PTY closed, and returned a live safe headless task-exit worker with the preserved overload warning.`;
+    details = `Head sent three bounded HTTP registration attempts for each spawn (${relay.workerRegistrations} total), kept unsafe PTY closed, and returned a live safe headless task-exit worker with the preserved overload warning; timestamped retries stayed within the fixed 200/400ms schedule and ${RETRY_DEADLINE_MS}ms deadline despite a nonzero Retry-After header.`;
   } else {
     throw new Error(
       `Unexpected ${arm} spawn observation: ${JSON.stringify({
@@ -189,6 +196,8 @@ try {
         safeNoWorker,
         safeWorkerPid,
         safeTaskExitCleaned,
+        registrationTimestamps,
+        retryScheduleBounded,
         checks: {
           unsafeStatus: unsafe.status === 500,
           unsafeMarkers: markers(unsafeError, 3),
@@ -201,6 +210,7 @@ try {
           safeWarning: markers(safeWarning, 3),
           livePid: Number.isInteger(safeWorkerPid) && safeWorkerPid > 0,
           safeTaskExitCleaned,
+          retryScheduleBounded,
           count: relay.workerRegistrations === 6,
         },
         stderr: brokerStderr.slice(-4_000),
@@ -220,7 +230,7 @@ try {
 
 async function startRelayProbe() {
   const sockets = new Set();
-  const state = { workerRegistrations: 0 };
+  const state = { workerRegistrations: 0, workerRegistrationTimestamps: [] };
   const server = http.createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
@@ -235,6 +245,11 @@ async function startRelayProbe() {
     if (request.method === 'POST' && pathname === '/v1/agents') {
       if (body?.name !== BROKER_NAME) {
         state.workerRegistrations += 1;
+        state.workerRegistrationTimestamps.push(Date.now());
+        // Keep a nonzero Retry-After in the fixture to guard the contract. The
+        // current Relaycast SDK drops this header for 503 errors, so the
+        // broker's documented fixed schedule/deadline is what can be proven
+        // here; 429 cooldowns are covered by the SDK fail-fast unit test.
         sendJson(
           response,
           ERROR_STATUS,
@@ -242,7 +257,7 @@ async function startRelayProbe() {
             ok: false,
             error: { code: ERROR_CODE, message: ERROR_MESSAGE },
           },
-          { 'x-request-id': REQUEST_ID }
+          { 'retry-after': String(RETRY_AFTER_SECONDS), 'x-request-id': REQUEST_ID }
         );
         return;
       }
@@ -275,6 +290,9 @@ async function startRelayProbe() {
     ...state,
     get workerRegistrations() {
       return state.workerRegistrations;
+    },
+    get workerRegistrationTimestamps() {
+      return state.workerRegistrationTimestamps;
     },
     baseUrl: `http://127.0.0.1:${address.port}`,
     async close() {
@@ -376,4 +394,21 @@ function isWithin(directory, candidate) {
     relative === '' ||
     (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
   );
+}
+
+function retryScheduleIsBounded(timestamps) {
+  // Relaycast 8.0 exposes no Retry-After value for a 503. Verify the
+  // observable broker-owned schedule and total deadline instead of adding a
+  // long, dependency-shaped sleep to this hermetic proof.
+  if (timestamps.length !== 6) return false;
+  for (let spawn = 0; spawn < 2; spawn += 1) {
+    const start = spawn * 3;
+    const elapsed = timestamps[start + 2] - timestamps[start];
+    if (elapsed > RETRY_DEADLINE_MS) return false;
+    for (let retry = 0; retry < RETRY_BACKOFFS_MS.length; retry += 1) {
+      const delta = timestamps[start + retry + 1] - timestamps[start + retry];
+      if (delta < RETRY_BACKOFFS_MS[retry] - 50) return false;
+    }
+  }
+  return true;
 }

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -203,10 +203,7 @@ try {
 } finally {
   if (broker && broker.exitCode === null) {
     broker.kill('SIGTERM');
-    await Promise.race([
-      onceExit(broker),
-      new Promise((resolve) => setTimeout(resolve, 5_000)),
-    ]);
+    await Promise.race([onceExit(broker), new Promise((resolve) => setTimeout(resolve, 5_000))]);
     if (broker.exitCode === null) broker.kill('SIGKILL');
   }
   await relay?.close();

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -119,7 +119,7 @@ try {
     task: 'run the local task',
     harnessConfig: {
       runtime: 'native',
-      command: 'cat',
+      command: "sh -c 'sleep 1; read -r _; exit 0'",
       sessionId: 'session-safe',
     },
   });
@@ -130,6 +130,10 @@ try {
   const safeNoWorker = spawnedList.every((agent) => agent?.name !== SAFE_AGENT);
   const safeWarning = typeof safe.body?.warning === 'string' ? safe.body.warning : '';
   const safeWorkerPid = spawnedList.find((agent) => agent?.name === SAFE_AGENT)?.workerPid;
+  const safeTaskExitCleaned = await waitFor(async () => {
+    const agents = (await api('GET', '/api/spawned')).body?.agents ?? [];
+    return agents.every((agent) => agent?.name !== SAFE_AGENT);
+  }, 'safe task-exit cleanup');
   const markers = (text, attempts) =>
     text.includes(`(${ERROR_STATUS})`) &&
     text.includes(ERROR_CODE) &&
@@ -144,6 +148,7 @@ try {
     markers(typeof safe.body?.error === 'string' ? safe.body.error : '', 1) &&
     unsafeNoWorker === true &&
     safeNoWorker === true &&
+    safeTaskExitCleaned === true &&
     relay.workerRegistrations === 2 &&
     !safe.body?.success;
   const headObserved =
@@ -159,6 +164,7 @@ try {
     markers(safeWarning, 3) &&
     Number.isInteger(safeWorkerPid) &&
     safeWorkerPid > 0 &&
+    safeTaskExitCleaned === true &&
     relay.workerRegistrations === 6;
 
   let outcome;
@@ -182,6 +188,7 @@ try {
         unsafeNoWorker,
         safeNoWorker,
         safeWorkerPid,
+        safeTaskExitCleaned,
         checks: {
           unsafeStatus: unsafe.status === 500,
           unsafeMarkers: markers(unsafeError, 3),
@@ -193,6 +200,7 @@ try {
           safePid: Number.isInteger(safe.body?.pid),
           safeWarning: markers(safeWarning, 3),
           livePid: Number.isInteger(safeWorkerPid) && safeWorkerPid > 0,
+          safeTaskExitCleaned,
           count: relay.workerRegistrations === 6,
         },
         stderr: brokerStderr.slice(-4_000),

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -1,0 +1,363 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import http from 'node:http';
+
+const CASE_ID = '1715-spawn-overload';
+const BROKER_NAME = 'relayflow-1715-broker';
+const BROKER_API_KEY = 'br_relayflow_1715';
+const ERROR_CODE = 'database_overloaded';
+const ERROR_MESSAGE = 'The database is temporarily overloaded. request_id: relayflow-1715-request';
+const ERROR_STATUS = 503;
+const REQUEST_ID = 'relayflow-1715-request';
+const UNSAFE_AGENT = 'relayflow-1715-unsafe';
+const SAFE_AGENT = 'relayflow-1715-safe';
+
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+if (!isWithin(harnessDir, fileURLToPath(import.meta.url))) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1715-'));
+const stateDir = path.join(probeDir, 'state');
+let relay;
+let broker;
+let brokerStderr = '';
+try {
+  await mkdir(stateDir, { recursive: true });
+  relay = await startRelayProbe();
+  broker = spawn(
+    binaryPath,
+    [
+      'init',
+      '--instance-name',
+      BROKER_NAME,
+      '--workspace-key',
+      'rk_relayflow_1715',
+      '--state-dir',
+      stateDir,
+      '--api-port',
+      '0',
+      '--api-bind',
+      '127.0.0.1',
+      '--channels',
+      '',
+    ],
+    {
+      cwd: probeDir,
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        HOME: probeDir,
+        TMPDIR: probeDir,
+        NO_COLOR: '1',
+        RELAYCAST_BASE_URL: relay.baseUrl,
+        RELAY_BASE_URL: relay.baseUrl,
+        RELAY_BROKER_API_KEY: BROKER_API_KEY,
+        RELAY_NODE_ID: 'node_relayflow_1715',
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+        RELAY_SKIP_TELEMETRY: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  broker.stderr.on('data', (chunk) => {
+    brokerStderr = `${brokerStderr}${chunk}`.slice(-20_000);
+  });
+
+  const brokerUrl = await waitForConnection(path.join(stateDir, 'connection.json'), broker);
+  const api = (method, pathname, body) =>
+    requestJson(`${brokerUrl}${pathname}`, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': BROKER_API_KEY,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  await waitFor(
+    () => api('GET', '/api/session').then((response) => response.status === 200),
+    'broker readiness'
+  ).catch((error) => {
+    throw new Error(`${error.message}; broker stderr: ${brokerStderr}`);
+  });
+  // No node token is supplied. The real node-control loop therefore reports
+  // its typed `node_token_missing` registration failure to `/api/spawn` while
+  // the fake Relaycast remains entirely local and deterministic.
+
+  const unsafe = await api('POST', '/api/spawn', {
+    name: UNSAFE_AGENT,
+    cli: 'codex',
+    transport: 'pty',
+  });
+  const safe = await api('POST', '/api/spawn', {
+    name: SAFE_AGENT,
+    cli: 'codex',
+    transport: 'headless',
+    spawnMode: 'task_exit',
+    skipRelayPrompt: true,
+    task: 'run the local task',
+    harnessConfig: {
+      runtime: 'native',
+      command: 'cat',
+      sessionId: 'session-safe',
+    },
+  });
+
+  const unsafeError = typeof unsafe.body?.error === 'string' ? unsafe.body.error : '';
+  const spawnedList = (await api('GET', '/api/spawned')).body?.agents ?? [];
+  const unsafeNoWorker = spawnedList.every((agent) => agent?.name !== UNSAFE_AGENT);
+  const safeWarning = typeof safe.body?.warning === 'string' ? safe.body.warning : '';
+  const safeWorkerPid = spawnedList.find((agent) => agent?.name === SAFE_AGENT)?.workerPid;
+  const markers = (text, attempts) =>
+    text.includes(`(${ERROR_STATUS})`) &&
+    text.includes(ERROR_CODE) &&
+    text.includes(REQUEST_ID) &&
+    text.includes(`attempts: ${attempts}`);
+
+  const baseObserved =
+    arm === 'base' &&
+    unsafe.status === 500 &&
+    safe.status === 500 &&
+    markers(unsafeError, 1) &&
+    markers(typeof safe.body?.error === 'string' ? safe.body.error : '', 1) &&
+    unsafeNoWorker === true &&
+    relay.workerRegistrations === 2 &&
+    !safe.body?.success;
+  const headObserved =
+    arm === 'head' &&
+    unsafe.status === 500 &&
+    markers(unsafeError, 3) &&
+    unsafeNoWorker === true &&
+    safe.status === 200 &&
+    safe.body?.success === true &&
+    safe.body?.runtime === 'headless' &&
+    safe.body?.pre_registered === false &&
+    Number.isInteger(safe.body?.pid) &&
+    markers(safeWarning, 3) &&
+    Number.isInteger(safeWorkerPid) &&
+    safeWorkerPid > 0 &&
+    relay.workerRegistrations === 6;
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'spawn_503_not_retried_and_safe_fallback_missing';
+    details = `Base sent one HTTP registration attempt per spawn (${relay.workerRegistrations} total), failed both the unsafe and safe API requests with the typed ${ERROR_STATUS} overload, and created no fallback worker.`;
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'spawn_503_retried_and_safe_fallback_is_live';
+    details = `Head sent three bounded HTTP registration attempts for each spawn (${relay.workerRegistrations} total), kept unsafe PTY closed, and returned a live safe headless task-exit worker with the preserved overload warning.`;
+  } else {
+    throw new Error(
+      `Unexpected ${arm} spawn observation: ${JSON.stringify({
+        arm,
+        workerRegistrations: relay.workerRegistrations,
+        unsafe,
+        safe,
+        unsafeNoWorker,
+        safeWorkerPid,
+        checks: {
+          unsafeStatus: unsafe.status === 500,
+          unsafeMarkers: markers(unsafeError, 3),
+          unsafeNoWorker,
+          safeStatus: safe.status === 200,
+          safeSuccess: safe.body?.success === true,
+          safeRuntime: safe.body?.runtime === 'headless',
+          safeNotPreRegistered: safe.body?.pre_registered === false,
+          safePid: Number.isInteger(safe.body?.pid),
+          safeWarning: markers(safeWarning, 3),
+          livePid: Number.isInteger(safeWorkerPid) && safeWorkerPid > 0,
+          count: relay.workerRegistrations === 6,
+        },
+        stderr: brokerStderr.slice(-4_000),
+      })}`
+    );
+  }
+  await writeObservation(resultPath, { version: 1, caseId: CASE_ID, arm, outcome, signature, details });
+} finally {
+  if (broker && broker.exitCode === null) {
+    broker.kill('SIGTERM');
+    await Promise.race([
+      onceExit(broker),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+    if (broker.exitCode === null) broker.kill('SIGKILL');
+  }
+  await relay?.close();
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+async function startRelayProbe() {
+  const sockets = new Set();
+  const state = { workerRegistrations: 0 };
+  const server = http.createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    let body;
+    try {
+      body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString('utf8')) : undefined;
+    } catch {
+      sendJson(response, 400, { ok: false, error: { code: 'invalid_json', message: 'invalid JSON' } });
+      return;
+    }
+    const pathname = new URL(request.url ?? '/', 'http://relayflow.invalid').pathname;
+    if (request.method === 'POST' && pathname === '/v1/agents') {
+      if (body?.name !== BROKER_NAME) {
+        state.workerRegistrations += 1;
+        sendJson(response, ERROR_STATUS, {
+          ok: false,
+          error: { code: ERROR_CODE, message: ERROR_MESSAGE },
+        }, { 'x-request-id': REQUEST_ID });
+        return;
+      }
+      sendJson(response, 200, {
+        ok: true,
+        data: {
+          id: 'agent_relayflow_1715_broker',
+          workspace_id: 'ws_relayflow_1715',
+          name: BROKER_NAME,
+          token: 'at_relayflow_1715_broker',
+          status: 'active',
+          created_at: '2026-09-10T00:00:00Z',
+        },
+      });
+      return;
+    }
+    sendJson(response, 200, { ok: true, data: {} });
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a TCP address.');
+  return {
+    ...state,
+    get workerRegistrations() {
+      return state.workerRegistrations;
+    },
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+function sendJson(response, status, value, headers = {}) {
+  response.writeHead(status, { 'content-type': 'application/json', ...headers });
+  response.end(JSON.stringify(value));
+}
+
+async function requestJson(url, options) {
+  let response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      redirect: 'error',
+      signal: AbortSignal.timeout(20_000),
+    });
+  } catch (error) {
+    throw new Error(
+      `request ${options.method ?? 'GET'} ${url} failed: ${error.message}; broker stderr: ${brokerStderr}`
+    );
+  }
+  const raw = await response.text();
+  let body;
+  try {
+    body = raw ? JSON.parse(raw) : undefined;
+  } catch {
+    body = { raw };
+  }
+  return { status: response.status, body };
+}
+
+async function waitForConnection(connectionPath, child) {
+  return waitFor(async () => {
+    if (child.exitCode !== null) throw new Error(`Broker exited during startup: ${brokerStderr}`);
+    try {
+      const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
+      const url = new URL(connection.url);
+      if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !/^\d+$/.test(url.port)) return false;
+      return `http://127.0.0.1:${Number(url.port)}`;
+    } catch {
+      return false;
+    }
+  }, 'connection metadata');
+}
+
+async function waitFor(check, label, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const result = await check();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}`);
+}
+
+async function writeObservation(observationPath, value) {
+  await mkdir(path.dirname(observationPath), { recursive: true });
+  await writeFile(observationPath, `${JSON.stringify(value)}\n`, 'utf8');
+}
+
+function onceExit(child) {
+  return new Promise((resolve) => child.once('exit', resolve));
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+async function requiredExecutable(name) {
+  const candidate = path.resolve(requiredValue(name));
+  try {
+    await access(candidate, fsConstants.R_OK | fsConstants.X_OK);
+  } catch {
+    throw new Error(`${name} must name a readable executable file.`);
+  }
+  return candidate;
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}

--- a/tests/relayflows/cases/1715-spawn-overload/run.mjs
+++ b/tests/relayflows/cases/1715-spawn-overload/run.mjs
@@ -127,6 +127,7 @@ try {
   const unsafeError = typeof unsafe.body?.error === 'string' ? unsafe.body.error : '';
   const spawnedList = (await api('GET', '/api/spawned')).body?.agents ?? [];
   const unsafeNoWorker = spawnedList.every((agent) => agent?.name !== UNSAFE_AGENT);
+  const safeNoWorker = spawnedList.every((agent) => agent?.name !== SAFE_AGENT);
   const safeWarning = typeof safe.body?.warning === 'string' ? safe.body.warning : '';
   const safeWorkerPid = spawnedList.find((agent) => agent?.name === SAFE_AGENT)?.workerPid;
   const markers = (text, attempts) =>
@@ -142,6 +143,7 @@ try {
     markers(unsafeError, 1) &&
     markers(typeof safe.body?.error === 'string' ? safe.body.error : '', 1) &&
     unsafeNoWorker === true &&
+    safeNoWorker === true &&
     relay.workerRegistrations === 2 &&
     !safe.body?.success;
   const headObserved =
@@ -178,6 +180,7 @@ try {
         unsafe,
         safe,
         unsafeNoWorker,
+        safeNoWorker,
         safeWorkerPid,
         checks: {
           unsafeStatus: unsafe.status === 500,
@@ -200,7 +203,10 @@ try {
 } finally {
   if (broker && broker.exitCode === null) {
     broker.kill('SIGTERM');
-    await Promise.race([onceExit(broker), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+    await Promise.race([
+      onceExit(broker),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
     if (broker.exitCode === null) broker.kill('SIGKILL');
   }
   await relay?.close();


### PR DESCRIPTION
- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1715-spawn-overload` <!-- relay-pr-proof:case -->

## Summary
- retry typed Relaycast HTTP 503 worker preregistration failures with three bounded attempts
- preserve terminal status, code, request ID, and truthful attempt count
- allow fallback only for headless task-exit workers with Relay messaging explicitly disabled
- fail closed for PTY, interactive, and messaging-enabled workers

## Validation
- full broker suite: 1,067 passed, 4 ignored
- real `/api/spawn` regression proves persistent 503 retry exhaustion, unsafe fail-closed, and safe live-worker fallback
- `cargo clippy -p agent-relay-broker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Veto diff review: PASS
- fresh independent exact-head review: `COMPREHENSIVELY_SATISFIED`

Closes #1715.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broker spawn and registration failure handling on overload paths; incorrect retry or fallback logic could block spawns or start workers without Relaycast identity.
> 
> **Overview**
> **Broker-owned bounded retries** now cover transient Relaycast registration overloads (especially typed **503** / `database_overloaded`) for worker preregistration and **`mcp-args --register`**, replacing the SDK’s single-shot path for unkeyed agent `POST`s. Up to **three attempts** use fixed **200/400ms** backoff (capped retry-after), terminal errors keep status/code/request ID with a **restamped attempt count**, and **429** does not burn retries during SDK cooldown.
> 
> **Spawn behavior is tightened:** after retries are exhausted, only **headless task-exit** workers with **`skipRelayPrompt`** may still start locally without preregistration; **PTY** and other modes **fail closed** instead of spawning unreachable agents.
> 
> Validation adds broker unit/integration coverage, a **RelayFlow `1715-spawn-overload`** base-red/head-green proof, and a changelog entry under **[Unreleased - Patch]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94efb1408487d8d4b258a79eda3436466cf5151b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->