### PR TITLE
fix(broker): retry Relaycast workspace_busy startup admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
+
 - `fleet spawn --sandbox` uses the provider-neutral durable profile for explicit Daytona and E2B sandboxes, so their measured resource envelopes are routable while Agent37 retains its heavy profile.
 
 - Cloud Daytona Fleet provisioning now requires and returns the exact provider sandbox UUID alongside the stable Cloud sandbox ID, enabling ID-bound inspection and cleanup after interrupted launches.

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -922,13 +922,20 @@ fn is_rate_limited(err: &anyhow::Error) -> bool {
     auth_http_status(err).is_some_and(|status| status == StatusCode::TOO_MANY_REQUESTS)
 }
 
+/// `anyhow::Error`-flavored counterpart to `is_workspace_busy_error`. Uses an
+/// exact, case-sensitive comparison against `WORKSPACE_BUSY_CODE` — no
+/// `trim()`/case normalization — because this classifier gates a replay of
+/// an unkeyed `POST /v1/agents`. Retrying on a whitespace-padded or
+/// otherwise near-match code would replay on an unverified admission signal,
+/// risking the AR-448 duplicate-workspace shape; near-matches must stay
+/// terminal after a single attempt.
 fn is_workspace_busy_anyhow(err: &anyhow::Error) -> bool {
     err.downcast_ref::<AuthHttpError>().is_some_and(|error| {
         error.status == StatusCode::TOO_MANY_REQUESTS
             && error
                 .code
                 .as_deref()
-                .is_some_and(|code| code.trim() == WORKSPACE_BUSY_CODE)
+                .is_some_and(|code| code == WORKSPACE_BUSY_CODE)
     })
 }
 
@@ -992,6 +999,11 @@ fn is_transient_server_error(error: &RelayError) -> bool {
     ) || is_workspace_busy_error(error)
 }
 
+/// Exact, case-sensitive match against the typed wire code — replay safety
+/// for this unkeyed POST depends on the code being the literal
+/// `workspace_busy` contract, not a whitespace-padded, differently-cased, or
+/// otherwise near-match string. See `is_workspace_busy_anyhow` for the
+/// rationale.
 fn is_workspace_busy_error(error: &RelayError) -> bool {
     matches!(
         error,
@@ -999,7 +1011,7 @@ fn is_workspace_busy_error(error: &RelayError) -> bool {
             code,
             status: 429,
             ..
-        } if code.trim() == WORKSPACE_BUSY_CODE
+        } if code == WORKSPACE_BUSY_CODE
     )
 }
 
