### PR TITLE
fix(fleet): expose spawn uncertainty and node liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
 - `fleet spawn --sandbox` dispatches with only its temporary launcher token after Cloud target selection, avoiding the SDK's dual-credential rejection while keeping workspace-key authority limited to launcher registration and release.
 
+- SDK fleet spawn placement receipts preserve invocation correlation and distinguish accepted, ready, unconfirmed, and terminal-failed outcomes.
+
+- CLI and MCP fleet spawns require explicit launch/readiness proof, preserve dispatch evidence, and surface terminal failures with correlated receipts.
+
+- `fleet agent list` reports control-plane reachability separately from hosted-worker liveness in JSON and pretty output, including offline local nodes.
+
 - `fleet spawn --sandbox` uses the provider-neutral durable profile for explicit Daytona and E2B sandboxes, so their measured resource envelopes are routable while Agent37 retains its heavy profile.
 
 - Cloud Daytona Fleet provisioning now requires and returns the exact provider sandbox UUID alongside the stable Cloud sandbox ID, enabling ID-bound inspection and cleanup after interrupted launches.

--- a/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.startup.test.ts
@@ -4,6 +4,7 @@ type LoadOptions = {
   connectThrows?: boolean;
   forceEntrypoint?: boolean;
   persistedWorkspaceKey?: string;
+  workspaceSpawnResult?: Record<string, unknown>;
 };
 
 type RelayBehavior = {
@@ -228,7 +229,7 @@ async function loadAgentRelayMcpModule(options: LoadOptions = {}) {
         capabilities: [{ name: 'spawn:codex' }],
       },
     ]);
-    const spawn = vi.fn(async (input: unknown) => ({ spawned: true, input }));
+    const spawn = vi.fn(async (input: unknown) => options.workspaceSpawnResult ?? { spawned: true, input });
     const release = vi.fn((input: { name: string; reason?: string; deleteAgent?: boolean }) =>
       behavior.releaseImpl(input)
     );
