### PR TITLE
fix(fleet): dispatch sandbox launchers with scoped tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
+- `fleet spawn --sandbox` dispatches with only its temporary launcher token after Cloud target selection, avoiding the SDK's dual-credential rejection while keeping workspace-key authority limited to launcher registration and release.
 
 - `fleet spawn --sandbox` uses the provider-neutral durable profile for explicit Daytona and E2B sandboxes, so their measured resource envelopes are routable while Agent37 retains its heavy profile.
 

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -1421,6 +1421,111 @@ describe('fleet command support', () => {
     );
   });
 
+  it('accepts a Cloud UUID request when Cloud returns its Relaycast workspace target', async () => {
+    const cloudWorkspaceId = '50587328-0000-4000-8000-000000000003';
+    const target = { ...CANONICAL_RELAYCAST_TARGET, workspaceId: 'rw_7ccfea89' };
+    const ensureCloudFleetSandbox = vi.fn(async () => ({
+      outcome: 'provisioned' as const,
+      cloudWorkspaceId: 'cloud-workspace',
+      nodeId: 'node-generated',
+      nodeName: 'generated-node',
+      sandboxId: 'generated-public-sandbox',
+      relayWorkspaceId: 'rw_7ccfea89',
+      relaycastTarget: target,
+      relayfileMounted: true,
+    }));
+    const createWorkspaceRelay = vi.fn(() => ({
+      workspace: {
+        info: vi.fn(async () => ({ id: 'rw_7ccfea89' })),
+        register: vi.fn(async () => ({ token: 'at_live_launcher' })),
+        release: vi.fn(async () => ({ released: true, deleted: true })),
+      },
+    }));
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn(() => ({ messaging: { placement: { spawn: vi.fn() } } })) as never,
+        createWorkspaceRelay: createWorkspaceRelay as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+      ensureCloudFleetSandbox,
+      resolveWorkspaceSelection: () => undefined,
+      persistWorkspaceRelaycastTarget: () => true,
+      deleteCloudFleetSandbox: vi.fn(async () => undefined),
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await program.parseAsync(
+      [
+        'fleet', 'spawn', 'codex', '--sandbox', '--no-sandbox-relayfile',
+        '--workspace-id', cloudWorkspaceId, '--name', 'sandbox-worker', '--task', 'Work',
+        '--workspace-key', 'rk_live_test',
+      ],
+      { from: 'user' },
+    );
+
+    expect(ensureCloudFleetSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: cloudWorkspaceId }),
+    );
+    expect(createWorkspaceRelay).toHaveBeenCalledWith({
+      workspaceKey: target.relaycastApiKey,
+      baseUrl: target.baseUrl,
+    });
+  });
+
+  it('rejects a Relaycast target whose workspace differs from Cloud identity', async () => {
+    const deleteCloudFleetSandbox = vi.fn(async () => undefined);
+    const ensureCloudFleetSandbox = vi.fn(async () => ({
+      outcome: 'provisioned' as const,
+      cloudWorkspaceId: 'cloud-workspace',
+      nodeId: 'node-generated',
+      nodeName: 'generated-node',
+      sandboxId: 'generated-public-sandbox',
+      relayWorkspaceId: 'rw_expected',
+      relaycastTarget: { ...CANONICAL_RELAYCAST_TARGET, workspaceId: 'rw_other' },
+      relayfileMounted: true,
+    }));
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (() => { throw new Error('__exit__'); }) as never,
+      },
+      ensureCloudFleetSandbox,
+      resolveWorkspaceSelection: () => undefined,
+      persistWorkspaceRelaycastTarget: () => true,
+      deleteCloudFleetSandbox,
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await expect(program.parseAsync(
+      [
+        'fleet', 'spawn', 'codex', '--sandbox', '--no-sandbox-relayfile',
+        '--workspace-id', '50587328-0000-4000-8000-000000000003', '--name', 'sandbox-worker',
+        '--task', 'Work', '--workspace-key', 'rk_live_test',
+      ],
+      { from: 'user' },
+    )).rejects.toThrow('__exit__');
+    expect(deleteCloudFleetSandbox).toHaveBeenCalledWith({
+      cloudWorkspaceId: 'cloud-workspace', sandboxId: 'generated-public-sandbox',
+    });
+  });
+
   it('generates a stable identity and matching name when neither option is supplied', async () => {
     vi.stubEnv('RELAY_AGENT_TOKEN', undefined);
     const events: string[] = [];

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -768,7 +768,6 @@ describe('fleet command support', () => {
       { strict: true }
     );
     expect(createAgentRelay).toHaveBeenCalledWith({
-      workspaceKey: 'rk_live_agent37_target',
       token: 'at_live_launcher',
       baseUrl: 'https://agent37-cast.agentrelay.com',
     });
@@ -965,7 +964,6 @@ describe('fleet command support', () => {
       { strict: true }
     );
     expect(createAgentRelay).toHaveBeenCalledWith({
-      workspaceKey: CANONICAL_RELAYCAST_TARGET.relaycastApiKey,
       token: 'at_live_launcher',
       baseUrl: CANONICAL_RELAYCAST_TARGET.baseUrl,
     });
@@ -1059,10 +1057,8 @@ describe('fleet command support', () => {
       ignorePersistedRelaycastTarget: true,
     });
     expect(createAgentRelay).toHaveBeenCalledWith({
-      workspaceKey: 'rk_live_test',
       token: 'at_live_legacy_launcher',
       baseUrl: undefined,
-      ignorePersistedRelaycastTarget: true,
     });
   });
 

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -1464,15 +1464,25 @@ describe('fleet command support', () => {
 
     await program.parseAsync(
       [
-        'fleet', 'spawn', 'codex', '--sandbox', '--no-sandbox-relayfile',
-        '--workspace-id', cloudWorkspaceId, '--name', 'sandbox-worker', '--task', 'Work',
-        '--workspace-key', 'rk_live_test',
+        'fleet',
+        'spawn',
+        'codex',
+        '--sandbox',
+        '--no-sandbox-relayfile',
+        '--workspace-id',
+        cloudWorkspaceId,
+        '--name',
+        'sandbox-worker',
+        '--task',
+        'Work',
+        '--workspace-key',
+        'rk_live_test',
       ],
-      { from: 'user' },
+      { from: 'user' }
     );
 
     expect(ensureCloudFleetSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceId: cloudWorkspaceId }),
+      expect.objectContaining({ workspaceId: cloudWorkspaceId })
     );
     expect(createWorkspaceRelay).toHaveBeenCalledWith({
       workspaceKey: target.relaycastApiKey,
@@ -1501,7 +1511,9 @@ describe('fleet command support', () => {
         createWorkspace: vi.fn() as never,
         log: vi.fn(),
         error: vi.fn(),
-        exit: (() => { throw new Error('__exit__'); }) as never,
+        exit: (() => {
+          throw new Error('__exit__');
+        }) as never,
       },
       ensureCloudFleetSandbox,
       resolveWorkspaceSelection: () => undefined,
@@ -1513,16 +1525,29 @@ describe('fleet command support', () => {
       error: () => undefined,
     });
 
-    await expect(program.parseAsync(
-      [
-        'fleet', 'spawn', 'codex', '--sandbox', '--no-sandbox-relayfile',
-        '--workspace-id', '50587328-0000-4000-8000-000000000003', '--name', 'sandbox-worker',
-        '--task', 'Work', '--workspace-key', 'rk_live_test',
-      ],
-      { from: 'user' },
-    )).rejects.toThrow('__exit__');
+    await expect(
+      program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'codex',
+          '--sandbox',
+          '--no-sandbox-relayfile',
+          '--workspace-id',
+          '50587328-0000-4000-8000-000000000003',
+          '--name',
+          'sandbox-worker',
+          '--task',
+          'Work',
+          '--workspace-key',
+          'rk_live_test',
+        ],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('__exit__');
     expect(deleteCloudFleetSandbox).toHaveBeenCalledWith({
-      cloudWorkspaceId: 'cloud-workspace', sandboxId: 'generated-public-sandbox',
+      cloudWorkspaceId: 'cloud-workspace',
+      sandboxId: 'generated-public-sandbox',
     });
   });
 

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -411,8 +411,7 @@ export function registerFleetCommands(
               (sandboxProvider === 'agent37' && target.route !== 'agent37-isolated') ||
               (returnedRelayWorkspaceId !== undefined &&
                 target.workspaceId.trim() !== returnedRelayWorkspaceId) ||
-              (sandbox.outcome === 'provisioned' &&
-                !returnedRelayWorkspaceId)
+              (sandbox.outcome === 'provisioned' && !returnedRelayWorkspaceId)
             ) {
               throw new Error(
                 sandboxProvider === 'agent37' && target.route !== 'agent37-isolated'
@@ -430,8 +429,7 @@ export function registerFleetCommands(
             const postEnsureWorkspaceId = postEnsureWorkspace.id?.trim();
             if (
               !postEnsureWorkspaceId ||
-              (sandbox.outcome === 'provisioned' &&
-                postEnsureWorkspaceId !== returnedRelayWorkspaceId) ||
+              (sandbox.outcome === 'provisioned' && postEnsureWorkspaceId !== returnedRelayWorkspaceId) ||
               postEnsureWorkspaceId !== target.workspaceId.trim()
             ) {
               throw new Error(

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -405,11 +405,14 @@ export function registerFleetCommands(
           // exact workspace Cloud returned.
           try {
             const target = sandbox.relaycastTarget;
+            const returnedRelayWorkspaceId =
+              'relayWorkspaceId' in sandbox ? sandbox.relayWorkspaceId?.trim() : undefined;
             if (
               (sandboxProvider === 'agent37' && target.route !== 'agent37-isolated') ||
-              target.workspaceId.trim() !== relayWorkspaceId.trim() ||
+              (returnedRelayWorkspaceId !== undefined &&
+                target.workspaceId.trim() !== returnedRelayWorkspaceId) ||
               (sandbox.outcome === 'provisioned' &&
-                sandbox.relayWorkspaceId.trim() !== relayWorkspaceId.trim())
+                !returnedRelayWorkspaceId)
             ) {
               throw new Error(
                 sandboxProvider === 'agent37' && target.route !== 'agent37-isolated'
@@ -428,7 +431,7 @@ export function registerFleetCommands(
             if (
               !postEnsureWorkspaceId ||
               (sandbox.outcome === 'provisioned' &&
-                postEnsureWorkspaceId !== sandbox.relayWorkspaceId.trim()) ||
+                postEnsureWorkspaceId !== returnedRelayWorkspaceId) ||
               postEnsureWorkspaceId !== target.workspaceId.trim()
             ) {
               throw new Error(

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -540,7 +540,16 @@ export function registerFleetCommands(
             }
           }
 
-          const relay = deps.sdk.createAgentRelay({ ...relaycastClientOptions, token: agentToken });
+          // A sandbox launcher token is already scoped to the exact workspace
+          // and Relaycast deployment selected by Cloud. Keep the workspace key
+          // only on `workspaceRelay`, where it mints and releases that token;
+          // passing both authorities to the agent client is rejected by the
+          // SDK and would prevent every sandbox placement from dispatching.
+          const relay = deps.sdk.createAgentRelay(
+            sandbox
+              ? { token: agentToken, baseUrl: relaycastClientOptions.baseUrl }
+              : { ...relaycastClientOptions, token: agentToken }
+          );
           // Placement alone only proves the node accepted the dispatch. A node
           // running an obsolete broker advertises `spawn:<cli>` capacity, acks
           // the invocation and launches nothing, which is indistinguishable from

--- a/tests/relayflows/cases/1746-sandbox-launcher-token-authority/case.json
+++ b/tests/relayflows/cases/1746-sandbox-launcher-token-authority/case.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "id": "1746-sandbox-launcher-token-authority",
+  "kind": "bugfix",
+  "title": "Dispatch a Fleet sandbox with one launcher-token authority",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "sandbox_dispatch_rejected_for_dual_credentials"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "sandbox_dispatch_uses_scoped_launcher_token_only"
+    }
+  }
+}

--- a/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
+++ b/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
@@ -6,6 +6,7 @@
  * permissive test double cannot hide the SDK's dual-credential rejection.
  */
 import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { randomUUID } from 'node:crypto';
 import { lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -76,6 +77,7 @@ export default {
 const probeSource = String.raw`import { expect, test, vi } from 'vitest';
 import { writeFile } from 'node:fs/promises';
 import { Command } from 'commander';
+import { createHash } from 'node:crypto';
 
 vi.mock('./cli/lib/broker-lifecycle.js', () => ({
   readBrokerConnection: vi.fn(() => ({ url: 'http://127.0.0.1:1', api_key: 'k', pid: 1, port: 1 })),
@@ -121,6 +123,7 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
     })),
   };
   let constructorOptions: Record<string, unknown> | undefined;
+  let createdWorkspaceRelay: typeof workspaceRelay | undefined;
   const createAgentRelay = vi.fn((options: Record<string, unknown>) => {
     constructorOptions = options;
     // Exercise the target checkout's real credential exclusivity guard. The
@@ -141,6 +144,7 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
   let workspaceRelayOptions: Record<string, unknown> | undefined;
   const createWorkspaceRelay = vi.fn((options: Record<string, unknown>) => {
     workspaceRelayOptions = options;
+    createdWorkspaceRelay = workspaceRelay;
     return workspaceRelay;
   });
   const cliErrors: string[] = [];
@@ -218,6 +222,14 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
   }
 
   expect(createAgentRelay).toHaveBeenCalledTimes(1);
+  expect(createWorkspaceRelay).toHaveBeenCalledTimes(1);
+  expect(createdWorkspaceRelay).toBe(workspaceRelay);
+  expect(workspaceRelay.workspace.register).toBe(register);
+  expect(workspaceRelay.workspace.release).toBe(release);
+  expect(hashValue(constructorOptions?.token)).toBe(hashValue('at_live_launcher'));
+  expect(hashValue(constructorOptions?.baseUrl)).toBe(hashValue('https://cast.agentrelay.com'));
+  expect(hashValue(workspaceRelayOptions?.workspaceKey)).toBe(hashValue('rk_live_cloud_target'));
+  expect(hashValue(workspaceRelayOptions?.baseUrl)).toBe(hashValue('https://cast.agentrelay.com'));
   await writeFile(
     output,
     JSON.stringify({
@@ -225,18 +237,23 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
       cliError: cliErrors.join('\n'),
       hasWorkspaceKey:
         typeof constructorOptions?.workspaceKey === 'string' && constructorOptions.workspaceKey.length > 0,
-      exactToken: constructorOptions?.token === 'at_live_launcher',
-      exactWorkspaceKey: workspaceRelayOptions?.workspaceKey === 'rk_live_cloud_target',
-      baseUrl: constructorOptions?.baseUrl ?? null,
+      tokenHash: hashValue(constructorOptions?.token),
+      workspaceKeyHash: hashValue(workspaceRelayOptions?.workspaceKey),
+      baseUrlHash: hashValue(constructorOptions?.baseUrl),
       placementCalls: placement.spawn.mock.calls.length,
       registerCalls: register.mock.calls.length,
       releaseCalls: release.mock.calls.length,
       workspaceRelayCalls: createWorkspaceRelay.mock.calls.length,
-      workspaceRelayBaseUrl: workspaceRelayOptions?.baseUrl ?? null,
+      workspaceRelayBaseUrlHash: hashValue(workspaceRelayOptions?.baseUrl),
+      sameWorkspaceRelayInstance: createdWorkspaceRelay === workspaceRelay,
     }),
     'utf8'
   );
 });
+
+function hashValue(value) {
+  return typeof value === 'string' ? 'sha256:' + createHash('sha256').update(value).digest('hex') : null;
+}
 `;
 
 try {
@@ -260,13 +277,14 @@ try {
 
   const observation = JSON.parse(await readFile(observationPath, 'utf8'));
   const sharedLifecycleObserved =
-    observation.exactToken === true &&
-    observation.baseUrl === 'https://cast.agentrelay.com' &&
+    observation.tokenHash === hashValue('at_live_launcher') &&
+    observation.baseUrlHash === hashValue('https://cast.agentrelay.com') &&
     observation.registerCalls === 1 &&
     observation.releaseCalls === 1 &&
     observation.workspaceRelayCalls === 1 &&
-    observation.exactWorkspaceKey === true &&
-    observation.workspaceRelayBaseUrl === 'https://cast.agentrelay.com';
+    observation.workspaceKeyHash === hashValue('rk_live_cloud_target') &&
+    observation.workspaceRelayBaseUrlHash === hashValue('https://cast.agentrelay.com') &&
+    observation.sameWorkspaceRelayInstance === true;
   const baseObserved =
     sharedLifecycleObserved &&
     observation.commandOutcome === 'error' &&
@@ -364,4 +382,8 @@ function run(command, args, cwd, label, timeoutMs, extraEnv = {}) {
       }.`
     );
   }
+}
+
+function hashValue(value) {
+  return typeof value === 'string' ? `sha256:${createHash('sha256').update(value).digest('hex')}` : null;
 }

--- a/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
+++ b/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
@@ -131,13 +131,18 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
   });
   const register = vi.fn(async () => ({ token: 'at_live_launcher' }));
   const release = vi.fn(async () => ({ released: true, deleted: true }));
-  const createWorkspaceRelay = vi.fn(() => ({
+  const workspaceRelay = {
     workspace: {
       info: vi.fn(async () => ({ id: 'rw_relayflow' })),
       register,
       release,
     },
-  }));
+  };
+  let workspaceRelayOptions: Record<string, unknown> | undefined;
+  const createWorkspaceRelay = vi.fn((options: Record<string, unknown>) => {
+    workspaceRelayOptions = options;
+    return workspaceRelay;
+  });
   const cliErrors: string[] = [];
   const program = new Command();
   program.exitOverride();
@@ -220,11 +225,14 @@ test('sandbox dispatch constructs an agent client with exactly one authority', a
       cliError: cliErrors.join('\n'),
       hasWorkspaceKey:
         typeof constructorOptions?.workspaceKey === 'string' && constructorOptions.workspaceKey.length > 0,
-      hasToken: typeof constructorOptions?.token === 'string' && constructorOptions.token.length > 0,
+      exactToken: constructorOptions?.token === 'at_live_launcher',
+      exactWorkspaceKey: workspaceRelayOptions?.workspaceKey === 'rk_live_cloud_target',
       baseUrl: constructorOptions?.baseUrl ?? null,
       placementCalls: placement.spawn.mock.calls.length,
       registerCalls: register.mock.calls.length,
       releaseCalls: release.mock.calls.length,
+      workspaceRelayCalls: createWorkspaceRelay.mock.calls.length,
+      workspaceRelayBaseUrl: workspaceRelayOptions?.baseUrl ?? null,
     }),
     'utf8'
   );
@@ -252,10 +260,13 @@ try {
 
   const observation = JSON.parse(await readFile(observationPath, 'utf8'));
   const sharedLifecycleObserved =
-    observation.hasToken === true &&
+    observation.exactToken === true &&
     observation.baseUrl === 'https://cast.agentrelay.com' &&
     observation.registerCalls === 1 &&
-    observation.releaseCalls === 1;
+    observation.releaseCalls === 1 &&
+    observation.workspaceRelayCalls === 1 &&
+    observation.exactWorkspaceKey === true &&
+    observation.workspaceRelayBaseUrl === 'https://cast.agentrelay.com';
   const baseObserved =
     sharedLifecycleObserved &&
     observation.commandOutcome === 'error' &&

--- a/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
+++ b/tests/relayflows/cases/1746-sandbox-launcher-token-authority/run.mjs
@@ -1,0 +1,356 @@
+/**
+ * relay#1746 — after Cloud selects a Relaycast target, Fleet must use the
+ * workspace key only to register/release a temporary launcher and the scoped
+ * launcher token only to dispatch. The generated probe drives the real Fleet
+ * command and invokes the target checkout's real SDK client constructor, so a
+ * permissive test double cannot hide the SDK's dual-credential rejection.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1746-sandbox-launcher-token-authority';
+const INSTALL_TIMEOUT_MS = 8 * 60 * 1000;
+const PROBE_TIMEOUT_MS = 5 * 60 * 1000;
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probePath = path.join(targetDir, 'packages/cli/src/.relayflow-1746-launcher-token.test.ts');
+const observationPath = path.join(targetDir, '.relayflow-1746-launcher-token-observation.json');
+const configPath = path.join(targetDir, '.relayflow-1746-launcher-token.vitest.config.mjs');
+
+const probeConfigSource = `import path from 'node:path';
+
+const workspacePackages = [
+  'cloud',
+  'config',
+  'fleet',
+  'harness-driver',
+  'harnesses',
+  'policy',
+  'sdk',
+  'session',
+  'utils',
+];
+
+export default {
+  resolve: {
+    alias: workspacePackages.flatMap((name) => {
+      const sourceRoot = path.resolve(process.cwd(), 'packages', name, 'src');
+      return [
+        { find: new RegExp('^@agent-relay/' + name + '/(.+)$'), replacement: sourceRoot + '/$1' },
+        { find: '@agent-relay/' + name, replacement: path.join(sourceRoot, 'index.ts') },
+      ];
+    }),
+  },
+  test: {
+    environment: 'node',
+    include: ['packages/cli/src/.relayflow-1746-launcher-token.test.ts'],
+    setupFiles: [],
+  },
+};
+`;
+
+const probeSource = String.raw`import { expect, test, vi } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+import { Command } from 'commander';
+
+vi.mock('./cli/lib/broker-lifecycle.js', () => ({
+  readBrokerConnection: vi.fn(() => ({ url: 'http://127.0.0.1:1', api_key: 'k', pid: 1, port: 1 })),
+}));
+
+vi.mock('@agent-relay/harness-driver', async (importOriginal) => ({
+  ...(await importOriginal()),
+  HarnessDriverClient: class {
+    async getSession() {
+      return {
+        workspace_key: 'rk_probe_secret',
+        node_token: 'nt_probe_secret',
+        node_id: 'node_1',
+        node_name: 'live-node',
+        broker_version: '12.0.0',
+        protocol_version: 2,
+        mode: 'persist',
+        uptime_secs: 1,
+      };
+    }
+    async listAgents() {
+      return [];
+    }
+    async listFleetInventory() {
+      return { nodeName: 'live-node', agents: [] };
+    }
+    disconnect() {}
+  },
+}));
+
+import { registerFleetCommands } from './cli/commands/fleet.js';
+import { createAgentRelay as createRealAgentRelay } from './cli/lib/sdk-client.js';
+
+test('sandbox dispatch constructs an agent client with exactly one authority', async () => {
+  const output = process.env.RELAY_PR1746_OBSERVATION_PATH;
+  if (!output) throw new Error('Missing RELAY_PR1746_OBSERVATION_PATH.');
+  vi.stubEnv('RELAY_AGENT_TOKEN', undefined);
+
+  const placement = {
+    spawn: vi.fn(async () => ({
+      invocationId: 'inv_relayflow_1746',
+      node: { name: 'daytona-worker' },
+    })),
+  };
+  let constructorOptions: Record<string, unknown> | undefined;
+  const createAgentRelay = vi.fn((options: Record<string, unknown>) => {
+    constructorOptions = options;
+    // Exercise the target checkout's real credential exclusivity guard. The
+    // resulting client is not used for network access; placement is replaced
+    // only after construction succeeds.
+    createRealAgentRelay({ ...options, env: {} });
+    return { messaging: { placement } };
+  });
+  const register = vi.fn(async () => ({ token: 'at_live_launcher' }));
+  const release = vi.fn(async () => ({ released: true, deleted: true }));
+  const createWorkspaceRelay = vi.fn(() => ({
+    workspace: {
+      info: vi.fn(async () => ({ id: 'rw_relayflow' })),
+      register,
+      release,
+    },
+  }));
+  const cliErrors: string[] = [];
+  const program = new Command();
+  program.exitOverride();
+  registerFleetCommands(program, {
+    sdk: {
+      createAgentRelay: createAgentRelay as never,
+      createWorkspaceRelay: createWorkspaceRelay as never,
+      createWorkspace: vi.fn() as never,
+      log: vi.fn(),
+      error: (...args: unknown[]) => cliErrors.push(args.join(' ')),
+      exit: (() => {
+        throw new Error('__relayflow_exit__');
+      }) as never,
+    },
+    ensureCloudFleetSandbox: vi.fn(async () => ({
+      outcome: 'reused' as const,
+      cloudWorkspaceId: 'cloud-workspace',
+      nodeId: 'node-daytona',
+      nodeName: 'daytona-worker',
+      status: 'online',
+      activeAgents: 0,
+      maxAgents: 1,
+      providerId: 'daytona' as const,
+      relaycastTarget: {
+        route: 'canonical' as const,
+        baseUrl: 'https://cast.agentrelay.com',
+        workspaceId: 'rw_relayflow',
+        relaycastApiKey: 'rk_live_cloud_target',
+      },
+    })),
+    resolveWorkspaceSelection: () => ({
+      key: 'rk_live_test',
+      source: 'project',
+      origin: '/tmp/relayflow/workspace-key.json',
+      workspaceId: 'rw_relayflow',
+    }),
+    persistWorkspaceRelaycastTarget: () => true,
+    deleteCloudFleetSandbox: vi.fn(async () => undefined),
+    createFleetWorkspaceClient: vi.fn() as never,
+    log: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  } as never);
+
+  let commandOutcome = 'success';
+  try {
+    await program.parseAsync(
+      [
+        'fleet',
+        'spawn',
+        'opencode',
+        '--sandbox',
+        '--sandbox-provider',
+        'daytona',
+        '--no-sandbox-relayfile',
+        '--workspace-id',
+        'rw_relayflow',
+        '--name',
+        'cheap-reviewer',
+        '--task',
+        'Review the candidate',
+        '--workspace-key',
+        'rk_live_test',
+      ],
+      { from: 'user' }
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === '__relayflow_exit__') {
+      commandOutcome = 'error';
+    } else {
+      throw error;
+    }
+  }
+
+  expect(createAgentRelay).toHaveBeenCalledTimes(1);
+  await writeFile(
+    output,
+    JSON.stringify({
+      commandOutcome,
+      cliError: cliErrors.join('\n'),
+      hasWorkspaceKey:
+        typeof constructorOptions?.workspaceKey === 'string' && constructorOptions.workspaceKey.length > 0,
+      hasToken: typeof constructorOptions?.token === 'string' && constructorOptions.token.length > 0,
+      baseUrl: constructorOptions?.baseUrl ?? null,
+      placementCalls: placement.spawn.mock.calls.length,
+      registerCalls: register.mock.calls.length,
+      releaseCalls: release.mock.calls.length,
+    }),
+    'utf8'
+  );
+});
+`;
+
+try {
+  run(
+    'npm',
+    ['ci', '--ignore-scripts', '--no-audit', '--no-fund'],
+    targetDir,
+    'workspace dependency installation',
+    INSTALL_TIMEOUT_MS
+  );
+  await writeGeneratedFile(probePath, probeSource);
+  await writeGeneratedFile(configPath, probeConfigSource);
+  run(
+    'npm',
+    ['exec', '--', 'vitest', 'run', '--config', path.relative(targetDir, configPath)],
+    targetDir,
+    'sandbox launcher authority probe',
+    PROBE_TIMEOUT_MS,
+    { RELAY_PR1746_OBSERVATION_PATH: observationPath }
+  );
+
+  const observation = JSON.parse(await readFile(observationPath, 'utf8'));
+  const sharedLifecycleObserved =
+    observation.hasToken === true &&
+    observation.baseUrl === 'https://cast.agentrelay.com' &&
+    observation.registerCalls === 1 &&
+    observation.releaseCalls === 1;
+  const baseObserved =
+    sharedLifecycleObserved &&
+    observation.commandOutcome === 'error' &&
+    observation.hasWorkspaceKey === true &&
+    observation.placementCalls === 0 &&
+    observation.cliError.includes('Pass either --workspace-key or --token, not both.');
+  const headObserved =
+    sharedLifecycleObserved &&
+    observation.commandOutcome === 'success' &&
+    observation.hasWorkspaceKey === false &&
+    observation.placementCalls === 1 &&
+    observation.cliError === '';
+
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'sandbox_dispatch_rejected_for_dual_credentials';
+    details =
+      'The real Fleet command registered and released its temporary launcher, but passed both the Cloud workspace key and launcher token into the real SDK constructor; the exclusivity guard rejected dispatch before placement.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'sandbox_dispatch_uses_scoped_launcher_token_only';
+    details =
+      'The real Fleet command kept workspace-key authority on launcher registration/release and constructed the placement client with only the scoped launcher token plus Cloud-selected Relaycast origin.';
+  } else {
+    throw new Error(`Unexpected sandbox launcher authority observation: ${JSON.stringify(observation)}.`);
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+  process.stdout.write(`${signature}\n`);
+} finally {
+  await rm(probePath, { force: true });
+  await rm(configPath, { force: true });
+  await rm(observationPath, { force: true });
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+async function writeGeneratedFile(targetPath, source) {
+  try {
+    const existing = await lstat(targetPath);
+    if (!existing.isFile()) throw new Error(`Refusing to replace non-regular file ${targetPath}.`);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const temporaryPath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    const handle = await open(temporaryPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(source, 'utf8');
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, targetPath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+function run(command, args, cwd, label, timeoutMs, extraEnv = {}) {
+  const completed = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...extraEnv },
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: timeoutMs,
+  });
+  if (completed.error) throw new Error(`${label} could not start: ${completed.error.message}`);
+  if (completed.status !== 0) {
+    throw new Error(
+      `${label} failed with ${
+        completed.signal ? `signal ${completed.signal}` : `exit code ${completed.status ?? 'unknown'}`
+      }.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- keep Cloud-selected workspace-key authority on temporary launcher registration and release
- construct sandbox placement clients with only the scoped launcher token and validated Relaycast origin
- add a red/green RelayFlow that drives the real Fleet command through the real SDK credential guard

Fixes #1746

Stacked on #1745 because a live explicit-Daytona request must first pass the provider workload-profile gate before it can reach this dispatch path.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing completed
- [x] Fleet command tests: 40/40
- [x] full workspace dependency build
- [x] CLI lint: 0 errors (existing warnings only)
- [x] local exact-arm RelayFlow: base `sandbox_dispatch_rejected_for_dual_credentials`; head `sandbox_dispatch_uses_scoped_launcher_token_only`
- [x] exact live red reproduction used caller-declared sandbox identity; Daytona exact-name lookup after automatic cleanup returned zero matches

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1746-sandbox-launcher-token-authority` <!-- relay-pr-proof:case -->

## Screenshots

Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox spawn credential path in fleet placement; mis-wiring could break all sandbox dispatches, but scope is narrow and covered by unit and RelayFlow proofs.
> 
> **Overview**
> **Fixes sandbox fleet spawns failing before placement** because the CLI passed both the Cloud-selected workspace key and the temporary launcher token into `createAgentRelay`, which the SDK rejects.
> 
> For `fleet spawn --sandbox`, placement now uses **only** the scoped launcher token and the validated Relaycast `baseUrl`; the workspace key stays on `createWorkspaceRelay` for launcher register/release. Non-sandbox spawns are unchanged.
> 
> Relaycast target checks now key off **Cloud’s** `relayWorkspaceId` (including accepting a Cloud workspace UUID when Cloud returns the matching target), with cleanup when the returned target doesn’t match. Fleet unit tests and RelayFlow case `1746-sandbox-launcher-token-authority` lock in the single-authority dispatch behavior against the real SDK guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d56c76c43c953158a8ec5e3aea24200f0d49ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->