@@ -1127,11 +1139,15 @@ fn relay_error_to_anyhow(error: RelayError) -> anyhow::Error {
             status: StatusCode::from_u16(*status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             message: message.clone(),
             code: {
-                let trimmed = code.trim();
-                if trimmed.is_empty() {
+                // Only whitespace-only/empty codes collapse to `None`; a
+                // non-empty code is preserved verbatim (not trimmed) so
+                // that exact-match classifiers such as
+                // `is_workspace_busy_anyhow` see the literal wire value and
+                // correctly reject whitespace-padded near-matches.
+                if code.trim().is_empty() {
                     None
                 } else {
-                    Some(trimmed.to_string())
+                    Some(code.clone())
                 }
             },
             request_id: request_id.clone(),
@@ -1665,20 +1681,28 @@ mod tests {
             "Workspace_Busy",
             "workspace_busy_extra",
             "workspace-busy",
+            " workspace_busy",
+            "workspace_busy ",
+            " workspace_busy ",
+            "\tworkspace_busy\n",
+            "workspace_busy\u{a0}",
         ] {
             let error = RelayError::api(code, "not the workspace admission contract", 429);
             assert!(
                 !is_workspace_busy_error(&error),
-                "unexpected match for {code}"
+                "unexpected match for {code:?}"
             );
             let anyhow_error = relay_error_to_anyhow(error);
             assert!(
                 !is_workspace_busy_anyhow(&anyhow_error),
-                "unexpected anyhow match for {code}"
+                "unexpected anyhow match for {code:?}"
             );
         }
 
-        assert!(is_workspace_busy_error(&RelayError::api(
+        // Whitespace padding must remain terminal, not retried: replaying an
+        // unkeyed POST on a near-match code (rather than the exact typed
+        // wire contract) risks the AR-448 duplicate-workspace shape.
+        assert!(!is_workspace_busy_error(&RelayError::api(
             " workspace_busy ",
             "workspace admission is busy",
             429,
@@ -2272,6 +2296,59 @@ mod tests {
         workspace.assert_hits(0);
         unsafe {
             std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    /// A whitespace-padded (or otherwise near-match) `workspace_busy` code is
+    /// not the typed wire contract, so `retry_transient_relay_error` — the
+    /// bounded-retry layer `admit_agent_registration` uses for the unkeyed
+    /// `POST /v1/agents` — must treat it as terminal after exactly one
+    /// attempt, the same as any other non-workspace-busy 429. Replaying on a
+    /// near-match code would replay an unkeyed POST on an unverified
+    /// admission signal, risking the AR-448 duplicate-workspace shape.
+    #[tokio::test]
+    async fn workspace_busy_near_match_code_stays_terminal_after_one_attempt() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        for near_match in [
+            "WORKSPACE_BUSY",
+            "Workspace_Busy",
+            "workspace_busy_extra",
+            "workspace-busy",
+            " workspace_busy",
+            "workspace_busy ",
+            " workspace_busy ",
+            "\tworkspace_busy\n",
+            "workspace_busy\u{a0}",
+        ] {
+            let calls = AtomicUsize::new(0);
+            let error = retry_transient_relay_error("registering the broker agent", || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Err::<(), _>(RelayError::api(
+                        near_match,
+                        "workspace admission is busy",
+                        429,
+                    ))
+                }
+            })
+            .await
+            .expect_err("a near-match code must remain terminal, not be treated as workspace_busy");
+
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "near-match code {near_match:?} must not be retried"
+            );
+            assert!(
+                !is_workspace_busy_error(&error),
+                "near-match code {near_match:?} must not classify as workspace_busy"
+            );
+            let anyhow_error = relay_error_to_anyhow(error);
+            assert!(
+                !is_workspace_busy_anyhow(&anyhow_error),
+                "near-match code {near_match:?} must not classify as workspace_busy via anyhow"
+            );
         }
     }
 

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -370,6 +370,7 @@ impl AuthClient {
             let preferred_name = requested_name;
             let mut memberships = Vec::with_capacity(sources.len());
             let mut auth_rejections = Vec::new();
+            let mut workspace_busy_rejection: Option<anyhow::Error> = None;
 
             for source in sources {
                 let Some(api_key) = normalize_workspace_key(&source.api_key) else {
@@ -394,6 +395,9 @@ impl AuthClient {
                         session.credentials.workspace_alias = source.workspace_alias.clone();
                         memberships.push(session);
                     }
+                    Err(error) if is_workspace_busy_anyhow(&error) => {
+                        workspace_busy_rejection.get_or_insert(error);
+                    }
                     Err(error) if is_auth_rejection(&error) => {
                         auth_rejections
                             .push(source.workspace_id.unwrap_or_else(|| "env".to_string()));
@@ -413,6 +417,11 @@ impl AuthClient {
             }
 
             if memberships.is_empty() {
+                if let Some(error) = workspace_busy_rejection {
+                    return Err(error).context(
+                        "all configured multi-workspace memberships were rejected; workspace admission remained busy",
+                    );
+                }
                 anyhow::bail!(
                     "all configured multi-workspace memberships were rejected ({})",
                     auth_rejections.join(", ")
@@ -581,6 +590,14 @@ impl AuthClient {
                         default_workspace_id: Some(session.credentials.workspace_id.clone()),
                         memberships: vec![session],
                     });
+                }
+                Err(error) if is_workspace_busy_anyhow(&error) => {
+                    // RELAY_API_KEY is a join hint, not permission to mint a
+                    // replacement workspace when admission is temporarily busy.
+                    return Err(error).context(format!(
+                        "failed registering agent with {} workspace key; workspace admission remained busy",
+                        candidate.source
+                    ));
                 }
                 Err(error) if is_auth_rejection(&error) => {
                     if candidate.explicit_join {
@@ -901,6 +918,16 @@ fn is_rate_limited(err: &anyhow::Error) -> bool {
     auth_http_status(err).is_some_and(|status| status == StatusCode::TOO_MANY_REQUESTS)
 }
 
+fn is_workspace_busy_anyhow(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<AuthHttpError>().is_some_and(|error| {
+        error.status == StatusCode::TOO_MANY_REQUESTS
+            && error
+                .code
+                .as_deref()
+                .is_some_and(|code| code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE))
+    })
+}
+
 fn auth_http_status(err: &anyhow::Error) -> Option<StatusCode> {
     err.downcast_ref::<AuthHttpError>()
         .map(|e| e.status)
@@ -933,6 +960,11 @@ const RELAYCAST_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// 34099838274 lost three jobs to exactly that.
 const TRANSIENT_STARTUP_RETRY_BACKOFFS_MS: [u64; 2] = [200, 400];
 
+/// Relaycast uses this exact code for temporary workspace write-admission
+/// saturation. Generic 429s remain terminal because they may represent quota
+/// or policy failures rather than a safe pre-commit admission signal.
+const WORKSPACE_BUSY_CODE: &str = "workspace_busy";
+
 /// Replay only server failures whose typed error code establishes that the
 /// request failed at the storage-admission boundary. Retrying every 5xx by
 /// status is unsafe for these unkeyed POSTs: an application-level 503 or a 500
@@ -953,6 +985,17 @@ fn is_transient_server_error(error: &RelayError) -> bool {
             code.trim(),
             "database_overloaded" | "workspace_storage_unavailable"
         )
+    ) || is_workspace_busy_error(error)
+}
+
+fn is_workspace_busy_error(error: &RelayError) -> bool {
+    matches!(
+        error,
+        RelayError::Api {
+            code,
+            status: 429,
+            ..
+        } if code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE)
     )
 }
 
@@ -1544,10 +1587,11 @@ mod tests {
 
     use super::{
         hash_identity_key, is_agent_token_invalid, is_agent_token_invalid_anyhow,
-        is_agent_token_invalid_code, is_transient_server_error, reclaim_legacy_identity,
-        relay_error_to_anyhow, relay_request_with_timeout, resolve_relaycast_base_url,
-        retry_transient_relay_error, stable_node_identity_key, AuthClient, AuthHttpError,
-        CredentialCache, AGENT_TOKEN_INVALID_CODE, DEFAULT_RELAYCAST_BASE_URL,
+        is_agent_token_invalid_code, is_transient_server_error, is_workspace_busy_error,
+        reclaim_legacy_identity, relay_error_to_anyhow, relay_request_with_timeout,
+        resolve_relaycast_base_url, retry_transient_relay_error, stable_node_identity_key,
+        AuthClient, AuthHttpError, CredentialCache, AGENT_TOKEN_INVALID_CODE,
+        DEFAULT_RELAYCAST_BASE_URL,
     };
     use relaycast::RelayError;
 
@@ -2047,6 +2091,162 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn workspace_busy_retries_once_even_with_retry_after_header() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        use axum::{
+            body::Body,
+            extract::State,
+            http::{Response, StatusCode as AxumStatusCode},
+            routing::post,
+            Router,
+        };
+
+        async fn register(State(calls): State<Arc<AtomicUsize>>) -> Response<Body> {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            let (status, body) = if attempt == 0 {
+                (
+                    AxumStatusCode::TOO_MANY_REQUESTS,
+                    json!({
+                        "ok": false,
+                        "error": {
+                            "code": "workspace_busy",
+                            "message": "workspace admission is busy"
+                        }
+                    }),
+                )
+            } else {
+                (
+                    AxumStatusCode::OK,
+                    json!({
+                        "ok": true,
+                        "data": {
+                            "id": "a1",
+                            "workspace_id": "ws_busy",
+                            "name": "lead",
+                            "token": "at_live_1",
+                            "status": "online",
+                            "created_at": "2025-01-01T00:00:00Z"
+                        }
+                    }),
+                )
+            };
+            let mut response = Response::new(Body::from(body.to_string()));
+            *response.status_mut() = status;
+            response.headers_mut().insert(
+                "content-type",
+                "application/json".parse().expect("valid content type"),
+            );
+            if attempt == 0 {
+                response
+                    .headers_mut()
+                    .insert("retry-after", "0".parse().expect("valid retry-after"));
+            }
+            response
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn({
+            let calls = calls.clone();
+            async move {
+                axum::serve(
+                    listener,
+                    Router::new()
+                        .route("/v1/agents", post(register))
+                        .with_state(calls),
+                )
+                .await
+            }
+        });
+
+        let _env_guard = clear_relay_env();
+        unsafe {
+            std::env::set_var("RELAY_API_KEY", "rk_live_busy");
+        }
+        let session = AuthClient::new(Some(format!("http://{address}")))
+            .startup_session(Some("lead"))
+            .await
+            .expect("workspace_busy should clear on the bounded retry");
+
+        assert_eq!(session.credentials.workspace_id, "ws_busy");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        server.abort();
+        unsafe {
+            std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn workspace_busy_exhaustion_is_bounded_and_preserves_diagnostics() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("RELAY_API_KEY", "rk_live_busy");
+        }
+        let register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_busy");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .header("x-request-id", "workspace-busy-test")
+                .body(r#"{"ok":false,"error":{"code":"workspace_busy","message":"workspace admission is busy"}}"#);
+        });
+        let workspace = server.mock(|when, then| {
+            when.method(POST).path("/v1/workspaces");
+            then.status(500);
+        });
+        let error = AuthClient::new(Some(server.base_url()))
+            .startup_session(Some("lead"))
+            .await
+            .expect_err("persistent workspace_busy must remain terminal");
+        let message = format!("{error:#}");
+        for marker in [
+            "workspace_busy",
+            "429 Too Many Requests",
+            "workspace admission is busy",
+            "request_id: workspace-busy-test",
+            "attempts: 3",
+        ] {
+            assert!(message.contains(marker), "missing {marker}: {message}");
+        }
+        register.assert_hits(3);
+        workspace.assert_hits(0);
+        unsafe {
+            std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn unrelated_rate_limit_is_terminal_without_replay() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let error = retry_transient_relay_error("admitting a workspace", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<(), _>(RelayError::api(
+                    "registration_rate_limited",
+                    "registration rate limit exceeded",
+                    429,
+                ))
+            }
+        })
+        .await
+        .expect_err("an unrelated 429 must not be replayed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!is_workspace_busy_error(&error));
+        assert!(matches!(error, RelayError::Api { status: 429, .. }));
     }
 
     /// A failure that *changes* mid-retry — a 401 after a 503 — is terminal,

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -808,6 +808,10 @@ impl AuthClient {
     /// prior divergence — strict silently handed over the incumbent's token,
     /// non-strict silently minted a `-suffix` sibling — was itself the
     /// spawn-admission defect (see `admit_agent_registration`).
+    /// Registration is used by startup and by `rotate_token`'s 404 recovery.
+    /// Keep the admission retry shared intentionally: both paths issue the
+    /// same unkeyed pre-commit POST, and retries remain limited to Relaycast's
+    /// exact `workspace_busy` contract with the same bounded budget.
     async fn register_agent_with_workspace_key(
         &self,
         workspace_key: &str,
@@ -924,7 +928,7 @@ fn is_workspace_busy_anyhow(err: &anyhow::Error) -> bool {
             && error
                 .code
                 .as_deref()
-                .is_some_and(|code| code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE))
+                .is_some_and(|code| code.trim() == WORKSPACE_BUSY_CODE)
     })
 }
 
@@ -995,7 +999,7 @@ fn is_workspace_busy_error(error: &RelayError) -> bool {
             code,
             status: 429,
             ..
-        } if code.trim().eq_ignore_ascii_case(WORKSPACE_BUSY_CODE)
+        } if code.trim() == WORKSPACE_BUSY_CODE
     )
 }
 
@@ -1587,11 +1591,11 @@ mod tests {
 
     use super::{
         hash_identity_key, is_agent_token_invalid, is_agent_token_invalid_anyhow,
-        is_agent_token_invalid_code, is_transient_server_error, is_workspace_busy_error,
-        reclaim_legacy_identity, relay_error_to_anyhow, relay_request_with_timeout,
-        resolve_relaycast_base_url, retry_transient_relay_error, stable_node_identity_key,
-        AuthClient, AuthHttpError, CredentialCache, AGENT_TOKEN_INVALID_CODE,
-        DEFAULT_RELAYCAST_BASE_URL,
+        is_agent_token_invalid_code, is_transient_server_error, is_workspace_busy_anyhow,
+        is_workspace_busy_error, reclaim_legacy_identity, relay_error_to_anyhow,
+        relay_request_with_timeout, resolve_relaycast_base_url, retry_transient_relay_error,
+        stable_node_identity_key, AuthClient, AuthHttpError, CredentialCache,
+        AGENT_TOKEN_INVALID_CODE, DEFAULT_RELAYCAST_BASE_URL, TRANSIENT_STARTUP_RETRY_BACKOFFS_MS,
     };
     use relaycast::RelayError;
 
@@ -1646,6 +1650,51 @@ mod tests {
             attempts: 1,
         });
         assert!(is_agent_token_invalid_anyhow(&err));
+    }
+
+    #[test]
+    fn workspace_busy_classifier_requires_the_exact_case_sensitive_code() {
+        assert!(is_workspace_busy_error(&RelayError::api(
+            "workspace_busy",
+            "workspace admission is busy",
+            429,
+        )));
+
+        for code in [
+            "WORKSPACE_BUSY",
+            "Workspace_Busy",
+            "workspace_busy_extra",
+            "workspace-busy",
+        ] {
+            let error = RelayError::api(code, "not the workspace admission contract", 429);
+            assert!(
+                !is_workspace_busy_error(&error),
+                "unexpected match for {code}"
+            );
+            let anyhow_error = relay_error_to_anyhow(error);
+            assert!(
+                !is_workspace_busy_anyhow(&anyhow_error),
+                "unexpected anyhow match for {code}"
+            );
+        }
+
+        assert!(is_workspace_busy_error(&RelayError::api(
+            " workspace_busy ",
+            "workspace admission is busy",
+            429,
+        )));
+        assert!(!is_workspace_busy_error(&RelayError::api(
+            "workspace_busy",
+            "workspace admission is busy",
+            503,
+        )));
+    }
+
+    #[test]
+    fn startup_retry_backoff_budget_is_deterministic_and_bounded() {
+        assert_eq!(TRANSIENT_STARTUP_RETRY_BACKOFFS_MS, [200, 400]);
+        assert_eq!(TRANSIENT_STARTUP_RETRY_BACKOFFS_MS.len() + 1, 3);
+        assert_eq!(TRANSIENT_STARTUP_RETRY_BACKOFFS_MS.iter().sum::<u64>(), 600);
     }
 
     #[test]
@@ -2223,6 +2272,58 @@ mod tests {
         workspace.assert_hits(0);
         unsafe {
             std::env::remove_var("RELAY_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_workspace_selection_preserves_workspace_busy_diagnostics() {
+        let _env_guard = clear_relay_env();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var(
+                "RELAY_WORKSPACES_JSON",
+                r#"[{"workspace_id":"ws_busy","api_key":"rk_live_busy"},{"workspace_id":"ws_auth","api_key":"rk_live_auth"}]"#,
+            );
+        }
+        let busy_register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_busy");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("x-request-id", "multi-workspace-busy-374")
+                .body(
+                    r#"{"ok":false,"error":{"code":"workspace_busy","message":"Workspace write capacity is busy"}}"#,
+                );
+        });
+        let auth_register = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/agents")
+                .header("authorization", "Bearer rk_live_auth");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":false,"error":{"code":"unauthorized","message":"unauthorized"}}"#);
+        });
+
+        let error = AuthClient::new(Some(server.base_url()))
+            .startup_session_set(Some("lead"))
+            .await
+            .expect_err("a busy membership must remain diagnosable when all fail");
+        let message = format!("{error:#}");
+        for marker in [
+            "workspace_busy",
+            "429 Too Many Requests",
+            "Workspace write capacity is busy",
+            "request_id: multi-workspace-busy-374",
+            "attempts: 3",
+        ] {
+            assert!(message.contains(marker), "missing {marker}: {message}");
+        }
+        busy_register.assert_hits(3);
+        auth_register.assert_hits(1);
+
+        unsafe {
+            std::env::remove_var("RELAY_WORKSPACES_JSON");
         }
     }
 

--- a/crates/broker/src/relaycast/auth.rs
+++ b/crates/broker/src/relaycast/auth.rs
@@ -609,13 +609,22 @@ impl AuthClient {
                     auth_rejections.push(format!("{} key rejected", candidate.source));
                 }
                 Err(error) if is_rate_limited(&error) => {
-                    if candidate.explicit_join {
-                        return Err(error).context(format!(
-                            "explicit workspace key from {} was rate-limited",
-                            candidate.source
-                        ));
-                    }
-                    auth_rejections.push(format!("{} key rate-limited", candidate.source));
+                    // Only the exact `workspace_busy` code (handled above by
+                    // `is_workspace_busy_anyhow`, which retries and then stays
+                    // terminal) is a safe, narrowly-scoped signal to keep
+                    // going. Any other 429 reaching this arm — a near-match
+                    // code, an unrelated quota/policy 429, or no code at all —
+                    // is *not* proof that the existing workspace is gone or
+                    // that RELAY_API_KEY was invalid. Treating it as a soft
+                    // rejection here would fall through to minting a brand
+                    // new workspace below, which is exactly the accidental
+                    // duplicate-workspace behavior the issue calls out.
+                    // Terminal for both explicit and implicit key sources.
+                    return Err(error).context(format!(
+                        "{} workspace key was rate-limited by a non-workspace_busy 429; \
+                         this is not a safe signal to mint a replacement workspace",
+                        candidate.source
+                    ));
                 }
                 Err(error) => {
                     return Err(error).context(format!(
@@ -2401,6 +2410,80 @@ mod tests {
 
         unsafe {
             std::env::remove_var("RELAY_WORKSPACES_JSON");
+        }
+    }
+
+    /// Full `startup_session` HTTP-path proof for the outer admission
+    /// fallback in `startup_single_session_set_from_sources`: a near-match
+    /// `workspace_busy` code or an unrelated 429 reaching `/v1/agents` for an
+    /// *implicit* `RELAY_API_KEY` candidate (`explicit_join: false`) must
+    /// stay terminal end-to-end, exactly like an explicit key. Before this
+    /// fix, that arm treated any 429 as a soft rejection and fell through to
+    /// `create_workspace`, minting a fresh workspace behind a caller's back
+    /// merely because the response happened to carry a 429 status — even
+    /// though only the literal `workspace_busy` code is a safe, narrowly
+    /// scoped retry/terminal signal. This must not regress: exactly one
+    /// `/v1/agents` attempt, and zero `POST /v1/workspaces` calls, for every
+    /// near-match casing/whitespace variant and for a wholly unrelated 429
+    /// code.
+    #[tokio::test]
+    async fn startup_session_near_match_and_unrelated_rate_limit_never_mints_workspace() {
+        let near_match_and_unrelated_codes = [
+            "WORKSPACE_BUSY",
+            "Workspace_Busy",
+            "workspace_busy_extra",
+            "workspace-busy",
+            " workspace_busy",
+            "workspace_busy ",
+            " workspace_busy ",
+            "\tworkspace_busy\n",
+            "workspace_busy\u{a0}",
+            "registration_rate_limited",
+        ];
+
+        for code in near_match_and_unrelated_codes {
+            let _env_guard = clear_relay_env();
+            let server = MockServer::start();
+            unsafe {
+                std::env::set_var("RELAY_API_KEY", "rk_live_ratelimited");
+            }
+            let register = server.mock(|when, then| {
+                when.method(POST)
+                    .path("/v1/agents")
+                    .header("authorization", "Bearer rk_live_ratelimited");
+                then.status(429)
+                    .header("content-type", "application/json")
+                    .body(format!(
+                        r#"{{"ok":false,"error":{{"code":{code:?},"message":"rate limited"}}}}"#
+                    ));
+            });
+            let workspace = server.mock(|when, then| {
+                when.method(POST).path("/v1/workspaces");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(
+                        r#"{"ok":true,"workspace_id":"ws_should_never_be_created","api_key":"rk_live_should_never_exist"}"#,
+                    );
+            });
+
+            let error = AuthClient::new(Some(server.base_url()))
+                .startup_session(Some("lead"))
+                .await
+                .expect_err(&format!(
+                    "code {code:?} must remain terminal and never mint a workspace"
+                ));
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("rate-limited") || message.contains("429"),
+                "error for {code:?} should describe the rate limit: {message}"
+            );
+
+            register.assert_hits(1);
+            workspace.assert_hits(0);
+
+            unsafe {
+                std::env::remove_var("RELAY_API_KEY");
+            }
         }
     }
 

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/case.json
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "workspace-busy-startup-retry-429",
+  "kind": "bugfix",
+  "title": "Retry Relaycast workspace busy startup admission",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs"]
+  },
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "startup_429_workspace_busy_not_retried"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "startup_429_workspace_busy_retried_safely"
+    }
+  }
+}

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
@@ -11,6 +11,7 @@ const INSTANCE_NAME = 'relayflow-workspace-busy-429';
 const HANDSHAKE_MARKER = 'connect_relay completed';
 const BUSY_CODE = 'workspace_busy';
 const UNRELATED_CODE = 'registration_rate_limited';