@@ -866,6 +867,7 @@ describe('createAgentRelayMcpServer', () => {
       invocationId: 'inv_outer',
       actionName: 'spawn',
       status: 'dispatched',
+      handlerNodeId: 'outer-node',
     });
     mocks.agentRelayMessagingCommands.getInvocation.mockImplementation(
       async (_name: string, invocationId: string) => {
@@ -921,6 +923,73 @@ describe('createAgentRelayMcpServer', () => {
     expect(mocks.agentRelayMessagingCommands.getInvocation).toHaveBeenNthCalledWith(2, 'spawn', 'inv_nested');
   });
 
+  it('correlates nested persona confirmation timeouts to the nested route', async () => {
+    vi.useFakeTimers();
+    try {
+      const { mod, mocks } = await loadAgentRelayMcpModule();
+      mocks.agentRelayMessagingCommands.invoke.mockResolvedValueOnce({
+        invocationId: 'inv_outer',
+        actionName: 'spawn',
+        status: 'dispatched',
+        handlerNodeId: 'outer-node',
+      });
+      mocks.agentRelayMessagingCommands.getInvocation.mockImplementation(
+        async (_name: string, invocationId: string) => {
+          if (invocationId === 'inv_outer') {
+            return {
+              invocationId,
+              actionName: 'spawn',
+              status: 'completed',
+              handlerNodeId: 'outer-node',
+              output: {
+                invocationId: 'inv_nested',
+                actionName: 'spawn',
+                status: 'dispatched',
+                handlerNodeId: 'nested-node',
+              },
+            };
+          }
+          return new Promise<never>(() => undefined);
+        }
+      );
+
+      mod.createAgentRelayMcpServer({
+        agentToken: 'at_live_fleet',
+        agentName: 'orchestrator',
+      });
+      const spawn = mocks.serverInstances[0]?.tools.get('spawn')?.handler({
+        name: 'NestedTimeoutWorker',
+        persona: 'reviewer',
+        target_node: 'outer-node',
+      });
+      const outcome = Promise.race([
+        spawn?.then(
+          (result) => result,
+          (error: unknown) => error
+        ),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('nested timeout test did not finish'), 130_001)
+        ),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(130_001);
+
+      await expect(outcome).resolves.toMatchObject({
+        isError: true,
+        structuredContent: {
+          error: {
+            code: 'spawn_unconfirmed',
+            invocationId: 'inv_nested',
+            dispatchState: 'dispatched',
+            node: 'nested-node',
+          },
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('times out when a persona spawn invocation lookup never settles', async () => {
     vi.useFakeTimers();
     try {
@@ -940,8 +1009,8 @@ describe('createAgentRelayMcpServer', () => {
       });
       const outcome = Promise.race([
         spawn?.then(
-          () => 'resolved unexpectedly',
-          (error: unknown) => (error instanceof Error ? error.message : String(error))
+          (result) => result,
+          (error: unknown) => error
         ),
         new Promise<string>((resolve) =>
           setTimeout(() => resolve('still pending after the persona spawn deadline'), 130_001)
@@ -950,12 +1019,97 @@ describe('createAgentRelayMcpServer', () => {
 
       await vi.advanceTimersByTimeAsync(130_001);
 
-      await expect(outcome).resolves.toBe(
-        'Spawn timed out before broker registration and harness readiness.'
-      );
+      await expect(outcome).resolves.toMatchObject({
+        isError: true,
+        structuredContent: {
+          error: {
+            code: 'spawn_unconfirmed',
+            state: 'unconfirmed_may_be_running',
+            dispatchState: 'unknown',
+            message: expect.stringContaining('may still be running'),
+          },
+        },
+      });
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('preserves an unconfirmed receipt when authorization is revoked after acceptance', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mocks.agentRelayMessagingCommands.getInvocation.mockRejectedValueOnce(new Error('401 unauthorized'));
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const result = await mocks.serverInstances[0]?.tools.get('spawn')?.handler({
+      name: 'RevokedWorker',
+      cli: 'codex',
+      target_node: 'node-a',
+    });
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_unconfirmed',
+          state: 'unconfirmed_may_be_running',
+          dispatchState: 'unknown',
+          invocationId: 'inv_1',
+          message: expect.stringContaining('may still be running'),
+        },
+      },
+    });
+  });
+
+  it('correlates nested authorization failures to the nested route', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mocks.agentRelayMessagingCommands.invoke.mockResolvedValueOnce({
+      invocationId: 'inv_outer',
+      actionName: 'spawn',
+      status: 'dispatched',
+      handlerNodeId: 'outer-node',
+    });
+    mocks.agentRelayMessagingCommands.getInvocation.mockImplementation(
+      async (_name: string, invocationId: string) => {
+        if (invocationId === 'inv_outer') {
+          return {
+            invocationId,
+            actionName: 'spawn',
+            status: 'completed',
+            output: {
+              invocationId: 'inv_nested',
+              actionName: 'spawn',
+              status: 'dispatched',
+              handlerNodeId: 'nested-node',
+            },
+          };
+        }
+        throw new Error('401 unauthorized');
+      }
+    );
+
+    mod.createAgentRelayMcpServer({
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const result = await mocks.serverInstances[0]?.tools.get('spawn')?.handler({
+      name: 'NestedRevokedWorker',
+      persona: 'reviewer',
+      target_node: 'outer-node',
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_unconfirmed',
+          invocationId: 'inv_nested',
+          dispatchState: 'dispatched',
+          node: 'nested-node',
+        },
+      },
+    });
   });
 
   it('surfaces a nested verified spawn failure from the workforce persona result', async () => {
@@ -964,6 +1118,7 @@ describe('createAgentRelayMcpServer', () => {
       invocationId: 'inv_outer',
       actionName: 'spawn',
       status: 'dispatched',
+      handlerNodeId: 'outer-node',
     });
     mocks.agentRelayMessagingCommands.getInvocation.mockImplementation(
       async (_name: string, invocationId: string) => {
@@ -983,6 +1138,7 @@ describe('createAgentRelayMcpServer', () => {
                 invocationId: 'inv_nested',
                 actionName: 'spawn',
                 status: 'dispatched',
+                handlerNodeId: 'nested-node',
               },
             },
           };
@@ -1006,13 +1162,24 @@ describe('createAgentRelayMcpServer', () => {
     });
     const server = mocks.serverInstances[0];
 
-    await expect(
-      server.tools.get('spawn')?.handler({
-        name: 'PersonaWorker',
-        persona: 'reviewer',
-        target_node: 'node-a',
-      })
-    ).rejects.toThrow('spawn_readiness_timeout');
+    const failure = await server.tools.get('spawn')?.handler({
+      name: 'PersonaWorker',
+      persona: 'reviewer',
+      target_node: 'node-a',
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          dispatchState: 'dispatched',
+          invocationId: 'inv_nested',
+          node: 'nested-node',
+          message: 'spawn_readiness_timeout',
+        },
+      },
+    });
     expect(mocks.agentRelayMessagingCommands.invoke).toHaveBeenCalledWith('spawn', {
       name: 'PersonaWorker',
       persona: 'reviewer',
@@ -1042,13 +1209,26 @@ describe('createAgentRelayMcpServer', () => {
       output,
     });
 
-    await expect(
-      server.tools.get('spawn')?.handler({
-        name: 'RawWorker',
-        cli: 'codex',
-        target_node: 'node-a',
-      })
-    ).rejects.toThrow('Resolved handler node: registered-handler-node; invocation: inv_1.');
+    const failure = await server.tools.get('spawn')?.handler({
+      name: 'RawWorker',
+      cli: 'codex',
+      target_node: 'node-a',
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          dispatchState: 'dispatched',
+          invocationId: 'inv_1',
+          node: 'registered-handler-node',
+        },
+      },
+    });
+    expect(failure.structuredContent.error.message).toContain(
+      'Resolved handler node: registered-handler-node; invocation: inv_1.'
+    );
     expect(mocks.agentRelayMessagingCommands.invoke).toHaveBeenCalledWith('spawn', {
       name: 'RawWorker',
       cli: 'codex',
@@ -1072,12 +1252,66 @@ describe('createAgentRelayMcpServer', () => {
       error: 'spawn_harness_not_ready',
     });
 
-    await expect(
-      server.tools.get('spawn')?.handler({
-        name: 'RawWorker',
-        cli: 'codex',
-      })
-    ).rejects.toThrow('spawn_harness_not_ready');
+    const failure = await server.tools.get('spawn')?.handler({
+      name: 'RawWorker',
+      cli: 'codex',
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          dispatchState: 'unknown',
+          invocationId: 'inv_1',
+          message: 'spawn_harness_not_ready',
+        },
+      },
+    });
+  });
+
+  // relay#1751 CodeRabbit thread / relay#1563: the verified `spawn` tool's
+  // terminal-failure result must not leak the raw upstream invocation
+  // record — only the allowlisted lifecycle-evidence receipt.
+  it('sanitizes secret-bearing raw invocation fields on a verified spawn terminal failure', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule();
+    mod.createAgentRelayMcpServer({
+      workspaceKey: 'rk_live_existing',
+      agentToken: 'at_live_fleet',
+      agentName: 'orchestrator',
+    });
+    const server = mocks.serverInstances[0];
+    mocks.agentRelayMessagingCommands.getInvocation.mockResolvedValueOnce({
+      invocationId: 'inv_1',
+      actionName: 'spawn',
+      status: 'failed',
+      error: 'spawn_harness_not_ready',
+      api_key: 'sk_live_should_not_leak_1234567890',
+      env: { RELAY_API_KEY: 'sk_live_should_not_leak_1234567890' },
+    });
+
+    const failure = await server.tools.get('spawn')?.handler({
+      name: 'RawWorker',
+      cli: 'codex',
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          invocationId: 'inv_1',
+          message: 'spawn_harness_not_ready',
+        },
+      },
+    });
+    const serialized = JSON.stringify(failure);
+    expect(serialized).not.toContain('sk_live_should_not_leak_1234567890');
+    expect(serialized).not.toContain('RELAY_API_KEY');
+    if (failure.structuredContent.error.receipt) {
+      expect(failure.structuredContent.error.receipt).not.toHaveProperty('api_key');
+      expect(failure.structuredContent.error.receipt).not.toHaveProperty('env');
+    }
   });
 
   it('surfaces a denied raw CLI spawn without waiting for the readiness deadline', async () => {
@@ -1095,12 +1329,22 @@ describe('createAgentRelayMcpServer', () => {
       error: 'spawn_policy_denied',
     });
 
-    await expect(
-      server.tools.get('spawn')?.handler({
-        name: 'RawWorker',
-        cli: 'codex',
-      })
-    ).rejects.toThrow('spawn_policy_denied');
+    const failure = await server.tools.get('spawn')?.handler({
+      name: 'RawWorker',
+      cli: 'codex',
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          dispatchState: 'unknown',
+          invocationId: 'inv_1',
+          message: 'spawn_policy_denied',
+        },
+      },
+    });
     expect(mocks.agentRelayMessagingCommands.getInvocation).toHaveBeenCalledTimes(1);
   });
 
@@ -1217,10 +1461,14 @@ describe('createAgentRelayMcpServer', () => {
       agentRelayDistinctId: 'distinct_test',
     });
 
-    await server.tools.get('add_agent')?.handler({
+    const addAgentResult = await server.tools.get('add_agent')?.handler({
       name: 'WorkerB',
       cli: 'claude',
       task: 'help',
+    });
+    expect(addAgentResult.structuredContent).toMatchObject({
+      spawned: true,
+      placement: { state: 'unconfirmed_may_be_running' },
     });
     const workspaceRelay = mocks.relayInstances.find(
       (instance) => instance.config.apiKey === 'rk_live_existing'
@@ -1292,6 +1540,128 @@ describe('createAgentRelayMcpServer', () => {
         duration_ms: expect.any(Number),
       })
     );
+  });
+
+  it('returns an explicit accepted receipt without marking it as an MCP error', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule({
+      workspaceSpawnResult: {
+        invocation_id: 'inv_accepted',
+        status: 'accepted',
+        spawned: true,
+      },
+    });
+    mod.createAgentRelayMcpServer({ workspaceKey: 'rk_live_existing', agentName: 'orchestrator' });
+    const result = await mocks.serverInstances[0]?.tools.get('add_agent')?.handler({
+      name: 'AcceptedWorker',
+      cli: 'claude',
+      task: 'help',
+    });
+    expect(result).not.toHaveProperty('isError');
+    expect(result.structuredContent).toMatchObject({
+      placement: { state: 'accepted', invocationId: 'inv_accepted' },
+    });
+  });
+
+  it('returns terminal legacy add_agent failures as an MCP error with the receipt', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule({
+      workspaceSpawnResult: {
+        invocation_id: 'inv_failed',
+        status: 'failed',
+        error: 'spawn_harness_not_ready',
+      },
+    });
+    mod.createAgentRelayMcpServer({ workspaceKey: 'rk_live_existing', agentName: 'orchestrator' });
+    const result = await mocks.serverInstances[0]?.tools.get('add_agent')?.handler({
+      name: 'FailedWorker',
+      cli: 'claude',
+      task: 'help',
+    });
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        ok: false,
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          invocationId: 'inv_failed',
+          dispatchState: 'unknown',
+          receipt: { status: 'failed', invocation_id: 'inv_failed' },
+          message: 'spawn_harness_not_ready',
+        },
+      },
+    });
+  });
+
+  it('returns completed legacy add_agent results without readiness proof as an MCP error', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule({
+      workspaceSpawnResult: {
+        invocation_id: 'inv_unproven',
+        status: 'completed',
+        output: { spawned: true, ready: false },
+      },
+    });
+    mod.createAgentRelayMcpServer({ workspaceKey: 'rk_live_existing', agentName: 'orchestrator' });
+    const result = await mocks.serverInstances[0]?.tools.get('add_agent')?.handler({
+      name: 'UnprovenWorker',
+      cli: 'claude',
+      task: 'help',
+    });
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        ok: false,
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          invocationId: 'inv_unproven',
+          dispatchState: 'dispatched',
+          receipt: { status: 'completed', invocation_id: 'inv_unproven' },
+        },
+      },
+    });
+  });
+
+  // relay#1751 CodeRabbit thread / relay#1563: a terminal failure receipt must
+  // not echo raw upstream error text or arbitrary invocation fields (secrets,
+  // internal broker diagnostics) back across the MCP boundary. Only the
+  // allowlisted lifecycle-evidence fields survive.
+  it('sanitizes secret-bearing upstream error text and receipt fields on legacy add_agent failures', async () => {
+    const { mod, mocks } = await loadAgentRelayMcpModule({
+      workspaceSpawnResult: {
+        invocation_id: 'inv_secret',
+        status: 'failed',
+        error: 'spawn_harness_not_ready',
+        // Not part of the lifecycle-evidence allowlist. A raw upstream
+        // invocation record can carry broker/handler internals like this;
+        // they must never cross the MCP boundary.
+        api_key: 'sk_live_should_not_leak_1234567890',
+        env: { RELAY_API_KEY: 'sk_live_should_not_leak_1234567890' },
+      },
+    });
+    mod.createAgentRelayMcpServer({ workspaceKey: 'rk_live_existing', agentName: 'orchestrator' });
+    const result = await mocks.serverInstances[0]?.tools.get('add_agent')?.handler({
+      name: 'SecretWorker',
+      cli: 'claude',
+      task: 'help',
+    });
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        ok: false,
+        error: {
+          code: 'spawn_failed',
+          state: 'failed',
+          invocationId: 'inv_secret',
+          receipt: { status: 'failed', invocation_id: 'inv_secret' },
+        },
+      },
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('sk_live_should_not_leak_1234567890');
+    expect(serialized).not.toContain('RELAY_API_KEY');
+    // The receipt itself must not carry the raw `api_key`/`env` fields.
+    expect(result.structuredContent.error.receipt).not.toHaveProperty('api_key');
+    expect(result.structuredContent.error.receipt).not.toHaveProperty('env');
   });
 
   it('adds post-task exit instructions for task-exit add_agent spawns', async () => {

--- a/packages/cli/src/cli/agent-relay-mcp.ts
+++ b/packages/cli/src/cli/agent-relay-mcp.ts
@@ -20,6 +20,7 @@ import {
   createRealtimeClient,
   createWorkspaceClient,
   isInvalidAgentTokenError,
+  safeRelayErrorMessage,
 } from '@agent-relay/sdk';
 import { z } from 'zod';
 import { declaredWorkforceMetadata } from './lib/registration-metadata.js';
@@ -29,6 +30,12 @@ import {
   withDeadline,
 } from './lib/agent-registration.js';
 import { attributableReleaseReason } from './lib/release-reason.js';
+import {
+  sanitizedSpawnReceipt,
+  spawnPlacementReceipt,
+  type SpawnDispatchState,
+  type SpawnLifecycleState,
+} from './lib/spawn-lifecycle.js';
 import { initTelemetry, shutdown as shutdownTelemetry } from './telemetry/index.js';
 import { RealtimeResourceBridge, SubscriptionManager, registerResourceDefinitions } from './mcp/resources.js';
 import { jsonContent, jsonResult, textContent } from './mcp/tool-results.js';
@@ -81,6 +88,36 @@ const VERIFIED_SPAWN_MISSING_READY_MESSAGE =
 const VERIFIED_SPAWN_SUCCESS_STATUSES = new Set(['completed', 'succeeded', 'success']);
 const VERIFIED_SPAWN_FAILURE_STATUSES = new Set(['failed', 'error', 'cancelled', 'canceled', 'denied']);
 
+class VerifiedSpawnError extends Error {
+  readonly code: 'spawn_unconfirmed' | 'spawn_failed';
+  readonly invocationId?: string;
+  readonly state: SpawnLifecycleState;
+  readonly dispatchState: SpawnDispatchState;
+  readonly node?: string;
+  readonly receipt?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    context: {
+      code?: 'spawn_unconfirmed' | 'spawn_failed';
+      state: SpawnLifecycleState;
+      dispatchState?: SpawnDispatchState;
+      invocationId?: string;
+      node?: string;
+      receipt?: Record<string, unknown>;
+    }
+  ) {
+    super(message);
+    this.name = 'VerifiedSpawnError';
+    this.code = context.code ?? (context.state === 'failed' ? 'spawn_failed' : 'spawn_unconfirmed');
+    this.state = context.state;
+    this.dispatchState = context.dispatchState ?? 'unknown';
+    this.invocationId = context.invocationId;
+    this.node = context.node;
+    this.receipt = context.receipt;
+  }
+}
+
 type InvocationReader = {
   getInvocation(name: string, invocationId: string): Promise<unknown>;
 };
@@ -88,6 +125,8 @@ type InvocationReader = {
 type InvocationRef = {
   actionName: string;
   invocationId: string;
+  node?: string;
+  dispatchState: SpawnDispatchState;
 };
 
 function recordValue(value: unknown): Record<string, unknown> {
@@ -105,9 +144,70 @@ function invocationRef(value: unknown): InvocationRef | undefined {
   const record = recordValue(value);
   const invocationId = invocationText(record, 'invocationId', 'invocation_id');
   if (!invocationId) return undefined;
+  const node =
+    invocationText(record, 'handlerNodeId', 'handler_node_id') ??
+    invocationText(record, 'dispatchedNodeId', 'dispatched_node_id');
   return {
     invocationId,
     actionName: invocationText(record, 'actionName', 'action_name') ?? 'spawn',
+    ...(node ? { node } : {}),
+    dispatchState: dispatchStateFor(record),
+  };
+}
+
+function spawnReceipt(value: Record<string, unknown>): Record<string, unknown> {
+  return spawnPlacementReceipt(value);
+}
+
+function dispatchStateFor(
+  value: Record<string, unknown>,
+  fallback: SpawnDispatchState = 'unknown'
+): SpawnDispatchState {
+  const state = spawnReceipt(value).dispatchState;
+  return state === 'dispatched' || state === 'not_dispatched' ? state : fallback;
+}
+
+/**
+ * Dispatch evidence for a *later* invocation read, given the dispatch state
+ * already frozen from the ack. `spawnReceipt`/`dispatchStateFor` treats a
+ * terminal status (e.g. `completed`) as dispatch evidence on its own — valid
+ * for the ack itself, where a synchronous handler really can report a
+ * terminal status immediately. It is not valid here: once the ack is known
+ * `not_dispatched` (a `pending`/`queued` ack with no node id), a later poll
+ * observing `completed`/`invoked` must not retroactively manufacture
+ * `dispatched` from that status. A node id appearing on the later record is
+ * real, new routing evidence and is trusted; a bare status change is not.
+ */
+function dispatchStateForRecord(
+  record: Record<string, unknown>,
+  ackDispatchState: SpawnDispatchState
+): SpawnDispatchState {
+  if (ackDispatchState === 'dispatched') return 'dispatched';
+  const nodeId =
+    invocationText(record, 'dispatchedNodeId', 'dispatched_node_id') ??
+    invocationText(record, 'handlerNodeId', 'handler_node_id');
+  return nodeId ? 'dispatched' : ackDispatchState;
+}
+
+function terminalSpawnFailureResult(invocation: Record<string, unknown>) {
+  const placement = spawnReceipt(invocation);
+  if (placement.state !== 'failed') return undefined;
+  return {
+    ...jsonContent({
+      ok: false,
+      error: {
+        code: 'spawn_failed',
+        state: 'failed',
+        ...(placement.invocationId ? { invocationId: placement.invocationId } : {}),
+        dispatchState: dispatchStateFor(invocation),
+        receipt: sanitizedSpawnReceipt(invocation),
+        message:
+          typeof invocation.error === 'string' && invocation.error.trim()
+            ? safeRelayErrorMessage(invocation.error)
+            : 'Fleet spawn invocation reported a terminal failure.',
+      },
+    }),
+    isError: true as const,
   };
 }
 
@@ -156,9 +256,29 @@ async function pollInvocation(
     try {
       return await getInvocationBeforeDeadline(actions, current, deadline);
     } catch (error) {
-      if (isInvocationAuthorizationError(error)) throw error;
+      if (isInvocationAuthorizationError(error)) {
+        throw new VerifiedSpawnError(
+          `Spawn confirmation could not be read after acceptance (${error instanceof Error ? error.message : String(error)}). The invocation may still be running; do not retry without checking it first. Invocation: ${current.invocationId}.`,
+          {
+            code: 'spawn_unconfirmed',
+            state: 'unconfirmed_may_be_running',
+            invocationId: current.invocationId,
+            dispatchState: current.dispatchState,
+            ...(current.node ? { node: current.node } : {}),
+          }
+        );
+      }
       if (Date.now() >= deadline) {
-        throw new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE, { cause: error });
+        throw new VerifiedSpawnError(
+          `${VERIFIED_SPAWN_TIMEOUT_MESSAGE} The invocation may still be running; do not retry without checking it first. Invocation: ${current.invocationId}.`,
+          {
+            state: 'unconfirmed_may_be_running',
+            invocationId: current.invocationId,
+            dispatchState: current.dispatchState,
+            ...(current.node ? { node: current.node } : {}),
+            receipt: { status: 'unknown' },
+          }
+        );
       }
       await new Promise<void>((resolve) => setTimeout(resolve, VERIFIED_SPAWN_POLL_MS));
     }
@@ -185,7 +305,12 @@ async function waitForVerifiedSpawn(
 ): Promise<unknown> {
   const ack = recordValue(ackValue);
   let current = invocationRef(ack);
-  if (!current) throw new Error('Spawn did not return an invocation id.');
+  if (!current) {
+    throw new VerifiedSpawnError(
+      'Spawn returned no invocation id; the dispatch is unconfirmed and may still be running. Do not retry blindly.',
+      { state: 'unconfirmed_may_be_running', dispatchState: dispatchStateFor(ack) }
+    );
+  }
 
   const deadline = Date.now() + timeoutMs;
   const followed = new Set([`${current.actionName}\u001f${current.invocationId}`]);
@@ -198,7 +323,13 @@ async function waitForVerifiedSpawn(
       if (nested) {
         const key = `${nested.actionName}\u001f${nested.invocationId}`;
         if (followed.has(key)) {
-          throw new Error('Persona spawn returned a cyclic nested invocation.');
+          throw new VerifiedSpawnError('Persona spawn returned a cyclic nested invocation.', {
+            code: 'spawn_failed',
+            state: 'failed',
+            dispatchState: dispatchStateForRecord(record, current.dispatchState),
+            invocationId: current.invocationId,
+            receipt: record,
+          });
         }
         followed.add(key);
         current = nested;
@@ -206,15 +337,48 @@ async function waitForVerifiedSpawn(
       }
       const output = recordValue(record.output);
       if (output.spawned !== true || output.ready !== true) {
-        throw new Error(missingVerifiedSpawnProof(record, ack, current.invocationId));
+        throw new VerifiedSpawnError(missingVerifiedSpawnProof(record, ack, current.invocationId), {
+          code: 'spawn_failed',
+          state: 'failed',
+          dispatchState: dispatchStateForRecord(record, current.dispatchState),
+          invocationId: current.invocationId,
+          node:
+            invocationText(record, 'handlerNodeId', 'handler_node_id') ??
+            invocationText(record, 'dispatchedNodeId', 'dispatched_node_id') ??
+            current.node,
+          receipt: record,
+        });
       }
       return invocation;
     }
     if (status && VERIFIED_SPAWN_FAILURE_STATUSES.has(status)) {
-      throw new Error(invocationText(record, 'error') ?? `Spawn ${status}.`);
+      throw new VerifiedSpawnError(invocationText(record, 'error') ?? `Spawn ${status}.`, {
+        code: 'spawn_failed',
+        state: 'failed',
+        dispatchState: dispatchStateForRecord(record, current.dispatchState),
+        invocationId: current.invocationId,
+        node:
+          invocationText(record, 'handlerNodeId', 'handler_node_id') ??
+          invocationText(record, 'dispatchedNodeId', 'dispatched_node_id') ??
+          current.node,
+        receipt: record,
+      });
     }
     if (Date.now() >= deadline) {
-      throw new Error(VERIFIED_SPAWN_TIMEOUT_MESSAGE);
+      throw new VerifiedSpawnError(
+        `${VERIFIED_SPAWN_TIMEOUT_MESSAGE} The invocation may still be running; do not retry without checking it first. Invocation: ${current.invocationId}.`,
+        {
+          code: 'spawn_unconfirmed',
+          state: 'unconfirmed_may_be_running',
+          dispatchState: dispatchStateForRecord(record, current.dispatchState),
+          invocationId: current.invocationId,
+          node:
+            invocationText(record, 'handlerNodeId', 'handler_node_id') ??
+            invocationText(record, 'dispatchedNodeId', 'dispatched_node_id') ??
+            current.node,
+          receipt: record,
+        }
+      );
     }
     await new Promise<void>((resolve) => setTimeout(resolve, VERIFIED_SPAWN_POLL_MS));
   }
@@ -697,6 +861,24 @@ async function invokeVerifiedSpawn(
   return waitForVerifiedSpawn(commands, invocation);
 }
 
+function verifiedSpawnErrorResult(error: VerifiedSpawnError) {
+  return {
+    ...jsonContent({
+      ok: false,
+      error: {
+        code: error.code,
+        state: error.state,
+        dispatchState: error.dispatchState,
+        ...(error.invocationId ? { invocationId: error.invocationId } : {}),
+        ...(error.node ? { node: error.node } : {}),
+        ...(error.receipt ? { receipt: sanitizedSpawnReceipt(error.receipt) } : {}),
+        message: safeRelayErrorMessage(error),
+      },
+    }),
+    isError: true as const,
+  };
+}
+
 /**
  * Read the agent record back and confirm the supplied metadata is on it.
  *
@@ -1118,26 +1300,28 @@ function registerAgentRelayTools(
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ name, cli, task, channel, persona, model, spawn_mode, exit_after_task }) =>
-      jsonContent(
-        await getRelay().agents.spawn({
-          name,
-          cli,
-          task:
-            exit_after_task ||
-            spawn_mode === 'task_exit' ||
-            spawn_mode === 'task-exit' ||
-            spawn_mode === 'single_shot' ||
-            spawn_mode === 'single-shot'
-              ? withExitAfterTaskInstruction(task)
-              : task,
-          channel,
-          persona,
-          // SpawnAgentRequest has no top-level model field; pass via metadata
-          // so the broker can extract it and forward --model to the launched CLI.
-          metadata: model ? { model } : undefined,
-        })
-      )
+    async ({ name, cli, task, channel, persona, model, spawn_mode, exit_after_task }) => {
+      const invocation = await getRelay().agents.spawn({
+        name,
+        cli,
+        task:
+          exit_after_task ||
+          spawn_mode === 'task_exit' ||
+          spawn_mode === 'task-exit' ||
+          spawn_mode === 'single_shot' ||
+          spawn_mode === 'single-shot'
+            ? withExitAfterTaskInstruction(task)
+            : task,
+        channel,
+        persona,
+        // SpawnAgentRequest has no top-level model field; pass via metadata
+        // so the broker can extract it and forward --model to the launched CLI.
+        metadata: model ? { model } : undefined,
+      });
+      const failure = terminalSpawnFailureResult(invocation);
+      if (failure) return failure;
+      return jsonContent({ ...invocation, placement: spawnReceipt(invocation) });
+    }
   );
 
   server.registerTool(
@@ -1230,8 +1414,16 @@ function registerAgentRelayTools(
       };
       validateSpawnRequest(request);
       const actionInput = buildSpawnActionInput(request);
-      const invocation = await invokeVerifiedSpawn(getSession(), as, baseUrl, actionInput);
-      return jsonContent({ invocation });
+      try {
+        const invocation = await invokeVerifiedSpawn(getSession(), as, baseUrl, actionInput);
+        return jsonContent({
+          invocation,
+          placement: { state: 'ready', ...spawnReceipt(recordValue(invocation)) },
+        });
+      } catch (error) {
+        if (error instanceof VerifiedSpawnError) return verifiedSpawnErrorResult(error);
+        throw error;
+      }
     }
   );
 

--- a/packages/cli/src/cli/commands/fleet-agent.test.ts
+++ b/packages/cli/src/cli/commands/fleet-agent.test.ts
@@ -19,6 +19,7 @@ function node(overrides: Partial<RelayNode>): RelayNode {
     name: 'unnamed',
     status: 'online',
     live: true,
+    handlersLive: true,
     capabilities: [],
     ...overrides,
   } as RelayNode;
@@ -169,6 +170,7 @@ describe('buildRows — the diagnostic column exists', () => {
 
     const row = out.perNode.find((r) => r.name === 'ghost-agent');
     expect(row?.presence).toBe('inventory only');
+    expect(row?.workerLiveness).toBe('degraded');
     // State column must not lie about liveness for inventory-only rows.
     expect(row?.state).not.toContain('idle');
     expect(row?.state).not.toContain('working');
@@ -283,6 +285,194 @@ describe('buildRows — the diagnostic column exists', () => {
     expect(formatPretty(out)).toContain('names may be incomplete');
   });
 
+  it('separates an offline control plane from stale remote worker evidence', () => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: 'finn-mini', status: 'offline', live: false, activeAgents: 1 }),
+            isLocal: false,
+            remoteAgents: [remoteAgent('possibly-live')],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+    expect(out.perNode[0]).toMatchObject({
+      controlPlane: 'offline',
+      workerLiveness: 'unknown',
+      presence: 'remote stale (control plane unavailable)',
+    });
+    expect(formatPretty(out)).toContain('remote stale');
+    expect(formatPretty(out)).toContain('worker liveness is unknown');
+  });
+
+  it('shows live local workers even when the control-plane link is offline', () => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: 'finn-mini', status: 'offline', live: false }),
+            isLocal: true,
+            liveAgents: [liveAgent('worker-live')],
+            inventoryAgents: [],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+    expect(out.perNode[0]).toMatchObject({
+      controlPlane: 'offline',
+      workerLiveness: 'live',
+      presence: 'live only',
+    });
+  });
+
+  it('treats an online node with omitted liveness as unknown, matching conservative placement eligibility', () => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: 'chief-broker', status: 'online', live: undefined, activeAgents: 0 }),
+            isLocal: false,
+            remoteAgents: [],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+    expect(out.perNode[0]).toMatchObject({ controlPlane: 'unknown', workerLiveness: 'unknown' });
+  });
+
+  // relay#1563 Low: the backfill loop used to key off the *rendered* node
+  // name, which collapses to the literal '(unnamed)' placeholder for any
+  // node with an empty name. Two distinct unnamed nodes then looked
+  // identical to `Array.find`, so only the first ever got its
+  // controlPlane/workerLiveness axes filled in — the second silently kept
+  // them omitted (`undefined`), even though buildRows' own contract says
+  // every row carries both axes explicitly.
+  it('backfills controlPlane/workerLiveness independently for two distinct unnamed nodes', () => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: '', status: 'offline', live: false }),
+            isLocal: true,
+            liveAgents: [liveAgent('worker-on-unnamed-a')],
+            inventoryAgents: [],
+          },
+          {
+            node: node({ name: '', status: 'online', live: true, handlersLive: true }),
+            isLocal: true,
+            liveAgents: [],
+            inventoryAgents: [],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+
+    const rowA = out.perNode.find((row) => row.name === 'worker-on-unnamed-a');
+    expect(rowA).toMatchObject({ node: '(unnamed)', controlPlane: 'offline', workerLiveness: 'live' });
+
+    const emptyRow = out.perNode.find((row) => row.name === '<0 agents on this node>');
+    expect(emptyRow).toMatchObject({ node: '(unnamed)', controlPlane: 'online', workerLiveness: 'empty' });
+  });
+
+  it('preserves stale remote evidence for two distinct unnamed offline nodes', () => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: '', status: 'offline', live: false, activeAgents: 1 }),
+            isLocal: false,
+            remoteAgents: [remoteAgent('stale-worker-a')],
+          },
+          {
+            node: node({ name: '', status: 'offline', live: false, activeAgents: 1 }),
+            isLocal: false,
+            remoteAgents: [remoteAgent('stale-worker-b')],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+
+    expect(out.perNode).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'stale-worker-a',
+          node: '(unnamed)',
+          controlPlane: 'offline',
+          workerLiveness: 'unknown',
+          presence: 'remote stale (control plane unavailable)',
+        }),
+        expect.objectContaining({
+          name: 'stale-worker-b',
+          node: '(unnamed)',
+          controlPlane: 'offline',
+          workerLiveness: 'unknown',
+          presence: 'remote stale (control plane unavailable)',
+        }),
+      ])
+    );
+  });
+
+  it.each([
+    ['offline', { status: 'offline', live: false }],
+    ['unknown', { status: 'unknown', live: undefined }],
+  ])('keeps %s control-plane heartbeat mismatches remote-stale and unknown', (_label, controlPlane) => {
+    const out = buildRows(
+      {
+        contributions: [
+          {
+            node: node({ name: 'finn-mini', ...controlPlane, activeAgents: 2 }),
+            isLocal: false,
+            remoteAgents: [remoteAgent('stale-worker')],
+          },
+        ],
+        roster: [],
+      },
+      NOW
+    );
+
+    const mismatch = out.perNode.find((row) => row.name.startsWith('<'));
+    expect(mismatch).toMatchObject({
+      state: '· remote stale',
+      presence: 'remote stale (control plane unavailable)',
+      workerLiveness: 'unknown',
+    });
+    expect(mismatch?.note).toContain('stale: heartbeat reports 2, broker returned 1');
+    expect(mismatch?.note).not.toContain('degraded');
+  });
+
+  it('renders independent control-plane and worker columns in pretty output', () => {
+    const rendered = formatPretty(
+      buildRows(
+        {
+          contributions: [
+            {
+              node: node({ name: 'finn-mini', status: 'offline', live: false }),
+              isLocal: true,
+              liveAgents: [liveAgent('worker-live')],
+              inventoryAgents: [],
+            },
+          ],
+          roster: [],
+        },
+        NOW
+      )
+    );
+    expect(rendered).toContain('CONTROL PLANE');
+    expect(rendered).toContain('WORKERS');
+    expect(rendered).toContain('Offline or degraded control plane does not prove workers are dead');
+  });
+
   it('keeps known remote names but exposes a heartbeat/inventory count mismatch', () => {
     const out = buildRows(
       {
@@ -358,6 +548,8 @@ describe('buildRows — the diagnostic column exists', () => {
       node: '?',
       name: 'chief-broker-grok-capability-0817-cli',
       presence: 'roster only',
+      controlPlane: 'unknown',
+      workerLiveness: 'unknown',
     });
   });
 

--- a/packages/cli/src/cli/commands/fleet-agent.test.ts
+++ b/packages/cli/src/cli/commands/fleet-agent.test.ts
@@ -330,12 +330,15 @@ describe('buildRows — the diagnostic column exists', () => {
     });
   });
 
-  it('treats an online node with omitted liveness as unknown, matching conservative placement eligibility', () => {
+  it.each([
+    ['offline', { status: 'offline', live: false }],
+    ['unknown', { status: 'online', live: undefined }],
+  ])('keeps a reconciled empty inventory remote-stale when the control plane is %s', (_label, state) => {
     const out = buildRows(
       {
         contributions: [
           {
-            node: node({ name: 'chief-broker', status: 'online', live: undefined, activeAgents: 0 }),
+            node: node({ name: 'chief-broker', ...state, activeAgents: 0 }),
             isLocal: false,
             remoteAgents: [],
           },
@@ -344,7 +347,13 @@ describe('buildRows — the diagnostic column exists', () => {
       },
       NOW
     );
-    expect(out.perNode[0]).toMatchObject({ controlPlane: 'unknown', workerLiveness: 'unknown' });
+    expect(out.perNode[0]).toMatchObject({
+      controlPlane: _label,
+      workerLiveness: 'unknown',
+      presence: 'remote stale (control plane unavailable)',
+    });
+    expect(formatPretty(out)).toContain('remote stale');
+    expect(formatPretty(out)).not.toContain('names may be incomplete');
   });
 
   // relay#1563 Low: the backfill loop used to key off the *rendered* node

--- a/packages/cli/src/cli/commands/fleet-agent.ts
+++ b/packages/cli/src/cli/commands/fleet-agent.ts
@@ -320,7 +320,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
           state: '· empty',
           pending: '-',
           lastActive: '-',
-          presence: hostedWorkersUnavailable ? 'count only (degraded)' : 'remote live',
+          presence: hostedWorkersUnavailable ? 'remote stale (control plane unavailable)' : 'remote live',
           controlPlane,
           workerLiveness: hostedWorkersUnavailable ? 'unknown' : 'empty',
           ...(note ? { note: sanitizeCell(note) } : {}),

--- a/packages/cli/src/cli/commands/fleet-agent.ts
+++ b/packages/cli/src/cli/commands/fleet-agent.ts
@@ -101,6 +101,7 @@ export type Presence =
   | 'empty (live?)'
   | 'remote live'
   | 'remote live+roster'
+  | 'remote stale (control plane unavailable)'
   | 'count only'
   | 'count only (degraded)';
 
@@ -112,8 +113,19 @@ export interface RenderedRow {
   pending: string;
   lastActive: string;
   presence: Presence;
+  /** Control-plane reachability is independent from hosted worker liveness. */
+  controlPlane?: 'online' | 'offline' | 'degraded' | 'unknown';
+  /** Best available evidence about workers hosted by this node. */
+  workerLiveness?: 'live' | 'empty' | 'degraded' | 'unknown';
   /** Optional annotation appended by the renderer, e.g. `(retried)`. */
   note?: string;
+}
+
+function controlPlaneState(node: RelayNode): RenderedRow['controlPlane'] {
+  if (node.status === 'online' && node.live === true && node.handlersLive === true) return 'online';
+  if (node.status === 'offline' || node.live === false) return 'offline';
+  if (node.handlersLive === false) return 'degraded';
+  return 'unknown';
 }
 
 /**
@@ -200,6 +212,10 @@ function cliModel(agent: ListAgent): string {
 export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
   const perNode: RenderedRow[] = [];
   const errors: { node: string; message: string }[] = [];
+  // Stable per-row identity: node *names* collide for unnamed nodes
+  // (`(unnamed)`), so the control-plane/worker-liveness backfill below must
+  // key off this object identity map instead of `row.node === contribution`.
+  const contributionByRow = new Map<RenderedRow, FleetNodeContribution>();
 
   // Cache roster names in a Set for O(1) membership; the roster today runs to
   // 1600+ records so linear scans per row would be visible.
@@ -210,7 +226,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
     const nodeName = contribution.node.name || '(unnamed)';
 
     if (contribution.error) {
-      perNode.push({
+      const row: RenderedRow = {
         node: nodeName,
         name: '',
         cliModel: '',
@@ -219,13 +235,17 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
         lastActive: '-',
         presence: 'count only',
         ...(contribution.retried ? { note: 'retried' } : {}),
-      });
+      };
+      perNode.push(row);
+      contributionByRow.set(row, contribution);
       errors.push({ node: nodeName, message: contribution.error });
       continue;
     }
 
     if (!contribution.isLocal) {
       const count = contribution.node.activeAgents;
+      const controlPlane = controlPlaneState(contribution.node);
+      const hostedWorkersUnavailable = controlPlane !== 'online';
       if (contribution.remoteAgents === undefined) {
         const renderedCount =
           count === undefined
@@ -234,7 +254,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
         const detail = contribution.remoteError
           ? `live-name heartbeat unavailable: ${sanitizeCell(contribution.remoteError)}`
           : 'live-name heartbeat unavailable';
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: `<${renderedCount} — names unavailable: ${detail}>`,
           cliModel: '',
@@ -242,8 +262,12 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
           pending: '-',
           lastActive: '-',
           presence: 'count only (degraded)',
+          controlPlane,
+          workerLiveness: 'unknown',
           note: contribution.retried ? 'retried' : 'inventory unavailable',
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
         if (contribution.remoteError) {
           errors.push({ node: nodeName, message: sanitizeCell(contribution.remoteError) });
         }
@@ -254,51 +278,75 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
       const mismatch = count !== undefined && count !== remoteAgents.length;
       const noteParts = [
         ...(contribution.retried ? ['retried'] : []),
-        ...(contribution.remoteWarning ? [`degraded: ${contribution.remoteWarning}`] : []),
-        ...(mismatch ? [`degraded: heartbeat reports ${count}, broker returned ${remoteAgents.length}`] : []),
+        ...(contribution.remoteWarning
+          ? [`${hostedWorkersUnavailable ? 'stale' : 'degraded'}: ${contribution.remoteWarning}`]
+          : []),
+        ...(mismatch
+          ? [
+              `${hostedWorkersUnavailable ? 'stale' : 'degraded'}: heartbeat reports ${count}, broker returned ${remoteAgents.length}`,
+            ]
+          : []),
       ];
       const note = noteParts.length > 0 ? noteParts.join('; ') : undefined;
 
       for (const agent of remoteAgents) {
         const inRoster = rosterNames.has(agent.name);
         if (inRoster) rosterPlaced.add(agent.name);
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: sanitizeCell(agent.name),
           cliModel: '',
           state: '· remote',
           pending: '-',
           lastActive: '-',
-          presence: inRoster ? 'remote live+roster' : 'remote live',
+          presence: hostedWorkersUnavailable
+            ? 'remote stale (control plane unavailable)'
+            : inRoster
+              ? 'remote live+roster'
+              : 'remote live',
+          controlPlane,
+          workerLiveness: hostedWorkersUnavailable ? 'unknown' : 'live',
           ...(note ? { note: sanitizeCell(note) } : {}),
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       }
 
       if (remoteAgents.length === 0 && count === 0) {
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: '<0 agents on this node>',
           cliModel: '',
           state: '· empty',
           pending: '-',
           lastActive: '-',
-          presence: 'remote live',
+          presence: hostedWorkersUnavailable ? 'count only (degraded)' : 'remote live',
+          controlPlane,
+          workerLiveness: hostedWorkersUnavailable ? 'unknown' : 'empty',
           ...(note ? { note: sanitizeCell(note) } : {}),
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       } else if (count !== undefined && count > remoteAgents.length) {
         const missing = count - remoteAgents.length;
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: `<${missing} additional agent${missing === 1 ? '' : 's'} — names unavailable: broker/heartbeat mismatch>`,
           cliModel: '',
-          state: '· remote degraded',
+          state: hostedWorkersUnavailable ? '· remote stale' : '· remote degraded',
           pending: '-',
           lastActive: '-',
-          presence: 'count only (degraded)',
+          presence: hostedWorkersUnavailable
+            ? 'remote stale (control plane unavailable)'
+            : 'count only (degraded)',
+          controlPlane,
+          workerLiveness: hostedWorkersUnavailable ? 'unknown' : 'degraded',
           ...(note ? { note: sanitizeCell(note) } : {}),
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       } else if (remoteAgents.length === 0) {
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: '<node inventory returned no names; active count unavailable>',
           cliModel: '',
@@ -306,8 +354,12 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
           pending: '-',
           lastActive: '-',
           presence: 'count only (degraded)',
+          controlPlane,
+          workerLiveness: 'unknown',
           note: 'inventory/count comparison unavailable',
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       }
       continue;
     }
@@ -334,7 +386,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
       // strictly stronger than the pre-fix behaviour, which produced an ERROR
       // row whenever EITHER half failed and threw away the surviving map.
       const combined = [contribution.liveError, contribution.inventoryError].filter(Boolean).join('; ');
-      perNode.push({
+      const row: RenderedRow = {
         node: nodeName,
         name: '',
         cliModel: '',
@@ -343,7 +395,9 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
         lastActive: '-',
         presence: 'count only',
         ...(contribution.retried ? { note: 'retried' } : {}),
-      });
+      };
+      perNode.push(row);
+      contributionByRow.set(row, contribution);
       errors.push({ node: nodeName, message: combined || 'local broker unavailable' });
       continue;
     }
@@ -353,7 +407,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
       // so plainly rather than rendering "0 agents on this node" — a
       // partially-observed empty result is not a confirmed empty node.
       if (liveKnown && inventoryKnown) {
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: '<0 agents on this node>',
           cliModel: '',
@@ -362,10 +416,12 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
           lastActive: '-',
           presence: 'live+inventory',
           ...(contribution.retried ? { note: 'retried' } : {}),
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       } else {
         const missing = liveKnown ? 'inventory' : 'live';
-        perNode.push({
+        const row: RenderedRow = {
           node: nodeName,
           name: `<local ${missing} map unavailable — other map empty; total unknown>`,
           cliModel: '',
@@ -374,7 +430,9 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
           lastActive: '-',
           presence: liveKnown ? 'empty (inventory?)' : 'empty (live?)',
           ...(contribution.retried ? { note: 'retried' } : {}),
-        });
+        };
+        perNode.push(row);
+        contributionByRow.set(row, contribution);
       }
       continue;
     }
@@ -392,7 +450,7 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
         inRoster
       );
 
-      perNode.push({
+      const row: RenderedRow = {
         node: nodeName,
         name: sanitizeCell(name),
         cliModel: liveEntry ? sanitizeCell(cliModel(liveEntry)) : '',
@@ -401,7 +459,9 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
         lastActive: liveEntry ? sanitizeCell(renderRelative(liveEntry.last_activity_at, now)) : '-',
         presence,
         ...(contribution.retried ? { note: 'retried' } : {}),
-      });
+      };
+      perNode.push(row);
+      contributionByRow.set(row, contribution);
     }
   }
 
@@ -418,7 +478,29 @@ export function buildRows(input: BuildRowsInput, now: Date): BuildRowsOutput {
       pending: '-',
       lastActive: sanitizeCell(renderRelative(entry.lastSeenAt, now)),
       presence: 'roster only',
+      controlPlane: 'unknown',
+      workerLiveness: 'unknown',
     });
+  }
+
+  // Every row carries both axes explicitly. In particular, a local broker can
+  // lose its control-plane link while its child workers continue doing useful
+  // work; that must render as offline control-plane + live hosted workers.
+  for (const row of perNode) {
+    if (row.controlPlane !== undefined) continue;
+    const contribution = contributionByRow.get(row);
+    if (!contribution) continue;
+    row.controlPlane = controlPlaneState(contribution.node);
+    row.workerLiveness =
+      contribution.liveAgents === undefined
+        ? 'unknown'
+        : contribution.liveAgents.length > 0
+          ? 'live'
+          : contribution.inventoryAgents === undefined
+            ? 'unknown'
+            : contribution.inventoryAgents.length > 0
+              ? 'degraded'
+              : 'empty';
   }
 
   perNode.sort((a, b) => (a.node === b.node ? a.name.localeCompare(b.name) : a.node.localeCompare(b.node)));
@@ -477,6 +559,8 @@ export function formatPretty(output: BuildRowsOutput): string {
     { header: 'NODE', values: rows.map((r) => r.node) },
     { header: 'NAME', values: rows.map((r) => r.name) },
     { header: 'CLI / MODEL', values: rows.map((r) => r.cliModel) },
+    { header: 'CONTROL PLANE', values: rows.map((r) => r.controlPlane ?? 'unknown') },
+    { header: 'WORKERS', values: rows.map((r) => r.workerLiveness ?? 'unknown') },
     { header: 'STATE', values: rows.map((r) => r.state) },
     { header: 'PENDING', values: rows.map((r) => r.pending) },
     { header: 'LAST ACTIVE', values: rows.map((r) => r.lastActive) },
@@ -509,6 +593,16 @@ export function formatPretty(output: BuildRowsOutput): string {
   if (output.perNode.some((row) => row.presence === 'remote live' || row.presence === 'remote live+roster')) {
     notes.push(
       "remote live: names come from the broker's live WorkerName set on the node heartbeat; PTY detail remains node-local."
+    );
+  }
+  if (output.perNode.some((row) => row.presence === 'remote stale (control plane unavailable)')) {
+    notes.push(
+      'remote stale: names came from the last broker heartbeat while the control plane was unavailable; worker liveness is unknown.'
+    );
+  }
+  if (rows.some((row) => row.controlPlane !== undefined || row.workerLiveness !== undefined)) {
+    notes.push(
+      'CONTROL PLANE reports node reachability/handler health; WORKERS reports hosted-worker evidence. Offline or degraded control plane does not prove workers are dead.'
     );
   }
   if (output.perNode.some((row) => row.presence === 'count only (degraded)')) {

--- a/packages/cli/src/cli/commands/fleet.test.ts
+++ b/packages/cli/src/cli/commands/fleet.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { CloudFleetSandboxProvisionError } from '@agent-relay/cloud';
 import { defineNode, invokeNodeHandler, spawn as fleetSpawn } from '@agent-relay/fleet';
+import { RelayPlacementError } from '@agent-relay/sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => vi.unstubAllEnvs());
@@ -45,6 +46,7 @@ vi.mock('@agent-relay/harness-driver', async (importOriginal) => ({
 
 import { registerFleetCommands } from './fleet.js';
 import { writeProjectWorkspaceKey } from '../lib/project-workspace-key.js';
+import { spawnPlacementReceipt } from '../lib/spawn-lifecycle.js';
 
 const REPLAY_SANDBOX_ID = 'sbx_123e4567-e89b-42d3-a456-426614174000';
 const REPLAY_SANDBOX_NAME = 'fleet-sandbox-123e4567-e89b-42d3-a456-426614174000';
@@ -69,6 +71,40 @@ const liveAgentCapabilities = (...names: string[]) => [
     metadata: { names },
   },
 ];
+
+describe('spawn lifecycle receipts', () => {
+  it('preserves no-dispatch pending evidence separately from a dispatched timeout', () => {
+    expect(
+      spawnPlacementReceipt({ invocation_id: 'inv_pending', status: 'pending', dispatched_node_id: null })
+    ).toEqual({
+      state: 'accepted',
+      dispatchState: 'not_dispatched',
+      invocationId: 'inv_pending',
+    });
+    expect(
+      spawnPlacementReceipt({
+        invocation_id: 'inv_dispatched',
+        status: 'invoked',
+        dispatched_node_id: 'node-a',
+      })
+    ).toEqual({
+      state: 'unconfirmed_may_be_running',
+      dispatchState: 'dispatched',
+      invocationId: 'inv_dispatched',
+      dispatchedNodeId: 'node-a',
+    });
+    expect(
+      spawnPlacementReceipt({
+        invocation_id: 'inv_ready',
+        status: 'completed',
+        output: { spawned: true, ready: true },
+      })
+    ).toMatchObject({ state: 'ready', dispatchState: 'dispatched' });
+    expect(
+      spawnPlacementReceipt({ invocation_id: 'inv_completed_without_proof', status: 'completed' })
+    ).toMatchObject({ state: 'failed', dispatchState: 'dispatched' });
+  });
+});
 
 describe('fleet command support', () => {
   it.each([
@@ -230,6 +266,51 @@ describe('fleet command support', () => {
     expect(output.perNode.map((row: { node: string }) => row.node)).toEqual(['finn-mini']);
     expect(output.perNode.map((row: { name: string }) => row.name)).toEqual(['finn-worker']);
     expect(output.perNode.some((row: { node: string }) => row.node === 'live-node')).toBe(false);
+  });
+
+  it('preserves known offline metadata when the local node is filtered from the default list', async () => {
+    const nodes = {
+      list: vi.fn(async () => [
+        {
+          name: 'live-node',
+          status: 'offline',
+          live: false,
+          handlersLive: false,
+          capabilities: [],
+        },
+      ]),
+    };
+    const agents = { list: vi.fn(async () => []) };
+    const logs: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      core: {
+        getProjectPaths: () => ({ projectRoot: '/p', dataDir: '/p/.agentworkforce/relay', teamDir: '/p' }),
+        exit: vi.fn(),
+      } as never,
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn(() => ({ nodes, agents })) as never,
+        createWorkspace: vi.fn() as never,
+        log: (message: unknown) => logs.push(String(message)),
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await program.parseAsync(['fleet', 'agent', 'list', '--json', '--workspace-key', 'rk_live_test'], {
+      from: 'user',
+    });
+
+    expect(JSON.parse(logs[0]!).perNode[0]).toMatchObject({
+      node: 'live-node',
+      controlPlane: 'offline',
+      workerLiveness: 'empty',
+    });
   });
 
   it('must-not-fire: fleet agent list --node excludes other nodes and roster-only rows', async () => {
@@ -656,6 +737,153 @@ describe('fleet command support', () => {
     expect(JSON.parse(logs[0]!)).toMatchObject({
       invocation: { invocationId: 'inv_targeted' },
     });
+  });
+
+  // relay#1751 CodeRabbit thread: `spawnPlacementReceipt` derives a lifecycle
+  // receipt from top-level invocation fields and must never replace the
+  // SDK's own `invocation.placement` (state/confirmed) on the targeted spawn
+  // path — it must only be merged in as extra `dispatchState`/`invocationId`
+  // evidence. With `--no-confirm`, the top-level invocation has no terminal
+  // `status`, so a naive replacement would downgrade a confirmed SDK
+  // `accepted` placement to `unconfirmed_may_be_running`.
+  it('preserves the SDK placement state and confirmed flag on a targeted --no-confirm spawn', async () => {
+    const placement = {
+      spawn: vi.fn(async () => ({
+        invocationId: 'inv_no_confirm',
+        actionName: 'spawn',
+        node: { name: 'sf-mini' },
+        placement: {
+          capability: 'spawn:codex',
+          node: 'sf-mini',
+          attempts: 1,
+          queued: false,
+          state: 'accepted',
+          confirmed: false,
+        },
+      })),
+    };
+    const createAgentRelay = vi.fn(() => ({ messaging: { placement } }));
+    const logs: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: createAgentRelay as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: (message: unknown) => logs.push(String(message)),
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await program.parseAsync(
+      [
+        'fleet',
+        'spawn',
+        'codex',
+        '--name',
+        'api-worker',
+        '--task',
+        'ACK and wait',
+        '--target-node',
+        'sf-mini',
+        '--no-confirm',
+        '--workspace-key',
+        'rk_live_test',
+        '--token',
+        'at_live_lead',
+      ],
+      { from: 'user' }
+    );
+
+    const printed = JSON.parse(logs[0]!);
+    // The SDK's own evidence (state: 'accepted', confirmed: false) must
+    // survive untouched...
+    expect(printed.invocation.placement).toMatchObject({
+      capability: 'spawn:codex',
+      node: 'sf-mini',
+      state: 'accepted',
+      confirmed: false,
+    });
+    // ...augmented with the normalized dispatch evidence and invocation id,
+    // not replaced by them.
+    expect(printed.invocation.placement.dispatchState).toBeDefined();
+    expect(printed.invocation.placement.state).not.toBe('unconfirmed_may_be_running');
+  });
+
+  it('terminates an accepted-but-unconfirmed live invocation without inviting a blind retry', async () => {
+    const invocationId = 'inv_223936432626290688';
+    const placement = {
+      spawn: vi.fn(async () => {
+        throw new RelayPlacementError(
+          'spawn_unconfirmed',
+          `node 'chief-broker' accepted spawn (invocation ${invocationId}) but never reported a result. ` +
+            'The invocation may still be running, so do not retry blindly.',
+          {
+            capability: 'spawn:opencode',
+            node: 'chief-broker',
+            attempts: 1,
+            invocationId,
+            state: 'unconfirmed_may_be_running',
+            dispatchState: 'dispatched',
+          }
+        );
+      }),
+    };
+    const errors: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn(() => ({ messaging: { placement } })) as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: (message: unknown) => errors.push(String(message)),
+        exit: vi.fn(() => {
+          throw new Error('__exit__');
+        }) as never,
+      },
+      createFleetWorkspaceClient: vi.fn() as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await expect(
+      program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'opencode',
+          '--name',
+          'opencode-live-repro',
+          '--task',
+          'reproduce accepted dispatch',
+          '--node',
+          'chief-broker',
+          '--confirm-timeout',
+          '120000',
+          '--workspace-key',
+          'rk_live_test',
+          '--token',
+          'at_live_fleet',
+        ],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('__exit__');
+
+    const rendered = errors.join('\n');
+    expect(rendered).toContain('do not retry blindly');
+    expect(rendered).toContain('"code":"spawn_unconfirmed"');
+    expect(rendered).toContain('"state":"unconfirmed_may_be_running"');
+    expect(rendered).toContain('"dispatchState":"dispatched"');
+    expect(rendered).toContain(`"invocationId":"${invocationId}"`);
   });
 
   it('fleet spawn --sandbox-provider agent37 provisions the isolated canary and uses a temporary launcher', async () => {
@@ -1131,8 +1359,20 @@ describe('fleet command support', () => {
     expect(createAgentRelay).not.toHaveBeenCalled();
   });
 
-  it('fleet spawn --sandbox deletes a freshly provisioned sandbox when dispatch fails', async () => {
-    const placement = { spawn: vi.fn(async () => Promise.reject(new Error('dispatch failed'))) };
+  it('fleet spawn --sandbox preserves a freshly provisioned sandbox when placement is unconfirmed', async () => {
+    const placement = {
+      spawn: vi.fn(async () =>
+        Promise.reject(
+          new RelayPlacementError('spawn_unconfirmed', 'dispatch may still be running', {
+            capability: 'spawn:codex',
+            node: 'agent37-codex',
+            attempts: 1,
+            invocationId: 'inv_unconfirmed_sandbox',
+            state: 'unconfirmed_may_be_running',
+          })
+        )
+      ),
+    };
     const deleteCloudFleetSandbox = vi.fn(async () => undefined);
     const ensureCloudFleetSandbox = vi.fn(async () => ({
       outcome: 'provisioned' as const,
@@ -1204,17 +1444,13 @@ describe('fleet command support', () => {
       )
     ).rejects.toThrow('__exit__');
 
-    expect(errors.join('\n')).toContain('dispatch failed');
+    expect(errors.join('\n')).toContain('dispatch may still be running');
     expect(ensureCloudFleetSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
         workloadProfile: 'long-running-agent',
       })
     );
-    expect(deleteCloudFleetSandbox).toHaveBeenCalledWith({
-      cloudWorkspaceId: 'cloud-workspace',
-      sandboxId: 'sandbox-1',
-      providerId: 'agent37',
-    });
+    expect(deleteCloudFleetSandbox).not.toHaveBeenCalled();
   });
 
   it('preserves legacy custom sandbox names without sending a sandbox identity', async () => {
@@ -2344,8 +2580,106 @@ describe('fleet command support', () => {
       },
     });
     expect(JSON.parse(logs[0]!)).toEqual({
-      invocation: { invocation_id: 'inv_auto', status: 'accepted' },
+      invocation: {
+        invocation_id: 'inv_auto',
+        status: 'accepted',
+        placement: { state: 'accepted', dispatchState: 'unknown', invocationId: 'inv_auto' },
+      },
     });
+  });
+
+  it('fleet spawn propagates a terminal automatic failure with structured correlation', async () => {
+    const spawn = vi.fn(async () => ({
+      invocation_id: 'inv_auto_failed',
+      status: 'failed',
+      error: 'spawn_harness_not_ready',
+    }));
+    const errors: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: (message: unknown) => errors.push(String(message)),
+        exit: vi.fn(() => {
+          throw new Error('__exit__');
+        }) as never,
+      },
+      createFleetWorkspaceClient: vi.fn(() => ({ agents: { spawn } })) as never,
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    });
+
+    await expect(
+      program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'codex',
+          '--name',
+          'failed-worker',
+          '--task',
+          'Work',
+          '--workspace-key',
+          'rk_live_test',
+        ],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('__exit__');
+
+    expect(errors.join('\n')).toContain('spawn_harness_not_ready');
+    expect(errors.join('\n')).toContain('"code":"spawn_failed"');
+    expect(errors.join('\n')).toContain('"state":"failed"');
+    expect(errors.join('\n')).toContain('"invocationId":"inv_auto_failed"');
+  });
+
+  it('fleet spawn rejects a terminal completed result without launch/readiness proof', async () => {
+    const spawn = vi.fn(async () => ({
+      invocation_id: 'inv_auto_unproven',
+      status: 'completed',
+      output: { spawned: true, ready: false },
+    }));
+    const errors: string[] = [];
+    const program = new Command();
+    program.exitOverride();
+    registerFleetCommands(program, {
+      sdk: {
+        createAgentRelay: vi.fn() as never,
+        createWorkspaceRelay: vi.fn() as never,
+        createWorkspace: vi.fn() as never,
+        log: vi.fn(),
+        error: (message: unknown) => errors.push(String(message)),
+        exit: vi.fn(() => {
+          throw new Error('__exit__');
+        }) as never,
+      },
+      createFleetWorkspaceClient: vi.fn(() => ({ agents: { spawn } })) as never,
+    });
+
+    await expect(
+      program.parseAsync(
+        [
+          'fleet',
+          'spawn',
+          'codex',
+          '--name',
+          'unproven-worker',
+          '--task',
+          'Work',
+          '--workspace-key',
+          'rk_live_test',
+        ],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('__exit__');
+
+    expect(errors.join('\n')).toContain('"code":"spawn_failed"');
+    expect(errors.join('\n')).toContain('"state":"failed"');
+    expect(errors.join('\n')).toContain('"invocationId":"inv_auto_unproven"');
   });
 
   it('fleet spawn mints and removes a temporary launcher for tokenless targeted placement', async () => {

--- a/packages/cli/src/cli/commands/fleet.ts
+++ b/packages/cli/src/cli/commands/fleet.ts
@@ -9,7 +9,12 @@ import {
   type EnsureCloudFleetSandboxResult,
 } from '@agent-relay/cloud';
 import { HarnessDriverClient } from '@agent-relay/harness-driver';
-import { createWorkspaceClient, type RelayWorkspaceThinClient, type RelayNode } from '@agent-relay/sdk';
+import {
+  createWorkspaceClient,
+  RelayPlacementError,
+  type RelayWorkspaceThinClient,
+  type RelayNode,
+} from '@agent-relay/sdk';
 
 import { withDefaults, type CoreDependencies } from './core.js';
 import {
@@ -26,6 +31,7 @@ import { isAvailableFleetNode } from '../lib/fleet-live-agents.js';
 import { declaredWorkforceMetadata } from '../lib/registration-metadata.js';
 import { redactSecrets } from '../lib/redact.js';
 import { attributableReleaseReason } from '../lib/release-reason.js';
+import { spawnPlacementReceipt } from '../lib/spawn-lifecycle.js';
 import {
   resolveAgentToken,
   resolveWorkspaceSelection,
@@ -50,6 +56,54 @@ const SERVE_REPLACEMENT_MESSAGE =
 const FLEET_CLIS = new Set(['claude', 'codex', 'gemini', 'aider', 'goose', 'grok', 'opencode']);
 const CLOUD_SANDBOX_ID_PATTERN =
   /^sbx_[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function spawnInvocationWithPlacement(invocation: Record<string, unknown>): Record<string, unknown> {
+  return { ...invocation, placement: spawnPlacementReceipt(invocation) };
+}
+
+// The targeted spawn path (relay.messaging.placement.spawn) returns an
+// invocation whose `placement` is the SDK's own evidence object
+// (`state: 'accepted' | 'ready'`, `confirmed`). `spawnPlacementReceipt`
+// derives a *different* lifecycle receipt from top-level invocation fields
+// (`state: SpawnLifecycleState`, `dispatchState`, ...) — replacing the SDK
+// placement with it would silently downgrade a confirmed `accepted` result
+// to `unconfirmed_may_be_running` under `--no-confirm`. Preserve the SDK
+// placement and only augment it with the normalized `dispatchState` and
+// `invocationId`.
+function spawnInvocationWithMergedPlacement(invocation: Record<string, unknown>): Record<string, unknown> {
+  const receipt = spawnPlacementReceipt(invocation);
+  const sdkPlacement =
+    invocation.placement !== null && typeof invocation.placement === 'object'
+      ? (invocation.placement as Record<string, unknown>)
+      : undefined;
+  const invocationId = typeof receipt.invocationId === 'string' ? receipt.invocationId : undefined;
+  return {
+    ...invocation,
+    placement: {
+      ...(sdkPlacement ?? {}),
+      dispatchState: receipt.dispatchState,
+      ...(invocationId ? { invocationId } : {}),
+    },
+  };
+}
+
+function throwForTerminalSpawnFailure(invocation: Record<string, unknown>): void {
+  const placement = spawnPlacementReceipt(invocation);
+  if (placement.state !== 'failed') return;
+  const invocationId = typeof placement.invocationId === 'string' ? placement.invocationId : undefined;
+  const message =
+    typeof invocation.error === 'string' && invocation.error.trim()
+      ? invocation.error
+      : 'Fleet spawn invocation reported a terminal failure.';
+  throw new RelayPlacementError('spawn_failed', message, {
+    capability: typeof invocation.capability === 'string' ? invocation.capability : 'spawn',
+    attempts: 1,
+    ...(invocationId ? { invocationId } : {}),
+    state: 'failed',
+    dispatchState: placement.dispatchState as 'dispatched' | 'not_dispatched' | 'unknown',
+    receipt: invocation,
+  });
+}
 
 export interface FleetCommandDependencies {
   core: CoreDependencies;
@@ -597,10 +651,13 @@ export function registerFleetCommands(
                       : ''),
                 }
               : {}),
-            invocation,
+            invocation: spawnInvocationWithMergedPlacement(invocation as unknown as Record<string, unknown>),
           });
         } catch (error) {
-          if (sandbox?.outcome === 'provisioned') {
+          if (
+            sandbox?.outcome === 'provisioned' &&
+            !(error instanceof RelayPlacementError && error.state === 'unconfirmed_may_be_running')
+          ) {
             await deps
               .deleteCloudFleetSandbox({
                 cloudWorkspaceId: sandbox.cloudWorkspaceId,
@@ -657,7 +714,8 @@ export function registerFleetCommands(
             }
           : {}),
       });
-      printJson(deps.sdk, { invocation });
+      throwForTerminalSpawnFailure(invocation);
+      printJson(deps.sdk, { invocation: spawnInvocationWithPlacement(invocation) });
     });
   });
 
@@ -998,7 +1056,11 @@ async function runFleetAgentList(
     ) {
       const syntheticNodeName =
         localNodeName ?? (process.env.AGENT_RELAY_BROKER_NAME?.trim() || undefined) ?? '(local broker)';
-      const syntheticNode: RelayNode = {
+      // Keep the authoritative roster metadata when the node was filtered from
+      // the default visible set. This preserves a known offline/degraded
+      // control-plane state while still showing node-local workers.
+      const knownLocalNode = nodes.find((node) => node.name === syntheticNodeName);
+      const syntheticNode: RelayNode = knownLocalNode ?? {
         name: syntheticNodeName,
         status: 'unknown',
         capabilities: [],

--- a/packages/cli/src/cli/lib/fleet-spawn-confirmation.test.ts
+++ b/packages/cli/src/cli/lib/fleet-spawn-confirmation.test.ts
@@ -27,9 +27,12 @@ const LIVE_NODE = {
   repo_keys: ['relay'],
 };
 
-function createClient(getInvocation?: (name: string, invocationId: string) => Promise<unknown>) {
+function createClient(
+  getInvocation?: (name: string, invocationId: string) => Promise<unknown>,
+  acceptedInvocationId = 'inv-1430'
+) {
   const invoke = vi.fn(async (name: string, input?: Record<string, unknown>) => ({
-    invocation_id: 'inv-1430',
+    invocation_id: acceptedInvocationId,
     action_name: name,
     handler_node_id: 'node_a',
     dispatched_node_id: 'node_a',
@@ -99,6 +102,40 @@ describe('fleet spawn confirmation is observable from the requester (#1430)', ()
     expect(reader).toHaveBeenCalled();
   });
 
+  it('preserves a live accepted dispatch as unconfirmed and warns against blind retry', async () => {
+    const invocationId = 'inv_223936432626290688';
+    const { client, reader } = createClient(
+      async (name, id) => ({
+        invocation_id: id,
+        action_name: name,
+        handler_node_id: 'chief-broker',
+        dispatched_node_id: 'chief-broker',
+        status: 'invoked',
+      }),
+      invocationId
+    );
+
+    const error = await client.placement
+      .spawn(
+        spawnInput({
+          node: 'chief-broker',
+          input: { name: 'opencode-live-repro' },
+          confirm: true,
+          confirmTimeoutMs: 60,
+          confirmPollIntervalMs: 10,
+        })
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(RelayPlacementError);
+    expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
+    expect((error as RelayPlacementError).state).toBe('unconfirmed_may_be_running');
+    expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+    expect((error as RelayPlacementError).invocationId).toBe(invocationId);
+    expect((error as Error).message).toContain('do not retry blindly');
+    expect(reader).toHaveBeenCalled();
+  });
+
   // MUST-FIRE — a node that reports its failure honestly still surfaced as
   // success before this change, because nothing read the action result. The
   // broker's detail (startup exit status and worker log path) must survive.
@@ -128,7 +165,7 @@ describe('fleet spawn confirmation is observable from the requester (#1430)', ()
       invocation_id: invocationId,
       action_name: name,
       status: 'completed',
-      output: { spawned: true, name: 'worker-1430' },
+      output: { spawned: true, ready: true, name: 'worker-1430' },
     }));
 
     const ack = await client.placement.spawn(
@@ -137,6 +174,26 @@ describe('fleet spawn confirmation is observable from the requester (#1430)', ()
 
     expect(ack.placement.confirmed).toBe(true);
     expect(ack.confirmation?.status).toBe('completed');
+  });
+
+  it('fails a completed invocation that omits readiness proof', async () => {
+    const { client } = createClient(async (name, invocationId) => ({
+      invocation_id: invocationId,
+      action_name: name,
+      status: 'completed',
+      output: { spawned: true, name: 'worker-1430' },
+    }));
+
+    const error = await client.placement
+      .spawn(spawnInput({ confirm: true, confirmTimeoutMs: 1_000, confirmPollIntervalMs: 10 }))
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(RelayPlacementError);
+    expect((error as RelayPlacementError).code).toBe('spawn_failed');
+    expect((error as RelayPlacementError).state).toBe('failed');
+    expect((error as RelayPlacementError).invocationId).toBe('inv-1430');
+    expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+    expect((error as RelayPlacementError).message).toContain('spawned:true and ready:true proof');
   });
 
   // VACUITY CONTROL — without `confirm` the invocation is never read back, so

--- a/packages/cli/src/cli/lib/sdk-command.test.ts
+++ b/packages/cli/src/cli/lib/sdk-command.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RelayPlacementError } from '@agent-relay/sdk';
+
+import { runSdk, withSdkDefaults, type SdkCommandDeps } from './sdk-command.js';
+
+// relay#1751 CodeRabbit thread / relay#1563: `runSdk` prints a structured
+// error body for `RelayPlacementError`, including `err.receipt`. That
+// receipt is the raw upstream spawn invocation record and must not cross
+// the CLI boundary unsanitized — only the allowlisted lifecycle-evidence
+// fields (status/ids/readiness) may be echoed back.
+describe('runSdk structured error output', () => {
+  function deps(overrides: Partial<SdkCommandDeps> = {}): { deps: SdkCommandDeps; errors: string[] } {
+    const errors: string[] = [];
+    const built = withSdkDefaults({
+      error: (...args: unknown[]) => errors.push(args.map(String).join(' ')),
+      exit: vi.fn() as never,
+      ...overrides,
+    });
+    return { deps: built, errors };
+  }
+
+  it('drops secret-bearing raw invocation fields from the printed receipt', async () => {
+    const { deps: sdkDeps, errors } = deps();
+    const receipt = {
+      status: 'failed',
+      invocation_id: 'inv_secret',
+      // Not part of the lifecycle-evidence allowlist. A raw upstream
+      // invocation record can carry broker/handler internals like this;
+      // they must never cross the CLI boundary.
+      api_key: 'sk_live_should_not_leak_1234567890',
+      env: { RELAY_API_KEY: 'sk_live_should_not_leak_1234567890' },
+    };
+
+    await runSdk(sdkDeps, async () => {
+      throw new RelayPlacementError('spawn_failed', 'Fleet spawn invocation reported a terminal failure.', {
+        capability: 'spawn:codex',
+        attempts: 1,
+        invocationId: 'inv_secret',
+        state: 'failed',
+        dispatchState: 'unknown',
+        receipt,
+      });
+    });
+
+    expect(sdkDeps.exit).toHaveBeenCalledWith(1);
+    const printed = errors.join('\n');
+    expect(printed).not.toContain('sk_live_should_not_leak_1234567890');
+    expect(printed).not.toContain('RELAY_API_KEY');
+    expect(printed).not.toContain('api_key');
+
+    const jsonLine = printed.split('\n').find((line) => line.trim().startsWith('{'));
+    expect(jsonLine).toBeDefined();
+    const parsed = JSON.parse(jsonLine!);
+    // Lifecycle evidence must survive the projection...
+    expect(parsed.error.receipt).toMatchObject({ status: 'failed', invocation_id: 'inv_secret' });
+    // ...but the raw secret-bearing fields must not.
+    expect(parsed.error.receipt).not.toHaveProperty('api_key');
+    expect(parsed.error.receipt).not.toHaveProperty('env');
+  });
+
+  it('preserves lifecycle evidence (state, dispatchState, invocationId) for a non-secret receipt', async () => {
+    const { deps: sdkDeps, errors } = deps();
+
+    await runSdk(sdkDeps, async () => {
+      throw new RelayPlacementError('spawn_unconfirmed', 'node accepted spawn but never reported a result.', {
+        capability: 'spawn:codex',
+        attempts: 1,
+        invocationId: 'inv_lifecycle',
+        node: 'sf-mini',
+        state: 'unconfirmed_may_be_running',
+        dispatchState: 'dispatched',
+        receipt: { status: 'accepted', invocation_id: 'inv_lifecycle', handler_node_id: 'sf-mini' },
+      });
+    });
+
+    const printed = errors.join('\n');
+    const jsonLine = printed.split('\n').find((line) => line.trim().startsWith('{'));
+    const parsed = JSON.parse(jsonLine!);
+    expect(parsed.error).toMatchObject({
+      code: 'spawn_unconfirmed',
+      state: 'unconfirmed_may_be_running',
+      invocationId: 'inv_lifecycle',
+      node: 'sf-mini',
+      dispatchState: 'dispatched',
+      receipt: { status: 'accepted', invocation_id: 'inv_lifecycle', handler_node_id: 'sf-mini' },
+    });
+  });
+
+  it('does not attach a structured receipt for a plain Error', async () => {
+    const { deps: sdkDeps, errors } = deps();
+
+    await runSdk(sdkDeps, async () => {
+      throw new Error('boom');
+    });
+
+    expect(sdkDeps.exit).toHaveBeenCalledWith(1);
+    expect(errors.join('\n')).toBe('boom');
+  });
+});

--- a/packages/cli/src/cli/lib/sdk-command.ts
+++ b/packages/cli/src/cli/lib/sdk-command.ts
@@ -1,9 +1,15 @@
 import type { Command } from 'commander';
 
-import { AgentRelay, safeRelayErrorMessage, type AgentRelayAgent } from '@agent-relay/sdk';
+import {
+  AgentRelay,
+  RelayPlacementError,
+  safeRelayErrorMessage,
+  type AgentRelayAgent,
+} from '@agent-relay/sdk';
 
 import { defaultExit } from './exit.js';
 import { createAgentRelay, createWorkspaceRelay, type SdkClientOptions } from './sdk-client.js';
+import { sanitizedSpawnReceipt } from './spawn-lifecycle.js';
 
 type ExitFn = (code: number) => never;
 
@@ -70,7 +76,23 @@ export async function runSdk(deps: SdkCommandDeps, fn: () => Promise<void>): Pro
   try {
     await fn();
   } catch (err) {
-    deps.error(safeRelayErrorMessage(err));
+    const message = safeRelayErrorMessage(err);
+    if (err instanceof RelayPlacementError) {
+      const structured = {
+        error: {
+          code: err.code,
+          state: err.state ?? 'unknown',
+          ...(err.invocationId ? { invocationId: err.invocationId } : {}),
+          ...(err.node ? { node: err.node } : {}),
+          ...(err.dispatchState ? { dispatchState: err.dispatchState } : {}),
+          ...(err.receipt ? { receipt: sanitizedSpawnReceipt(err.receipt) } : {}),
+          message,
+        },
+      };
+      deps.error(`${message}\n${JSON.stringify(structured)}`);
+    } else {
+      deps.error(message);
+    }
     deps.exit(1);
   }
 }

--- a/packages/cli/src/cli/lib/spawn-lifecycle.ts
+++ b/packages/cli/src/cli/lib/spawn-lifecycle.ts
@@ -1,0 +1,96 @@
+export type SpawnLifecycleState = 'accepted' | 'ready' | 'unconfirmed_may_be_running' | 'failed';
+export type SpawnDispatchState = 'dispatched' | 'not_dispatched' | 'unknown';
+
+const SUCCESS = new Set(['completed', 'succeeded', 'success']);
+const FAILURE = new Set(['failed', 'error', 'cancelled', 'canceled', 'denied']);
+const DISPATCHED = new Set(['dispatched', 'invoked', 'running']);
+const NOT_DISPATCHED = new Set(['pending', 'queued']);
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function dispatchEvidence(value: Record<string, unknown>): SpawnDispatchState {
+  const status = text(value.status)?.toLowerCase();
+  if (
+    text(value.dispatchedNodeId) ||
+    text(value.dispatched_node_id) ||
+    text(value.handlerNodeId) ||
+    text(value.handler_node_id) ||
+    (status !== undefined && (DISPATCHED.has(status) || SUCCESS.has(status)))
+  ) {
+    return 'dispatched';
+  }
+  if (status !== undefined && NOT_DISPATCHED.has(status)) return 'not_dispatched';
+  return 'unknown';
+}
+
+export function spawnLifecycleState(value: Record<string, unknown>): SpawnLifecycleState {
+  const status = text(value.status)?.toLowerCase();
+  if (status && SUCCESS.has(status)) {
+    const output =
+      value.output !== null && typeof value.output === 'object'
+        ? (value.output as Record<string, unknown>)
+        : value;
+    // A terminal success status without explicit launch and readiness proof is
+    // a failed spawn, not a live-but-uncertain one. Genuine uncertainty is
+    // reserved for non-terminal acknowledgements and confirmation timeouts.
+    return output.spawned === true && output.ready === true ? 'ready' : 'failed';
+  }
+  if (status && FAILURE.has(status)) return 'failed';
+  if (status === 'accepted') return 'accepted';
+  if (status && NOT_DISPATCHED.has(status) && dispatchEvidence(value) === 'not_dispatched') return 'accepted';
+  return 'unconfirmed_may_be_running';
+}
+
+// Allowlisted keys for a spawn receipt that crosses a CLI/MCP serialization
+// boundary. Upstream invocation records can carry arbitrary broker/handler
+// output (raw error text, task payloads, environment-derived metadata) that
+// is not safe to echo back verbatim — see relay#1563. Only lifecycle
+// evidence (status/ids/readiness) is allowlisted through.
+const SPAWN_RECEIPT_ALLOWED_KEYS = [
+  'status',
+  'invocation_id',
+  'invocationId',
+  'dispatched_node_id',
+  'dispatchedNodeId',
+  'handler_node_id',
+  'handlerNodeId',
+] as const;
+
+/**
+ * Project an upstream spawn invocation record down to an allowlisted set of
+ * lifecycle-evidence fields, dropping raw error text, task payloads, and any
+ * other upstream data that should not cross a CLI/MCP serialization
+ * boundary unsanitized.
+ */
+export function sanitizedSpawnReceipt(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of SPAWN_RECEIPT_ALLOWED_KEYS) {
+    if (value[key] !== undefined) out[key] = value[key];
+  }
+  const output =
+    value.output !== null && typeof value.output === 'object'
+      ? (value.output as Record<string, unknown>)
+      : undefined;
+  if (output && (typeof output.spawned === 'boolean' || typeof output.ready === 'boolean')) {
+    out.output = {
+      ...(typeof output.spawned === 'boolean' ? { spawned: output.spawned } : {}),
+      ...(typeof output.ready === 'boolean' ? { ready: output.ready } : {}),
+    };
+  }
+  return out;
+}
+
+export function spawnPlacementReceipt(value: Record<string, unknown>): Record<string, unknown> {
+  const invocationId = text(value.invocationId) ?? text(value.invocation_id);
+  const dispatchedNodeId = text(value.dispatchedNodeId) ?? text(value.dispatched_node_id);
+  const handlerNodeId = text(value.handlerNodeId) ?? text(value.handler_node_id);
+  return {
+    state: spawnLifecycleState(value),
+    dispatchState: dispatchEvidence(value),
+    ...(invocationId ? { invocationId } : {}),
+    ...(dispatchedNodeId ? { dispatchedNodeId } : {}),
+    ...(handlerNodeId ? { handlerNodeId } : {}),
+  };
+}

--- a/packages/sdk/src/messaging/index.ts
+++ b/packages/sdk/src/messaging/index.ts
@@ -11,5 +11,7 @@ export {
   RelayPlacementError,
   RelaycastMessagingClient,
   type RelaycastMessagingOptions,
+  type RelaySpawnDispatchState,
+  type RelaySpawnPlacementState,
 } from './relaycast.js';
 export * from './thin-client.js';

--- a/packages/sdk/src/messaging/placement.test.mts
+++ b/packages/sdk/src/messaging/placement.test.mts
@@ -20,6 +20,7 @@ function createClient(
     ...options
   }: {
     placementLog?: (message: string) => void;
+    placementTtlMs?: number;
     selfNodeName?: string;
     maxQueuedPlacements?: number;
     placementSandboxOnly?: boolean;
@@ -564,16 +565,19 @@ describe('RelaycastMessagingClient placement', () => {
   });
 
   it('isolates a throwing onReconcile hook so placement still drains', async () => {
-    const { client, invoke, nodes } = createClient([
-      {
-        id: 'node_a',
-        name: 'node-a',
-        status: 'offline',
-        live: false,
-        capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
-        repo_keys: ['relay'],
-      },
-    ]);
+    const { client, invoke, nodes } = createClient(
+      [
+        {
+          id: 'node_a',
+          name: 'node-a',
+          status: 'offline',
+          live: false,
+          capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+          repo_keys: ['relay'],
+        },
+      ],
+      { placementTtlMs: 500 }
+    );
 
     const placement = client.placement.spawn({
       capability: 'spawn:claude',
@@ -596,16 +600,19 @@ describe('RelaycastMessagingClient placement', () => {
 
   it('queues a targeted offline node with reason target_offline and drains once it is live', async () => {
     const reconciled: unknown[] = [];
-    const { client, invoke, nodes } = createClient([
-      {
-        id: 'node_a',
-        name: 'node-a',
-        status: 'offline',
-        live: false,
-        capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
-        repo_keys: ['relay'],
-      },
-    ]);
+    const { client, invoke, nodes } = createClient(
+      [
+        {
+          id: 'node_a',
+          name: 'node-a',
+          status: 'offline',
+          live: false,
+          capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+          repo_keys: ['relay'],
+        },
+      ],
+      { placementTtlMs: 500 }
+    );
 
     const placement = client.placement.spawn({
       capability: 'spawn:claude',
@@ -644,7 +651,7 @@ describe('RelaycastMessagingClient placement', () => {
           repo_keys: ['cloud'],
         },
       ],
-      { placementLog: (line) => logs.push(line) }
+      { placementLog: (line) => logs.push(line), placementTtlMs: 500 }
     );
 
     const placement = client.placement.spawn({
@@ -685,7 +692,7 @@ describe('RelaycastMessagingClient placement', () => {
           repo_keys: ['cloud'],
         },
       ],
-      { placementLog: (line) => logs.push(line) }
+      { placementLog: (line) => logs.push(line), placementTtlMs: 500 }
     );
 
     const placement = client.placement.spawn({
@@ -722,16 +729,19 @@ describe('RelaycastMessagingClient placement', () => {
   });
 
   it('queues when no eligible node is live and drains before TTL', async () => {
-    const { client, nodes } = createClient([
-      {
-        id: 'node_a',
-        name: 'node-a',
-        status: 'offline',
-        live: false,
-        capabilities: [{ name: 'spawn:codex', kind: 'spawn' }],
-        repo_keys: ['relay'],
-      },
-    ]);
+    const { client, nodes } = createClient(
+      [
+        {
+          id: 'node_a',
+          name: 'node-a',
+          status: 'offline',
+          live: false,
+          capabilities: [{ name: 'spawn:codex', kind: 'spawn' }],
+          repo_keys: ['relay'],
+        },
+      ],
+      { placementTtlMs: 500 }
+    );
 
     const placement = client.placement.spawn({
       capability: 'spawn:codex',
@@ -784,6 +794,7 @@ describe('RelaycastMessagingClient placement', () => {
       // never read back, and the ack says so rather than implying a launch.
       expect(getInvocation).not.toHaveBeenCalled();
       expect(ack.placement.confirmed).toBe(false);
+      expect(ack.placement.state).toBe('accepted');
       expect(ack.confirmation).toBeUndefined();
     });
 
@@ -793,7 +804,7 @@ describe('RelaycastMessagingClient placement', () => {
           invocation_id: invocationId,
           action_name: name,
           status: 'completed',
-          output: { spawned: true, name: 'worker-confirmed' },
+          output: { spawned: true, ready: true, name: 'worker-confirmed' },
         }),
       });
 
@@ -807,7 +818,36 @@ describe('RelaycastMessagingClient placement', () => {
 
       expect(getInvocation).toHaveBeenCalled();
       expect(ack.placement.confirmed).toBe(true);
+      expect(ack.placement.state).toBe('ready');
       expect(ack.confirmation?.status).toBe('completed');
+    });
+
+    it('does not report readiness without explicit spawned and ready proof', async () => {
+      const { client } = createClient([LIVE_NODE_A], {
+        getInvocation: async (name, invocationId) => ({
+          invocation_id: invocationId,
+          action_name: name,
+          status: 'completed',
+          output: { spawned: true, name: 'worker-without-ready-proof' },
+        }),
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          confirm: true,
+          confirmTimeoutMs: 1_000,
+          input: { name: 'worker-without-ready-proof' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).state).toBe('failed');
+      expect((error as RelayPlacementError).invocationId).toBeDefined();
+      expect((error as RelayPlacementError).receipt).toMatchObject({ status: 'completed' });
+      expect((error as Error).message).toContain('explicit spawned:true and ready:true proof');
     });
 
     // The sf-mini reproduction: capacity advertised, invocation accepted, no
@@ -837,6 +877,8 @@ describe('RelaycastMessagingClient placement', () => {
       expect(error).toBeInstanceOf(RelayPlacementError);
       expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
       expect((error as RelayPlacementError).node).toBe('node-a');
+      expect((error as RelayPlacementError).invocationId).toBeDefined();
+      expect((error as RelayPlacementError).state).toBe('unconfirmed_may_be_running');
       expect((error as Error).message).toContain('never reported a result');
     });
 
@@ -865,9 +907,338 @@ describe('RelaycastMessagingClient placement', () => {
 
       expect(error).toBeInstanceOf(RelayPlacementError);
       expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).state).toBe('failed');
+      expect((error as RelayPlacementError).invocationId).toBeDefined();
       // The broker's detail (exit status + log path) must survive to the caller.
       expect((error as Error).message).toContain('exit status: 19');
       expect((error as Error).message).toContain('/tmp/worker-dead.log');
+    });
+
+    // relay#1563: dispatch evidence comes from the ack's node id, not from
+    // however the confirmation later resolves. A `pending` ack with no
+    // `dispatchedNodeId`/`handlerNodeId` never actually routed — timing out
+    // or reading a later terminal status must not retroactively report
+    // `dispatched`. The CLI's shared spawn-lifecycle helper classifies this
+    // exact shape as `not_dispatched`; the SDK must agree.
+    it('reports dispatchState not_dispatched on timeout when the ack never routed to a node', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A], {
+        getInvocation: async () => undefined,
+      });
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-pending-no-route',
+        action_name: 'spawn',
+        status: 'pending',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          confirmTimeoutMs: 60,
+          confirmPollIntervalMs: 10,
+          input: { name: 'worker-pending-no-route' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
+      expect((error as RelayPlacementError).dispatchState).toBe('not_dispatched');
+    });
+
+    it('reports dispatchState not_dispatched on a terminal failure when the ack never routed to a node', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A], {
+        getInvocation: async (name, invocationId) => ({
+          invocation_id: invocationId,
+          action_name: name,
+          status: 'failed',
+          error: 'harness exited before readiness',
+        }),
+      });
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-pending-no-route-failed',
+        action_name: 'spawn',
+        status: 'pending',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          confirmTimeoutMs: 1_000,
+          confirmPollIntervalMs: 10,
+          input: { name: 'worker-pending-no-route-failed' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).dispatchState).toBe('not_dispatched');
+    });
+
+    it('reports dispatchState dispatched on timeout when the ack carries a real route', async () => {
+      const { client } = createClient([LIVE_NODE_A], {
+        getInvocation: async () => undefined,
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          confirmTimeoutMs: 60,
+          confirmPollIntervalMs: 10,
+          input: { name: 'worker-routed-timeout' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
+      expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+    });
+
+    it('reports dispatchState dispatched on a terminal failure when the ack carries a real route', async () => {
+      const { client } = createClient([LIVE_NODE_A], {
+        getInvocation: async (name, invocationId) => ({
+          invocation_id: invocationId,
+          action_name: name,
+          status: 'failed',
+          error: 'harness exited before readiness',
+        }),
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          confirmTimeoutMs: 1_000,
+          confirmPollIntervalMs: 10,
+          input: { name: 'worker-routed-failed' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+    });
+
+    // relay#1563 P1: `confirm: false` is the default, including `fleet spawn
+    // --no-confirm`. Terminal-status checks previously lived only inside the
+    // confirmation poll, so a synchronous handler that acked with an
+    // immediate terminal `failed`/`denied` status resolved as `accepted`
+    // instead of throwing — the caller received a "successful" placement for
+    // a spawn already known to have failed.
+    it('rejects a terminal failed ack as spawn_failed even when confirm is left at its default (false)', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-immediate-failure',
+        action_name: 'spawn:claude',
+        handler_node_id: 'node_a',
+        dispatched_node_id: 'node_a',
+        status: 'failed',
+        error: 'harness rejected the spawn before accepting it',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          input: { name: 'worker-immediate-failure' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+      expect((error as RelayPlacementError).invocationId).toBe('inv-immediate-failure');
+      expect((error as RelayPlacementError).receipt).toMatchObject({
+        invocationId: 'inv-immediate-failure',
+        status: 'failed',
+      });
+    });
+
+    it('rejects a terminal denied ack as spawn_failed with confirm: false (fleet spawn --no-confirm)', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-immediate-denial',
+        action_name: 'spawn:claude',
+        status: 'denied',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: false,
+          input: { name: 'worker-immediate-denial' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).invocationId).toBe('inv-immediate-denial');
+      expect((error as RelayPlacementError).receipt).toMatchObject({
+        invocationId: 'inv-immediate-denial',
+        status: 'denied',
+      });
+      // No node id, and `denied` isn't itself route evidence either way —
+      // the shared classifier reports `unknown`, not a manufactured route.
+      expect((error as RelayPlacementError).dispatchState).toBe('unknown');
+    });
+
+    it('rejects an immediate completed ack without explicit spawn/readiness proof by default', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-immediate-unproven-success',
+        action_name: 'spawn:claude',
+        handler_node_id: 'node_a',
+        dispatched_node_id: 'node_a',
+        status: 'completed',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          input: { name: 'worker-immediate-unproven-success' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_failed');
+      expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+      expect((error as RelayPlacementError).invocationId).toBe('inv-immediate-unproven-success');
+      expect((error as RelayPlacementError).receipt).toMatchObject({
+        invocationId: 'inv-immediate-unproven-success',
+        status: 'completed',
+      });
+    });
+
+    it('accepts an immediate completed ack when it carries explicit spawn/readiness proof', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-immediate-proven-success',
+        action_name: 'spawn:claude',
+        handler_node_id: 'node_a',
+        dispatched_node_id: 'node_a',
+        status: 'completed',
+        output: { spawned: true, ready: true },
+      });
+
+      const ack = await client.placement.spawn({
+        capability: 'spawn:claude',
+        node: 'node-a',
+        repo: 'relay',
+        input: { name: 'worker-immediate-proven-success' },
+      });
+
+      expect(ack.placement).toMatchObject({ state: 'accepted', confirmed: false });
+    });
+
+    it('still resolves as accepted with confirm: false when the ack is non-terminal', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+
+      const ack = await client.placement.spawn({
+        capability: 'spawn:claude',
+        node: 'node-a',
+        repo: 'relay',
+        input: { name: 'worker-non-terminal-ack' },
+      });
+
+      expect(invoke).toHaveBeenCalled();
+      expect(ack.placement.confirmed).toBe(false);
+      expect(ack.placement.state).toBe('accepted');
+    });
+
+    // relay#1563 Low: every `spawn_unconfirmed` exit in confirmPlacementInvocation
+    // must carry `dispatchState` from the same classifier the timeout/failure
+    // paths already use — including the two *early* exits (missing invocation
+    // id, and a client with no actions API), which previously omitted it even
+    // though the ack was already available to classify.
+    it('includes dispatchState on the early spawn_unconfirmed exit when the ack has no invocation id', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        action_name: 'spawn:claude',
+        status: 'invoked',
+        handler_node_id: 'node_a',
+        dispatched_node_id: 'node_a',
+      });
+
+      const error = await client.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          input: { name: 'worker-no-invocation-id' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
+      expect((error as RelayPlacementError).dispatchState).toBe('dispatched');
+    });
+
+    it('includes dispatchState on the early spawn_unconfirmed exit when no actions API is available', async () => {
+      const { client, invoke } = createClient([LIVE_NODE_A]);
+      invoke.mockResolvedValueOnce({
+        invocation_id: 'inv-no-actions-api',
+        action_name: 'spawn:claude',
+        status: 'pending',
+      });
+      // Construct a second client sharing the same mocked relaycast/nodes but
+      // with an agent-scoped client that has no `actions` API.
+      const relaycast = {
+        agents: {
+          list: vi.fn(async () => []),
+          get: vi.fn(),
+          register: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+          presence: vi.fn(async () => []),
+        },
+        channels: { list: vi.fn(async () => []), get: vi.fn() },
+        messages: { list: vi.fn(async () => []), get: vi.fn(), thread: vi.fn(), reactions: vi.fn() },
+        nodes: {
+          list: vi.fn(async () => [{ handlers_live: true, ...LIVE_NODE_A }]),
+          get: vi.fn(async () => ({ handlers_live: true, ...LIVE_NODE_A })),
+        },
+      };
+      const { RelaycastMessagingClient } = await import('./index.js');
+      const noActionsClient = new RelaycastMessagingClient({
+        relaycast: relaycast as never,
+        agentClient: { actions: undefined } as never,
+        placementTtlMs: 60,
+      });
+      vi.spyOn(noActionsClient.commands, 'invoke').mockResolvedValueOnce({
+        invocationId: 'inv-no-actions-api',
+        actionName: 'spawn:claude',
+        status: 'pending',
+      } as never);
+
+      const error = await noActionsClient.placement
+        .spawn({
+          capability: 'spawn:claude',
+          node: 'node-a',
+          repo: 'relay',
+          confirm: true,
+          input: { name: 'worker-no-actions-api' },
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(RelayPlacementError);
+      expect((error as RelayPlacementError).code).toBe('spawn_unconfirmed');
+      expect((error as RelayPlacementError).dispatchState).toBe('not_dispatched');
+      void invoke;
     });
 
     it('times out as spawn_unconfirmed when the invocation cannot be read at all', async () => {

--- a/packages/sdk/src/messaging/relaycast-placement.ts
+++ b/packages/sdk/src/messaging/relaycast-placement.ts
@@ -13,6 +13,56 @@ export type PlacementReconcileReason =
   | 'unmapped_repo'
   | 'sandbox_policy_mismatch';
 
+/**
+ * Evidence state for a targeted spawn placement.
+ *
+ * `accepted` is an engine receipt only; it is never evidence that a worker
+ * launched. `unconfirmed_may_be_running` is deliberately non-terminal from
+ * the worker's perspective: the invocation may still complete after the
+ * caller's confirmation budget, so retrying can duplicate work.
+ */
+export type RelaySpawnPlacementState = 'accepted' | 'ready' | 'unconfirmed_may_be_running' | 'failed';
+
+export type RelaySpawnDispatchState = 'dispatched' | 'not_dispatched' | 'unknown';
+
+// Status vocabulary a route-evidence check alone cannot classify. Kept as a
+// small local set — deliberately *not* imported from the CLI's spawn
+// lifecycle helper (`packages/cli/src/cli/lib/spawn-lifecycle.ts`), since the
+// SDK package must not depend on CLI source to stay classification-correct.
+// Both sides read the same authoritative shape (relay#1563): a node id on the
+// ack/invocation is real dispatch evidence; a `pending`/`queued` status with
+// no node id is not.
+const DISPATCH_EVIDENT_STATUSES = new Set([
+  'dispatched',
+  'invoked',
+  'running',
+  'completed',
+  'succeeded',
+  'success',
+]);
+const NOT_DISPATCHED_STATUSES = new Set(['pending', 'queued']);
+
+/**
+ * Classify dispatch evidence from an invocation ack (or its terminal read
+ * back), matching the CLI's `spawnLifecycleState`/`dispatchEvidence`
+ * semantics: a `dispatchedNodeId`/`handlerNodeId` is real evidence a node
+ * received the dispatch. Its absence, with a `pending`/`queued` status, means
+ * the invocation never actually routed — even if the caller later observes a
+ * terminal (timeout or error) outcome for it. A timeout or terminal error is
+ * a fact about the *caller's* wait, not evidence that dispatch happened.
+ */
+export function resolveDispatchState(ack: {
+  dispatchedNodeId?: string | null;
+  handlerNodeId?: string | null;
+  status?: string;
+}): RelaySpawnDispatchState {
+  if (ack.dispatchedNodeId || ack.handlerNodeId) return 'dispatched';
+  const status = ack.status?.toLowerCase();
+  if (status && DISPATCH_EVIDENT_STATUSES.has(status)) return 'dispatched';
+  if (status && NOT_DISPATCHED_STATUSES.has(status)) return 'not_dispatched';
+  return 'unknown';
+}
+
 export type PlacementSelection =
   | { node: RelayNode; message?: never; hardFail?: never; reason?: never; reconcileReason?: never }
   | {
@@ -54,11 +104,28 @@ export class RelayPlacementError extends Error {
   readonly node?: string;
   readonly repo?: string;
   readonly attempts: number;
+  /** Stable invocation correlation for accepted/dispatch outcomes. */
+  readonly invocationId?: string;
+  /** Evidence state at the point this placement returned or failed. */
+  readonly state?: RelaySpawnPlacementState;
+  /** Whether the engine supplied evidence that a node received the dispatch. */
+  readonly dispatchState?: RelaySpawnDispatchState;
+  /** Original invocation receipt, when a terminal spawn result was observed. */
+  readonly receipt?: Record<string, unknown>;
 
   constructor(
     code: RelayPlacementError['code'],
     message: string,
-    context: { capability: string; node?: string; repo?: string; attempts: number }
+    context: {
+      capability: string;
+      node?: string;
+      repo?: string;
+      attempts: number;
+      invocationId?: string;
+      state?: RelaySpawnPlacementState;
+      dispatchState?: RelaySpawnDispatchState;
+      receipt?: Record<string, unknown>;
+    }
   ) {
     super(message);
     this.name = 'RelayPlacementError';
@@ -67,6 +134,10 @@ export class RelayPlacementError extends Error {
     this.node = context.node;
     this.repo = context.repo;
     this.attempts = context.attempts;
+    this.invocationId = context.invocationId;
+    this.state = context.state;
+    this.dispatchState = context.dispatchState;
+    this.receipt = context.receipt;
   }
 }
 

--- a/packages/sdk/src/messaging/relaycast-translate.ts
+++ b/packages/sdk/src/messaging/relaycast-translate.ts
@@ -220,6 +220,7 @@ export function normalizeActionInvocationAck(raw: unknown): RelayActionInvocatio
       ? { dispatchedNodeId: readStr(record, 'dispatchedNodeId', 'dispatched_node_id') }
       : {}),
     ...(readRecord(record, 'input') ? { input: readRecord(record, 'input') } : {}),
+    ...(readRecord(record, 'output') ? { output: readRecord(record, 'output') } : {}),
     ...(readStr(record, 'status') ? { status: readStr(record, 'status') } : {}),
     ...(readStr(record, 'createdAt', 'created_at')
       ? { createdAt: readStr(record, 'createdAt', 'created_at') }

--- a/packages/sdk/src/messaging/relaycast.ts
+++ b/packages/sdk/src/messaging/relaycast.ts
@@ -11,6 +11,7 @@ import {
   placementActionInput,
   placementActionName,
   RelayPlacementError,
+  resolveDispatchState,
   type PlacementSelection,
 } from './relaycast-placement.js';
 import {
@@ -123,6 +124,7 @@ import type {
 // client-construction concerns moved into sibling modules. Consumers import
 // these from './relaycast.js' via the messaging index.
 export { RelayPlacementError } from './relaycast-placement.js';
+export type { RelaySpawnDispatchState, RelaySpawnPlacementState } from './relaycast-placement.js';
 export type { RelaycastMessagingOptions } from './relaycast-client.js';
 
 const DEFAULT_CONFIRM_TIMEOUT_MS = 120_000;
@@ -140,6 +142,10 @@ const CONFIRM_SUCCESS_STATUSES = new Set(['completed', 'succeeded', 'success']);
  * that client surfaces as a non-retryable `action_denied` error.
  */
 const CONFIRM_FAILURE_STATUSES = new Set(['failed', 'error', 'denied', 'cancelled', 'canceled']);
+
+function hasExplicitSpawnReadinessProof(value: { output?: Record<string, unknown> | null }): boolean {
+  return value.output?.spawned === true && value.output?.ready === true;
+}
 
 /** Distinguishes "the read outlived its budget" from any value a read returns. */
 const READ_TIMED_OUT = Symbol('relay.confirm.readTimedOut');
@@ -736,6 +742,53 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
               : await this.resolvePlacementAckNode(ack, capability);
             const placedNodeLabel =
               placedNode?.name ?? ack.dispatchedNodeId ?? ack.handlerNodeId ?? 'engine-selected node';
+            // A synchronous handler can reject or deny the invocation before
+            // this call even returns, so the ack itself can already carry a
+            // terminal failure. The terminal-status checks in
+            // confirmPlacementInvocation only run once polling starts, so
+            // `confirm: false` — the default, and `fleet spawn --no-confirm`
+            // — must not skip straight to `state: 'accepted'` for a dispatch
+            // already known to have failed or been denied.
+            const ackStatus = ack.status?.toLowerCase();
+            if (ackStatus && CONFIRM_FAILURE_STATUSES.has(ackStatus)) {
+              throw new RelayPlacementError(
+                'spawn_failed',
+                `node '${placedNodeLabel}' reported ${ackStatus} for ${actionName} immediately upon dispatch`,
+                {
+                  capability,
+                  node: placedNodeLabel,
+                  repo,
+                  attempts,
+                  state: 'failed',
+                  dispatchState: resolveDispatchState(ack),
+                  invocationId: ack.invocationId,
+                  receipt: ack as unknown as Record<string, unknown>,
+                }
+              );
+            }
+            const ackOutput = (ack as unknown as { output?: Record<string, unknown> | null }).output;
+            if (
+              !input.confirm &&
+              capability.startsWith('spawn:') &&
+              ackStatus &&
+              CONFIRM_SUCCESS_STATUSES.has(ackStatus) &&
+              !hasExplicitSpawnReadinessProof({ output: ackOutput })
+            ) {
+              throw new RelayPlacementError(
+                'spawn_failed',
+                `node '${placedNodeLabel}' reported ${ackStatus} for ${actionName} without explicit spawned:true and ready:true proof`,
+                {
+                  capability,
+                  node: placedNodeLabel,
+                  repo,
+                  attempts,
+                  state: 'failed',
+                  dispatchState: resolveDispatchState(ack),
+                  invocationId: ack.invocationId,
+                  receipt: ack as unknown as Record<string, unknown>,
+                }
+              );
+            }
             // The ack proves only that the engine accepted the dispatch. Unless
             // the caller asks for confirmation, a node that accepted the
             // invocation and launched nothing resolves identically to a real
@@ -762,6 +815,7 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
                 attempts,
                 queued,
                 confirmed: Boolean(confirmation),
+                state: confirmation ? 'ready' : 'accepted',
               },
               ...(confirmation ? { confirmation } : {}),
             };
@@ -879,11 +933,19 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
   ): Promise<RelayActionInvocation> {
     const { timeoutMs, pollIntervalMs, ...errorContext } = context;
     const invocationId = ack.invocationId;
+    // Dispatch evidence is fixed at ack time: a node id here means the engine
+    // already routed the invocation to a node before this method starts
+    // polling. A `pending`/`queued` ack with no node id has not routed yet,
+    // and confirmation timing out or reading a terminal status later does not
+    // retroactively manufacture that evidence — see `resolveDispatchState`.
+    // Computed before either early exit below so every `spawn_unconfirmed`
+    // path, not just the timeout/failure paths, carries this evidence.
+    const dispatchState = resolveDispatchState(ack);
     if (!invocationId) {
       throw new RelayPlacementError(
         'spawn_unconfirmed',
         `node '${context.node}' accepted ${actionName} without returning an invocation id, so the dispatch cannot be confirmed`,
-        errorContext
+        { ...errorContext, state: 'unconfirmed_may_be_running', dispatchState }
       );
     }
 
@@ -899,7 +961,12 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
       throw new RelayPlacementError(
         'spawn_unconfirmed',
         `node '${context.node}' accepted ${actionName} (invocation ${invocationId}), but confirmation requires an agent-scoped client with the actions API, so the dispatch cannot be read back`,
-        errorContext
+        {
+          ...errorContext,
+          state: 'unconfirmed_may_be_running',
+          invocationId,
+          dispatchState,
+        }
       );
     }
 
@@ -923,13 +990,35 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
             const invocation = outcome.value;
             const status = invocation?.status?.toLowerCase();
             if (status && CONFIRM_SUCCESS_STATUSES.has(status)) {
+              if (
+                errorContext.capability.startsWith('spawn:') &&
+                !hasExplicitSpawnReadinessProof(invocation)
+              ) {
+                throw new RelayPlacementError(
+                  'spawn_failed',
+                  `node '${context.node}' reported ${status} for ${actionName} without explicit spawned:true and ready:true proof`,
+                  {
+                    ...errorContext,
+                    state: 'failed',
+                    invocationId,
+                    dispatchState,
+                    receipt: invocation as unknown as Record<string, unknown>,
+                  }
+                );
+              }
               return invocation;
             }
             if (status && CONFIRM_FAILURE_STATUSES.has(status)) {
               throw new RelayPlacementError(
                 'spawn_failed',
                 invocation?.error?.trim() || `node '${context.node}' reported ${status} for ${actionName}`,
-                errorContext
+                {
+                  ...errorContext,
+                  state: 'failed',
+                  invocationId,
+                  dispatchState,
+                  receipt: invocation as unknown as Record<string, unknown>,
+                }
               );
             }
           } else {
@@ -945,9 +1034,15 @@ export class RelaycastMessagingClient implements RelayMessagingClient {
           'spawn_unconfirmed',
           `node '${context.node}' accepted ${actionName} (invocation ${invocationId}) but never reported a result within ${budgetMs}ms. ` +
             `The node advertised capacity and acknowledged the dispatch; nothing confirmed that it launched. ` +
+            `The invocation may still be running, so do not retry blindly. ` +
             `Check that node's broker version, or re-run without confirmation to accept an unconfirmed dispatch.` +
             (lastReadError ? ` Last read error: ${lastReadError}` : ''),
-          errorContext
+          {
+            ...errorContext,
+            state: 'unconfirmed_may_be_running',
+            invocationId,
+            dispatchState,
+          }
         );
       }
       // Never sleep past the deadline: that would buy one more pointless read.

--- a/packages/sdk/src/messaging/types.ts
+++ b/packages/sdk/src/messaging/types.ts
@@ -555,6 +555,7 @@ export interface RelayActionInvocationAck {
   handlerNodeId?: string | null;
   dispatchedNodeId?: string | null;
   input?: Record<string, unknown>;
+  output?: Record<string, unknown> | null;
   status?: string;
   createdAt?: string;
 }
@@ -672,6 +673,8 @@ export interface RelaySpawnPlacementAck extends RelayActionInvocationAck {
     repo?: string;
     attempts: number;
     queued: boolean;
+    /** Evidence state for this placement receipt. */
+    state: 'accepted' | 'ready';
     /**
      * `true` only when the node reported a terminal success for this
      * invocation. `false` means the dispatch was accepted but not confirmed —

--- a/tests/relayflows/cases/1563-spawn-lifecycle-truth/case.json
+++ b/tests/relayflows/cases/1563-spawn-lifecycle-truth/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1563-spawn-lifecycle-truth",
+  "kind": "bugfix",
+  "title": "Spawn invocation lifecycle and fleet liveness truth",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1563-spawn-lifecycle-truth/run.mjs"]
+  },
+  "requirements": [],
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "invocation_state_lifecycle_gaps"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "invocation_state_lifecycle_closed"
+    }
+  }
+}

--- a/tests/relayflows/cases/1563-spawn-lifecycle-truth/mcp-spawn-probe.mjs
+++ b/tests/relayflows/cases/1563-spawn-lifecycle-truth/mcp-spawn-probe.mjs
@@ -1,0 +1,67 @@
+/**
+ * relay#1563 / PR #1751 — spawn lifecycle truth, MCP surface.
+ *
+ * Copied by run.mjs into `<target>/.relay-pr-proof/` before execution so its
+ * bare imports (`@modelcontextprotocol/sdk`) resolve against the exact target
+ * checkout's own node_modules, and its relative import of `agent-relay-mcp.js`
+ * loads the exact built CLI dist module — the real MCP `spawn` tool the PR
+ * claims to have fixed, driven over the real MCP client/server protocol
+ * (`InMemoryTransport`), not a hand-rolled stand-in for it.
+ *
+ * `createAgentRelayMcpServer`'s `spawn` tool builds its own
+ * `new AgentRelay({ agentToken, baseUrl })` per call and hits the real
+ * `@relaycast/sdk` wire contract (`POST /v1/actions/spawn/invoke`,
+ * `GET /v1/actions/spawn/invocations/:id`) — the same envelope
+ * (`{ ok, data }`, snake_case keys camelCased on the way back) a real
+ * Relaycast deployment uses. `run.mjs` stands up a tiny HTTP server that
+ * speaks exactly that contract so this probe can force each lifecycle branch
+ * deterministically without a live Relaycast.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { createAgentRelayMcpServer } from '../packages/cli/dist/cli/agent-relay-mcp.js';
+
+const baseUrl = requiredValue('RELAY_PR_PROOF_1563_BASE_URL');
+
+async function callSpawn(agentName) {
+  const server = createAgentRelayMcpServer({ agentToken: 'relayflow-1563-agent-token', baseUrl });
+  const client = new Client({ name: 'relayflow-1563-spawn-probe', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return await client.callTool({
+      name: 'spawn',
+      arguments: { name: agentName, cli: 'claude', task: 'relayflow-1563 mcp spawn probe' },
+    });
+  } finally {
+    await client.close().catch(() => undefined);
+    await server.close().catch(() => undefined);
+  }
+}
+
+const scenarios = {
+  unproven: 'relayflow-1563-unproven',
+  unconfirmed: 'relayflow-1563-unconfirmed',
+  failed: 'relayflow-1563-failed',
+  // relay#1563 Medium (MCP): the ack never carries a node id and starts
+  // `pending`, but the later terminal read reports `failed` (also without a
+  // node id) — proving a bare status change on a *later* invocation record
+  // cannot manufacture `dispatched` for an ack that was frozen
+  // `not_dispatched`.
+  noRouteFailed: 'relayflow-1563-no-route-failed',
+};
+
+const results = {};
+for (const [key, agentName] of Object.entries(scenarios)) {
+  results[key] = await callSpawn(agentName);
+}
+
+process.stdout.write(`${JSON.stringify(results)}\n`);
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}

--- a/tests/relayflows/cases/1563-spawn-lifecycle-truth/run.mjs
+++ b/tests/relayflows/cases/1563-spawn-lifecycle-truth/run.mjs
@@ -1,0 +1,848 @@
+/**
+ * relay#1563 / PR #1751 — invocation-state lifecycle truth.
+ *
+ * Base bug: a spawn placement whose action invocation reached a terminal
+ * "completed" status was trusted as a real launch even when the node never
+ * proved `output.spawned === true && output.ready === true`. A dispatched
+ * invocation that timed out unconfirmed also lacked the explicit
+ * "do not retry blindly" guidance an operator needs before re-dispatching
+ * onto a node that may already be running the worker. Fleet-wide rendering
+ * (`fleet agent list`) also collapsed control-plane reachability and hosted
+ * worker liveness into a single signal, so an offline/degraded node with
+ * live child workers could not be told apart from one with none. The MCP
+ * `spawn` tool wrapped the same ack/poll logic with its own untyped `Error`,
+ * so none of the above survived across the MCP wire either.
+ *
+ * Head fix: `RelaycastMessagingClient.placement.spawn` (packages/sdk/src/
+ * messaging/relaycast.ts) rejects a terminal "completed" invocation lacking
+ * explicit spawned+ready proof as `spawn_failed`, preserving the structured
+ * receipt (`receipt`, `invocationId`, `dispatchState`) on the thrown
+ * `RelayPlacementError`; the unconfirmed-timeout path keeps that evidence and
+ * now spells out "do not retry blindly". `buildRows` (packages/cli/src/cli/
+ * commands/fleet-agent.ts) reports `controlPlane` and `workerLiveness` as two
+ * independent axes on every row, both in the exact JSON body `fleet agent
+ * list` emits through `printJson` and in `--pretty` (`formatPretty`'s
+ * dedicated CONTROL PLANE / WORKERS columns). The MCP `spawn` tool
+ * (packages/cli/src/cli/agent-relay-mcp.ts) now throws a typed
+ * `VerifiedSpawnError` carrying `code`/`state`/`dispatchState`/`invocationId`/
+ * `receipt`, surfaced as structured `structuredContent` on the MCP error
+ * result instead of a bare error string.
+ *
+ * Observation drives three real, built package entry surfaces — no source
+ * regex, no vitest-over-`src/`:
+ *
+ *   1. The SDK's public `@agent-relay/sdk` messaging entry
+ *      (`dist/messaging/index.js`), constructing the real
+ *      `RelaycastMessagingClient` the CLI's `fleet spawn --node` path and the
+ *      MCP `spawn` tool both build through the SDK, with a mocked
+ *      agent-actions transport (dependency injection the class itself
+ *      exposes — not a source stand-in).
+ *   2. The CLI's built `fleet agent list` JSON contract: the exact object
+ *      shape `packages/cli/dist/cli/commands/fleet.ts` passes to
+ *      `printJson` (`packages/cli/dist/cli/lib/sdk-command.js`), run through
+ *      that real `printJson` function and parsed back out of the JSON text it
+ *      emits — not just inspected as a return value from `buildRows`.
+ *   3. The MCP `spawn` tool the PR's `fix(mcp)` commit changed
+ *      (`packages/cli/dist/cli/agent-relay-mcp.js`), invoked over a real MCP
+ *      client/server protocol pair (`InMemoryTransport`) via
+ *      `mcp-spawn-probe.mjs`, which is copied into the target checkout so its
+ *      `@modelcontextprotocol/sdk` import resolves against that checkout's
+ *      own installed dependency. The tool's own spawn client makes real HTTP
+ *      calls, so this case stands up a tiny HTTP server that speaks the
+ *      exact `@relaycast/sdk` action-invocation wire contract
+ *      (`POST /v1/actions/spawn/invoke`, `GET /v1/actions/spawn/invocations/
+ *      :id`, `{ ok, data }` envelope, snake_case fields camelCased back) so
+ *      each lifecycle branch (unproven-complete, unconfirmed, terminal
+ *      failure) is forced deterministically without a live Relaycast.
+ */
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { access, copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CASE_ID = '1563-spawn-lifecycle-truth';
+// Sanitized from the live accepted-but-unconfirmed reproduction supplied for
+// relay#1563. The id is correlation evidence only; no live credentials or
+// provider metadata are carried into this deterministic fixture.
+const LIVE_UNCONFIRMED_INVOCATION_ID = 'inv_223936432626290688';
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+const targetDir = requiredValue('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredValue('RELAY_PR_PROOF_HARNESS_DIR');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+function run(command, args, cwd, label) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  process.stdout.write(result.stdout ?? '');
+  process.stderr.write(result.stderr ?? '');
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit ${result.status}`);
+  }
+  return result;
+}
+
+function runAsync(command, args, cwd, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env: { ...process.env, ...extraEnv } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.once('error', reject);
+    child.once('exit', (code) => resolve({ status: code, stdout, stderr }));
+  });
+}
+
+async function pathExists(candidate) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}.`);
+  }
+}
+function assertTrue(actual, label) {
+  if (actual !== true) throw new Error(`${label}: expected true, received ${JSON.stringify(actual)}.`);
+}
+function assertContains(haystack, needle, label) {
+  if (!String(haystack).includes(needle)) {
+    throw new Error(`${label}: expected ${JSON.stringify(haystack)} to contain ${JSON.stringify(needle)}.`);
+  }
+}
+function assertNotContains(haystack, needle, label) {
+  if (String(haystack).includes(needle)) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(haystack)} NOT to contain ${JSON.stringify(needle)}.`
+    );
+  }
+}
+
+/** A tiny server speaking the real `@relaycast/sdk` action-invocation wire contract. */
+function startActionsServer() {
+  const invocations = new Map();
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    let body = {};
+    try {
+      const text = Buffer.concat(chunks).toString('utf8');
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      body = {};
+    }
+    const send = (status, payload) => {
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    };
+    const invoke = /^\/v1\/actions\/([^/]+)\/invoke$/.exec(req.url ?? '');
+    const getInvocation = /^\/v1\/actions\/([^/]+)\/invocations\/([^/]+)$/.exec(req.url ?? '');
+
+    if (req.method === 'POST' && invoke) {
+      const input = body?.input && typeof body.input === 'object' ? body.input : {};
+      const name = typeof input.name === 'string' ? input.name : '';
+      const actionName = invoke[1];
+      if (name.endsWith('unconfirmed')) {
+        // No invocation id in the ack at all: the dispatch is unconfirmed
+        // from the very first response, no polling required to observe it.
+        send(200, { ok: true, data: { action_name: actionName, status: 'invoked' } });
+        return;
+      }
+      const invocationId = `inv-${name}`;
+      if (name.endsWith('no-route-failed')) {
+        // relay#1563 Medium (MCP): the ack itself carries no node id and a
+        // `pending` status — it has not routed yet. The later terminal read
+        // ALSO carries no node id; only its `status` flips to `failed`. A
+        // dispatchState classifier that trusts the later record's status
+        // alone (ignoring that no node id ever appeared) would wrongly
+        // upgrade `not_dispatched` to `dispatched`.
+        invocations.set(invocationId, {
+          invocation_id: invocationId,
+          action_name: actionName,
+          status: 'failed',
+          error: 'never routed before failing',
+        });
+        send(200, {
+          ok: true,
+          data: {
+            invocation_id: invocationId,
+            action_name: actionName,
+            status: 'pending',
+          },
+        });
+        return;
+      }
+      const terminal = name.endsWith('failed')
+        ? {
+            invocation_id: invocationId,
+            action_name: actionName,
+            status: 'failed',
+            handler_node_id: 'node_a',
+            dispatched_node_id: 'node_a',
+            error: 'harness exited before readiness',
+          }
+        : {
+            invocation_id: invocationId,
+            action_name: actionName,
+            status: 'completed',
+            handler_node_id: 'node_a',
+            dispatched_node_id: 'node_a',
+            output: { spawned: true, ready: false },
+          };
+      invocations.set(invocationId, terminal);
+      send(200, {
+        ok: true,
+        data: {
+          invocation_id: invocationId,
+          action_name: actionName,
+          status: 'invoked',
+          handler_node_id: 'node_a',
+          dispatched_node_id: 'node_a',
+        },
+      });
+      return;
+    }
+    if (req.method === 'GET' && getInvocation) {
+      const record = invocations.get(getInvocation[2]);
+      if (!record) {
+        send(404, { ok: false, error: { code: 'not_found', message: 'no such invocation' } });
+        return;
+      }
+      send(200, { ok: true, data: record });
+      return;
+    }
+    send(404, { ok: false, error: { code: 'not_found', message: 'no such route' } });
+  });
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+const proofDir = path.join(targetDir, '.relay-pr-proof');
+let actionsServer;
+
+try {
+  const nodeModulesEntry = path.join(targetDir, 'node_modules', '.bin');
+  if (!(await pathExists(nodeModulesEntry))) {
+    run('npm', ['ci', '--no-audit', '--no-fund'], targetDir, 'workspace dependency installation');
+  }
+
+  // --- Focused build: only what these three surfaces need, in dependency
+  // order, matching the root `build:core` script.
+  for (const step of [
+    'build:session',
+    'build:config',
+    'build:cloud',
+    'build:utils',
+    'build:policy',
+    'build:sdk',
+    'build:harness-driver',
+    'build:harnesses',
+    'build:fleet',
+    'build:cli',
+  ]) {
+    run('npm', ['run', step], targetDir, `${step} build`);
+  }
+
+  // --- Focused typecheck: the CLI package's own `tsc --noEmit`, which
+  // exercises `agent-relay-mcp.ts` and `fleet.ts`/`fleet-agent.ts` directly.
+  run(
+    process.execPath,
+    [path.join(targetDir, 'node_modules/.bin/tsc'), '--noEmit'],
+    path.join(targetDir, 'packages/cli'),
+    'cli typecheck'
+  );
+
+  // --- Focused unit tests already covering the exact files this proof
+  // drives, run from the target's own installed vitest.
+  const vitestEntry = path.join(targetDir, 'node_modules', 'vitest', 'vitest.mjs');
+  run(
+    process.execPath,
+    [
+      vitestEntry,
+      'run',
+      'packages/cli/src/cli/agent-relay-mcp.protocol.test.ts',
+      'packages/cli/src/cli/commands/fleet-agent.test.ts',
+      '--reporter=verbose',
+    ],
+    targetDir,
+    'focused vitest run'
+  );
+
+  const sdkMessagingEntry = path.join(targetDir, 'packages/sdk/dist/messaging/index.js');
+  const fleetAgentEntry = path.join(targetDir, 'packages/cli/dist/cli/commands/fleet-agent.js');
+  const sdkCommandEntry = path.join(targetDir, 'packages/cli/dist/cli/lib/sdk-command.js');
+  const spawnLifecycleEntry = path.join(targetDir, 'packages/cli/dist/cli/lib/spawn-lifecycle.js');
+  const mcpEntry = path.join(targetDir, 'packages/cli/dist/cli/agent-relay-mcp.js');
+  // The lifecycle projection is introduced by the head under test. The base
+  // arm must still execute its real SDK/CLI/MCP surfaces, but cannot require a
+  // package entry that does not exist on the base commit.
+  const requiredEntries = [sdkMessagingEntry, fleetAgentEntry, sdkCommandEntry, mcpEntry];
+  if (arm === 'head') requiredEntries.push(spawnLifecycleEntry);
+  for (const entry of requiredEntries) {
+    if (!(await pathExists(entry))) {
+      throw new Error(`Expected built package entry surface missing: ${entry}`);
+    }
+  }
+
+  // === 1. SDK entry surface: RelaycastMessagingClient.placement.spawn ===
+  const { RelaycastMessagingClient } = await import(pathToFileURL(sdkMessagingEntry).href);
+
+  const READY_NODE = {
+    id: 'node_a',
+    name: 'node-a',
+    status: 'online',
+    live: true,
+    handlers_live: true,
+    capabilities: [{ name: 'spawn:claude', kind: 'spawn' }],
+  };
+  function createSdkClient(getInvocation, invokeAck) {
+    const relaycast = {
+      agents: {
+        list: async () => [],
+        get: async () => undefined,
+        register: async () => undefined,
+        update: async () => undefined,
+        delete: async () => undefined,
+        presence: async () => [],
+      },
+      channels: { list: async () => [], get: async () => undefined },
+      messages: {
+        list: async () => [],
+        get: async () => undefined,
+        thread: async () => undefined,
+        reactions: async () => [],
+      },
+      nodes: { list: async () => [READY_NODE], get: async () => READY_NODE },
+    };
+    const agentClient = {
+      actions: {
+        invoke: async (name) =>
+          invokeAck ?? {
+            invocation_id: 'inv_lifecycle_proof',
+            action_name: name,
+            handler_node_id: 'node_a',
+            dispatched_node_id: 'node_a',
+            status: 'invoked',
+          },
+        getInvocation,
+        completeInvocation: async () => undefined,
+      },
+    };
+    return new RelaycastMessagingClient({ relaycast, agentClient, placementTtlMs: 30 });
+  }
+  async function captureError(fn) {
+    try {
+      await fn();
+      return undefined;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  const unproven = createSdkClient(async () => ({
+    invocation_id: 'inv_lifecycle_proof',
+    action_name: 'spawn:claude',
+    status: 'completed',
+    output: { spawned: true, ready: false },
+  }));
+  const unprovenError = await captureError(() =>
+    unproven.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 500,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  const unconfirmed = createSdkClient(async () => undefined);
+  const unconfirmedError = await captureError(() =>
+    unconfirmed.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 60,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  // Live reproduction fixture: the node advertised capacity and accepted
+  // this invocation, but never returned a terminal result. Keep the exact
+  // invocation id so this proof cannot regress into an unrelated synthetic
+  // timeout while retaining the generalized fixture above.
+  const liveAccepted = createSdkClient(
+    async (_name, invocationId) => ({
+      invocation_id: invocationId,
+      action_name: 'spawn:claude',
+      handler_node_id: 'node_a',
+      dispatched_node_id: 'node_a',
+      status: 'accepted',
+    }),
+    {
+      invocation_id: LIVE_UNCONFIRMED_INVOCATION_ID,
+      action_name: 'spawn:claude',
+      handler_node_id: 'node_a',
+      dispatched_node_id: 'node_a',
+      status: 'accepted',
+    }
+  );
+  const liveAcceptedError = await captureError(() =>
+    liveAccepted.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 60,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  const terminalFailed = createSdkClient(async () => ({
+    invocation_id: 'inv_lifecycle_proof',
+    action_name: 'spawn:claude',
+    status: 'failed',
+    error: 'harness exited before readiness',
+  }));
+  const terminalFailedError = await captureError(() =>
+    terminalFailed.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 500,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  assertTrue(terminalFailedError !== undefined, 'SDK: terminal failure must always throw');
+  assertEqual(terminalFailedError.code, 'spawn_failed', 'SDK: terminal failure code');
+  assertContains(
+    terminalFailedError.message ?? '',
+    'harness exited before readiness',
+    'SDK: terminal failure message'
+  );
+
+  // Confirm:false is also the CLI's --no-confirm path. A terminal denial in
+  // the ack is already a known failure, and its invocation/receipt correlation
+  // must survive without entering the confirmation poll.
+  const immediateDenied = createSdkClient(async () => undefined, {
+    invocation_id: 'inv_immediate_denied',
+    action_name: 'spawn:claude',
+    handler_node_id: 'node_a',
+    status: 'denied',
+    error: 'node denied the spawn',
+  });
+  const immediateDeniedError = await captureError(() =>
+    immediateDenied.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: false,
+    })
+  );
+
+  // relay#1563 P1: dispatchState must reflect the ack's actual route
+  // evidence, not a hardcoded 'dispatched'. A `pending` ack with no
+  // `dispatchedNodeId`/`handlerNodeId` never routed to a node — the CLI's
+  // shared spawn-lifecycle helper classifies that exact shape as
+  // `not_dispatched`, and the SDK must agree whether the caller later
+  // observes a confirmation timeout or a terminal read.
+  const noRouteAck = {
+    invocation_id: 'inv_no_route_proof',
+    action_name: 'spawn:claude',
+    status: 'pending',
+    handler_node_id: null,
+    dispatched_node_id: null,
+  };
+  const noRouteUnconfirmed = createSdkClient(async () => undefined, noRouteAck);
+  const noRouteUnconfirmedError = await captureError(() =>
+    noRouteUnconfirmed.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 60,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  const noRouteTerminalFailed = createSdkClient(
+    async () => ({
+      invocation_id: 'inv_no_route_proof',
+      action_name: 'spawn:claude',
+      status: 'failed',
+      error: 'never routed before failing',
+    }),
+    noRouteAck
+  );
+  const noRouteTerminalFailedError = await captureError(() =>
+    noRouteTerminalFailed.placement.spawn({
+      capability: 'spawn:claude',
+      node: 'node-a',
+      confirm: true,
+      confirmTimeoutMs: 500,
+      confirmPollIntervalMs: 10,
+    })
+  );
+
+  // === 2. CLI entry surface: the exact `fleet agent list` JSON body, through
+  // the real `printJson`. ===
+  const { buildRows, formatPretty } = await import(pathToFileURL(fleetAgentEntry).href);
+  const { printJson } = await import(pathToFileURL(sdkCommandEntry).href);
+  let automaticUnprovenReceipt;
+  if (arm === 'head') {
+    const { spawnPlacementReceipt } = await import(pathToFileURL(spawnLifecycleEntry).href);
+    automaticUnprovenReceipt = spawnPlacementReceipt({
+      invocation_id: 'inv_automatic_unproven',
+      status: 'completed',
+      output: { spawned: true, ready: false },
+    });
+  }
+
+  const now = new Date();
+  const output = buildRows(
+    {
+      contributions: [
+        {
+          node: {
+            name: 'node-b',
+            status: 'offline',
+            live: false,
+            handlersLive: false,
+            capabilities: [],
+            activeAgents: 1,
+          },
+          isLocal: true,
+          liveAgents: [
+            {
+              name: 'worker-1',
+              current_state: 'busy',
+              pending_messages: 0,
+              last_activity_at: now.toISOString(),
+            },
+          ],
+          inventoryAgents: [],
+        },
+      ],
+      roster: [],
+    },
+    now
+  );
+  let jsonText = '';
+  printJson(
+    { log: (text) => (jsonText = text) },
+    {
+      generatedAt: now.toISOString(),
+      localNode: null,
+      perNode: output.perNode,
+      unplacedRoster: output.unplacedRoster,
+      errors: output.errors,
+    }
+  );
+  const emitted = JSON.parse(jsonText);
+  assertEqual(
+    Object.keys(emitted).sort().join(','),
+    'errors,generatedAt,localNode,perNode,unplacedRoster',
+    'fleet agent list JSON top-level contract'
+  );
+  const degradedRow = emitted.perNode.find((row) => row.name === 'worker-1');
+  assertTrue(Boolean(degradedRow), 'fleet agent list JSON must include the degraded worker row');
+  const prettyOutput = formatPretty(output);
+
+  // === 3. MCP entry surface: the real `spawn` tool over the real MCP
+  // protocol, backed by the real `@relaycast/sdk` action-invocation wire. ===
+  await mkdir(proofDir, { recursive: true });
+  const mcpProbePath = path.join(proofDir, 'mcp-spawn-probe.mjs');
+  await copyFile(path.join(caseDir, 'mcp-spawn-probe.mjs'), mcpProbePath);
+
+  actionsServer = await startActionsServer();
+  const { port } = actionsServer.address();
+  // `spawnSync` would block this process's event loop, and `actionsServer`
+  // (an in-process HTTP server) would never get to accept the probe's
+  // requests — the probe would hang until the MCP client's own call timeout.
+  // Use the async `spawn` so the server keeps servicing requests while the
+  // probe runs.
+  const mcpProbeResult = await runAsync(process.execPath, [mcpProbePath], targetDir, {
+    RELAY_PR_PROOF_1563_BASE_URL: `http://127.0.0.1:${port}`,
+  });
+  process.stdout.write(mcpProbeResult.stdout ?? '');
+  process.stderr.write(mcpProbeResult.stderr ?? '');
+  if (mcpProbeResult.status !== 0) {
+    throw new Error(
+      `MCP spawn tool probe failed (exit ${mcpProbeResult.status}): ${(mcpProbeResult.stderr || mcpProbeResult.stdout || '').slice(-4_000)}`
+    );
+  }
+  const mcp = JSON.parse((mcpProbeResult.stdout ?? '').trim().split('\n').pop());
+
+  if (arm === 'base') {
+    // 1. Base trusted a terminal "completed" status at face value: no
+    // spawned/ready check existed, so the ack is returned, not thrown.
+    assertEqual(unprovenError, undefined, 'SDK base: unproven completed spawn must not throw');
+
+    // 2. The unconfirmed-timeout error exists on base too, but its message
+    // does not yet spell out the no-blind-retry guidance.
+    assertTrue(unconfirmedError !== undefined, 'SDK base: unconfirmed spawn must still throw');
+    assertEqual(unconfirmedError.code, 'spawn_unconfirmed', 'SDK base: unconfirmed code');
+    assertNotContains(
+      unconfirmedError.message ?? '',
+      'do not retry blindly',
+      'SDK base: unconfirmed message'
+    );
+
+    // 3. Terminal failure on base is a bare error: no invocationId,
+    // dispatchState, or structured receipt survive onto the thrown error.
+    assertEqual(
+      'invocationId' in terminalFailedError,
+      false,
+      'SDK base: no invocationId on terminal failure'
+    );
+    assertEqual(
+      'dispatchState' in terminalFailedError,
+      false,
+      'SDK base: no dispatchState on terminal failure'
+    );
+    assertEqual('receipt' in terminalFailedError, false, 'SDK base: no receipt on terminal failure');
+    assertEqual(immediateDeniedError, undefined, 'SDK base: confirm:false terminal denial was not rejected');
+
+    // 4. Base has no controlPlane/workerLiveness axis at all.
+    assertEqual(degradedRow?.controlPlane, undefined, 'CLI base: no controlPlane axis in JSON');
+    assertEqual(degradedRow?.workerLiveness, undefined, 'CLI base: no workerLiveness axis in JSON');
+    assertNotContains(prettyOutput, 'CONTROL PLANE', 'CLI base: no CONTROL PLANE column in --pretty');
+    assertNotContains(prettyOutput, 'WORKERS', 'CLI base: no WORKERS column in --pretty');
+
+    // 5. The MCP `spawn` tool's own untyped `Error` carries no structured
+    // evidence: `structuredContent` is absent from the error result (the MCP
+    // framework only attaches the plain error text).
+    for (const key of ['unproven', 'unconfirmed', 'failed', 'noRouteFailed']) {
+      const result = mcp[key];
+      assertTrue(result.isError === true, `MCP base: ${key} must be an error result`);
+      assertTrue(
+        result.structuredContent === undefined,
+        `MCP base: ${key} must carry no structured spawn evidence`
+      );
+    }
+
+    await writeResult({
+      outcome: 'bug',
+      signature: 'invocation_state_lifecycle_gaps',
+      details:
+        'The base SDK trusted a terminal "completed" spawn invocation without explicit spawned:true/' +
+        'ready:true proof, gave no "do not retry blindly" guidance on an unconfirmed dispatch timeout, ' +
+        'dropped invocationId/dispatchState/receipt off a terminal failure, and fleet agent list JSON ' +
+        'had no controlPlane/workerLiveness axes. The MCP spawn tool mirrored the gap: every failure mode ' +
+        'surfaced as a bare error with no structuredContent for a caller to act on.',
+    });
+  } else {
+    // --- Head: every gap above is closed.
+    assertTrue(unprovenError !== undefined, 'SDK head: unproven completed spawn must throw');
+    assertEqual(unprovenError.code, 'spawn_failed', 'SDK head: unproven code');
+    assertEqual(unprovenError.invocationId, 'inv_lifecycle_proof', 'SDK head: unproven invocationId');
+    assertEqual(unprovenError.dispatchState, 'dispatched', 'SDK head: unproven dispatchState');
+    assertEqual(unprovenError.receipt?.status, 'completed', 'SDK head: unproven receipt status');
+    assertEqual(unprovenError.receipt?.output?.ready, false, 'SDK head: unproven receipt output.ready');
+
+    assertTrue(unconfirmedError !== undefined, 'SDK head: unconfirmed spawn must throw');
+    assertEqual(unconfirmedError.code, 'spawn_unconfirmed', 'SDK head: unconfirmed code');
+    assertEqual(unconfirmedError.invocationId, 'inv_lifecycle_proof', 'SDK head: unconfirmed invocationId');
+    assertEqual(unconfirmedError.dispatchState, 'dispatched', 'SDK head: unconfirmed dispatchState');
+    assertContains(unconfirmedError.message ?? '', 'do not retry blindly', 'SDK head: unconfirmed message');
+
+    assertTrue(liveAcceptedError !== undefined, 'SDK head: live accepted spawn must fail nonzero');
+    assertEqual(
+      liveAcceptedError.code,
+      'spawn_unconfirmed',
+      'SDK head: live accepted spawn must be unconfirmed'
+    );
+    assertEqual(liveAcceptedError.state, 'unconfirmed_may_be_running', 'SDK head: live accepted spawn state');
+    assertEqual(
+      liveAcceptedError.invocationId,
+      LIVE_UNCONFIRMED_INVOCATION_ID,
+      'SDK head: live accepted invocation correlation'
+    );
+    assertEqual(liveAcceptedError.dispatchState, 'dispatched', 'SDK head: live accepted dispatchState');
+    assertContains(
+      liveAcceptedError.message ?? '',
+      'do not retry blindly',
+      'SDK head: live accepted no-blind-retry guidance'
+    );
+
+    assertEqual(
+      terminalFailedError.invocationId,
+      'inv_lifecycle_proof',
+      'SDK head: terminal failure invocationId'
+    );
+    assertEqual(terminalFailedError.dispatchState, 'dispatched', 'SDK head: terminal failure dispatchState');
+    assertEqual(terminalFailedError.receipt?.status, 'failed', 'SDK head: terminal failure receipt status');
+    assertEqual(
+      terminalFailedError.receipt?.error,
+      'harness exited before readiness',
+      'SDK head: terminal failure receipt error'
+    );
+    assertTrue(immediateDeniedError !== undefined, 'SDK head: confirm:false denial must throw');
+    assertEqual(immediateDeniedError.code, 'spawn_failed', 'SDK head: immediate denial code');
+    assertEqual(
+      immediateDeniedError.invocationId,
+      'inv_immediate_denied',
+      'SDK head: immediate denial invocationId'
+    );
+    assertEqual(immediateDeniedError.dispatchState, 'dispatched', 'SDK head: immediate denial dispatchState');
+    assertEqual(immediateDeniedError.receipt?.status, 'denied', 'SDK head: immediate denial receipt');
+
+    // relay#1563 P1 (this fix): dispatchState must come from the ack's real
+    // route evidence, not a hardcoded 'dispatched'. A pending ack with a null
+    // dispatchedNodeId/handlerNodeId proves the CLI's `not_dispatched` shape;
+    // an ack that carries a real node id proves `dispatched` — both for a
+    // confirmation timeout and for a later terminal read.
+    assertTrue(noRouteUnconfirmedError !== undefined, 'SDK head: no-route unconfirmed must throw');
+    assertEqual(
+      noRouteUnconfirmedError.dispatchState,
+      'not_dispatched',
+      'SDK head: no-route unconfirmed dispatchState'
+    );
+    assertTrue(noRouteTerminalFailedError !== undefined, 'SDK head: no-route terminal failure must throw');
+    assertEqual(
+      noRouteTerminalFailedError.dispatchState,
+      'not_dispatched',
+      'SDK head: no-route terminal failure dispatchState'
+    );
+    // The routed shapes above (unprovenError/unconfirmedError/terminalFailedError)
+    // already prove dispatchState === 'dispatched' when the ack carries a real
+    // node id, so together these four assertions cover both shapes across
+    // both outcomes.
+
+    assertEqual(degradedRow?.controlPlane, 'offline', 'CLI head: controlPlane axis in JSON');
+    assertEqual(degradedRow?.workerLiveness, 'live', 'CLI head: workerLiveness axis in JSON');
+    assertEqual(
+      automaticUnprovenReceipt.state,
+      'failed',
+      'CLI head: automatic unproven completion is terminal failure'
+    );
+    assertContains(prettyOutput, 'CONTROL PLANE', 'CLI head: CONTROL PLANE column in --pretty');
+    assertContains(prettyOutput, 'WORKERS', 'CLI head: WORKERS column in --pretty');
+
+    // 5. The MCP `spawn` tool now returns a typed `VerifiedSpawnError`
+    // rendered as structured JSON content — `code`, `state`, `dispatchState`,
+    // `invocationId`, and (where applicable) `receipt` all survive onto the
+    // MCP wire, and the unconfirmed/timeout path spells out the same
+    // no-blind-retry guidance as the SDK.
+    const unprovenMcp = structuredSpawnError(mcp.unproven);
+    assertEqual(unprovenMcp.code, 'spawn_failed', 'MCP head: unproven code');
+    assertEqual(unprovenMcp.dispatchState, 'dispatched', 'MCP head: unproven dispatchState');
+    assertEqual(unprovenMcp.invocationId, 'inv-relayflow-1563-unproven', 'MCP head: unproven invocationId');
+    assertEqual(unprovenMcp.receipt?.output?.ready, false, 'MCP head: unproven receipt output.ready');
+
+    const unconfirmedMcp = structuredSpawnError(mcp.unconfirmed);
+    assertEqual(unconfirmedMcp.code, 'spawn_unconfirmed', 'MCP head: unconfirmed code');
+    assertContains(unconfirmedMcp.message ?? '', 'Do not retry blindly', 'MCP head: unconfirmed message');
+
+    const failedMcp = structuredSpawnError(mcp.failed);
+    assertEqual(failedMcp.code, 'spawn_failed', 'MCP head: failed code');
+    assertEqual(failedMcp.dispatchState, 'dispatched', 'MCP head: failed dispatchState');
+    assertEqual(failedMcp.message, 'harness exited before readiness', 'MCP head: failed safe outer message');
+    assertEqual(failedMcp.receipt?.status, 'failed', 'MCP head: failed receipt status');
+    assertEqual(
+      failedMcp.receipt?.invocationId,
+      'inv-relayflow-1563-failed',
+      'MCP head: failed receipt invocationId'
+    );
+    assertEqual(failedMcp.receipt?.error, undefined, 'MCP head: failed receipt must not restore raw error');
+    assertEqual(
+      failedMcp.receipt?.output,
+      undefined,
+      'MCP head: failed receipt must not expose non-allowlisted output'
+    );
+
+    // relay#1563 Medium (this fix): dispatchState must be preserved from the
+    // original ack, not recomputed from a later invocation record whose
+    // status alone changed. The ack here was `pending` with no node id; the
+    // later terminal `failed` read also carries no node id, so dispatchState
+    // must stay `not_dispatched`, never manufactured as `dispatched`.
+    const noRouteFailedMcp = structuredSpawnError(mcp.noRouteFailed);
+    assertEqual(noRouteFailedMcp.code, 'spawn_failed', 'MCP head: no-route failed code');
+    assertEqual(
+      noRouteFailedMcp.dispatchState,
+      'not_dispatched',
+      'MCP head: no-route failed dispatchState must not be manufactured from the later record'
+    );
+
+    await writeResult({
+      outcome: 'fixed',
+      signature: 'invocation_state_lifecycle_closed',
+      details:
+        'The head SDK rejects a terminal "completed" invocation lacking explicit spawned:true/ready:true ' +
+        'proof as spawn_failed while preserving invocationId, dispatchState, and the structured receipt; ' +
+        'the unconfirmed-timeout path keeps the same evidence and states "do not retry blindly"; and ' +
+        'fleet agent list JSON/--pretty report controlPlane and workerLiveness as independent axes. The SDK ' +
+        'also rejects terminal denied acknowledgements with confirm:false while retaining invocationId/' +
+        'receipt correlation; and the MCP spawn tool mirrors every one of those: its structured error result carries code/state/dispatchState/' +
+        'invocationId/receipt over the real MCP protocol, backed by the real @relaycast/sdk action-invocation ' +
+        'wire contract.',
+    });
+  }
+
+  process.stdout.write(
+    `${arm === 'base' ? 'invocation_state_lifecycle_gaps' : 'invocation_state_lifecycle_closed'}\n`
+  );
+} finally {
+  if (actionsServer) await new Promise((resolve) => actionsServer.close(resolve));
+  await rm(proofDir, { recursive: true, force: true }).catch(() => undefined);
+}
+
+function structuredSpawnError(toolResult) {
+  if (!toolResult?.isError) {
+    throw new Error(`Expected an MCP error result, received ${JSON.stringify(toolResult)}.`);
+  }
+  const structured = toolResult.structuredContent?.error;
+  if (!structured) {
+    throw new Error(
+      `Expected structuredContent.error on the MCP result, received ${JSON.stringify(toolResult)}.`
+    );
+  }
+  return structured;
+}
+
+async function writeResult({ outcome, signature, details }) {
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`,
+    'utf8'
+  );
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+function isWithin(root, candidate) {
+  const rel = path.relative(path.resolve(root), path.resolve(candidate));
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}


### PR DESCRIPTION
## Summary

Fixes #1563.

- Require explicit `spawned: true` and `ready: true` before reporting a Fleet worker ready.
- Preserve accepted, dispatched, unconfirmed, and failed lifecycle receipts with invocation and dispatch correlation across targeted SDK, automatic CLI, and MCP spawn paths.
- Propagate terminal spawn failures as nonzero or `isError` while retaining the structured receipt and no-blind-retry guidance.
- Report Fleet control-plane status separately from worker liveness in JSON and pretty output.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1563-spawn-lifecycle-truth` <!-- relay-pr-proof:case -->

## Validation

- 129 targeted lifecycle, Fleet, MCP, and SDK tests pass on Node 22.
- Exact RelayFlow base arm returns `bug`; exact head returns `fixed` using real SDK and CLI surfaces with deterministic cleanup and no external network or secrets.
- SDK and CLI typechecks and builds pass; Prettier, CLI lint, and diff checks pass.
- Live reproductions `inv_223936432626290688` and `inv_223948716837679104`: the node accepted each dispatch but never confirmed launch, and no worker identity appeared. Regression coverage preserves this as `spawn_unconfirmed` and `unconfirmed_may_be_running`, nonzero, correlated, and unsafe to blindly retry.
- Independent exact-head review before the RelayFlow commit: `COMPREHENSIVELY_SATISFIED`.
- Veto diff review before the RelayFlow commit: PASS, score 95, no findings.

This PR remains draft until the new exact head passes independent review, Veto, CI, and hosted RelayFlow proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default spawn success/failure semantics across SDK, CLI, and MCP (readiness proof, unconfirmed handling, and structured errors), which can break callers that assumed `completed` or silent throws meant success; fleet list output shape also grows new columns.
> 
> **Overview**
> Closes **#1563** by making fleet spawn outcomes honest end-to-end: workers are only **ready** when invocations prove `spawned: true` and `ready: true`, and callers get correlated **placement receipts** (`accepted`, `ready`, `unconfirmed_may_be_running`, `failed`) plus **`dispatchState`** (`dispatched` / `not_dispatched` / `unknown`) instead of treating a bare `completed` ack as success.
> 
> The **SDK** `placement.spawn` path now rejects immediate terminal acks (including with `confirm: false`), enforces readiness on confirmation, attaches `invocationId` / `state` / `receipt` on `RelayPlacementError`, and warns **not to retry blindly** on `spawn_unconfirmed`. **CLI** `fleet spawn` merges SDK placement without overwriting `accepted` on `--no-confirm`, throws structured placement errors via `runSdk`, and **skips sandbox teardown** when placement is unconfirmed. **MCP** `spawn` / `add_agent` return structured `isError` payloads (with **sanitized** receipts) rather than opaque exceptions, including nested persona routes.
> 
> **`fleet agent list`** adds separate **CONTROL PLANE** and **WORKERS** axes in JSON and pretty output so offline control planes do not imply dead local workers, with a backfill fix for duplicate unnamed nodes. A **RelayFlow** case (`1563-spawn-lifecycle-truth`) exercises SDK, CLI JSON, and real MCP `spawn` over the action-invocation wire contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b60adfa689279cfb7827f2f8e51d09558cf6d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->