### PR TITLE
test(pr-proof): add provider identity to scoped mount fixture

### DIFF
--- a/tests/relayflows/cases/1630-scoped-relayfile-sandbox-mount/run.mjs
+++ b/tests/relayflows/cases/1630-scoped-relayfile-sandbox-mount/run.mjs
@@ -90,6 +90,7 @@ test('observes exact Relayfile subtree forwarding', async () => {
           relayWorkspaceId: 'rw_relayflow',
           relayfileMounted: true,
           providerId: 'daytona',
+          providerSandboxId: '223e4567-e89b-42d3-a456-426614174000',
         },
         { status: 201 }
       ),


### PR DESCRIPTION
## Summary

- Add the required valid Daytona providerSandboxId to the case 1630 scoped Relayfile mount fixture.
- Isolate this test-only fixture repair so PR #1733 can declare only its 1732 RelayFlow case.

## Test Plan

- `bun build tests/relayflows/cases/1630-scoped-relayfile-sandbox-mount/run.mjs --outdir /tmp/relay-1630-syntax --target=node`
- Proof-contract classification confirms the changed file is non-runtime and the declaration is non-functional/n/a.
- `git diff --check`

## RelayFlow Proof

Use `non-functional` and `n/a`: this PR changes only a test fixture and does not change shipped runtime behavior.

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

Fixes the exact changed-case scope failure reported by PR #1733’s RelayFlow dispatcher.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a81ae623224caee9b8f46bbf0070345174fd6700. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