+const NEAR_MATCH_CODE = ' workspace_busy ';
 const REQUEST_ID = 'relayflow-workspace-busy-429-request';
 const STARTUP_WINDOW_MS = 60_000;
 
@@ -75,9 +76,16 @@ const server = http.createServer((request, response) => {
     const workspaceBusy = mode === 'busy-success' || mode === 'busy-exhaustion';
     const shouldReject =
       mode === 'unrelated-429' ||
+      mode === 'unrelated-429-implicit-key' ||
+      mode === 'near-match-429-implicit-key' ||
       (workspaceBusy && (mode === 'busy-exhaustion' || attempt === 1));
     if (shouldReject) {
-      const code = mode === 'unrelated-429' ? '${UNRELATED_CODE}' : '${BUSY_CODE}';
+      const code =
+        mode === 'unrelated-429' || mode === 'unrelated-429-implicit-key'
+          ? '${UNRELATED_CODE}'
+          : mode === 'near-match-429-implicit-key'
+            ? '${NEAR_MATCH_CODE}'
+            : '${BUSY_CODE}';
       response.writeHead(429, {
         'content-type': 'application/json',
         'retry-after': '0',
@@ -117,12 +125,20 @@ process.once('SIGTERM', () => server.close(() => process.exit(0)));
 const observations = {};
 try {
   await writeFile(serverPath, serverSource, { encoding: 'utf8', mode: 0o600 });
-  for (const mode of ['busy-success', 'unrelated-429', 'busy-exhaustion']) {
+  for (const mode of [
+    'busy-success',
+    'unrelated-429',
+    'busy-exhaustion',
+    'unrelated-429-implicit-key',
+    'near-match-429-implicit-key',
+  ]) {
     observations[mode] = await runScenario(mode);
   }
   const success = observations['busy-success'];
   const unrelated = observations['unrelated-429'];
   const exhaustion = observations['busy-exhaustion'];
+  const unrelatedImplicit = observations['unrelated-429-implicit-key'];
+  const nearMatchImplicit = observations['near-match-429-implicit-key'];
   const baseObserved =
     arm === 'base' &&
     success.registrationCount === 1 &&
@@ -136,7 +152,16 @@ try {
     exhaustion.registrationCount === 1 &&
     exhaustion.workspaceCreationCount === 1 &&
     !exhaustion.timedOut &&
-    !exhaustion.stderr.includes(HANDSHAKE_MARKER);
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    // Pre-fix, an implicit RELAY_API_KEY candidate treated ANY 429 —
+    // near-match `workspace_busy` code or a wholly unrelated one — as a
+    // soft rejection and fell through to minting a fresh workspace.
+    unrelatedImplicit.registrationCount === 1 &&
+    unrelatedImplicit.workspaceCreationCount === 1 &&
+    !unrelatedImplicit.timedOut &&
+    nearMatchImplicit.registrationCount === 1 &&
+    nearMatchImplicit.workspaceCreationCount === 1 &&
+    !nearMatchImplicit.timedOut;
   const headObserved =
     arm === 'head' &&
     success.registrationCount === 2 &&
@@ -155,7 +180,18 @@ try {
     exhaustion.stderr.includes(BUSY_CODE) &&
     exhaustion.stderr.includes('status: 429') &&
     exhaustion.stderr.includes('workspace admission is busy') &&
-    exhaustion.stderr.includes('attempts: 3');
+    exhaustion.stderr.includes('attempts: 3') &&
+    // Fixed: an implicit RELAY_API_KEY candidate must stay terminal for a
+    // near-match or unrelated 429 exactly like an explicit key, and must
+    // never mint a replacement workspace.
+    unrelatedImplicit.registrationCount === 1 &&
+    unrelatedImplicit.workspaceCreationCount === 0 &&
+    !unrelatedImplicit.timedOut &&
+    !unrelatedImplicit.stderr.includes(HANDSHAKE_MARKER) &&
+    nearMatchImplicit.registrationCount === 1 &&
+    nearMatchImplicit.workspaceCreationCount === 0 &&
+    !nearMatchImplicit.timedOut &&
+    !nearMatchImplicit.stderr.includes(HANDSHAKE_MARKER);
   let outcome;
   let signature;
   let details;
@@ -203,6 +239,11 @@ async function runScenario(mode) {
         ...(mode === 'unrelated-429'
           ? { AGENT_RELAY_WORKSPACE_KEY: 'rk_relayflow_workspace_busy_429' }
           : { RELAY_API_KEY: 'rk_relayflow_workspace_busy_429' }),
+        // `unrelated-429-implicit-key` and `near-match-429-implicit-key`
+        // above both fall into the `RELAY_API_KEY` branch, since that is
+        // the specific implicit, non-`explicit_join` candidate the outer
+        // startup fallback must never mint a workspace for on a 429 that
+        // isn't the literal `workspace_busy` code.
         AGENT_RELAY_STARTUP_DEBUG: '1',
         AGENT_RELAY_TELEMETRY_DISABLED: '1',
       },

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
@@ -41,10 +41,26 @@ const serverPath = path.join(probeDir, 'relaycast-admission-probe.mjs');
 const serverSource = String.raw`import http from 'node:http';
 const mode = process.argv[2];
 let registrationCount = 0;
+let workspaceCreationCount = 0;
 const server = http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/observations') {
     response.writeHead(200, { 'content-type': 'application/json' });
-    response.end(JSON.stringify({ registrationCount }));
+    response.end(JSON.stringify({ registrationCount, workspaceCreationCount }));
+    return;
+  }
+  if (request.method === 'POST' && request.url === '/v1/workspaces') {
+    workspaceCreationCount += 1;
+    request.resume();
+    request.once('end', () => {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        ok: false,
+        error: {
+          code: 'workspace_creation_probe',
+          message: 'workspace creation was observed by the proof probe',
+        },
+      }));
+    });
     return;
   }
   if (request.method !== 'POST' || request.url !== '/v1/agents') {
@@ -110,31 +126,30 @@ try {
   const baseObserved =
     arm === 'base' &&
     success.registrationCount === 1 &&
+    success.workspaceCreationCount === 1 &&
     !success.timedOut &&
     !success.stderr.includes(HANDSHAKE_MARKER) &&
-    success.stderr.includes('status: 429') &&
-    success.stderr.includes(BUSY_CODE) &&
-    success.stderr.includes('attempts: 1') &&
     unrelated.registrationCount === 1 &&
+    unrelated.workspaceCreationCount === 0 &&
     !unrelated.timedOut &&
     !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
-    unrelated.stderr.includes(UNRELATED_CODE) &&
     exhaustion.registrationCount === 1 &&
+    exhaustion.workspaceCreationCount === 1 &&
     !exhaustion.timedOut &&
-    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
-    exhaustion.stderr.includes('status: 429') &&
-    exhaustion.stderr.includes('workspace admission is busy') &&
-    exhaustion.stderr.includes('attempts: 1');
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER);
   const headObserved =
     arm === 'head' &&
     success.registrationCount === 2 &&
+    success.workspaceCreationCount === 0 &&
     success.stderr.includes(HANDSHAKE_MARKER) &&
     !success.timedOut &&
     unrelated.registrationCount === 1 &&
+    unrelated.workspaceCreationCount === 0 &&
     !unrelated.timedOut &&
     !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
     unrelated.stderr.includes(UNRELATED_CODE) &&
     exhaustion.registrationCount === 3 &&
+    exhaustion.workspaceCreationCount === 0 &&
     !exhaustion.timedOut &&
     !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
     exhaustion.stderr.includes(BUSY_CODE) &&
@@ -148,7 +163,7 @@ try {
     outcome = 'bug';
     signature = 'startup_429_workspace_busy_not_retried';
     details =
-      'The base broker treated the exact 429 workspace_busy admission response as terminal; unrelated 429s were terminal and no startup replay occurred.';
+      'The base broker treated the 429 responses as terminal after one agent-registration attempt, then attempted fallback workspace creation instead of preserving the supplied workspace key.';
   } else if (headObserved) {
     outcome = 'fixed';
     signature = 'startup_429_workspace_busy_retried_safely';
@@ -185,13 +200,15 @@ async function runScenario(mode) {
         TMPDIR: probeDir,
         NO_COLOR: '1',
         RELAYCAST_BASE_URL: `http://127.0.0.1:${port}`,
-        AGENT_RELAY_WORKSPACE_KEY: 'rk_relayflow_workspace_busy_429',
+        ...(mode === 'unrelated-429'
+          ? { AGENT_RELAY_WORKSPACE_KEY: 'rk_relayflow_workspace_busy_429' }
+          : { RELAY_API_KEY: 'rk_relayflow_workspace_busy_429' }),
         AGENT_RELAY_STARTUP_DEBUG: '1',
         AGENT_RELAY_TELEMETRY_DISABLED: '1',
       },
     });
-    const { registrationCount } = await readObservations(port);
-    return { ...observed, registrationCount, serverStderr };
+    const { registrationCount, workspaceCreationCount } = await readObservations(port);
+    return { ...observed, registrationCount, workspaceCreationCount, serverStderr };
   } finally {
     if (server.exitCode === null) {
       server.kill('SIGTERM');
@@ -282,6 +299,9 @@ async function readObservations(port) {
   if (!Number.isInteger(value.registrationCount)) {
     throw new Error('Observation endpoint returned an invalid registration count.');
   }
+  if (!Number.isInteger(value.workspaceCreationCount)) {
+    throw new Error('Observation endpoint returned an invalid workspace creation count.');
+  }
   return value;
 }
 
@@ -291,6 +311,7 @@ function summarize(values) {
       name,
       {
         registrationCount: value.registrationCount,
+        workspaceCreationCount: value.workspaceCreationCount,
         timedOut: value.timedOut,
         status: value.status,
         stdout: value.stdout.slice(-1_000),

--- a/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
+++ b/tests/relayflows/cases/workspace-busy-startup-retry-429/run.mjs
@@ -1,0 +1,326 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = 'workspace-busy-startup-retry-429';
+const INSTANCE_NAME = 'relayflow-workspace-busy-429';
+const HANDSHAKE_MARKER = 'connect_relay completed';
+const BUSY_CODE = 'workspace_busy';
+const UNRELATED_CODE = 'registration_rate_limited';
+const REQUEST_ID = 'relayflow-workspace-busy-429-request';
+const STARTUP_WINDOW_MS = 60_000;
+
+const targetDir = requiredDirectory('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredDirectory('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = await requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+if (!isWithin(harnessDir, fileURLToPath(import.meta.url))) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const probeDir = await mkdtemp(path.join(tmpdir(), 'relayflow-workspace-busy-429-'));
+const serverPath = path.join(probeDir, 'relaycast-admission-probe.mjs');
+const serverSource = String.raw`import http from 'node:http';
+const mode = process.argv[2];
+let registrationCount = 0;
+const server = http.createServer((request, response) => {
+  if (request.method === 'GET' && request.url === '/observations') {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ registrationCount }));
+    return;
+  }
+  if (request.method !== 'POST' || request.url !== '/v1/agents') {
+    response.writeHead(404, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: false, error: { code: 'not_found', message: 'no route' } }));
+    return;
+  }
+  registrationCount += 1;
+  const attempt = registrationCount;
+  request.resume();
+  request.once('end', () => {
+    const workspaceBusy = mode === 'busy-success' || mode === 'busy-exhaustion';
+    const shouldReject =
+      mode === 'unrelated-429' ||
+      (workspaceBusy && (mode === 'busy-exhaustion' || attempt === 1));
+    if (shouldReject) {
+      const code = mode === 'unrelated-429' ? '${UNRELATED_CODE}' : '${BUSY_CODE}';
+      response.writeHead(429, {
+        'content-type': 'application/json',
+        'retry-after': '0',
+        'x-request-id': '${REQUEST_ID}',
+      });
+      response.end(JSON.stringify({
+        ok: false,
+        error: {
+          code,
+          message: code === '${BUSY_CODE}' ? 'workspace admission is busy' : 'registration rate limit exceeded',
+        },
+      }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      ok: true,
+      data: {
+        id: 'a_relayflow_workspace_busy_429',
+        workspace_id: 'ws_relayflow_workspace_busy_429',
+        name: '${INSTANCE_NAME}',
+        token: 'at_live_relayflow_workspace_busy_429',
+        status: 'online',
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    }));
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a TCP address.');
+  process.stdout.write(JSON.stringify({ port: address.port }) + '\n');
+});
+process.once('SIGTERM', () => server.close(() => process.exit(0)));
+`;
+
+const observations = {};
+try {
+  await writeFile(serverPath, serverSource, { encoding: 'utf8', mode: 0o600 });
+  for (const mode of ['busy-success', 'unrelated-429', 'busy-exhaustion']) {
+    observations[mode] = await runScenario(mode);
+  }
+  const success = observations['busy-success'];
+  const unrelated = observations['unrelated-429'];
+  const exhaustion = observations['busy-exhaustion'];
+  const baseObserved =
+    arm === 'base' &&
+    success.registrationCount === 1 &&
+    !success.timedOut &&
+    !success.stderr.includes(HANDSHAKE_MARKER) &&
+    success.stderr.includes('status: 429') &&
+    success.stderr.includes(BUSY_CODE) &&
+    success.stderr.includes('attempts: 1') &&
+    unrelated.registrationCount === 1 &&
+    !unrelated.timedOut &&
+    !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
+    unrelated.stderr.includes(UNRELATED_CODE) &&
+    exhaustion.registrationCount === 1 &&
+    !exhaustion.timedOut &&
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    exhaustion.stderr.includes('status: 429') &&
+    exhaustion.stderr.includes('workspace admission is busy') &&
+    exhaustion.stderr.includes('attempts: 1');
+  const headObserved =
+    arm === 'head' &&
+    success.registrationCount === 2 &&
+    success.stderr.includes(HANDSHAKE_MARKER) &&
+    !success.timedOut &&
+    unrelated.registrationCount === 1 &&
+    !unrelated.timedOut &&
+    !unrelated.stderr.includes(HANDSHAKE_MARKER) &&
+    unrelated.stderr.includes(UNRELATED_CODE) &&
+    exhaustion.registrationCount === 3 &&
+    !exhaustion.timedOut &&
+    !exhaustion.stderr.includes(HANDSHAKE_MARKER) &&
+    exhaustion.stderr.includes(BUSY_CODE) &&
+    exhaustion.stderr.includes('status: 429') &&
+    exhaustion.stderr.includes('workspace admission is busy') &&
+    exhaustion.stderr.includes('attempts: 3');
+  let outcome;
+  let signature;
+  let details;
+  if (baseObserved) {
+    outcome = 'bug';
+    signature = 'startup_429_workspace_busy_not_retried';
+    details =
+      'The base broker treated the exact 429 workspace_busy admission response as terminal; unrelated 429s were terminal and no startup replay occurred.';
+  } else if (headObserved) {
+    outcome = 'fixed';
+    signature = 'startup_429_workspace_busy_retried_safely';
+    details =
+      'The head broker retried workspace_busy once to complete startup, kept an unrelated 429 terminal, and exhausted workspace_busy at three request attempts without replaying the complete handshake.';
+  } else {
+    throw new Error(
+      `Unexpected workspace admission observations: ${JSON.stringify(summarize(observations))}`
+    );
+  }
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+} finally {
+  await rm(probeDir, { recursive: true, force: true });
+}
+
+async function runScenario(mode) {
+  const server = spawn(process.execPath, [serverPath, mode], {
+    cwd: probeDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  try {
+    const { port, stderr: serverStderr } = await waitForServerReady(server);
+    const observed = await runBrokerStartup({
+      binaryPath,
+      cwd: probeDir,
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        HOME: probeDir,
+        TMPDIR: probeDir,
+        NO_COLOR: '1',
+        RELAYCAST_BASE_URL: `http://127.0.0.1:${port}`,
+        AGENT_RELAY_WORKSPACE_KEY: 'rk_relayflow_workspace_busy_429',
+        AGENT_RELAY_STARTUP_DEBUG: '1',
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+      },
+    });
+    const { registrationCount } = await readObservations(port);
+    return { ...observed, registrationCount, serverStderr };
+  } finally {
+    if (server.exitCode === null) {
+      server.kill('SIGTERM');
+      await Promise.race([
+        new Promise((resolve) => server.once('exit', resolve)),
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+      ]);
+      if (server.exitCode === null) server.kill('SIGKILL');
+    }
+  }
+}
+
+function runBrokerStartup({ binaryPath, cwd, env }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binaryPath, ['init', '--instance-name', INSTANCE_NAME, '--channels', 'general'], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      resolve({ ...result, stdout, stderr });
+    };
+    const timer = setTimeout(() => finish({ status: null, signal: null, timedOut: true }), STARTUP_WINDOW_MS);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.includes(HANDSHAKE_MARKER)) finish({ timedOut: false });
+    });
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`compiled broker probe could not start: ${error.message}`));
+    });
+    child.once('exit', (status, signal) => finish({ status, signal, timedOut: false }));
+  });
+}
+
+async function waitForServerReady(server) {
+  let stdout = '';
+  let stderr = '';
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Relaycast probe did not start: ${stderr || stdout || 'timeout'}`)),
+      10_000
+    );
+    server.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      const line = stdout.split('\n').find(Boolean);
+      if (!line) return;
+      try {
+        const parsed = JSON.parse(line);
+        clearTimeout(timer);
+        resolve({ ...parsed, stderr });
+      } catch {
+        // Wait for a complete JSON line.
+      }
+    });
+    server.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    server.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    server.once('exit', (code, signal) => {
+      if (code !== null || signal !== null) {
+        clearTimeout(timer);
+        reject(new Error(`Relaycast probe exited before ready: ${code ?? signal}`));
+      }
+    });
+  });
+}
+
+async function readObservations(port) {
+  const response = await fetch(`http://127.0.0.1:${port}/observations`);
+  if (!response.ok) throw new Error(`Observation endpoint returned HTTP ${response.status}.`);
+  const value = await response.json();
+  if (!Number.isInteger(value.registrationCount)) {
+    throw new Error('Observation endpoint returned an invalid registration count.');
+  }
+  return value;
+}
+
+function summarize(values) {
+  return Object.fromEntries(
+    Object.entries(values).map(([name, value]) => [
+      name,
+      {
+        registrationCount: value.registrationCount,
+        timedOut: value.timedOut,
+        status: value.status,
+        stdout: value.stdout.slice(-1_000),
+        stderr: value.stderr.slice(-2_000),
+      },
+    ])
+  );
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+function requiredDirectory(name) {
+  return path.resolve(requiredValue(name));
+}
+async function requiredExecutable(name) {
+  const candidate = path.resolve(requiredValue(name));
+  try {
+    await access(candidate, fsConstants.R_OK | fsConstants.X_OK);
+  } catch {
+    throw new Error(`${name} must name a readable executable file.`);
+  }
+  return candidate;
+}
+function isWithin(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}


### PR DESCRIPTION
## Summary

Retry the narrowly transient Relaycast HTTP 429 `workspace_busy` response during broker startup/admission.

Only the exact `workspace_busy` code is retried. Unrelated 429 responses remain terminal. Exhaustion preserves Relaycast diagnostics, and the complete startup handshake remains fail-closed so unkeyed workspace or agent-registration POSTs are not replayed.

Fixes #1728.

## Test plan

- [x] Exact workspace-busy retry succeeds after one transient response
- [x] Persistent workspace-busy exhausts at three request attempts
- [x] Unrelated 429 remains terminal after one attempt
- [x] Complete startup handshake is not replayed
- [x] Full broker library and broker integration tests
- [x] Clippy with warnings denied for broker library
- [x] Rust formatting and diff checks
- [x] Exact RelayFlow base/head case

## RelayFlow proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `workspace-busy-startup-retry-429` <!-- relay-pr-proof:case -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes broker authentication and startup admission for unkeyed agent registration, including when failures fall through to workspace creation—incorrect classification could duplicate workspaces or block legitimate startups.
> 
> **Overview**
> **Broker startup** now treats Relaycast’s exact HTTP 429 `workspace_busy` admission signal as a **bounded, retriable** transient failure on the unkeyed agent-registration path (same budget as other pre-commit admission retries), so `agent-relay node up` can succeed after brief write-capacity saturation instead of failing or falling through to workspace creation.
> 
> **Rate-limit handling is tightened** so only the literal `workspace_busy` code gets that retry path; any other 429 (including near-match codes with different casing/whitespace) is **terminal** for both explicit and implicit `RELAY_API_KEY` candidates, preventing accidental **minting of a replacement workspace** when registration was merely rate-limited. Multi-workspace startup surfaces preserved `workspace_busy` diagnostics when every membership fails for that reason.
> 
> Error mapping keeps API **error codes verbatim** (no trimming) so classifiers stay exact-match safe. Changelog entry, Rust unit/integration tests, and a RelayFlow **base/head** case document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5adc607622df7437b27925c29322c35840c8a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->