### PR TITLE
fix(broker): clean up Cursor MCP credential leases

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,6 +34,20 @@ env:
   AGENT_RELAY_TELEMETRY_DISABLED: 1
 
 jobs:
+  windows-broker-check:
+    name: Windows broker Cursor lease check
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-broker-cursor-lease
+          cache-bin: false
+      - name: Compile and run Cursor MCP lease tests
+        run: cargo test -p agent-relay-broker cursor_mcp_lease --lib
+
   e2e-test:
     name: E2E Integration Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -119,19 +119,22 @@ jobs:
             done
 
             # Even when `npm view` succeeds, the tarball may still 404 from
-            # the CDN edge that npm install hits. Probe the tarball URL of
-            # the matching broker directly.
+            # the CDN edge that npm install hits. Probe every package's
+            # tarball URL directly — the v12.0.0 publish passed a broker-only
+            # probe and then 404'd on the harness driver's own tarball.
             if [ "${#missing[@]}" -eq 0 ]; then
-              TARBALL_URL=$(npm view "${EXPECTED_BROKER}@$VERSION" dist.tarball 2>/dev/null || true)
-              if [ -z "$TARBALL_URL" ]; then
-                missing+=("${EXPECTED_BROKER}@$VERSION (no tarball url)")
-              else
+              for pkg in "${PACKAGES[@]}"; do
+                TARBALL_URL=$(npm view "$pkg" dist.tarball 2>/dev/null || true)
+                if [ -z "$TARBALL_URL" ]; then
+                  missing+=("$pkg (no tarball url)")
+                  continue
+                fi
                 STATUS=$(curl -sS -o /dev/null -w "%{http_code}" -I \
                   --connect-timeout 5 --max-time 15 "$TARBALL_URL" || echo "000")
                 if [ "$STATUS" != "200" ]; then
-                  missing+=("${EXPECTED_BROKER}@$VERSION (tarball HTTP $STATUS)")
+                  missing+=("$pkg (tarball HTTP $STATUS)")
                 fi
-              fi
+              done
             fi
 
             if [ "${#missing[@]}" -eq 0 ]; then
@@ -157,7 +160,21 @@ jobs:
           cd "$SCRATCH"
           npm init -y --silent >/dev/null
           echo "Installing ${{ steps.spec.outputs.spec }}"
-          npm install --no-audit --no-fund "${{ steps.spec.outputs.spec }}"
+          # A probe from this runner can hit a warm CDN edge while npm's
+          # fetch hits a cold one, so retry the install on transient 404s.
+          for i in 1 2 3 4 5; do
+            if npm install --no-audit --no-fund "${{ steps.spec.outputs.spec }}"; then
+              break
+            fi
+            if [ "$i" -eq 5 ]; then
+              echo "FAIL: npm install did not succeed after $i attempts"
+              exit 1
+            fi
+            WAIT=$((15 * i))
+            echo "install attempt $i failed, clearing npm cache and retrying in ${WAIT}s"
+            npm cache clean --force >/dev/null 2>&1 || true
+            sleep "$WAIT"
+          done
           echo ""
           echo "=== installed @agent-relay/ packages ==="
           ls node_modules/@agent-relay/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node startup recovery and shutdown require a persisted process and runtime-lock identity for the selected state directory, preserving unrelated agents.
 
 ### Changed
+
 - Spawning a Cursor worker no longer leaves plaintext Agent Relay credentials in `<cwd>/.cursor/mcp.json` after release. The broker leases that file per-cwd across concurrent workers and restores the pre-existing config or absence on every cleanup path; Unix files remain `0600`, while Windows secures new files and preserves existing ACLs.
 - `up` and `node up` refuse startup outside macOS and Linux (including WSL, with `ps` and `lsof` available) because broker ownership cannot be verified elsewhere. Brokers started by earlier versions have no verifiable identity and are not shut down or recovered automatically; stop them manually and restart once to create one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Node startup recovery and shutdown require a persisted process and runtime-lock identity for the selected state directory, preserving unrelated agents.
 
+- Spawning a Cursor worker no longer leaves plaintext Agent Relay credentials in `<cwd>/.cursor/mcp.json` after release. The broker leases that file per-cwd across concurrent workers and restores the pre-existing config or absence on every cleanup path; Unix files remain `0600`, while Windows secures new files and preserves existing ACLs.
+
 ### Breaking Changes
 
 - `up` and `node up` refuse startup outside macOS and Linux because broker ownership cannot be verified on other platforms. Legacy brokers without a verifiable identity no longer support automatic shutdown or recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Major]
+## [Unreleased - Minor]
 
 ### Added
 
 - `agent-relay node up --local-only` runs local agents during Relaycast outages, visibly reports degraded capabilities, and retains local delivery records for reconciliation after reconnect.
 
 ### Fixed
+
+- HTTP agent spawn rejects failed Relaycast node binding, cleans up the newly registered identity, and publishes declared metadata for successful spawns using either new or supplied tokens.
 
 - `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
 - `fleet spawn --sandbox` dispatches with only its temporary launcher token after Cloud target selection, avoiding the SDK's dual-credential rejection while keeping workspace-key authority limited to launcher registration and release.
@@ -29,15 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Node startup recovery and shutdown require a persisted process and runtime-lock identity for the selected state directory, preserving unrelated agents.
 
+### Changed
 - Spawning a Cursor worker no longer leaves plaintext Agent Relay credentials in `<cwd>/.cursor/mcp.json` after release. The broker leases that file per-cwd across concurrent workers and restores the pre-existing config or absence on every cleanup path; Unix files remain `0600`, while Windows secures new files and preserves existing ACLs.
-
-### Breaking Changes
-
-- `up` and `node up` refuse startup outside macOS and Linux because broker ownership cannot be verified on other platforms. Legacy brokers without a verifiable identity no longer support automatic shutdown or recovery.
-
-### Migration Guidance
-
-- Run nodes on macOS or Linux (including WSL) with `ps` and `lsof` available. Manually verify and stop legacy brokers before removing their retained state and restarting to create a verifiable identity.
+- `up` and `node up` refuse startup outside macOS and Linux (including WSL, with `ps` and `lsof` available) because broker ownership cannot be verified elsewhere. Brokers started by earlier versions have no verifiable identity and are not shut down or recovered automatically; stop them manually and restart once to create one.
 
 ## [12.0.0] - 2026-09-10
 

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1461,14 +1461,17 @@ impl CursorMcpLeaseRegistry {
     }
 
     fn lock_path(&self, root: &Path) -> io::Result<PathBuf> {
-        let journal_dir = self
-            .journal_path
-            .as_ref()
-            .and_then(|path| path.parent().map(Path::to_path_buf))
-            .unwrap_or_else(|| std::env::temp_dir().join("agent-relay-cursor-mcp"));
+        // Keep the lease lock independent from the broker state directory so
+        // brokers with different journals still coordinate on the same cwd.
+        let journal_dir = std::env::temp_dir().join("agent-relay-cursor-mcp");
         fs::create_dir_all(&journal_dir)?;
         let digest = Sha256::digest(root.as_os_str().to_string_lossy().as_bytes());
         Ok(journal_dir.join(format!(".cursor-mcp-lease-{:x}.lock", digest)))
+    }
+
+    fn purge_path_workers(&mut self, path: &Path) {
+        self.path_by_worker
+            .retain(|_, worker_path| worker_path != path);
     }
 
     pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
@@ -1781,7 +1784,7 @@ impl CursorMcpLeaseRegistry {
 
     fn release_path(&mut self, path: &Path, worker: &WorkerName) -> io::Result<()> {
         let Some(state) = self.leases.get_mut(path) else {
-            self.path_by_worker.remove(worker);
+            self.purge_path_workers(path);
             return Ok(());
         };
         state.holders.remove(worker);
@@ -1813,7 +1816,7 @@ impl CursorMcpLeaseRegistry {
                 .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))?,
         )?;
         let state = self.leases.remove(path).expect("lease checked above");
-        self.path_by_worker.remove(worker);
+        self.purge_path_workers(path);
         if let Err(error) = self.persist_journal() {
             // The file is restored, but journal removal was not durable. Keep
             // ownership in memory so the periodic retry can finish the
@@ -3121,5 +3124,58 @@ mod tests {
             !journal.exists(),
             "journal must be cleaned up after successful retry"
         );
+    }
+
+    #[test]
+    fn final_cleanup_purges_stale_worker_names() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        let primary = WorkerName::new("w1");
+        let secondary = WorkerName::new("w2");
+        let path = registry.acquire(dir.path(), &primary).unwrap();
+        registry.write_worker_cursor_file(&primary, b"{}").unwrap();
+
+        // Force the last-holder release to fail after the on-disk cleanup has
+        // completed so the original worker remains pending retry in memory.
+        let lock_path = journal.with_file_name(".cursor-mcp-leases.lock");
+        let held_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        held_lock.try_lock().unwrap();
+        let error = registry.release_worker(&primary).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        drop(held_lock);
+
+        // Another worker can join the same lease and finish the cleanup.
+        registry.acquire(dir.path(), &secondary).unwrap();
+        registry.release_worker(&secondary).unwrap();
+
+        assert!(registry.is_empty());
+        assert!(
+            registry.acquire(dir.path(), &primary).is_ok(),
+            "stale worker names must be cleared after final cleanup"
+        );
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn lock_path_does_not_depend_on_journal_location() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("cwd");
+        fs::create_dir_all(root.join(".cursor")).unwrap();
+        let journal_a = dir.path().join("state-a").join("journal.json");
+        let journal_b = dir.path().join("state-b").join("journal.json");
+        let registry_a = CursorMcpLeaseRegistry::with_journal(journal_a);
+        let registry_b = CursorMcpLeaseRegistry::with_journal(journal_b);
+
+        let lock_a = registry_a.lock_path(&root).unwrap();
+        let lock_b = registry_b.lock_path(&root).unwrap();
+
+        assert_eq!(lock_a, lock_b);
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -23,6 +23,11 @@ struct LeaseState {
     pre_existing: PreExisting,
     holders: HashSet<WorkerName>,
     lock: LeaseLock,
+    /// The exact `.cursor` directory captured while acquiring `lock`. Keeping
+    /// this descriptor alive is essential: the pathname may be renamed and
+    /// replaced while a worker is running, but all generated-file I/O and
+    /// cleanup must continue to address the original directory.
+    cursor_dir: Option<fs::File>,
 }
 
 /// A kernel-held lock on the requested cwd. Locking the existing cwd rather
@@ -95,6 +100,32 @@ impl LeaseLock {
                 fs::TryLockError::Error(error) => error,
             })?;
             Ok(Self { _file: file })
+        }
+    }
+
+    fn acquire_with_cursor(
+        root: &Path,
+        create_cursor: bool,
+    ) -> io::Result<(Self, Option<fs::File>, bool)> {
+        let lock = Self::acquire(root)?;
+        #[cfg(unix)]
+        {
+            match lock.open_cursor_dir(create_cursor) {
+                Ok((cursor, created)) => Ok((lock, Some(cursor), created)),
+                Err(error) if !create_cursor && error.kind() == io::ErrorKind::NotFound => {
+                    // Recovery must retain the cwd lock even when the
+                    // journaled `.cursor` directory has disappeared. The
+                    // caller will keep the journal entry and finalize while
+                    // still holding this lock.
+                    Ok((lock, None, false))
+                }
+                Err(error) => Err(error),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = create_cursor;
+            Ok((lock, None, false))
         }
     }
 }
@@ -390,7 +421,39 @@ fn remove_cursor_target(cursor: &fs::File) -> io::Result<bool> {
 
 #[cfg(unix)]
 fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
     let name = std::ffi::CString::new(".cursor").expect("literal has no NUL");
+    let mut cursor_stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(cursor.as_raw_fd(), cursor_stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let cursor_stat = unsafe { cursor_stat.assume_init() };
+    let mut entry_stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let result = unsafe {
+        libc::fstatat(
+            lock.root_fd(),
+            name.as_ptr(),
+            entry_stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::NotFound {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "pinned Cursor directory was renamed before cleanup",
+            ));
+        }
+        return Err(error);
+    }
+    let entry_stat = unsafe { entry_stat.assume_init() };
+    if cursor_stat.st_dev != entry_stat.st_dev || cursor_stat.st_ino != entry_stat.st_ino {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "refusing to remove a replacement .cursor directory",
+        ));
+    }
     let result = unsafe { libc::unlinkat(lock.root_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
     if result == 0 {
         lock._file.sync_all()?;
@@ -400,7 +463,6 @@ fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
     if error.kind() == io::ErrorKind::NotFound {
         Ok(())
     } else {
-        let _ = cursor;
         Err(error)
     }
 }
@@ -547,17 +609,20 @@ impl CursorMcpLeaseRegistry {
             return Ok(key);
         }
 
-        let lock = LeaseLock::acquire(&canonical)?;
         // Re-check after taking the kernel lock using descriptor-relative
         // operations. A hostile process can rename `.cursor` after a pathname
-        // check, but it cannot redirect the already-open directory descriptor.
+        // check, but it cannot redirect the descriptor captured here. Keep
+        // that descriptor in LeaseState for the full lease lifetime.
+        let (lock, cursor_dir, created_dir) = LeaseLock::acquire_with_cursor(&canonical, true)?;
         #[cfg(unix)]
-        let (cursor_dir, created_dir) = lock.open_cursor_dir(true)?;
-        #[cfg(unix)]
-        let pre_existing = if let Some((contents, mode)) = read_cursor_target(&cursor_dir)? {
-            PreExisting::Present { contents, mode }
+        let pre_existing = if let Some(cursor) = cursor_dir.as_ref() {
+            if let Some((contents, mode)) = read_cursor_target(cursor)? {
+                PreExisting::Present { contents, mode }
+            } else {
+                PreExisting::Absent { created_dir }
+            }
         } else {
-            PreExisting::Absent { created_dir }
+            unreachable!("Unix lease must retain a Cursor directory descriptor")
         };
         #[cfg(not(unix))]
         let pre_existing = unreachable!("LeaseLock acquisition is unsupported on non-Unix");
@@ -570,6 +635,7 @@ impl CursorMcpLeaseRegistry {
                 pre_existing,
                 holders,
                 lock,
+                cursor_dir,
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
@@ -581,7 +647,7 @@ impl CursorMcpLeaseRegistry {
         Ok(key)
     }
 
-    fn lock_for_worker(&self, worker: &WorkerName) -> io::Result<&LeaseLock> {
+    fn state_for_worker(&self, worker: &WorkerName) -> io::Result<&LeaseState> {
         let path = self.path_by_worker.get(worker).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
@@ -600,7 +666,7 @@ impl CursorMcpLeaseRegistry {
                 format!("worker '{worker}' has pending Cursor MCP cleanup"),
             ));
         }
-        Ok(&state.lock)
+        Ok(state)
     }
 
     /// Read the currently leased config through the root and `.cursor`
@@ -611,15 +677,20 @@ impl CursorMcpLeaseRegistry {
         &self,
         worker: &WorkerName,
     ) -> io::Result<Option<Vec<u8>>> {
-        let lock = self.lock_for_worker(worker)?;
+        let state = self.state_for_worker(worker)?;
         #[cfg(unix)]
         {
-            let (cursor, _) = lock.open_cursor_dir(false)?;
-            Ok(read_cursor_target(&cursor)?.map(|(contents, _)| contents))
+            let cursor = state.cursor_dir.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Cursor MCP lease has no pinned directory descriptor",
+                )
+            })?;
+            Ok(read_cursor_target(cursor)?.map(|(contents, _)| contents))
         }
         #[cfg(not(unix))]
         {
-            let _ = lock;
+            let _ = state;
             Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Cursor MCP leasing requires Unix directory descriptors",
@@ -635,15 +706,20 @@ impl CursorMcpLeaseRegistry {
         worker: &WorkerName,
         contents: &[u8],
     ) -> io::Result<()> {
-        let lock = self.lock_for_worker(worker)?;
+        let state = self.state_for_worker(worker)?;
         #[cfg(unix)]
         {
-            let (cursor, _) = lock.open_cursor_dir(false)?;
-            write_cursor_target(&cursor, contents)
+            let cursor = state.cursor_dir.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Cursor MCP lease has no pinned directory descriptor",
+                )
+            })?;
+            write_cursor_target(cursor, contents)
         }
         #[cfg(not(unix))]
         {
-            let _ = (lock, contents);
+            let _ = (state, contents);
             Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Cursor MCP leasing requires Unix directory descriptors",
@@ -704,7 +780,7 @@ impl CursorMcpLeaseRegistry {
                 mode: *mode,
             },
         };
-        Self::restore(path, &pre_existing, &state.lock)?;
+        Self::restore(path, &pre_existing, &state.lock, state.cursor_dir.as_ref())?;
         let state = self.leases.remove(path).expect("lease checked above");
         self.path_by_worker.remove(worker);
         if let Err(error) = self.persist_journal() {
@@ -719,20 +795,21 @@ impl CursorMcpLeaseRegistry {
         Ok(())
     }
 
-    fn restore(_path: &Path, pre_existing: &PreExisting, lock: &LeaseLock) -> io::Result<()> {
+    fn restore(
+        _path: &Path,
+        pre_existing: &PreExisting,
+        lock: &LeaseLock,
+        pinned_cursor: Option<&fs::File>,
+    ) -> io::Result<()> {
         #[cfg(unix)]
         {
-            let cursor = match lock.open_cursor_dir(false) {
-                Ok((cursor, _)) => Some(cursor),
-                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-                Err(error) => return Err(error),
-            };
+            let cursor = pinned_cursor;
             match pre_existing {
                 PreExisting::Absent { created_dir } => {
                     if let Some(cursor) = cursor {
-                        let _ = remove_cursor_target(&cursor)?;
+                        let _ = remove_cursor_target(cursor)?;
                         if *created_dir {
-                            remove_cursor_dir(lock, &cursor)?;
+                            remove_cursor_dir(lock, cursor)?;
                         }
                     }
                 }
@@ -743,8 +820,8 @@ impl CursorMcpLeaseRegistry {
                             "Cursor directory disappeared during restore",
                         )
                     })?;
-                    write_cursor_target(&cursor, contents)?;
-                    let target = open_cursor_target(&cursor)?.ok_or_else(|| {
+                    write_cursor_target(cursor, contents)?;
+                    let target = open_cursor_target(cursor)?.ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::NotFound,
                             "Cursor MCP target disappeared after restore",
@@ -877,8 +954,8 @@ impl CursorMcpLeaseRegistry {
                     "Cursor MCP lease journal path is not canonical",
                 ));
             }
-            let lock = match LeaseLock::acquire(root) {
-                Ok(lock) => lock,
+            let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(root, false) {
+                Ok(value) => value,
                 Err(error) => {
                     tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
                     remaining.push(JournalEntry {
@@ -897,7 +974,9 @@ impl CursorMcpLeaseRegistry {
                 held_locks.push(lock);
                 continue;
             }
-            if let Err(error) = Self::restore(&entry.path, &pre_existing, &lock) {
+            if let Err(error) =
+                Self::restore(&entry.path, &pre_existing, &lock, cursor_dir.as_ref())
+            {
                 tracing::warn!(path = %entry.path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
                     path: entry.path,
@@ -1150,6 +1229,57 @@ mod tests {
             b"updated inside bytes"
         );
         assert!(!outside.path().join(".cursor/mcp.json").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinned_cursor_survives_rename_and_replacement_during_cleanup() {
+        let parent = tempdir().unwrap();
+        let root = parent.path().join("cwd");
+        fs::create_dir(&root).unwrap();
+        let worker = WorkerName::new("cursor-replaced");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        registry.acquire(&root, &worker).unwrap();
+        registry
+            .write_worker_cursor_file(&worker, b"generated in pinned dir")
+            .unwrap();
+
+        let moved = root.join(".cursor-original");
+        fs::rename(root.join(".cursor"), &moved).unwrap();
+        fs::create_dir(root.join(".cursor")).unwrap();
+        fs::write(root.join(".cursor/mcp.json"), b"replacement untouched").unwrap();
+
+        assert_eq!(
+            registry.read_worker_cursor_file(&worker).unwrap().unwrap(),
+            b"generated in pinned dir"
+        );
+        registry
+            .write_worker_cursor_file(&worker, b"updated in pinned dir")
+            .unwrap();
+        assert_eq!(read(&moved.join("mcp.json")), b"updated in pinned dir");
+        assert_eq!(
+            read(&root.join(".cursor/mcp.json")),
+            b"replacement untouched"
+        );
+
+        let error = registry.release_worker(&worker).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(
+            read(&root.join(".cursor/mcp.json")),
+            b"replacement untouched"
+        );
+        assert!(
+            !moved.join("mcp.json").exists(),
+            "pinned target was removed"
+        );
+        assert!(root.join(".cursor").is_dir(), "replacement was not removed");
+
+        fs::remove_file(root.join(".cursor/mcp.json")).unwrap();
+        fs::remove_dir(root.join(".cursor")).unwrap();
+        fs::rename(&moved, root.join(".cursor")).unwrap();
+        registry.release_worker(&worker).unwrap();
+        assert!(!root.join(".cursor").exists());
+        assert!(registry.is_empty());
     }
 
     #[cfg(unix)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1,0 +1,403 @@
+//! Per-worker lease over an injected Cursor `.cursor/mcp.json`.
+//!
+//! [`relay#1753`](https://github.com/AgentWorkforce/relay/issues/1753):
+//! spawning a Cursor worker with Agent Relay MCP injection writes plaintext
+//! credentials into `<cwd>/.cursor/mcp.json`. Releasing the worker used to
+//! leave that file behind untouched — a worktree-local credential leak.
+//!
+//! This registry treats the injected config as a lease owned by whichever
+//! [`WorkerRegistry`](crate::worker::WorkerRegistry) workers currently share a
+//! `cwd`. The first worker to lease a given `.cursor/mcp.json` path captures
+//! whatever was there beforehand (a pre-existing user config, or nothing).
+//! Every subsequent worker sharing that cwd joins the same lease. Only when
+//! the *last* holder releases does the registry restore the captured
+//! pre-existing state — never a stale intermediate worker's credentials.
+//!
+//! Restoration is triggered from every lifecycle exit this issue calls out:
+//! spawn failure, explicit release, task-exit/reap, orphan cleanup, broker
+//! shutdown, and ambiguous-timeout recovery — because all of those paths
+//! funnel through [`WorkerRegistry::release`](crate::worker::WorkerRegistry::release),
+//! [`WorkerRegistry::cleanup_rejected_spawn`](crate::worker::WorkerRegistry::cleanup_rejected_spawn),
+//! or [`WorkerRegistry::reap_exited`](crate::worker::WorkerRegistry::reap_exited).
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use crate::ids::WorkerName;
+
+/// What existed at the leased path before the first worker claimed it.
+#[derive(Debug, Clone)]
+enum PreExisting {
+    /// Nothing was there. `created_dir` is true when this lease also had to
+    /// create the parent `.cursor` directory, so restore can remove it again
+    /// if — and only if — it is still empty (never delete a directory a user
+    /// populated with something else in the meantime).
+    Absent { created_dir: bool },
+    /// The raw bytes that were on disk, preserved verbatim (not reparsed) so
+    /// restore is byte-for-byte even if the file was invalid JSON or had
+    /// unusual formatting/comments.
+    Present(Vec<u8>),
+}
+
+struct LeaseState {
+    pre_existing: PreExisting,
+    holders: HashSet<WorkerName>,
+}
+
+/// Tracks in-process leases over injected `.cursor/mcp.json` files, keyed by
+/// the canonicalized `.cursor/mcp.json` path. Lives on [`WorkerRegistry`] so
+/// concurrent Cursor workers that share one `cwd` are correctly recognized as
+/// sharing one lease instead of each capturing/restoring independently.
+#[derive(Default)]
+pub(crate) struct CursorMcpLeaseRegistry {
+    leases: HashMap<PathBuf, LeaseState>,
+    /// Reverse index so release call sites (which only know the worker name,
+    /// not its cwd — e.g. a generic reap sweep) can find the lease to drop
+    /// without threading `cwd` through every call site.
+    path_by_worker: HashMap<WorkerName, PathBuf>,
+}
+
+fn lease_path(root: &Path) -> PathBuf {
+    // Canonicalize `root` itself, not `.cursor` — the worker cwd is
+    // guaranteed to already exist (broker `spawn()` validates that before
+    // any harness config is built), whereas `.cursor` may not exist yet on a
+    // from-scratch spawn. Canonicalizing whichever of the two happens to
+    // exist would make two concurrent workers sharing one cwd resolve to
+    // different keys purely based on acquire ordering (one arriving before
+    // `.cursor` is created, the other after), which would let two "same
+    // cwd" leases diverge and let one worker's release stomp another's
+    // config. Falling back to the joined (non-canonical) path when `root`
+    // itself can't be resolved keeps this a best-effort dedup, not a
+    // correctness requirement.
+    let joined = root.join(".cursor").join("mcp.json");
+    match root.canonicalize() {
+        Ok(canonical) => canonical.join(".cursor").join("mcp.json"),
+        Err(_) => joined,
+    }
+}
+
+#[cfg(unix)]
+fn secure_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn secure_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Write `contents` to `path` and enforce owner-only permissions. Used both
+/// for the initial credential-bearing write and for lease restoration, so a
+/// restored pre-existing config is at least as tightly permissioned as the
+/// credential file it replaced.
+pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<()> {
+    fs::write(path, contents)?;
+    secure_permissions(path)
+}
+
+impl CursorMcpLeaseRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Acquire (or join) the lease over `<root>/.cursor/mcp.json` for
+    /// `worker`. Idempotent for a given worker/path pair. Must be called
+    /// before the caller overwrites the file, so the pre-existing content is
+    /// captured, never a config another Agent Relay worker already wrote.
+    pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
+        let key = lease_path(root);
+        if let Some(state) = self.leases.get_mut(&key) {
+            state.holders.insert(worker.clone());
+            self.path_by_worker.insert(worker.clone(), key.clone());
+            return Ok(key);
+        }
+
+        let cursor_dir = root.join(".cursor");
+        let dir_existed = cursor_dir.is_dir();
+        let pre_existing = if key.exists() {
+            PreExisting::Present(fs::read(&key)?)
+        } else {
+            PreExisting::Absent {
+                created_dir: !dir_existed,
+            }
+        };
+
+        let mut holders = HashSet::new();
+        holders.insert(worker.clone());
+        self.leases.insert(
+            key.clone(),
+            LeaseState {
+                pre_existing,
+                holders,
+            },
+        );
+        self.path_by_worker.insert(worker.clone(), key.clone());
+        Ok(key)
+    }
+
+    /// Release `worker`'s hold on whatever lease it currently has (a no-op if
+    /// it has none — every removal call site can call this unconditionally
+    /// rather than re-deriving whether the worker was a Cursor worker).
+    /// Restores the pre-existing state only when `worker` was the last
+    /// remaining holder.
+    pub(crate) fn release_worker(&mut self, worker: &WorkerName) -> io::Result<()> {
+        let Some(path) = self.path_by_worker.remove(worker) else {
+            return Ok(());
+        };
+        self.release_path(&path, worker)
+    }
+
+    fn release_path(&mut self, path: &Path, worker: &WorkerName) -> io::Result<()> {
+        let Some(state) = self.leases.get_mut(path) else {
+            return Ok(());
+        };
+        state.holders.remove(worker);
+        if !state.holders.is_empty() {
+            return Ok(());
+        }
+        let state = self.leases.remove(path).expect("checked above");
+        match state.pre_existing {
+            PreExisting::Absent { created_dir } => {
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+                if created_dir {
+                    if let Some(dir) = path.parent() {
+                        // Only removes a genuinely empty directory; leaves it
+                        // alone (and swallows the error) if the user or
+                        // another process put something else there.
+                        let _ = fs::remove_dir(dir);
+                    }
+                }
+            }
+            PreExisting::Present(contents) => {
+                write_credential_file(path, &contents)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// True when any worker currently holds a lease (used by tests/shutdown
+    /// bookkeeping to assert full drain).
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.leases.is_empty() && self.path_by_worker.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn read(path: &Path) -> String {
+        fs::read_to_string(path).unwrap()
+    }
+
+    #[test]
+    fn clean_cwd_creates_then_removes_on_release() {
+        let dir = tempdir().unwrap();
+        let worker = WorkerName::new("w1");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let path = registry.acquire(dir.path(), &worker).unwrap();
+        assert!(!path.exists(), "acquire must not create the file itself");
+
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_credential_file(&path, b"{\"mcpServers\":{}}").unwrap();
+        assert!(path.exists());
+
+        registry.release_worker(&worker).unwrap();
+        assert!(!path.exists(), "generated file must be removed on release");
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn pre_existing_exact_config_is_restored() {
+        let dir = tempdir().unwrap();
+        let cursor_dir = dir.path().join(".cursor");
+        fs::create_dir_all(&cursor_dir).unwrap();
+        let path = cursor_dir.join("mcp.json");
+        let original = br#"{"mcpServers":{"filesystem":{"command":"fs"}}}"#;
+        fs::write(&path, original).unwrap();
+
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("w1");
+        registry.acquire(dir.path(), &worker).unwrap();
+        // Simulate the injection overwrite.
+        write_credential_file(
+            &path,
+            br#"{"mcpServers":{"filesystem":{"command":"fs"},"agent-relay":{"token":"secret"}}}"#,
+        )
+        .unwrap();
+
+        registry.release_worker(&worker).unwrap();
+        assert_eq!(
+            read(&path).as_bytes(),
+            original,
+            "must restore exact pre-existing bytes"
+        );
+    }
+
+    #[test]
+    fn user_edits_between_acquire_and_release_are_overwritten_by_restore() {
+        // The captured pre-existing snapshot — not whatever is on disk at
+        // release time — is authoritative, so a credential leak cannot
+        // survive as "the user's file now".
+        let dir = tempdir().unwrap();
+        let cursor_dir = dir.path().join(".cursor");
+        fs::create_dir_all(&cursor_dir).unwrap();
+        let path = cursor_dir.join("mcp.json");
+        let original = br#"{"mcpServers":{"filesystem":{"command":"fs"}}}"#;
+        fs::write(&path, original).unwrap();
+
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("w1");
+        registry.acquire(dir.path(), &worker).unwrap();
+        write_credential_file(
+            &path,
+            br#"{"mcpServers":{"agent-relay":{"token":"secret"}}}"#,
+        )
+        .unwrap();
+        // External edit after injection, before release.
+        fs::write(
+            &path,
+            br#"{"mcpServers":{"agent-relay":{"token":"secret"},"extra":true}}"#,
+        )
+        .unwrap();
+
+        registry.release_worker(&worker).unwrap();
+        assert_eq!(read(&path).as_bytes(), original);
+    }
+
+    #[test]
+    fn two_concurrent_workers_same_cwd_release_in_order_keeps_config_until_last() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".cursor").join("mcp.json");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let w1 = WorkerName::new("w1");
+        let w2 = WorkerName::new("w2");
+
+        registry.acquire(dir.path(), &w1).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_credential_file(
+            &path,
+            b"{\"mcpServers\":{\"agent-relay\":{\"token\":\"w1\"}}}",
+        )
+        .unwrap();
+        registry.acquire(dir.path(), &w2).unwrap();
+        write_credential_file(
+            &path,
+            b"{\"mcpServers\":{\"agent-relay\":{\"token\":\"w2\"}}}",
+        )
+        .unwrap();
+
+        registry.release_worker(&w1).unwrap();
+        assert!(path.exists(), "config must survive while a holder remains");
+
+        registry.release_worker(&w2).unwrap();
+        assert!(
+            !path.exists(),
+            "config must be removed once the last holder releases"
+        );
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn two_concurrent_workers_same_cwd_release_in_reverse_order() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".cursor").join("mcp.json");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let w1 = WorkerName::new("w1");
+        let w2 = WorkerName::new("w2");
+
+        registry.acquire(dir.path(), &w1).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_credential_file(&path, b"{}").unwrap();
+        registry.acquire(dir.path(), &w2).unwrap();
+
+        registry.release_worker(&w2).unwrap();
+        assert!(path.exists(), "config must survive while w1 remains");
+
+        registry.release_worker(&w1).unwrap();
+        assert!(!path.exists());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn spawn_failure_before_any_write_releases_cleanly() {
+        let dir = tempdir().unwrap();
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("w1");
+        registry.acquire(dir.path(), &worker).unwrap();
+        // No write happened (simulated spawn failure right after acquire).
+        registry.release_worker(&worker).unwrap();
+        assert!(!dir.path().join(".cursor").join("mcp.json").exists());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn explicit_release_of_unknown_worker_is_a_no_op() {
+        let mut registry = CursorMcpLeaseRegistry::new();
+        registry.release_worker(&WorkerName::new("ghost")).unwrap();
+    }
+
+    #[test]
+    fn reap_after_task_exit_restores_pre_existing_config() {
+        let dir = tempdir().unwrap();
+        let cursor_dir = dir.path().join(".cursor");
+        fs::create_dir_all(&cursor_dir).unwrap();
+        let path = cursor_dir.join("mcp.json");
+        fs::write(&path, b"{\"mcpServers\":{\"db\":{}}}").unwrap();
+
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("task-exit-worker");
+        registry.acquire(dir.path(), &worker).unwrap();
+        write_credential_file(&path, b"{\"mcpServers\":{\"db\":{},\"agent-relay\":{}}}").unwrap();
+
+        // reap_exited() path: worker process exited, registry sweeps it.
+        registry.release_worker(&worker).unwrap();
+        assert_eq!(read(&path), "{\"mcpServers\":{\"db\":{}}}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restrictive_mode_enforced_on_generated_and_restored_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("w1");
+        let path = registry.acquire(dir.path(), &worker).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_credential_file(&path, b"{}").unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "generated credential file must be 0600");
+
+        // Now exercise the restore-path permission enforcement too.
+        drop(registry);
+        let dir2 = tempdir().unwrap();
+        let cursor_dir2 = dir2.path().join(".cursor");
+        fs::create_dir_all(&cursor_dir2).unwrap();
+        let path2 = cursor_dir2.join("mcp.json");
+        fs::write(&path2, b"{\"mcpServers\":{}}").unwrap();
+        fs::set_permissions(&path2, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let mut registry2 = CursorMcpLeaseRegistry::new();
+        let worker2 = WorkerName::new("w2");
+        registry2.acquire(dir2.path(), &worker2).unwrap();
+        write_credential_file(&path2, b"{\"mcpServers\":{\"agent-relay\":{}}}").unwrap();
+        registry2.release_worker(&worker2).unwrap();
+        let restored_mode = fs::metadata(&path2).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            restored_mode, 0o600,
+            "restored config must also be locked to 0600"
+        );
+    }
+}

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -954,14 +954,27 @@ impl CursorMcpLeaseRegistry {
                     "Cursor MCP lease journal path is not canonical",
                 ));
             }
-            let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(root, false) {
-                Ok(value) => value,
+            let lock = match LeaseLock::acquire(root) {
+                Ok(lock) => lock,
                 Err(error) => {
                     tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
                     remaining.push(JournalEntry {
                         path: entry.path,
                         pre_existing: pre_existing.journal(),
                     });
+                    continue;
+                }
+            };
+            let cursor_dir = match lock.open_cursor_dir(false) {
+                Ok((cursor, _)) => Some(cursor),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                Err(error) => {
+                    tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because .cursor could not be opened safely");
+                    remaining.push(JournalEntry {
+                        path: entry.path,
+                        pre_existing: pre_existing.journal(),
+                    });
+                    held_locks.push(lock);
                     continue;
                 }
             };
@@ -1352,5 +1365,58 @@ mod tests {
             })
             .unwrap();
         assert!(journal.exists(), "failed restore remains journaled");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_defers_invalid_cursor_and_keeps_root_locked_until_finalize() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("mcp.json");
+        fs::write(&outside_file, b"outside bytes").unwrap();
+        fs::create_dir_all(root.join(".cursor")).unwrap();
+        let path = root.join(".cursor/mcp.json");
+        fs::write(&path, b"original").unwrap();
+        let body = serde_json::to_vec(&Journal {
+            entries: vec![JournalEntry {
+                path: path.clone(),
+                pre_existing: JournalPreExisting::Present {
+                    contents_base64: base64::engine::general_purpose::STANDARD.encode(b"original"),
+                    mode: 0o600,
+                },
+            }],
+        })
+        .unwrap();
+        fs::write(&journal, body).unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        let cursor_path = root.join(".cursor");
+        fs::remove_dir_all(&cursor_path).unwrap();
+        symlink(outside.path(), &cursor_path).unwrap();
+
+        recovery
+            .recover_journal_with_hook(|| {
+                match LeaseLock::acquire(&root) {
+                    Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
+                    Ok(_) => panic!("root lock should stay held until journal finalization"),
+                }
+                assert_eq!(read(&outside_file), b"outside bytes");
+            })
+            .unwrap();
+
+        assert!(
+            journal.exists(),
+            "invalid cursor entry must remain journaled"
+        );
+        assert_eq!(read(&path), b"outside bytes");
+        assert_eq!(read(&outside_file), b"outside bytes");
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -982,10 +982,10 @@ fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
     if result != 0 {
         let error = io::Error::last_os_error();
         if error.kind() == io::ErrorKind::NotFound {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                "pinned Cursor directory was renamed before cleanup",
-            ));
+            // The directory was already removed — cleanup is idempotently
+            // complete.  Another process or a prior retry may have removed
+            // it between the credential-file write and journal persistence.
+            return Ok(());
         }
         return Err(error);
     }
@@ -1484,8 +1484,16 @@ impl CursorMcpLeaseRegistry {
                 .lock()
                 .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))? =
                 generated_identity;
-            #[cfg(windows)]
-            self.persist_journal()?;
+            // Persist the journal immediately so the generated identity is
+            // durable before any crash can occur.  Without this, a crash
+            // between identity capture and journal write would orphan the
+            // credential file with no recoverable identity for cleanup.
+            if let Err(error) = self.persist_journal() {
+                // Journal persistence failed — remove the credential file to
+                // avoid leaving a secret on disk with no recoverable identity.
+                let _ = fs::remove_file(path);
+                return Err(error);
+            }
             Ok(())
         }
     }
@@ -2734,5 +2742,121 @@ mod tests {
         // with the owning handle. A later broker can recover after a clean exit
         // and the same mechanism also releases on process termination.
         let _second = LeaseLock::acquire(dir.path(), None).unwrap();
+    }
+
+    #[test]
+    fn absent_file_cleanup_retry_is_idempotent_after_directory_removal() {
+        let dir = tempdir().unwrap();
+        let worker = WorkerName::new("w1");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let path = registry.acquire(dir.path(), &worker).unwrap();
+        registry.write_worker_cursor_file(&worker, b"{}").unwrap();
+        assert!(path.exists());
+        assert!(path.parent().unwrap().exists());
+
+        // Simulate an external process or a prior retry removing the .cursor
+        // directory between the credential-file write and journal persistence.
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+
+        // Release must succeed even though the directory is already gone.
+        registry.release_worker(&worker).unwrap();
+        assert!(registry.is_empty());
+        assert!(!path.exists());
+        assert!(
+            !path.parent().unwrap().exists(),
+            ".cursor directory must not be recreated"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn credential_file_removed_on_journal_persist_failure() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        let worker = WorkerName::new("w1");
+        let path = registry.acquire(dir.path(), &worker).unwrap();
+
+        // Hold the journal lock file so persist_journal() fails with
+        // WouldBlock — the same failure mode as another broker updating.
+        let lock_path = journal.with_file_name(".cursor-mcp-leases.lock");
+        let _held_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        _held_lock.try_lock().unwrap();
+
+        // write_worker_cursor_file writes the credential file, then attempts
+        // persist_journal which fails.  The new code must remove the
+        // credential file to avoid leaving a secret on disk without a
+        // recoverable journal identity.
+        let error = registry
+            .write_worker_cursor_file(&worker, b"secret placeholders")
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(
+            !path.exists(),
+            "credential file must be removed when journal persistence fails"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absent_file_release_journal_failure_retains_lease_for_retry() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        let worker = WorkerName::new("w1");
+        let path = registry.acquire(dir.path(), &worker).unwrap();
+        registry.write_worker_cursor_file(&worker, b"{}").unwrap();
+        assert!(path.exists(), "cursor file must exist after write");
+        assert!(
+            path.parent().unwrap().exists(),
+            ".cursor directory must exist"
+        );
+
+        // Hold the journal lock to force persist_journal() failure on release.
+        let lock_path = journal.with_file_name(".cursor-mcp-leases.lock");
+        let held_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&lock_path)
+            .unwrap();
+        held_lock.try_lock().unwrap();
+
+        // Release removes the file and directory (Absent path) but journal
+        // persistence fails.  The lease must remain in-memory for retry.
+        let error = registry.release_worker(&worker).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(
+            !registry.is_empty(),
+            "failed journal persist must retain lease"
+        );
+        // The file and directory must still be cleaned up on-disk.
+        assert!(
+            !path.exists(),
+            "generated file must be removed even if journal fails"
+        );
+        assert!(
+            !path.parent().unwrap().exists(),
+            ".cursor directory must be removed even if journal fails"
+        );
+
+        // Drop the lock and retry — the retry should succeed and clean up
+        // the in-memory lease.
+        drop(held_lock);
+        registry.retry_pending_cleanups();
+        assert!(
+            registry.is_empty(),
+            "retry after lock release must clear lease"
+        );
+        assert!(
+            !journal.exists(),
+            "journal must be cleaned up after successful retry"
+        );
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1211,10 +1211,15 @@ impl CursorMcpLeaseRegistry {
         registry
     }
 
-    fn lock_path(&self, root: &Path) -> Option<PathBuf> {
-        let journal_dir = self.journal_path.as_ref()?.parent()?;
+    fn lock_path(&self, root: &Path) -> io::Result<PathBuf> {
+        let journal_dir = self
+            .journal_path
+            .as_ref()
+            .and_then(|path| path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| std::env::temp_dir().join("agent-relay-cursor-mcp"));
+        fs::create_dir_all(&journal_dir)?;
         let digest = Sha256::digest(root.as_os_str().to_string_lossy().as_bytes());
-        Some(journal_dir.join(format!(".cursor-mcp-lease-{:x}.lock", digest)))
+        Ok(journal_dir.join(format!(".cursor-mcp-lease-{:x}.lock", digest)))
     }
 
     pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
@@ -1258,9 +1263,9 @@ impl CursorMcpLeaseRegistry {
         // operations. A hostile process can rename `.cursor` after a pathname
         // check, but it cannot redirect the descriptor captured here. Keep
         // that descriptor in LeaseState for the full lease lifetime.
-        let lock_path = self.lock_path(&canonical);
+        let lock_path = self.lock_path(&canonical)?;
         let (lock, cursor_dir, created_dir) =
-            match LeaseLock::acquire_with_cursor(&canonical, true, lock_path.as_deref()) {
+            match LeaseLock::acquire_with_cursor(&canonical, true, Some(&lock_path)) {
                 Ok(value) => value,
                 Err(CursorAcquireError::Lock(error))
                 | Err(CursorAcquireError::Cursor { error, .. }) => return Err(error),
@@ -1330,12 +1335,16 @@ impl CursorMcpLeaseRegistry {
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
+        let deferred = self.deferred_journal.remove(&key);
         let newly_owned = self.journal_owned_paths.insert(key.clone());
         if let Err(error) = self.persist_journal() {
             self.leases.remove(&key);
             self.path_by_worker.remove(worker);
             if newly_owned {
                 self.journal_owned_paths.remove(&key);
+            }
+            if let Some(entry) = deferred {
+                self.deferred_journal.insert(key, entry);
             }
             return Err(error);
         }
@@ -1662,7 +1671,39 @@ impl CursorMcpLeaseRegistry {
                         }
                     }
                 }
-                PreExisting::Present { contents, mode } => restore_file(_path, contents, *mode)?,
+                PreExisting::Present { contents, mode } => {
+                    #[cfg(windows)]
+                    {
+                        let expected = generated_identity.ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "legacy Cursor MCP journal lacks generated identity",
+                            )
+                        })?;
+                        let mut generated =
+                            windows_child_file(_path, true, false).map_err(|error| {
+                                if error.kind() == io::ErrorKind::NotFound {
+                                    io::Error::new(
+                                        io::ErrorKind::WouldBlock,
+                                        "generated Cursor MCP file disappeared before restore",
+                                    )
+                                } else {
+                                    error
+                                }
+                            })?;
+                        if windows_handle_identity(&generated)? != expected {
+                            return Err(io::Error::new(
+                                io::ErrorKind::WouldBlock,
+                                "generated Cursor MCP file was replaced",
+                            ));
+                        }
+                        generated.set_len(0)?;
+                        generated.write_all(contents)?;
+                        generated.sync_all()?;
+                    }
+                    #[cfg(not(windows))]
+                    restore_file(_path, contents, *mode)?;
+                }
             }
             #[cfg(windows)]
             validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
@@ -1848,11 +1889,11 @@ impl CursorMcpLeaseRegistry {
                 });
                 continue;
             }
-            let lock_path = self.lock_path(root);
+            let lock_path = self.lock_path(root)?;
             let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(
                 root,
                 false,
-                lock_path.as_deref(),
+                Some(&lock_path),
             ) {
                 Ok(value) => value,
                 Err(CursorAcquireError::Lock(error)) => {
@@ -1961,6 +2002,10 @@ mod tests {
         registry.release_worker(&worker).unwrap();
         assert!(!path.exists());
         assert!(!path.parent().unwrap().exists());
+        assert!(
+            !dir.path().join(".cursor-mcp-lease.lock").exists(),
+            "one-shot registry must not leave a lock in the worker cwd"
+        );
         assert!(registry.is_empty());
     }
 
@@ -2410,6 +2455,45 @@ mod tests {
         let journal: Journal = serde_json::from_slice(&fs::read(&journal).unwrap()).unwrap();
         assert_eq!(journal.entries.len(), 1);
         assert_eq!(journal.entries[0].path, deferred_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reacquiring_deferred_path_clears_stale_entry_after_release() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().join("reacquired");
+        fs::create_dir_all(root.join(".cursor")).unwrap();
+        let root = root.canonicalize().unwrap();
+        let path = root.join(".cursor/mcp.json");
+        let stale = JournalEntry {
+            path: path.clone(),
+            pre_existing: JournalPreExisting::Absent { created_dir: false },
+        };
+        fs::write(
+            &journal,
+            serde_json::to_vec(&Journal {
+                entries: vec![stale.clone()],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        // Model a deferred entry whose cwd is now available again.
+        registry.deferred_journal.insert(path.clone(), stale);
+        registry.journal_owned_paths.insert(path.clone());
+        let worker = WorkerName::new("reacquired");
+        registry.acquire(&root, &worker).unwrap();
+        registry
+            .write_worker_cursor_file(&worker, b"fresh placeholders")
+            .unwrap();
+        registry.release_worker(&worker).unwrap();
+        assert!(
+            !journal.exists(),
+            "stale entry must not replay after release: {:?}",
+            fs::read(&journal).ok()
+        );
+        assert!(!path.exists());
     }
 
     #[cfg(unix)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -206,12 +206,19 @@ fn validate_windows_cursor_identity(
 }
 
 #[cfg(windows)]
-fn validate_windows_restore_path(lock: &LeaseLock, path: &Path) -> io::Result<()> {
+fn validate_windows_restore_path(
+    lock: &LeaseLock,
+    path: &Path,
+    expected: Option<(u32, u64)>,
+) -> io::Result<()> {
     lock.validate_root()?;
     let cursor = path
         .parent()
         .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
-    if cursor != lock.root.join(".cursor") || windows_directory_identity(cursor).is_err() {
+    if cursor != lock.root.join(".cursor")
+        || expected.is_some_and(|identity| windows_directory_identity(cursor) != Ok(identity))
+        || windows_directory_identity(cursor).is_err()
+    {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
             "Cursor .cursor directory was replaced during cleanup",
@@ -331,11 +338,22 @@ fn protect_journal_bytes(bytes: &[u8]) -> io::Result<Vec<u8>> {
     let result =
         unsafe { std::slice::from_raw_parts(output.pb_data, output.cb_data as usize) }.to_vec();
     unsafe { LocalFree(output.pb_data as *mut std::ffi::c_void) };
-    Ok(result)
+    let mut versioned = b"relay-dpapi-v1:".to_vec();
+    versioned.extend(result);
+    Ok(versioned)
 }
 
 #[cfg(windows)]
 fn unprotect_journal_bytes(bytes: &[u8]) -> io::Result<Vec<u8>> {
+    const PREFIX: &[u8] = b"relay-dpapi-v1:";
+    if !bytes.starts_with(PREFIX) {
+        // Journals written before Windows encryption used ordinary base64
+        // bytes. Treat those as a supported legacy format and immediately
+        // rewrite them through the versioned DPAPI path on the next persist;
+        // never attempt DPAPI on an unversioned payload.
+        return Ok(bytes.to_vec());
+    }
+    let bytes = &bytes[PREFIX.len()..];
     let input = WindowsDataBlob {
         cb_data: bytes.len().try_into().map_err(|_| {
             io::Error::new(
@@ -717,12 +735,18 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
 fn secure_windows_file(path: &Path) -> io::Result<()> {
     use std::process::Command;
 
+    let system_root = std::env::var_os("SystemRoot")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::PermissionDenied, "SystemRoot is not set"))?;
+    let system32 = PathBuf::from(system_root).join("System32");
+    let whoami_path = system32.join("whoami.exe");
+    let icacls_path = system32.join("icacls.exe");
+
     // `icacls` is part of supported Windows installations. Resolve the SID
     // rather than trusting a username, then remove inherited permissions and
     // grant access only to the current user and SYSTEM. Fail closed if either
     // utility is unavailable; an unprotected generated config must not be
     // published because it may contain restored user configuration.
-    let whoami = Command::new("whoami")
+    let whoami = Command::new(whoami_path)
         .args(["/user", "/fo", "csv", "/nh"])
         .output()?;
     if !whoami.status.success() {
@@ -745,7 +769,7 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
                 "whoami did not return a Windows user SID",
             )
         })?;
-    let status = Command::new("icacls")
+    let status = Command::new(icacls_path)
         .arg(path)
         .args(["/inheritance:r", "/grant:r"])
         .arg(format!("{sid}:F"))
@@ -1074,7 +1098,14 @@ impl CursorMcpLeaseRegistry {
                 mode: *mode,
             },
         };
-        Self::restore(path, &pre_existing, &state.lock, state.cursor_dir.as_ref())?;
+        Self::restore(
+            path,
+            &pre_existing,
+            &state.lock,
+            state.cursor_dir.as_ref(),
+            #[cfg(windows)]
+            Some(state.cursor_identity),
+        )?;
         let state = self.leases.remove(path).expect("lease checked above");
         self.path_by_worker.remove(worker);
         if let Err(error) = self.persist_journal() {
@@ -1094,6 +1125,7 @@ impl CursorMcpLeaseRegistry {
         pre_existing: &PreExisting,
         lock: &LeaseLock,
         pinned_cursor: Option<&fs::File>,
+        #[cfg(windows)] expected_cursor_identity: Option<(u32, u64)>,
     ) -> io::Result<()> {
         #[cfg(unix)]
         {
@@ -1132,7 +1164,7 @@ impl CursorMcpLeaseRegistry {
         #[cfg(not(unix))]
         {
             #[cfg(windows)]
-            validate_windows_restore_path(lock, _path)?;
+            validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             match pre_existing {
                 PreExisting::Absent { created_dir } => {
                     match fs::symlink_metadata(_path) {
@@ -1169,7 +1201,7 @@ impl CursorMcpLeaseRegistry {
                 PreExisting::Present { contents, mode } => restore_file(_path, contents, *mode)?,
             }
             #[cfg(windows)]
-            validate_windows_restore_path(lock, _path)?;
+            validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             Ok(())
         }
     }
@@ -1330,7 +1362,14 @@ impl CursorMcpLeaseRegistry {
                 held_locks.push(lock);
                 continue;
             }
-            if let Err(error) = Self::restore(&path, &pre_existing, &lock, cursor_dir.as_ref()) {
+            if let Err(error) = Self::restore(
+                &path,
+                &pre_existing,
+                &lock,
+                cursor_dir.as_ref(),
+                #[cfg(windows)]
+                Some(windows_directory_identity(path.parent().unwrap_or(root))?),
+            ) {
                 tracing::warn!(path = %path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
                     path,

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -22,7 +22,7 @@ enum PreExisting {
 struct LeaseState {
     pre_existing: PreExisting,
     holders: HashSet<WorkerName>,
-    _lock: LeaseLock,
+    lock: LeaseLock,
 }
 
 /// A kernel-held lock on the requested cwd. Locking the existing cwd rather
@@ -31,6 +31,33 @@ struct LeaseState {
 /// overwrite one another's placeholder config.
 struct LeaseLock {
     _file: fs::File,
+}
+
+#[cfg(unix)]
+impl LeaseLock {
+    fn root_fd(&self) -> std::os::unix::io::RawFd {
+        use std::os::unix::io::AsRawFd;
+        self._file.as_raw_fd()
+    }
+
+    fn open_cursor_dir(&self, create: bool) -> io::Result<(fs::File, bool)> {
+        let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
+        match openat_dir(self.root_fd(), &cursor) {
+            Ok(file) => Ok((file, false)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound && create => {
+                let mode = 0o700;
+                let result = unsafe { libc::mkdirat(self.root_fd(), cursor.as_ptr(), mode) };
+                if result != 0 {
+                    let error = io::Error::last_os_error();
+                    if error.kind() != io::ErrorKind::AlreadyExists {
+                        return Err(error);
+                    }
+                }
+                Ok((openat_dir(self.root_fd(), &cursor)?, true))
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 impl LeaseLock {
@@ -45,7 +72,7 @@ impl LeaseLock {
         }
         #[cfg(unix)]
         {
-            let file = fs::File::open(root)?;
+            let file = open_dir_nofollow(root)?;
             file.try_lock().map_err(|error| match error {
                 fs::TryLockError::WouldBlock => io::Error::new(
                     io::ErrorKind::WouldBlock,
@@ -56,6 +83,31 @@ impl LeaseLock {
             Ok(Self { _file: file })
         }
     }
+}
+
+#[cfg(unix)]
+fn open_dir_nofollow(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::FromRawFd;
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| invalid_path("directory path contains NUL"))?;
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let fd = unsafe { libc::open(path.as_ptr(), flags) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn openat_dir(parent: std::os::unix::io::RawFd, name: &std::ffi::CStr) -> io::Result<fs::File> {
+    use std::os::unix::io::FromRawFd;
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let fd = unsafe { libc::openat(parent, name.as_ptr(), flags) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { fs::File::from_raw_fd(fd) })
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -152,17 +204,6 @@ fn lease_path(root: &Path) -> io::Result<(PathBuf, PathBuf)> {
 }
 
 #[cfg(unix)]
-fn file_mode(path: &Path) -> io::Result<u32> {
-    use std::os::unix::fs::PermissionsExt;
-    Ok(open_read_nofollow(path)?.metadata()?.permissions().mode() & 0o777)
-}
-
-#[cfg(not(unix))]
-fn file_mode(_path: &Path) -> io::Result<u32> {
-    Ok(0)
-}
-
-#[cfg(unix)]
 fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     open_write_nofollow(path)?.set_permissions(fs::Permissions::from_mode(mode & 0o777))
@@ -238,6 +279,7 @@ fn open_write_nofollow(path: &Path) -> io::Result<fs::File> {
         .open(path)
 }
 
+#[cfg(not(unix))]
 fn read_regular_file(path: &Path) -> io::Result<Vec<u8>> {
     #[cfg(unix)]
     {
@@ -250,6 +292,170 @@ fn read_regular_file(path: &Path) -> io::Result<Vec<u8>> {
     {
         fs::read(path)
     }
+}
+
+#[cfg(unix)]
+fn open_cursor_target(cursor: &fs::File) -> io::Result<Option<fs::File>> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let name = std::ffi::CString::new("mcp.json").expect("literal has no NUL");
+    let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let fd = unsafe { libc::openat(cursor.as_raw_fd(), name.as_ptr(), flags) };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        return if error.kind() == io::ErrorKind::NotFound {
+            Ok(None)
+        } else if error.raw_os_error() == Some(libc::ELOOP) {
+            Err(invalid_path(".cursor/mcp.json must not be a symlink"))
+        } else {
+            Err(error)
+        };
+    }
+    let file = unsafe { fs::File::from_raw_fd(fd) };
+    if !file.metadata()?.is_file() {
+        return Err(invalid_path(".cursor/mcp.json must be a regular file"));
+    }
+    Ok(Some(file))
+}
+
+#[cfg(unix)]
+fn read_cursor_target(cursor: &fs::File) -> io::Result<Option<(Vec<u8>, u32)>> {
+    use std::os::unix::fs::PermissionsExt;
+    let Some(mut file) = open_cursor_target(cursor)? else {
+        return Ok(None);
+    };
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)?;
+    let mode = file.metadata()?.permissions().mode() & 0o777;
+    Ok(Some((contents, mode)))
+}
+
+#[cfg(unix)]
+fn write_cursor_target(cursor: &fs::File, contents: &[u8]) -> io::Result<()> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let temp_name = format!(".mcp.json.{}.tmp", Uuid::new_v4().simple());
+    let temp = std::ffi::CString::new(temp_name.as_str()).expect("UUID has no NUL");
+    let target = std::ffi::CString::new("mcp.json").expect("literal has no NUL");
+    let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let fd = unsafe { libc::openat(cursor.as_raw_fd(), temp.as_ptr(), flags, 0o600) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut file = unsafe { fs::File::from_raw_fd(fd) };
+    let result = (|| {
+        file.write_all(contents)?;
+        file.sync_all()?;
+        drop(file);
+        let result = unsafe {
+            libc::renameat(
+                cursor.as_raw_fd(),
+                temp.as_ptr(),
+                cursor.as_raw_fd(),
+                target.as_ptr(),
+            )
+        };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let target_file = open_cursor_target(cursor)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "renamed Cursor MCP target disappeared",
+            )
+        })?;
+        target_file.sync_all()?;
+        cursor.sync_all()
+    })();
+    if result.is_err() {
+        let _ = unsafe { libc::unlinkat(cursor.as_raw_fd(), temp.as_ptr(), 0) };
+    }
+    result
+}
+
+#[cfg(unix)]
+fn remove_cursor_target(cursor: &fs::File) -> io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+    let name = std::ffi::CString::new("mcp.json").expect("literal has no NUL");
+    let _ = open_cursor_target(cursor)?;
+    let result = unsafe { libc::unlinkat(cursor.as_raw_fd(), name.as_ptr(), 0) };
+    if result == 0 {
+        cursor.sync_all()?;
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(false)
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(unix)]
+fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
+    let name = std::ffi::CString::new(".cursor").expect("literal has no NUL");
+    let result = unsafe { libc::unlinkat(lock.root_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+    if result == 0 {
+        lock._file.sync_all()?;
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(())
+    } else {
+        let _ = cursor;
+        Err(error)
+    }
+}
+
+/// Write the Cursor config through directory descriptors. This is used after
+/// the registry has acquired the cwd lease; the descriptor-relative rename
+/// remains safe even if `.cursor` is concurrently renamed or replaced.
+#[cfg(unix)]
+pub(crate) fn write_cursor_credential_file(root: &Path, contents: &[u8]) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let root_file = open_dir_nofollow(root)?;
+    let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
+    let cursor_dir = match openat_dir(root_file.as_raw_fd(), &cursor) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let result = unsafe { libc::mkdirat(root_file.as_raw_fd(), cursor.as_ptr(), 0o700) };
+            if result != 0 {
+                let error = io::Error::last_os_error();
+                if error.kind() != io::ErrorKind::AlreadyExists {
+                    return Err(error);
+                }
+            }
+            openat_dir(root_file.as_raw_fd(), &cursor)?
+        }
+        Err(error) => return Err(error),
+    };
+    write_cursor_target(&cursor_dir, contents)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn write_cursor_credential_file(root: &Path, contents: &[u8]) -> io::Result<()> {
+    write_credential_file(&root.join(".cursor").join("mcp.json"), contents)
+}
+
+#[cfg(unix)]
+pub(crate) fn read_cursor_credential_file(root: &Path) -> io::Result<Vec<u8>> {
+    use std::os::unix::io::AsRawFd;
+    let root_file = open_dir_nofollow(root)?;
+    let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
+    let cursor_dir = openat_dir(root_file.as_raw_fd(), &cursor)?;
+    let Some(mut file) = open_cursor_target(&cursor_dir)? else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Cursor MCP config missing",
+        ));
+    };
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)?;
+    Ok(contents)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn read_cursor_credential_file(root: &Path) -> io::Result<Vec<u8>> {
+    read_regular_file(&root.join(".cursor").join("mcp.json"))
 }
 
 /// Atomically write a generated credential-bearing config with owner-only
@@ -300,6 +506,7 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     result
 }
 
+#[cfg(not(unix))]
 fn restore_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
     let _ = validate_target(path)?;
     write_credential_file(path, contents)?;
@@ -395,19 +602,19 @@ impl CursorMcpLeaseRegistry {
         }
 
         let lock = LeaseLock::acquire(&canonical)?;
-        // Re-check after taking the kernel lock so cooperating brokers cannot
-        // race a parent/file replacement between validation and capture.
-        let dir_existed = validate_cursor_dir(&canonical)?;
-        let pre_existing = if validate_target(&key)? {
-            PreExisting::Present {
-                contents: read_regular_file(&key)?,
-                mode: file_mode(&key)?,
-            }
+        // Re-check after taking the kernel lock using descriptor-relative
+        // operations. A hostile process can rename `.cursor` after a pathname
+        // check, but it cannot redirect the already-open directory descriptor.
+        #[cfg(unix)]
+        let (cursor_dir, created_dir) = lock.open_cursor_dir(true)?;
+        #[cfg(unix)]
+        let pre_existing = if let Some((contents, mode)) = read_cursor_target(&cursor_dir)? {
+            PreExisting::Present { contents, mode }
         } else {
-            PreExisting::Absent {
-                created_dir: !dir_existed,
-            }
+            PreExisting::Absent { created_dir }
         };
+        #[cfg(not(unix))]
+        let pre_existing = unreachable!("LeaseLock acquisition is unsupported on non-Unix");
 
         let mut holders = HashSet::new();
         holders.insert(worker.clone());
@@ -416,7 +623,7 @@ impl CursorMcpLeaseRegistry {
             LeaseState {
                 pre_existing,
                 holders,
-                _lock: lock,
+                lock,
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
@@ -481,7 +688,7 @@ impl CursorMcpLeaseRegistry {
                 mode: *mode,
             },
         };
-        self.restore(path, &pre_existing)?;
+        Self::restore(path, &pre_existing, &state.lock)?;
         let state = self.leases.remove(path).expect("lease checked above");
         self.path_by_worker.remove(worker);
         if let Err(error) = self.persist_journal() {
@@ -496,7 +703,46 @@ impl CursorMcpLeaseRegistry {
         Ok(())
     }
 
-    fn restore(&self, path: &Path, pre_existing: &PreExisting) -> io::Result<()> {
+    fn restore(_path: &Path, pre_existing: &PreExisting, lock: &LeaseLock) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            let cursor = match lock.open_cursor_dir(false) {
+                Ok((cursor, _)) => Some(cursor),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                Err(error) => return Err(error),
+            };
+            match pre_existing {
+                PreExisting::Absent { created_dir } => {
+                    if let Some(cursor) = cursor {
+                        let _ = remove_cursor_target(&cursor)?;
+                        if *created_dir {
+                            remove_cursor_dir(lock, &cursor)?;
+                        }
+                    }
+                }
+                PreExisting::Present { contents, mode } => {
+                    let cursor = cursor.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "Cursor directory disappeared during restore",
+                        )
+                    })?;
+                    write_cursor_target(&cursor, contents)?;
+                    let target = open_cursor_target(&cursor)?.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "Cursor MCP target disappeared after restore",
+                        )
+                    })?;
+                    use std::os::unix::fs::PermissionsExt;
+                    target.set_permissions(fs::Permissions::from_mode(*mode & 0o777))?;
+                    target.sync_all()?;
+                    cursor.sync_all()?;
+                }
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
         match pre_existing {
             PreExisting::Absent { created_dir } => {
                 match fs::symlink_metadata(path) {
@@ -532,7 +778,10 @@ impl CursorMcpLeaseRegistry {
             }
             PreExisting::Present { contents, mode } => restore_file(path, contents, *mode)?,
         }
-        Ok(())
+        #[cfg(not(unix))]
+        {
+            Ok(())
+        }
     }
 
     fn journal_entries(&self) -> Vec<JournalEntry> {
@@ -565,6 +814,13 @@ impl CursorMcpLeaseRegistry {
     }
 
     fn recover_journal(&mut self) -> io::Result<()> {
+        self.recover_journal_with_hook(|| {})
+    }
+
+    fn recover_journal_with_hook<F>(&mut self, mut before_finalize: F) -> io::Result<()>
+    where
+        F: FnMut(),
+    {
         let Some(path) = self.journal_path.clone() else {
             return Ok(());
         };
@@ -576,6 +832,11 @@ impl CursorMcpLeaseRegistry {
         let journal: Journal = serde_json::from_slice(&body)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
         let mut remaining = Vec::new();
+        // Keep every successfully acquired cwd lock until the journal
+        // transaction is finalized. Dropping a lock immediately after restore
+        // leaves a window where another broker can create a new live journal
+        // that this recovery pass would then unlink or replace.
+        let mut held_locks = Vec::new();
         for entry in journal.entries {
             let pre_existing = PreExisting::from_journal(entry.pre_existing)?;
             if !entry.path.is_absolute() {
@@ -600,7 +861,7 @@ impl CursorMcpLeaseRegistry {
                     "Cursor MCP lease journal path is not canonical",
                 ));
             }
-            let _lock = match LeaseLock::acquire(root) {
+            let lock = match LeaseLock::acquire(root) {
                 Ok(lock) => lock,
                 Err(error) => {
                     tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
@@ -619,14 +880,17 @@ impl CursorMcpLeaseRegistry {
                 });
                 continue;
             }
-            if let Err(error) = self.restore(&entry.path, &pre_existing) {
+            if let Err(error) = Self::restore(&entry.path, &pre_existing, &lock) {
                 tracing::warn!(path = %entry.path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
                     path: entry.path,
                     pre_existing: pre_existing.journal(),
                 });
+            } else {
+                held_locks.push(lock);
             }
         }
+        before_finalize();
         if remaining.is_empty() {
             match fs::remove_file(&path) {
                 Ok(()) => sync_entry_parent(&path)?,
@@ -788,5 +1052,65 @@ mod tests {
         symlink(&outside_file, cwd.path().join(".cursor/mcp.json")).unwrap();
         assert!(registry.acquire(cwd.path(), &worker).is_err());
         assert_eq!(read(&outside_file), b"outside bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn descriptor_relative_write_survives_hostile_cursor_parent_swap() {
+        use std::os::unix::fs::symlink;
+        use std::os::unix::io::AsRawFd;
+
+        let cwd = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("mcp.json");
+        fs::write(&outside_file, b"outside bytes").unwrap();
+        fs::create_dir(cwd.path().join(".cursor")).unwrap();
+        let root_file = open_dir_nofollow(cwd.path()).unwrap();
+        let cursor_name = std::ffi::CString::new(".cursor").unwrap();
+        let cursor = openat_dir(root_file.as_raw_fd(), &cursor_name).unwrap();
+
+        fs::rename(cwd.path().join(".cursor"), cwd.path().join(".cursor-moved")).unwrap();
+        symlink(outside.path(), cwd.path().join(".cursor")).unwrap();
+        write_cursor_target(&cursor, b"inside bytes").unwrap();
+
+        assert_eq!(
+            read(&cwd.path().join(".cursor-moved/mcp.json")),
+            b"inside bytes"
+        );
+        assert_eq!(read(&outside_file), b"outside bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_retains_cwd_lock_until_journal_finalization() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let path = dir.path().join(".cursor/mcp.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"original").unwrap();
+        {
+            let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+            registry
+                .acquire(dir.path(), &WorkerName::new("w1"))
+                .unwrap();
+            write_cursor_credential_file(dir.path(), b"generated").unwrap();
+        }
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        let mut second = CursorMcpLeaseRegistry::new();
+        recovery
+            .recover_journal_with_hook(|| {
+                let error = second
+                    .acquire(dir.path(), &WorkerName::new("racing"))
+                    .unwrap_err();
+                assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+            })
+            .unwrap();
+        assert!(!journal.exists());
+        assert_eq!(read(&path), b"original");
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1090,13 +1090,38 @@ fn write_credential_file_with_identity(
 
 #[cfg(windows)]
 fn secure_windows_file(path: &Path) -> io::Result<()> {
-    use std::mem::ManuallyDrop;
+    use std::mem::{self, ManuallyDrop};
     use std::os::windows::ffi::OsStrExt;
     use std::process::Command;
+
+    #[repr(C)]
+    #[allow(non_snake_case)]
+    struct TRUSTEE_W {
+        pMultipleTrustee: *mut std::ffi::c_void,
+        MultipleTrusteeOperation: u32,
+        TrusteeForm: u32,
+        TrusteeType: u32,
+        ptstrName: *mut u16,
+    }
+
+    #[repr(C)]
+    #[allow(non_snake_case)]
+    struct EXPLICIT_ACCESS_W {
+        grfAccessPermissions: u32,
+        grfAccessMode: u32,
+        grfInheritance: u32,
+        Trustee: TRUSTEE_W,
+    }
 
     #[link(name = "Advapi32")]
     unsafe extern "system" {
         fn ConvertStringSidToSidW(string_sid: *const u16, sid: *mut *mut u8) -> i32;
+        fn SetEntriesInAclW(
+            cExplicitEntries: u32,
+            pExplicitEntries: *const EXPLICIT_ACCESS_W,
+            pOldAcl: *mut u8,
+            ppNewAcl: *mut *mut u8,
+        ) -> u32;
         fn SetNamedSecurityInfoW(
             name: *const u16,
             object_type: u32,
@@ -1106,12 +1131,17 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
             dacl: *mut u8,
             sacl: *mut u8,
         ) -> u32;
+        fn LocalFree(ptr: *mut u8) -> *mut u8;
     }
 
     const SE_FILE_OBJECT: u32 = 1;
     const DACL_SECURITY_INFORMATION: u32 = 0x0000_0004;
-    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
-    const FILE_GENERIC_ALL: u32 = 0x001F_01FF;
+    const SET_ACCESS: u32 = 2;
+    const GRANT_ACCESS: u32 = 2;
+    const TRUSTEE_IS_SID: u32 = 0;
+    const TRUSTEE_IS_USER: u32 = 1;
+    const NO_INHERITANCE: u32 = 0;
+    const FILE_ALL_ACCESS: u32 = 0x001F_01FF;
 
     let system32 = windows_system_directory()?;
     let whoami_path = system32.join("whoami.exe");
@@ -1156,13 +1186,11 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
             )
         })?;
 
-    // Convert the SID string to a binary SID via Win32 API.  icacls cannot
-    // accept raw SID strings on some Windows Server configurations (error
-    // 1332 – ERROR_NONE_MAPPED), so we use the native API directly.
+    // Convert the SID string to a binary SID via Win32 API.
     let mut wide_sid: Vec<u16> = sid.encode_utf16().chain(std::iter::once(0)).collect();
-    let mut psid: *mut u8 = std::ptr::null_mut();
-    let ok = unsafe { ConvertStringSidToSidW(wide_sid.as_ptr(), &mut psid) };
-    if ok == 0 || psid.is_null() {
+    let mut user_sid: *mut u8 = std::ptr::null_mut();
+    let ok = unsafe { ConvertStringSidToSidW(wide_sid.as_ptr(), &mut user_sid) };
+    if ok == 0 || user_sid.is_null() {
         let err = io::Error::last_os_error();
         tracing::error!(
             sid = %sid,
@@ -1174,83 +1202,66 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
             format!("unable to convert SID string '{sid}' for Windows ACL"),
         ));
     }
-    // Prevent Rust from dropping the SID before SetNamedSecurityInfoW uses it.
-    // The pointer is consumed by the ACE we build; SetNamedSecurityInfoW reads
-    // the DACL synchronously, so the SID must remain valid for this scope.
-    let _sid_guard = ManuallyDrop::new(SidGuard(psid));
+    let _user_sid_guard = ManuallyDrop::new(SidGuard(user_sid));
 
-    // Build a minimal DACL: [ACL header][ACE(user)][ACE(SYSTEM)]
-    // ACCESS_ALLOWED_ACE: AceType(1) + AceFlags(1) + AceSize(2) + Mask(4) + Sid
-    let sid_user_len = (8 + 28) as usize; // SID revision(1)+sub_count(1)+authority(6)+5*sub_auth(20)=28
-    let sid_system_len = (8 + 12) as usize; // S-1-5-18: revision(1)+sub_count(1)+authority(6)+1*sub_auth(4)=12
-    let ace_user_size = 8 + sid_user_len; // ACE header(8) + SID
-    let ace_system_size = 8 + sid_system_len;
-    let acl_size = 8 + ace_user_size + ace_system_size;
-    let mut acl_buf: Vec<u8> = vec![0u8; acl_size];
+    // SYSTEM SID: S-1-5-18 (well-known, fixed layout).
+    let mut system_sid_buf: [u8; 12] = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0];
 
-    // ACL header
-    acl_buf[0] = 2; // AclRevision
-    acl_buf[1] = 0; // Sbz1
-    let total = (acl_size as u16).to_le_bytes();
-    acl_buf[2] = total[0];
-    acl_buf[3] = total[1];
-    let count = 2u16.to_le_bytes();
-    acl_buf[4] = count[0];
-    acl_buf[5] = count[1];
-    acl_buf[6] = 0; // Sbz2
-    acl_buf[7] = 0;
+    // Build EXPLICIT_ACCESS_W entries: grant FILE_ALL_ACCESS to user and SYSTEM.
+    let user_ea = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: FILE_ALL_ACCESS,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_USER,
+            ptstrName: user_sid,
+        },
+    };
+    let system_ea = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: FILE_ALL_ACCESS,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_USER,
+            ptstrName: system_sid_buf.as_mut_ptr(),
+        },
+    };
+    let explicit_entries: [EXPLICIT_ACCESS_W; 2] = [user_ea, system_ea];
 
-    // ACE for the current user
-    let mut offset = 8usize;
-    let ace_user_size_u16 = (ace_user_size as u16).to_le_bytes();
-    acl_buf[offset] = ACCESS_ALLOWED_ACE_TYPE;
-    acl_buf[offset + 1] = 0; // No inheritance
-    acl_buf[offset + 2] = ace_user_size_u16[0];
-    acl_buf[offset + 3] = ace_user_size_u16[1];
-    let mask_user = FILE_GENERIC_ALL.to_le_bytes();
-    acl_buf[offset + 4..offset + 8].copy_from_slice(&mask_user);
-    unsafe {
-        let ace_sid_ptr = acl_buf.as_mut_ptr().add(offset + 8);
-        std::ptr::copy_nonoverlapping(psid, ace_sid_ptr, sid_user_len);
+    // Build the new DACL via SetEntriesInAclW (allocates with LocalAlloc).
+    let mut new_dacl: *mut u8 = std::ptr::null_mut();
+    let acl_status = unsafe {
+        SetEntriesInAclW(
+            2,
+            explicit_entries.as_ptr(),
+            std::ptr::null_mut(), // No existing DACL — start fresh
+            &mut new_dacl,
+        )
+    };
+    if acl_status != 0 || new_dacl.is_null() {
+        let err = io::Error::last_os_error();
+        tracing::error!(
+            status = acl_status,
+            error = %err,
+            "SetEntriesInAclW failed to build DACL for Cursor config"
+        );
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "unable to build Windows DACL for generated Cursor config: \
+                 SetEntriesInAclW returned {acl_status}"
+            ),
+        ));
     }
-    offset += ace_user_size;
+    let _dacl_guard = ManuallyDrop::new(SidGuard(new_dacl));
 
-    // ACE for SYSTEM (S-1-5-18)
-    let ace_sys_size_u16 = (ace_system_size as u16).to_le_bytes();
-    acl_buf[offset] = ACCESS_ALLOWED_ACE_TYPE;
-    acl_buf[offset + 1] = 0;
-    acl_buf[offset + 2] = ace_sys_size_u16[0];
-    acl_buf[offset + 3] = ace_sys_size_u16[1];
-    let mask_sys = FILE_GENERIC_ALL.to_le_bytes();
-    acl_buf[offset + 4..offset + 8].copy_from_slice(&mask_sys);
-    // S-1-5-18 binary: Revision(1)=1, SubAuthorityCount(1)=1, IdentifierAuthority(6)={0,0,0,0,0,5}, SubAuthority(4)=18
-    let system_sid: [u8; 12] = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0];
-    unsafe {
-        let ace_sid_ptr = acl_buf.as_mut_ptr().add(offset + 8);
-        std::ptr::copy_nonoverlapping(system_sid.as_ptr(), ace_sid_ptr, sid_system_len);
-    }
-
-    // Build an absolute security descriptor with the DACL.
-    // Layout: Revision(1) + Sbz1(1) + Control(2) + Owner ptr + Group ptr +
-    //         Sacl ptr + Dacl ptr.  Pointer size is 4 on 32-bit, 8 on x64.
-    let ptr_size = std::mem::size_of::<usize>();
-    let sd_size = 4 + 4 * ptr_size;
-    let mut sd: Vec<u8> = vec![0u8; sd_size];
-    sd[0] = 1; // Revision
-    sd[1] = 0; // Sbz1
-    sd[2] = 0x80; // Control low byte: SE_DACL_PRESENT
-    sd[3] = 0; // Control high byte
-               // Owner (bytes 4..4+ptr_size) – leave null (not needed for DACL-only set)
-               // Group (bytes 4+ptr_size..4+2*ptr_size) – leave null
-               // Sacl  (bytes 4+2*ptr_size..4+3*ptr_size) – leave null
-               // Dacl  (bytes 4+3*ptr_size..4+4*ptr_size) – set to acl_buf pointer
-    let dacl_offset = 4 + 3 * ptr_size;
-    let acl_ptr = acl_buf.as_ptr();
-    unsafe {
-        let field = sd.as_mut_ptr().add(dacl_offset) as *mut *const u8;
-        std::ptr::write(field, acl_ptr);
-    }
-
+    // Apply the DACL to the credential file.
     let wide_path: Vec<u16> = path
         .as_os_str()
         .encode_wide()
@@ -1262,10 +1273,10 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
             wide_path.as_ptr(),
             SE_FILE_OBJECT,
             DACL_SECURITY_INFORMATION,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            sd.as_mut_ptr().add(4), // Pass body (skip 4-byte header) as absolute SD
-            std::ptr::null_mut(),
+            std::ptr::null_mut(), // owner
+            std::ptr::null_mut(), // group
+            new_dacl,             // dacl — direct pointer to ACL
+            std::ptr::null_mut(), // sacl
         )
     };
 

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1880,7 +1880,9 @@ impl CursorMcpLeaseRegistry {
                 Err(e) => return Err(e),
             };
             #[cfg(windows)]
-            if parent_guard.is_some() {
+            let had_guard = parent_guard.is_some();
+            #[cfg(windows)]
+            if had_guard {
                 validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             }
             match pre_existing {
@@ -1991,7 +1993,7 @@ impl CursorMcpLeaseRegistry {
                 }
             }
             #[cfg(windows)]
-            if parent_guard.is_some() {
+            if had_guard {
                 validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             }
             Ok(())

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1991,7 +1991,9 @@ impl CursorMcpLeaseRegistry {
                 }
             }
             #[cfg(windows)]
-            validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
+            if parent_guard.is_some() {
+                validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
+            }
             Ok(())
         }
     }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -818,7 +818,11 @@ fn sync_file(path: &Path) -> io::Result<()> {
     }
     #[cfg(not(unix))]
     {
-        fs::File::open(path)?.sync_all()
+        fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?
+            .sync_all()
     }
 }
 

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -173,6 +173,53 @@ fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
 }
 
 #[cfg(windows)]
+struct WindowsDirectoryGuard(std::os::windows::io::OwnedHandle);
+
+#[cfg(windows)]
+fn windows_directory_guard(path: &Path) -> io::Result<WindowsDirectoryGuard> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const std::ffi::c_void,
+            disposition: u32,
+            flags: u32,
+            template: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+    }
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const FILE_SHARE_READ: u32 = 1;
+    const FILE_SHARE_WRITE: u32 = 2;
+    const OPEN_EXISTING: u32 = 3;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == (-1isize) as *mut std::ffi::c_void {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(WindowsDirectoryGuard(unsafe {
+        OwnedHandle::from_raw_handle(handle)
+    }))
+}
+
+#[cfg(windows)]
 impl LeaseLock {
     fn validate_root(&self) -> io::Result<()> {
         let canonical = canonical_root(&self.root)?;
@@ -693,6 +740,8 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     }
     validate_credential_parent(parent)?;
     let _ = validate_target(path)?;
+    #[cfg(windows)]
+    let _parent_guard = windows_directory_guard(parent)?;
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -1163,6 +1212,12 @@ impl CursorMcpLeaseRegistry {
         }
         #[cfg(not(unix))]
         {
+            #[cfg(windows)]
+            let _parent_guard = windows_directory_guard(
+                _path
+                    .parent()
+                    .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?,
+            )?;
             #[cfg(windows)]
             validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             match pre_existing {

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1096,22 +1096,30 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
     let whoami_path = system32.join("whoami.exe");
     let icacls_path = system32.join("icacls.exe");
 
-    // `icacls` is part of supported Windows installations. Resolve the SID
+    // `icacls` is part of supported Windows installations.  Resolve the SID
     // rather than trusting a username, then remove inherited permissions and
-    // grant access only to the current user and SYSTEM. Fail closed if either
-    // utility is unavailable; an unprotected generated config must not be
-    // published because it may contain restored user configuration.
-    let whoami = Command::new(whoami_path)
+    // grant access only to the current user and SYSTEM.  Fail closed if
+    // either utility is unavailable; an unprotected generated config must
+    // not be published because it may contain restored user configuration.
+    let whoami = Command::new(&whoami_path)
         .args(["/user", "/fo", "csv", "/nh"])
         .output()?;
+    let whoami_stdout = String::from_utf8_lossy(&whoami.stdout).into_owned();
+    let whoami_stderr = String::from_utf8_lossy(&whoami.stderr).into_owned();
     if !whoami.status.success() {
+        tracing::error!(
+            whoami = %whoami_path.display(),
+            exit = ?whoami.status,
+            stdout = %whoami_stdout,
+            stderr = %whoami_stderr,
+            "whoami failed to resolve Windows user SID"
+        );
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "unable to resolve current Windows user SID",
         ));
     }
-    let line = String::from_utf8_lossy(&whoami.stdout);
-    let sid = line
+    let sid = whoami_stdout
         .trim()
         .split(',')
         .next_back()
@@ -1119,40 +1127,60 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
         .map(|sid| sid.trim_matches('"'))
         .filter(|sid| sid.starts_with("S-"))
         .ok_or_else(|| {
+            tracing::error!(
+                whoami = %whoami_path.display(),
+                stdout = %whoami_stdout,
+                "whoami did not return a SID in the expected CSV format"
+            );
             io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "whoami did not return a Windows user SID",
             )
         })?;
-    // Grant the current user and SYSTEM full control.  Then attempt to
-    // strip inherited ACEs: on locked-down environments (e.g. GitHub
-    // Actions runners) the inheritance removal may fail while the grant
-    // itself succeeded.  The grant is the critical security property —
-    // without it anyone on the box could read the credential file — so
-    // we treat a grant-only outcome as acceptable and log the inheritance
-    // failure rather than failing the entire write.
-    let granted = Command::new(&icacls_path)
+    // Step 1 – Grant the current user and SYSTEM full control.  This is the
+    // critical security property: without it anyone on the box could read the
+    // credential file.
+    let grant_out = Command::new(&icacls_path)
         .arg(path)
-        .args(["/grant:r"])
-        .arg(format!("{sid}:F"))
-        .arg("SYSTEM:F")
+        .args(["/grant:r", &format!("{sid}:F"), "SYSTEM:F"])
         .output()?;
-    if !granted.status.success() {
+    let grant_stdout = String::from_utf8_lossy(&grant_out.stdout).into_owned();
+    let grant_stderr = String::from_utf8_lossy(&grant_out.stderr).into_owned();
+    if !grant_out.status.success() {
+        tracing::error!(
+            icacls = %icacls_path.display(),
+            path = %path.display(),
+            sid = %sid,
+            exit = ?grant_out.status,
+            stdout = %grant_stdout,
+            stderr = %grant_stderr,
+            "icacls /grant:r failed to secure generated Cursor config"
+        );
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            "unable to apply owner-only Windows ACL to generated Cursor config",
+            format!(
+                "unable to apply owner-only Windows ACL to generated Cursor config: \
+                 icacls exit {:?}, stderr: {}",
+                grant_out.status,
+                grant_stderr.trim(),
+            ),
         ));
     }
-    let inheritance = Command::new(&icacls_path)
+    // Step 2 – Strip inherited ACEs (best-effort).  On locked-down hosts
+    // (e.g. GitHub Actions runners) /inheritance:r may fail because the
+    // parent DACL denies the modification, but the explicit grant above
+    // already enforces owner-only access.
+    let inh_out = Command::new(&icacls_path)
         .arg(path)
         .args(["/inheritance:r"])
         .output();
-    if let Ok(result) = inheritance {
+    if let Ok(result) = inh_out {
         if !result.status.success() {
             tracing::warn!(
                 path = %path.display(),
+                exit = ?result.status,
                 stderr = %String::from_utf8_lossy(&result.stderr),
-                "icacls inheritance removal failed; owner-only ACL still enforced via explicit grant"
+                "icacls /inheritance:r failed; owner-only ACL still enforced via explicit grant"
             );
         }
     }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -9,6 +9,7 @@ use std::{
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::ids::WorkerName;
@@ -96,7 +97,7 @@ impl LeaseLock {
 }
 
 impl LeaseLock {
-    fn acquire(root: &Path) -> io::Result<Self> {
+    fn acquire(root: &Path, _lock_path: Option<&Path>) -> io::Result<Self> {
         #[cfg(unix)]
         {
             let file = open_dir_nofollow(root)?;
@@ -111,7 +112,9 @@ impl LeaseLock {
         }
         #[cfg(not(unix))]
         {
-            let lock_path = root.join(".cursor-mcp-lease.lock");
+            let lock_path = _lock_path
+                .map(PathBuf::from)
+                .unwrap_or_else(|| root.join(".cursor-mcp-lease.lock"));
             #[cfg(windows)]
             let file = windows_lock_file(&lock_path)?;
             #[cfg(not(windows))]
@@ -140,8 +143,9 @@ impl LeaseLock {
     fn acquire_with_cursor(
         root: &Path,
         create_cursor: bool,
+        lock_path: Option<&Path>,
     ) -> Result<(Self, Option<fs::File>, bool), CursorAcquireError> {
-        let lock = Self::acquire(root).map_err(CursorAcquireError::Lock)?;
+        let lock = Self::acquire(root, lock_path).map_err(CursorAcquireError::Lock)?;
         #[cfg(unix)]
         {
             match lock.open_cursor_dir(create_cursor) {
@@ -252,7 +256,7 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
 }
 
 #[cfg(windows)]
-fn windows_child_file(path: &Path, write: bool) -> io::Result<fs::File> {
+fn windows_child_file(path: &Path, write: bool, delete: bool) -> io::Result<fs::File> {
     use std::os::windows::ffi::OsStrExt;
     use std::os::windows::fs::MetadataExt;
     use std::os::windows::io::{FromRawHandle, OwnedHandle};
@@ -278,6 +282,7 @@ fn windows_child_file(path: &Path, write: bool) -> io::Result<fs::File> {
     }
     const GENERIC_READ: u32 = 0x8000_0000;
     const GENERIC_WRITE: u32 = 0x4000_0000;
+    const DELETE: u32 = 0x0001_0000;
     const FILE_SHARE_READ: u32 = 1;
     const FILE_SHARE_WRITE: u32 = 2;
     const OPEN_EXISTING: u32 = 3;
@@ -291,7 +296,7 @@ fn windows_child_file(path: &Path, write: bool) -> io::Result<fs::File> {
                 GENERIC_READ | GENERIC_WRITE
             } else {
                 GENERIC_READ
-            },
+            } | if delete { DELETE } else { 0 },
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             std::ptr::null(),
             OPEN_EXISTING,
@@ -368,7 +373,7 @@ fn windows_delete_file(file: fs::File) -> io::Result<()> {
     use std::os::windows::io::AsRawHandle;
     #[repr(C)]
     struct Disposition {
-        delete: i32,
+        delete: u8,
     }
     #[link(name = "Kernel32")]
     unsafe extern "system" {
@@ -510,10 +515,13 @@ fn validate_windows_restore_path(
     let cursor = path
         .parent()
         .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
-    if cursor != lock.root.join(".cursor")
-        || expected.is_some_and(|identity| windows_directory_identity(cursor) != Ok(identity))
-        || windows_directory_identity(cursor).is_err()
-    {
+    let actual = windows_directory_identity(cursor).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("Cursor .cursor directory cannot be validated during cleanup: {error}"),
+        )
+    })?;
+    if cursor != lock.root.join(".cursor") || expected.is_some_and(|identity| identity != actual) {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
             "Cursor .cursor directory was replaced during cleanup",
@@ -552,7 +560,7 @@ struct Journal {
     entries: Vec<JournalEntry>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct JournalEntry {
     path: PathBuf,
     pre_existing: JournalPreExisting,
@@ -694,6 +702,8 @@ pub(crate) struct CursorMcpLeaseRegistry {
     leases: HashMap<PathBuf, LeaseState>,
     path_by_worker: HashMap<WorkerName, PathBuf>,
     journal_path: Option<PathBuf>,
+    deferred_journal: HashMap<PathBuf, JournalEntry>,
+    journal_owned_paths: HashSet<PathBuf>,
 }
 
 fn invalid_path(message: impl Into<String>) -> io::Error {
@@ -984,6 +994,13 @@ fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
 /// parent and child handle: existing files are updated in place to preserve
 /// their security descriptor, while new files use a secured temporary file.
 pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<()> {
+    write_credential_file_with_identity(path, contents).map(|_| ())
+}
+
+fn write_credential_file_with_identity(
+    path: &Path,
+    contents: &[u8],
+) -> io::Result<Option<(u32, u64)>> {
     let parent = path.parent().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "credential path has no parent")
     })?;
@@ -1000,11 +1017,11 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
         // Replacing it with a temporary file would silently change ACLs and
         // make exact restoration impossible. The child handle and identity
         // check bind this mutation to the file validated above.
-        let mut file = windows_child_file(path, true)?;
+        let mut file = windows_child_file(path, true, false)?;
         file.set_len(0)?;
         file.write_all(contents)?;
         file.sync_all()?;
-        return Ok(());
+        return Ok(Some(windows_handle_identity(&file)?));
     }
     let file_name = path
         .file_name()
@@ -1027,16 +1044,23 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
         file.sync_all()?;
         drop(file);
         validate_credential_parent(parent)?;
-        #[cfg(windows)]
-        if path.exists() {
-            fs::remove_file(path)?;
-        }
+        // The generated path was absent when this lease was acquired. Never
+        // remove a file that appeared while the temporary file was written:
+        // on Windows that pathname race could otherwise delete an unrelated
+        // replacement. A rename failure is fail-closed and leaves the
+        // replacement untouched.
         fs::rename(&temporary, path)?;
         #[cfg(unix)]
         set_mode(path, 0o600)?;
         sync_file(path)?;
         sync_entry_parent(path)?;
-        Ok(())
+        #[cfg(windows)]
+        let identity = Some(windows_handle_identity(&windows_child_file(
+            path, false, false,
+        )?)?);
+        #[cfg(not(windows))]
+        let identity = None;
+        Ok(identity)
     })();
     if result.is_err() {
         let _ = fs::remove_file(&temporary);
@@ -1187,6 +1211,12 @@ impl CursorMcpLeaseRegistry {
         registry
     }
 
+    fn lock_path(&self, root: &Path) -> Option<PathBuf> {
+        let journal_dir = self.journal_path.as_ref()?.parent()?;
+        let digest = Sha256::digest(root.as_os_str().to_string_lossy().as_bytes());
+        Some(journal_dir.join(format!(".cursor-mcp-lease-{:x}.lock", digest)))
+    }
+
     pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
         let (key, canonical) = lease_path(root)?;
         if let Some(existing) = self.path_by_worker.get(worker) {
@@ -1228,12 +1258,13 @@ impl CursorMcpLeaseRegistry {
         // operations. A hostile process can rename `.cursor` after a pathname
         // check, but it cannot redirect the descriptor captured here. Keep
         // that descriptor in LeaseState for the full lease lifetime.
-        let (lock, cursor_dir, created_dir) = match LeaseLock::acquire_with_cursor(&canonical, true)
-        {
-            Ok(value) => value,
-            Err(CursorAcquireError::Lock(error))
-            | Err(CursorAcquireError::Cursor { error, .. }) => return Err(error),
-        };
+        let lock_path = self.lock_path(&canonical);
+        let (lock, cursor_dir, created_dir) =
+            match LeaseLock::acquire_with_cursor(&canonical, true, lock_path.as_deref()) {
+                Ok(value) => value,
+                Err(CursorAcquireError::Lock(error))
+                | Err(CursorAcquireError::Cursor { error, .. }) => return Err(error),
+            };
         #[cfg(unix)]
         let pre_existing = if let Some(cursor) = cursor_dir.as_ref() {
             if let Some((contents, mode)) = read_cursor_target(cursor)? {
@@ -1264,7 +1295,7 @@ impl CursorMcpLeaseRegistry {
                     contents: {
                         #[cfg(windows)]
                         {
-                            let mut file = windows_child_file(&key, false)?;
+                            let mut file = windows_child_file(&key, false, false)?;
                             let mut contents = Vec::new();
                             file.read_to_end(&mut contents)?;
                             contents
@@ -1299,9 +1330,13 @@ impl CursorMcpLeaseRegistry {
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
+        let newly_owned = self.journal_owned_paths.insert(key.clone());
         if let Err(error) = self.persist_journal() {
             self.leases.remove(&key);
             self.path_by_worker.remove(worker);
+            if newly_owned {
+                self.journal_owned_paths.remove(&key);
+            }
             return Err(error);
         }
         Ok(key)
@@ -1366,7 +1401,7 @@ impl CursorMcpLeaseRegistry {
             if validate_target(path)? {
                 #[cfg(windows)]
                 {
-                    let mut file = windows_child_file(path, false)?;
+                    let mut file = windows_child_file(path, false, false)?;
                     let mut contents = Vec::new();
                     file.read_to_end(&mut contents)?;
                     Ok(Some(contents))
@@ -1413,13 +1448,13 @@ impl CursorMcpLeaseRegistry {
             )?;
             #[cfg(windows)]
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
-            write_credential_file(path, contents)?;
+            let generated_identity = write_credential_file_with_identity(path, contents)?;
             #[cfg(windows)]
             *state
                 .generated_identity
                 .lock()
                 .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))? =
-                Some(windows_handle_identity(&windows_child_file(path, false)?)?);
+                generated_identity;
             #[cfg(windows)]
             self.persist_journal()?;
             Ok(())
@@ -1561,21 +1596,31 @@ impl CursorMcpLeaseRegistry {
             match pre_existing {
                 PreExisting::Absent { created_dir } => {
                     #[cfg(windows)]
-                    let generated_identity = generated_identity.ok_or_else(|| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "legacy Cursor MCP journal lacks generated identity",
-                        )
-                    })?;
+                    let generated = match windows_child_file(_path, true, true) {
+                        Ok(file) => Some(file),
+                        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                        Err(error) => return Err(error),
+                    };
                     #[cfg(windows)]
-                    let generated = windows_child_file(_path, true)?;
-                    #[cfg(windows)]
-                    if windows_handle_identity(&generated)? != generated_identity {
-                        return Err(io::Error::new(
-                            io::ErrorKind::WouldBlock,
-                            "generated Cursor MCP file was replaced",
-                        ));
+                    if let Some(generated) = generated.as_ref() {
+                        let expected = generated_identity.ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "legacy Cursor MCP journal lacks generated identity",
+                            )
+                        })?;
+                        if windows_handle_identity(generated)? != expected {
+                            return Err(io::Error::new(
+                                io::ErrorKind::WouldBlock,
+                                "generated Cursor MCP file was replaced",
+                            ));
+                        }
+                    } else if generated_identity.is_some() {
+                        // The exact generated object is already gone; cleanup
+                        // is idempotently complete. Never infer ownership of a
+                        // replacement when the journal has no live handle.
                     }
+                    #[cfg(not(windows))]
                     match fs::symlink_metadata(_path) {
                         Ok(metadata) if metadata.file_type().is_symlink() => {
                             return Err(invalid_path(
@@ -1593,8 +1638,12 @@ impl CursorMcpLeaseRegistry {
                     }
                     #[cfg(windows)]
                     let removed = {
-                        windows_delete_file(generated)?;
-                        true
+                        if let Some(generated) = generated {
+                            windows_delete_file(generated)?;
+                            true
+                        } else {
+                            false
+                        }
                     };
                     #[cfg(not(windows))]
                     let removed = match fs::remove_file(_path) {
@@ -1641,28 +1690,61 @@ impl CursorMcpLeaseRegistry {
         let Some(path) = &self.journal_path else {
             return Ok(());
         };
-        if self.leases.is_empty() {
+        // Different cwd leases can share one state directory. Serialize the
+        // journal read/merge/write transaction with a stable kernel lock so a
+        // broker for one cwd cannot overwrite another broker's entry.
+        let lock_path = path.with_file_name(".cursor-mcp-leases.lock");
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let lock = options.open(lock_path)?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(fs::TryLockError::WouldBlock) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "another broker is updating the Cursor MCP lease journal",
+                ));
+            }
+            Err(fs::TryLockError::Error(error)) => return Err(error),
+        }
+        let mut merged: HashMap<PathBuf, JournalEntry> = match fs::read(path) {
+            Ok(body) => match serde_json::from_slice::<Journal>(&body) {
+                Ok(journal) => journal
+                    .entries
+                    .into_iter()
+                    .map(|entry| (entry.path.clone(), entry))
+                    .collect(),
+                Err(error) => return Err(io::Error::new(io::ErrorKind::InvalidData, error)),
+            },
+            Err(error) if error.kind() == io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => return Err(error),
+        };
+        let active = self.journal_entries()?;
+        let active_paths: HashSet<PathBuf> =
+            active.iter().map(|entry| entry.path.clone()).collect();
+        for owned in &self.journal_owned_paths {
+            if !active_paths.contains(owned) && !self.deferred_journal.contains_key(owned) {
+                merged.remove(owned);
+            }
+        }
+        for entry in &self.deferred_journal {
+            merged.insert(entry.0.clone(), entry.1.clone());
+        }
+        for entry in active {
+            merged.insert(entry.path.clone(), entry);
+        }
+        if merged.is_empty() {
             match fs::remove_file(path) {
                 Ok(()) => sync_entry_parent(path),
                 Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(error) => Err(error),
             }
         } else {
-            let mut merged: HashMap<PathBuf, JournalEntry> = match fs::read(path) {
-                Ok(body) => match serde_json::from_slice::<Journal>(&body) {
-                    Ok(journal) => journal
-                        .entries
-                        .into_iter()
-                        .map(|entry| (entry.path.clone(), entry))
-                        .collect(),
-                    Err(error) => return Err(io::Error::new(io::ErrorKind::InvalidData, error)),
-                },
-                Err(error) if error.kind() == io::ErrorKind::NotFound => HashMap::new(),
-                Err(error) => return Err(error),
-            };
-            for entry in self.journal_entries()? {
-                merged.insert(entry.path.clone(), entry);
-            }
             let body = serde_json::to_vec_pretty(&Journal {
                 entries: merged.into_values().collect(),
             })
@@ -1689,6 +1771,8 @@ impl CursorMcpLeaseRegistry {
         };
         let journal: Journal = serde_json::from_slice(&body)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        self.journal_owned_paths
+            .extend(journal.entries.iter().map(|entry| entry.path.clone()));
         let mut remaining = Vec::new();
         // Keep every successfully acquired cwd lock until the journal
         // transaction is finalized. Dropping a lock immediately after restore
@@ -1764,7 +1848,12 @@ impl CursorMcpLeaseRegistry {
                 });
                 continue;
             }
-            let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(root, false) {
+            let lock_path = self.lock_path(root);
+            let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(
+                root,
+                false,
+                lock_path.as_deref(),
+            ) {
                 Ok(value) => value,
                 Err(CursorAcquireError::Lock(error)) => {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
@@ -1799,13 +1888,29 @@ impl CursorMcpLeaseRegistry {
                 held_locks.push(lock);
                 continue;
             }
+            #[cfg(windows)]
+            let expected_cursor_identity = match windows_directory_identity(
+                path.parent().unwrap_or(root),
+            ) {
+                Ok(identity) => Some(identity),
+                Err(error) => {
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because .cursor identity is unavailable");
+                    remaining.push(JournalEntry {
+                        path,
+                        pre_existing: pre_existing.journal()?,
+                        generated_identity,
+                    });
+                    held_locks.push(lock);
+                    continue;
+                }
+            };
             if let Err(error) = Self::restore(
                 &path,
                 &pre_existing,
                 &lock,
                 cursor_dir.as_ref(),
                 #[cfg(windows)]
-                Some(windows_directory_identity(path.parent().unwrap_or(root))?),
+                expected_cursor_identity,
                 #[cfg(windows)]
                 generated_identity,
             ) {
@@ -1822,17 +1927,11 @@ impl CursorMcpLeaseRegistry {
             }
         }
         before_finalize();
-        if remaining.is_empty() {
-            match fs::remove_file(&path) {
-                Ok(()) => sync_entry_parent(&path)?,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error),
-            }
-        } else {
-            let body = serde_json::to_vec_pretty(&Journal { entries: remaining })
-                .map_err(|error| io::Error::other(error.to_string()))?;
-            write_credential_file(&path, &body)?;
-        }
+        self.deferred_journal = remaining
+            .into_iter()
+            .map(|entry| (entry.path.clone(), entry))
+            .collect();
+        self.persist_journal()?;
         Ok(())
     }
 
@@ -1869,7 +1968,7 @@ mod tests {
     #[test]
     fn raced_cursor_directory_creator_is_not_marked_for_cleanup() {
         let dir = tempdir().unwrap();
-        let lock = LeaseLock::acquire(dir.path()).unwrap();
+        let lock = LeaseLock::acquire(dir.path(), None).unwrap();
         let (cursor, created) = lock
             .open_cursor_dir_with(true, |root_fd, name, mode| {
                 // Deterministically model another creator winning between our
@@ -2138,6 +2237,7 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         let mut second = CursorMcpLeaseRegistry::new();
         recovery
@@ -2175,6 +2275,7 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         let mut racing = CursorMcpLeaseRegistry::new();
         recovery
@@ -2218,6 +2319,7 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         let cursor_path = root.join(".cursor");
         fs::remove_dir_all(&cursor_path).unwrap();
@@ -2225,7 +2327,7 @@ mod tests {
 
         recovery
             .recover_journal_with_hook(|| {
-                match LeaseLock::acquire(&root) {
+                match LeaseLock::acquire(&root, None) {
                     Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
                     Ok(_) => panic!("root lock should stay held until journal finalization"),
                 }
@@ -2263,9 +2365,10 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         recovery
-            .recover_journal_with_hook(|| match LeaseLock::acquire(&root) {
+            .recover_journal_with_hook(|| match LeaseLock::acquire(&root, None) {
                 Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
                 Ok(_) => panic!("root lock should stay held until journal finalization"),
             })
@@ -2274,6 +2377,39 @@ mod tests {
             journal.exists(),
             "invalid cursor entry must remain journaled"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_journal_entry_survives_unrelated_acquire_and_release() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let deferred_root = dir.path().join("deferred");
+        fs::create_dir_all(&deferred_root).unwrap();
+        fs::write(deferred_root.join(".cursor"), b"not a directory").unwrap();
+        let deferred_path = deferred_root.join(".cursor/mcp.json");
+        fs::write(
+            &journal,
+            serde_json::to_vec(&Journal {
+                entries: vec![JournalEntry {
+                    path: deferred_path.clone(),
+                    pre_existing: JournalPreExisting::Absent { created_dir: false },
+                }],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        let unrelated_root = dir.path().join("unrelated");
+        fs::create_dir(&unrelated_root).unwrap();
+        let worker = WorkerName::new("unrelated");
+        registry.acquire(&unrelated_root, &worker).unwrap();
+        registry.release_worker(&worker).unwrap();
+
+        let journal: Journal = serde_json::from_slice(&fs::read(&journal).unwrap()).unwrap();
+        assert_eq!(journal.entries.len(), 1);
+        assert_eq!(journal.entries[0].path, deferred_path);
     }
 
     #[cfg(unix)]
@@ -2299,9 +2435,10 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         recovery
-            .recover_journal_with_hook(|| match LeaseLock::acquire(&root) {
+            .recover_journal_with_hook(|| match LeaseLock::acquire(&root, None) {
                 Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
                 Ok(_) => panic!("root lock should stay held until journal finalization"),
             })
@@ -2352,6 +2489,7 @@ mod tests {
             leases: HashMap::new(),
             path_by_worker: HashMap::new(),
             journal_path: Some(journal.clone()),
+            ..Default::default()
         };
         recovery.recover_journal().unwrap();
         assert_eq!(read(&first), b"first-original");
@@ -2363,8 +2501,8 @@ mod tests {
     #[test]
     fn windows_lease_lock_is_reusable_after_owner_exit() {
         let dir = tempdir().unwrap();
-        let first = LeaseLock::acquire(dir.path()).unwrap();
-        let error = match LeaseLock::acquire(dir.path()) {
+        let first = LeaseLock::acquire(dir.path(), None).unwrap();
+        let error = match LeaseLock::acquire(dir.path(), None) {
             Ok(_) => panic!("second broker must not acquire a held cwd lease"),
             Err(error) => error,
         };
@@ -2374,6 +2512,6 @@ mod tests {
         // The stable lock file remains on disk, but the kernel lock is released
         // with the owning handle. A later broker can recover after a clean exit
         // and the same mechanism also releases on process termination.
-        let _second = LeaseLock::acquire(dir.path()).unwrap();
+        let _second = LeaseLock::acquire(dir.path(), None).unwrap();
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -230,6 +230,57 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
 }
 
 #[cfg(windows)]
+fn windows_child_file(path: &Path, create_new: bool, truncate: bool) -> io::Result<fs::File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const std::ffi::c_void,
+            disposition: u32,
+            flags: u32,
+            template: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+    }
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const FILE_SHARE_READ: u32 = 1;
+    const FILE_SHARE_WRITE: u32 = 2;
+    const CREATE_NEW: u32 = 1;
+    const OPEN_EXISTING: u32 = 3;
+    const TRUNCATE_EXISTING: u32 = 5;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let disposition = if create_new {
+        CREATE_NEW
+    } else if truncate {
+        TRUNCATE_EXISTING
+    } else {
+        OPEN_EXISTING
+    };
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            disposition,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == (-1isize) as *mut std::ffi::c_void {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) })
+}
+
+#[cfg(windows)]
 fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
     use std::os::windows::fs::MetadataExt;
     let metadata = fs::symlink_metadata(path)?;
@@ -798,9 +849,10 @@ fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
     }
 }
 
-/// Atomically write a generated credential-bearing config with owner-only
-/// permissions. The temporary file is created as 0600, so no 0644 window is
-/// observable between creation and the final rename.
+/// Write a generated credential-bearing config safely for the platform. Unix
+/// uses an owner-only temporary file and atomic rename. Windows uses a pinned
+/// parent and child handle: existing files are updated in place to preserve
+/// their security descriptor, while new files use a secured temporary file.
 pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<()> {
     let parent = path.parent().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "credential path has no parent")
@@ -818,10 +870,7 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
         // Replacing it with a temporary file would silently change ACLs and
         // make exact restoration impossible. The pinned parent handle prevents
         // replacement while this in-place mutation is active.
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(path)?;
+        let mut file = windows_child_file(path, false, true)?;
         file.write_all(contents)?;
         file.sync_all()?;
         return Ok(());
@@ -868,9 +917,7 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
 fn secure_windows_file(path: &Path) -> io::Result<()> {
     use std::process::Command;
 
-    let system_root = std::env::var_os("SystemRoot")
-        .ok_or_else(|| io::Error::new(io::ErrorKind::PermissionDenied, "SystemRoot is not set"))?;
-    let system32 = PathBuf::from(system_root).join("System32");
+    let system32 = windows_system_directory()?;
     let whoami_path = system32.join("whoami.exe");
     let icacls_path = system32.join("icacls.exe");
 
@@ -915,6 +962,33 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
         ));
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn windows_system_directory() -> io::Result<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn GetSystemDirectoryW(buffer: *mut u16, length: u32) -> u32;
+    }
+    let mut buffer = vec![0u16; 260];
+    loop {
+        let length = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
+        if length == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if (length as usize) < buffer.len() {
+            let path = PathBuf::from(std::ffi::OsString::from_wide(&buffer[..length as usize]));
+            if !path.is_absolute() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "Windows system directory is not absolute",
+                ));
+            }
+            return Ok(path);
+        }
+        buffer.resize(buffer.len().saturating_mul(2), 0);
+    }
 }
 
 #[cfg(not(unix))]
@@ -1143,6 +1217,14 @@ impl CursorMcpLeaseRegistry {
             #[cfg(windows)]
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             if validate_target(path)? {
+                #[cfg(windows)]
+                {
+                    let mut file = windows_child_file(path, false, false)?;
+                    let mut contents = Vec::new();
+                    file.read_to_end(&mut contents)?;
+                    Ok(Some(contents))
+                }
+                #[cfg(not(windows))]
                 Ok(Some(fs::read(path)?))
             } else {
                 Ok(None)

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1090,7 +1090,7 @@ fn write_credential_file_with_identity(
 
 #[cfg(windows)]
 fn secure_windows_file(path: &Path) -> io::Result<()> {
-    use std::mem::{self, ManuallyDrop};
+    use std::mem::ManuallyDrop;
     use std::os::windows::ffi::OsStrExt;
     use std::process::Command;
 
@@ -1101,7 +1101,9 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
         MultipleTrusteeOperation: u32,
         TrusteeForm: u32,
         TrusteeType: u32,
-        ptstrName: *mut u16,
+        // For TRUSTEE_IS_SID, this holds a *mut u8 pointing to a binary SID,
+        // despite the Win32 header declaring it as LPWSTR.
+        ptstrName: *mut u8,
     }
 
     #[repr(C)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1699,9 +1699,28 @@ impl CursorMcpLeaseRegistry {
             let _parent_guard = windows_directory_guard(
                 path.parent()
                     .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?,
-            )?;
+            )
+            .map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "guard .cursor directory in write_worker_cursor_file {}: {e}",
+                        path.display()
+                    ),
+                )
+            })?;
             #[cfg(windows)]
-            validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
+            validate_windows_cursor_identity(&state.lock, path, state.cursor_identity).map_err(
+                |e| {
+                    io::Error::new(
+                        e.kind(),
+                        format!(
+                            "validate cursor identity in write_worker_cursor_file {}: {e}",
+                            path.display()
+                        ),
+                    )
+                },
+            )?;
             let generated_identity = write_credential_file_with_identity(path, contents)?;
             #[cfg(windows)]
             {

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::ids::WorkerName;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum PreExisting {
     Absent { created_dir: bool },
     Present { contents: Vec<u8>, mode: u32 },
@@ -535,12 +535,15 @@ fn validate_windows_restore_path(
     let cursor = path
         .parent()
         .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
-    let actual = windows_directory_identity(cursor).map_err(|error| {
-        io::Error::new(
-            error.kind(),
-            format!("Cursor .cursor directory cannot be validated during cleanup: {error}"),
-        )
-    })?;
+    let actual = match windows_directory_identity(cursor) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return Err(io::Error::new(
+                error.kind(),
+                format!("Cursor .cursor directory cannot be validated during cleanup: {error}"),
+            ));
+        }
+    };
     if cursor != lock.root.join(".cursor") || expected.is_some_and(|identity| identity != actual) {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
@@ -575,12 +578,12 @@ fn openat_dir(parent: std::os::unix::io::RawFd, name: &std::ffi::CStr) -> io::Re
     Ok(unsafe { fs::File::from_raw_fd(fd) })
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct Journal {
     entries: Vec<JournalEntry>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct JournalEntry {
     path: PathBuf,
     pre_existing: JournalPreExisting,
@@ -589,7 +592,7 @@ struct JournalEntry {
     generated_identity: Option<(u32, u64)>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum JournalPreExisting {
     Absent { created_dir: bool },
@@ -1460,6 +1463,17 @@ impl CursorMcpLeaseRegistry {
         registry
     }
 
+    fn current_journal_entry(journal_path: &Path, path: &Path) -> io::Result<Option<JournalEntry>> {
+        let body = match fs::read(journal_path) {
+            Ok(body) => body,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let journal: Journal = serde_json::from_slice(&body)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        Ok(journal.entries.into_iter().find(|entry| entry.path == path))
+    }
+
     fn lock_path(&self, root: &Path) -> io::Result<PathBuf> {
         // Keep the lease lock independent from the broker state directory so
         // brokers with different journals still coordinate on the same cwd.
@@ -2113,20 +2127,29 @@ impl CursorMcpLeaseRegistry {
         self.recover_journal_with_hook(|| {})
     }
 
-    fn recover_journal_with_hook<F>(&mut self, mut before_finalize: F) -> io::Result<()>
+    fn recover_journal_with_hook<F>(&mut self, before_finalize: F) -> io::Result<()>
     where
         F: FnMut(),
     {
-        let Some(path) = self.journal_path.clone() else {
+        self.recover_journal_impl(|| {}, before_finalize)
+    }
+
+    fn recover_journal_impl<F, G>(&mut self, mut after_snapshot: F, mut before_finalize: G) -> io::Result<()>
+    where
+        F: FnMut(),
+        G: FnMut(),
+    {
+        let Some(journal_path) = self.journal_path.clone() else {
             return Ok(());
         };
-        let body = match fs::read(&path) {
+        let body = match fs::read(&journal_path) {
             Ok(body) => body,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(error) => return Err(error),
         };
         let journal: Journal = serde_json::from_slice(&body)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        after_snapshot();
         self.journal_owned_paths
             .extend(journal.entries.iter().map(|entry| entry.path.clone()));
         let mut remaining = Vec::new();
@@ -2241,6 +2264,37 @@ impl CursorMcpLeaseRegistry {
                     #[cfg(windows)]
                     generated_identity,
                 });
+                held_locks.push(lock);
+                continue;
+            }
+            let current_entry = match Self::current_journal_entry(&journal_path, &path) {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because the journal could not be revalidated");
+                    remaining.push(JournalEntry {
+                        path,
+                        pre_existing: pre_existing.journal()?,
+                        #[cfg(windows)]
+                        generated_identity,
+                    });
+                    held_locks.push(lock);
+                    continue;
+                }
+            };
+            let Some(current_entry) = current_entry else {
+                tracing::warn!(path = %path.display(), "Cursor MCP lease recovery deferred because the journal entry disappeared");
+                remaining.push(JournalEntry {
+                    path,
+                    pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
+                });
+                held_locks.push(lock);
+                continue;
+            };
+            if current_entry != entry {
+                tracing::warn!(path = %path.display(), "Cursor MCP lease recovery deferred because the journal entry changed");
+                remaining.push(current_entry);
                 held_locks.push(lock);
                 continue;
             }
@@ -2989,6 +3043,77 @@ mod tests {
         assert_eq!(read(&first), b"first-original");
         assert_eq!(read(&second), b"second-original");
         assert!(journal.exists(), "bad entry must remain journaled");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_revalidates_snapshot_before_restore() {
+        use base64::Engine;
+
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let path = root.join(".cursor/mcp.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"original").unwrap();
+        let initial_entry = JournalEntry {
+            path: path.clone(),
+            pre_existing: JournalPreExisting::Present {
+                contents_base64: base64::engine::general_purpose::STANDARD.encode(b"original"),
+                mode: 0o600,
+            },
+        };
+        fs::write(
+            &journal,
+            serde_json::to_vec(&Journal {
+                entries: vec![initial_entry],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+            ..Default::default()
+        };
+        recovery
+            .recover_journal_impl(
+                || {
+                    let updated_entry = JournalEntry {
+                        path: path.clone(),
+                        pre_existing: JournalPreExisting::Present {
+                            contents_base64: base64::engine::general_purpose::STANDARD
+                                .encode(b"replacement"),
+                            mode: 0o600,
+                        },
+                    };
+                    fs::write(&path, b"replacement").unwrap();
+                    fs::write(
+                        &journal,
+                        serde_json::to_vec(&Journal {
+                            entries: vec![updated_entry],
+                        })
+                        .unwrap(),
+                    )
+                    .unwrap();
+                },
+                || {},
+            )
+            .unwrap();
+
+        assert_eq!(read(&path), b"replacement");
+        let journal: Journal = serde_json::from_slice(&fs::read(&journal).unwrap()).unwrap();
+        assert_eq!(journal.entries.len(), 1);
+        assert_eq!(
+            journal.entries[0].pre_existing,
+            JournalPreExisting::Present {
+                contents_base64: base64::engine::general_purpose::STANDARD
+                    .encode(b"replacement"),
+                mode: 0o600,
+            }
+        );
     }
 
     #[cfg(not(unix))]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1163,9 +1163,10 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
     let mut psid: *mut u8 = std::ptr::null_mut();
     let ok = unsafe { ConvertStringSidToSidW(wide_sid.as_ptr(), &mut psid) };
     if ok == 0 || psid.is_null() {
+        let err = io::Error::last_os_error();
         tracing::error!(
             sid = %sid,
-            last_os_error = io::Error::last_os_error(),
+            error = %err,
             "ConvertStringSidToSidW failed for Cursor config ACL"
         );
         return Err(io::Error::new(
@@ -1269,11 +1270,12 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
     };
 
     if status != 0 {
+        let err = io::Error::last_os_error();
         tracing::error!(
             path = %path.display(),
             sid = %sid,
             status = status,
-            last_os_error = io::Error::last_os_error(),
+            error = %err,
             "SetNamedSecurityInfoW failed to secure generated Cursor config"
         );
         return Err(io::Error::new(

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -30,6 +30,8 @@ struct LeaseState {
     cursor_dir: Option<fs::File>,
     #[cfg(windows)]
     cursor_identity: (u32, u64),
+    #[cfg(windows)]
+    generated_identity: std::sync::Mutex<Option<(u32, u64)>>,
 }
 
 /// A kernel-held lock on the requested cwd. Locking the existing cwd rather
@@ -362,6 +364,37 @@ fn windows_handle_identity(file: &fs::File) -> io::Result<(u32, u64)> {
 }
 
 #[cfg(windows)]
+fn windows_delete_file(file: fs::File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    #[repr(C)]
+    struct Disposition {
+        delete: i32,
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn SetFileInformationByHandle(
+            file: *mut std::ffi::c_void,
+            class: u32,
+            info: *const Disposition,
+            size: u32,
+        ) -> i32;
+    }
+    let disposition = Disposition { delete: 1 };
+    if unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            4,
+            &disposition,
+            std::mem::size_of::<Disposition>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
 fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
     use std::os::windows::fs::MetadataExt;
     let metadata = fs::symlink_metadata(path)?;
@@ -523,6 +556,9 @@ struct Journal {
 struct JournalEntry {
     path: PathBuf,
     pre_existing: JournalPreExisting,
+    #[cfg(windows)]
+    #[serde(default)]
+    generated_identity: Option<(u32, u64)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1219,9 +1255,21 @@ impl CursorMcpLeaseRegistry {
                     Err(error) => return Err(error),
                 },
             };
+            #[cfg(windows)]
+            let _cursor_identity = windows_directory_identity(&cursor)?;
             let pre_existing = if validate_target(&key)? {
                 PreExisting::Present {
-                    contents: fs::read(&key)?,
+                    contents: {
+                        #[cfg(windows)]
+                        {
+                            let mut file = windows_child_file(&key, false)?;
+                            let mut contents = Vec::new();
+                            file.read_to_end(&mut contents)?;
+                            contents
+                        }
+                        #[cfg(not(windows))]
+                        fs::read(&key)?
+                    },
                     mode: 0o600,
                 }
             } else {
@@ -1244,6 +1292,8 @@ impl CursorMcpLeaseRegistry {
                 cursor_dir,
                 #[cfg(windows)]
                 cursor_identity,
+                #[cfg(windows)]
+                generated_identity: std::sync::Mutex::new(None),
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
@@ -1361,7 +1411,16 @@ impl CursorMcpLeaseRegistry {
             )?;
             #[cfg(windows)]
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
-            write_credential_file(path, contents)
+            write_credential_file(path, contents)?;
+            #[cfg(windows)]
+            *state
+                .generated_identity
+                .lock()
+                .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))? =
+                Some(windows_handle_identity(&windows_child_file(path, false)?)?);
+            #[cfg(windows)]
+            self.persist_journal()?;
+            Ok(())
         }
     }
 
@@ -1425,6 +1484,11 @@ impl CursorMcpLeaseRegistry {
             state.cursor_dir.as_ref(),
             #[cfg(windows)]
             Some(state.cursor_identity),
+            #[cfg(windows)]
+            *state
+                .generated_identity
+                .lock()
+                .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))?,
         )?;
         let state = self.leases.remove(path).expect("lease checked above");
         self.path_by_worker.remove(worker);
@@ -1446,6 +1510,7 @@ impl CursorMcpLeaseRegistry {
         lock: &LeaseLock,
         pinned_cursor: Option<&fs::File>,
         #[cfg(windows)] expected_cursor_identity: Option<(u32, u64)>,
+        #[cfg(windows)] generated_identity: Option<(u32, u64)>,
     ) -> io::Result<()> {
         #[cfg(unix)]
         {
@@ -1493,6 +1558,22 @@ impl CursorMcpLeaseRegistry {
             validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             match pre_existing {
                 PreExisting::Absent { created_dir } => {
+                    #[cfg(windows)]
+                    let generated_identity = generated_identity.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "legacy Cursor MCP journal lacks generated identity",
+                        )
+                    })?;
+                    #[cfg(windows)]
+                    let generated = windows_child_file(_path, true)?;
+                    #[cfg(windows)]
+                    if windows_handle_identity(&generated)? != generated_identity {
+                        return Err(io::Error::new(
+                            io::ErrorKind::WouldBlock,
+                            "generated Cursor MCP file was replaced",
+                        ));
+                    }
                     match fs::symlink_metadata(_path) {
                         Ok(metadata) if metadata.file_type().is_symlink() => {
                             return Err(invalid_path(
@@ -1508,6 +1589,12 @@ impl CursorMcpLeaseRegistry {
                         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                         Err(error) => return Err(error),
                     }
+                    #[cfg(windows)]
+                    let removed = {
+                        windows_delete_file(generated)?;
+                        true
+                    };
+                    #[cfg(not(windows))]
                     let removed = match fs::remove_file(_path) {
                         Ok(()) => true,
                         Err(error) if error.kind() == io::ErrorKind::NotFound => false,
@@ -1539,6 +1626,10 @@ impl CursorMcpLeaseRegistry {
                 Ok(JournalEntry {
                     path: path.clone(),
                     pre_existing: state.pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity: *state.generated_identity.lock().map_err(|_| {
+                        io::Error::other("Cursor MCP generated identity lock poisoned")
+                    })?,
                 })
             })
             .collect()
@@ -1695,6 +1786,8 @@ impl CursorMcpLeaseRegistry {
                 cursor_dir.as_ref(),
                 #[cfg(windows)]
                 Some(windows_directory_identity(path.parent().unwrap_or(root))?),
+                #[cfg(windows)]
+                entry.generated_identity,
             ) {
                 tracing::warn!(path = %path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1124,17 +1124,37 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
                 "whoami did not return a Windows user SID",
             )
         })?;
-    let status = Command::new(icacls_path)
+    // Grant the current user and SYSTEM full control.  Then attempt to
+    // strip inherited ACEs: on locked-down environments (e.g. GitHub
+    // Actions runners) the inheritance removal may fail while the grant
+    // itself succeeded.  The grant is the critical security property —
+    // without it anyone on the box could read the credential file — so
+    // we treat a grant-only outcome as acceptable and log the inheritance
+    // failure rather than failing the entire write.
+    let granted = Command::new(&icacls_path)
         .arg(path)
-        .args(["/inheritance:r", "/grant:r"])
+        .args(["/grant:r"])
         .arg(format!("{sid}:F"))
         .arg("SYSTEM:F")
         .output()?;
-    if !status.status.success() {
+    if !granted.status.success() {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "unable to apply owner-only Windows ACL to generated Cursor config",
         ));
+    }
+    let inheritance = Command::new(&icacls_path)
+        .arg(path)
+        .args(["/inheritance:r"])
+        .output();
+    if let Ok(result) = inheritance {
+        if !result.status.success() {
+            tracing::warn!(
+                path = %path.display(),
+                stderr = %String::from_utf8_lossy(&result.stderr),
+                "icacls inheritance removal failed; owner-only ACL still enforced via explicit grant"
+            );
+        }
     }
     Ok(())
 }
@@ -2620,6 +2640,7 @@ mod tests {
                     .read(true)
                     .write(true)
                     .create(true)
+                    .truncate(false)
                     .open(&lock_path)
                     .unwrap();
                 lock.try_lock().unwrap();
@@ -2824,6 +2845,7 @@ mod tests {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&lock_path)
             .unwrap();
         held_lock.try_lock().unwrap();

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -28,6 +28,8 @@ struct LeaseState {
     /// replaced while a worker is running, but all generated-file I/O and
     /// cleanup must continue to address the original directory.
     cursor_dir: Option<fs::File>,
+    #[cfg(windows)]
+    cursor_identity: (u32, u64),
 }
 
 /// A kernel-held lock on the requested cwd. Locking the existing cwd rather
@@ -38,7 +40,11 @@ struct LeaseLock {
     #[cfg(unix)]
     _file: fs::File,
     #[cfg(not(unix))]
-    lock_path: PathBuf,
+    _file: fs::File,
+    #[cfg(windows)]
+    root: PathBuf,
+    #[cfg(windows)]
+    root_identity: (u32, u64),
 }
 
 enum CursorAcquireError {
@@ -104,22 +110,25 @@ impl LeaseLock {
         #[cfg(not(unix))]
         {
             let lock_path = root.join(".cursor-mcp-lease.lock");
-            let result = fs::OpenOptions::new()
+            let file = fs::OpenOptions::new()
+                .read(true)
                 .write(true)
-                .create_new(true)
-                .open(&lock_path);
-            match result {
-                Ok(mut file) => {
-                    use std::io::Write as _;
-                    let _ = writeln!(file, "{}", std::process::id());
-                    Ok(Self { lock_path })
-                }
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Err(io::Error::new(
+                .create(true)
+                .open(&lock_path)?;
+            file.try_lock().map_err(|error| match error {
+                fs::TryLockError::WouldBlock => io::Error::new(
                     io::ErrorKind::WouldBlock,
                     "another broker owns the Cursor MCP cwd lease",
-                )),
-                Err(error) => Err(error),
-            }
+                ),
+                fs::TryLockError::Error(error) => error,
+            })?;
+            Ok(Self {
+                _file: file,
+                #[cfg(windows)]
+                root: root.to_path_buf(),
+                #[cfg(windows)]
+                root_identity: windows_directory_identity(root)?,
+            })
         }
     }
 
@@ -150,13 +159,65 @@ impl LeaseLock {
     }
 }
 
-impl Drop for LeaseLock {
-    fn drop(&mut self) {
-        #[cfg(not(unix))]
-        {
-            let _ = fs::remove_file(&self.lock_path);
-        }
+#[cfg(windows)]
+fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
+    use std::os::windows::fs::MetadataExt;
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() || metadata.reparse_tag() != 0 {
+        return Err(invalid_path(format!(
+            "Cursor worker cwd is not a non-reparse directory: {}",
+            path.display()
+        )));
     }
+    Ok((metadata.volume_serial_number(), metadata.file_index()))
+}
+
+#[cfg(windows)]
+impl LeaseLock {
+    fn validate_root(&self) -> io::Result<()> {
+        let canonical = canonical_root(&self.root)?;
+        if canonical != self.root || windows_directory_identity(&canonical)? != self.root_identity {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Cursor worker cwd was replaced during lease",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn validate_windows_cursor_identity(
+    lock: &LeaseLock,
+    path: &Path,
+    expected: (u32, u64),
+) -> io::Result<()> {
+    lock.validate_root()?;
+    let cursor = path
+        .parent()
+        .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
+    if cursor != lock.root.join(".cursor") || windows_directory_identity(cursor)? != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Cursor .cursor directory was replaced during lease",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn validate_windows_restore_path(lock: &LeaseLock, path: &Path) -> io::Result<()> {
+    lock.validate_root()?;
+    let cursor = path
+        .parent()
+        .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
+    if cursor != lock.root.join(".cursor") || windows_directory_identity(cursor).is_err() {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Cursor .cursor directory was replaced during cleanup",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -202,10 +263,116 @@ enum JournalPreExisting {
     Present { contents_base64: String, mode: u32 },
 }
 
+#[cfg(windows)]
+#[repr(C)]
+struct WindowsDataBlob {
+    cb_data: u32,
+    pb_data: *mut u8,
+}
+
+#[cfg(windows)]
+#[link(name = "Crypt32")]
+unsafe extern "system" {
+    fn CryptProtectData(
+        data_in: *const WindowsDataBlob,
+        description: *const u16,
+        entropy: *const WindowsDataBlob,
+        reserved: *mut std::ffi::c_void,
+        prompt: *mut std::ffi::c_void,
+        flags: u32,
+        data_out: *mut WindowsDataBlob,
+    ) -> i32;
+    fn CryptUnprotectData(
+        data_in: *const WindowsDataBlob,
+        description: *mut *mut u16,
+        entropy: *const WindowsDataBlob,
+        reserved: *mut std::ffi::c_void,
+        prompt: *mut std::ffi::c_void,
+        flags: u32,
+        data_out: *mut WindowsDataBlob,
+    ) -> i32;
+}
+
+#[cfg(windows)]
+#[link(name = "Kernel32")]
+unsafe extern "system" {
+    fn LocalFree(memory: *mut std::ffi::c_void) -> *mut std::ffi::c_void;
+}
+
+#[cfg(windows)]
+fn protect_journal_bytes(bytes: &[u8]) -> io::Result<Vec<u8>> {
+    let input = WindowsDataBlob {
+        cb_data: bytes.len().try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cursor MCP journal entry is too large",
+            )
+        })?,
+        pb_data: bytes.as_ptr() as *mut u8,
+    };
+    let mut output = WindowsDataBlob {
+        cb_data: 0,
+        pb_data: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptProtectData(
+            &input,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            &mut output,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pb_data, output.cb_data as usize) }.to_vec();
+    unsafe { LocalFree(output.pb_data as *mut std::ffi::c_void) };
+    Ok(result)
+}
+
+#[cfg(windows)]
+fn unprotect_journal_bytes(bytes: &[u8]) -> io::Result<Vec<u8>> {
+    let input = WindowsDataBlob {
+        cb_data: bytes.len().try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cursor MCP journal entry is too large",
+            )
+        })?,
+        pb_data: bytes.as_ptr() as *mut u8,
+    };
+    let mut output = WindowsDataBlob {
+        cb_data: 0,
+        pb_data: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptUnprotectData(
+            &input,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            &mut output,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pb_data, output.cb_data as usize) }.to_vec();
+    unsafe { LocalFree(output.pb_data as *mut std::ffi::c_void) };
+    Ok(result)
+}
+
 /// Tracks leases and a recovery journal. The journal contains pre-existing
 /// bytes and mode, which may themselves be sensitive user data; it is written
-/// 0600 and never contains generated Relay credentials because generated Cursor
-/// values are `${env:...}` placeholders.
+/// 0600 on Unix and protected with the current user's DPAPI on Windows. The
+/// generated Relay values are always `${env:...}` placeholders, never secrets.
 #[derive(Default)]
 pub(crate) struct CursorMcpLeaseRegistry {
     leases: HashMap<PathBuf, LeaseState>,
@@ -523,6 +690,8 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
             options.mode(0o600);
         }
         let mut file = options.open(&temporary)?;
+        #[cfg(windows)]
+        secure_windows_file(&temporary)?;
         file.write_all(contents)?;
         file.sync_all()?;
         drop(file);
@@ -544,6 +713,53 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     result
 }
 
+#[cfg(windows)]
+fn secure_windows_file(path: &Path) -> io::Result<()> {
+    use std::process::Command;
+
+    // `icacls` is part of supported Windows installations. Resolve the SID
+    // rather than trusting a username, then remove inherited permissions and
+    // grant access only to the current user and SYSTEM. Fail closed if either
+    // utility is unavailable; an unprotected generated config must not be
+    // published because it may contain restored user configuration.
+    let whoami = Command::new("whoami")
+        .args(["/user", "/fo", "csv", "/nh"])
+        .output()?;
+    if !whoami.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "unable to resolve current Windows user SID",
+        ));
+    }
+    let line = String::from_utf8_lossy(&whoami.stdout);
+    let sid = line
+        .trim()
+        .split(',')
+        .next_back()
+        .map(str::trim)
+        .map(|sid| sid.trim_matches('"'))
+        .filter(|sid| sid.starts_with("S-"))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "whoami did not return a Windows user SID",
+            )
+        })?;
+    let status = Command::new("icacls")
+        .arg(path)
+        .args(["/inheritance:r", "/grant:r"])
+        .arg(format!("{sid}:F"))
+        .arg("SYSTEM:F")
+        .output()?;
+    if !status.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "unable to apply owner-only Windows ACL to generated Cursor config",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(not(unix))]
 fn restore_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
     let _ = validate_target(path)?;
@@ -555,16 +771,22 @@ fn restore_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
 }
 
 impl PreExisting {
-    fn journal(&self) -> JournalPreExisting {
-        match self {
+    fn journal(&self) -> io::Result<JournalPreExisting> {
+        Ok(match self {
             Self::Absent { created_dir } => JournalPreExisting::Absent {
                 created_dir: *created_dir,
             },
-            Self::Present { contents, mode } => JournalPreExisting::Present {
-                contents_base64: base64::engine::general_purpose::STANDARD.encode(contents),
-                mode: *mode,
-            },
-        }
+            Self::Present { contents, mode } => {
+                #[cfg(windows)]
+                let contents = protect_journal_bytes(contents)?;
+                #[cfg(not(windows))]
+                let contents = contents.clone();
+                JournalPreExisting::Present {
+                    contents_base64: base64::engine::general_purpose::STANDARD.encode(contents),
+                    mode: *mode,
+                }
+            }
+        })
     }
 
     fn from_journal(value: JournalPreExisting) -> io::Result<Self> {
@@ -573,12 +795,14 @@ impl PreExisting {
             JournalPreExisting::Present {
                 contents_base64,
                 mode,
-            } => Ok(Self::Present {
-                contents: base64::engine::general_purpose::STANDARD
+            } => {
+                let contents = base64::engine::general_purpose::STANDARD
                     .decode(contents_base64.as_bytes())
-                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
-                mode,
-            }),
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                #[cfg(windows)]
+                let contents = unprotect_journal_bytes(&contents)?;
+                Ok(Self::Present { contents, mode })
+            }
         }
     }
 }
@@ -680,6 +904,9 @@ impl CursorMcpLeaseRegistry {
             (created_dir, pre_existing)
         };
 
+        #[cfg(windows)]
+        let cursor_identity = windows_directory_identity(&canonical.join(".cursor"))?;
+
         let mut holders = HashSet::new();
         holders.insert(worker.clone());
         self.leases.insert(
@@ -689,6 +916,8 @@ impl CursorMcpLeaseRegistry {
                 holders,
                 lock,
                 cursor_dir,
+                #[cfg(windows)]
+                cursor_identity,
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
@@ -743,13 +972,14 @@ impl CursorMcpLeaseRegistry {
         }
         #[cfg(not(unix))]
         {
-            let _ = state;
             let path = self.path_by_worker.get(worker).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("no Cursor MCP lease for worker '{worker}'"),
                 )
             })?;
+            #[cfg(windows)]
+            validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             if validate_target(path)? {
                 Ok(Some(fs::read(path)?))
             } else {
@@ -779,13 +1009,14 @@ impl CursorMcpLeaseRegistry {
         }
         #[cfg(not(unix))]
         {
-            let _ = state;
             let path = self.path_by_worker.get(worker).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("no Cursor MCP lease for worker '{worker}'"),
                 )
             })?;
+            #[cfg(windows)]
+            validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             write_credential_file(path, contents)
         }
     }
@@ -899,53 +1130,58 @@ impl CursorMcpLeaseRegistry {
             Ok(())
         }
         #[cfg(not(unix))]
-        match pre_existing {
-            PreExisting::Absent { created_dir } => {
-                match fs::symlink_metadata(_path) {
-                    Ok(metadata) if metadata.file_type().is_symlink() => {
-                        return Err(invalid_path(
-                            "refusing to remove a symlink at generated Cursor MCP path",
-                        ));
+        {
+            #[cfg(windows)]
+            validate_windows_restore_path(lock, _path)?;
+            match pre_existing {
+                PreExisting::Absent { created_dir } => {
+                    match fs::symlink_metadata(_path) {
+                        Ok(metadata) if metadata.file_type().is_symlink() => {
+                            return Err(invalid_path(
+                                "refusing to remove a symlink at generated Cursor MCP path",
+                            ));
+                        }
+                        Ok(metadata) if !metadata.is_file() => {
+                            return Err(invalid_path(
+                                "refusing to remove a non-regular generated Cursor MCP path",
+                            ));
+                        }
+                        Ok(_) => {}
+                        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                        Err(error) => return Err(error),
                     }
-                    Ok(metadata) if !metadata.is_file() => {
-                        return Err(invalid_path(
-                            "refusing to remove a non-regular generated Cursor MCP path",
-                        ));
+                    let removed = match fs::remove_file(_path) {
+                        Ok(()) => true,
+                        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+                        Err(error) => return Err(error),
+                    };
+                    if removed {
+                        sync_entry_parent(_path)?;
                     }
-                    Ok(_) => {}
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                    Err(error) => return Err(error),
-                }
-                let removed = match fs::remove_file(_path) {
-                    Ok(()) => true,
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => false,
-                    Err(error) => return Err(error),
-                };
-                if removed {
-                    sync_entry_parent(_path)?;
-                }
-                if *created_dir {
-                    if let Some(dir) = _path.parent() {
-                        if fs::remove_dir(dir).is_ok() {
-                            sync_entry_parent(dir)?;
+                    if *created_dir {
+                        if let Some(dir) = _path.parent() {
+                            if fs::remove_dir(dir).is_ok() {
+                                sync_entry_parent(dir)?;
+                            }
                         }
                     }
                 }
+                PreExisting::Present { contents, mode } => restore_file(_path, contents, *mode)?,
             }
-            PreExisting::Present { contents, mode } => restore_file(path, contents, *mode)?,
-        }
-        #[cfg(not(unix))]
-        {
+            #[cfg(windows)]
+            validate_windows_restore_path(lock, _path)?;
             Ok(())
         }
     }
 
-    fn journal_entries(&self) -> Vec<JournalEntry> {
+    fn journal_entries(&self) -> io::Result<Vec<JournalEntry>> {
         self.leases
             .iter()
-            .map(|(path, state)| JournalEntry {
-                path: path.clone(),
-                pre_existing: state.pre_existing.journal(),
+            .map(|(path, state)| {
+                Ok(JournalEntry {
+                    path: path.clone(),
+                    pre_existing: state.pre_existing.journal()?,
+                })
             })
             .collect()
     }
@@ -973,7 +1209,7 @@ impl CursorMcpLeaseRegistry {
                 Err(error) if error.kind() == io::ErrorKind::NotFound => HashMap::new(),
                 Err(error) => return Err(error),
             };
-            for entry in self.journal_entries() {
+            for entry in self.journal_entries()? {
                 merged.insert(entry.path.clone(), entry);
             }
             let body = serde_json::to_vec_pretty(&Journal {
@@ -1022,7 +1258,7 @@ impl CursorMcpLeaseRegistry {
                 tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-absolute path");
                 remaining.push(JournalEntry {
                     path,
-                    pre_existing: pre_existing.journal(),
+                    pre_existing: pre_existing.journal()?,
                 });
                 continue;
             }
@@ -1032,7 +1268,7 @@ impl CursorMcpLeaseRegistry {
                     tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped an invalid path");
                     remaining.push(JournalEntry {
                         path,
-                        pre_existing: pre_existing.journal(),
+                        pre_existing: pre_existing.journal()?,
                     });
                     continue;
                 }
@@ -1042,7 +1278,7 @@ impl CursorMcpLeaseRegistry {
                 tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-canonical path");
                 remaining.push(JournalEntry {
                     path,
-                    pre_existing: pre_existing.journal(),
+                    pre_existing: pre_existing.journal()?,
                 });
                 continue;
             }
@@ -1052,7 +1288,7 @@ impl CursorMcpLeaseRegistry {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery skipped an unsafe cwd");
                     remaining.push(JournalEntry {
                         path,
-                        pre_existing: pre_existing.journal(),
+                        pre_existing: pre_existing.journal()?,
                     });
                     continue;
                 }
@@ -1061,7 +1297,7 @@ impl CursorMcpLeaseRegistry {
                 tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-canonical path");
                 remaining.push(JournalEntry {
                     path,
-                    pre_existing: pre_existing.journal(),
+                    pre_existing: pre_existing.journal()?,
                 });
                 continue;
             }
@@ -1071,7 +1307,7 @@ impl CursorMcpLeaseRegistry {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
                     remaining.push(JournalEntry {
                         path,
-                        pre_existing: pre_existing.journal(),
+                        pre_existing: pre_existing.journal()?,
                     });
                     continue;
                 }
@@ -1079,7 +1315,7 @@ impl CursorMcpLeaseRegistry {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because .cursor could not be opened safely");
                     remaining.push(JournalEntry {
                         path,
-                        pre_existing: pre_existing.journal(),
+                        pre_existing: pre_existing.journal()?,
                     });
                     held_locks.push(lock);
                     continue;
@@ -1089,7 +1325,7 @@ impl CursorMcpLeaseRegistry {
                 tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery rejected an unsafe path");
                 remaining.push(JournalEntry {
                     path,
-                    pre_existing: pre_existing.journal(),
+                    pre_existing: pre_existing.journal()?,
                 });
                 held_locks.push(lock);
                 continue;
@@ -1098,7 +1334,7 @@ impl CursorMcpLeaseRegistry {
                 tracing::warn!(path = %path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
                     path,
-                    pre_existing: pre_existing.journal(),
+                    pre_existing: pre_existing.journal()?,
                 });
                 held_locks.push(lock);
             } else {
@@ -1641,5 +1877,23 @@ mod tests {
         assert_eq!(read(&first), b"first-original");
         assert_eq!(read(&second), b"second-original");
         assert!(journal.exists(), "bad entry must remain journaled");
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn windows_lease_lock_is_reusable_after_owner_exit() {
+        let dir = tempdir().unwrap();
+        let first = LeaseLock::acquire(dir.path()).unwrap();
+        let error = match LeaseLock::acquire(dir.path()) {
+            Ok(_) => panic!("second broker must not acquire a held cwd lease"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        drop(first);
+
+        // The stable lock file remains on disk, but the kernel lock is released
+        // with the owning handle. A later broker can recover after a clean exit
+        // and the same mechanism also releases on process termination.
+        let _second = LeaseLock::acquire(dir.path()).unwrap();
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1052,6 +1052,11 @@ impl CursorMcpLeaseRegistry {
                 )
             })?;
             #[cfg(windows)]
+            let _parent_guard = windows_directory_guard(
+                path.parent()
+                    .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?,
+            )?;
+            #[cfg(windows)]
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             if validate_target(path)? {
                 Ok(Some(fs::read(path)?))

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -41,19 +41,33 @@ impl LeaseLock {
     }
 
     fn open_cursor_dir(&self, create: bool) -> io::Result<(fs::File, bool)> {
+        self.open_cursor_dir_with(create, |root_fd, cursor, mode| {
+            let result = unsafe { libc::mkdirat(root_fd, cursor.as_ptr(), mode) };
+            if result == 0 {
+                return Ok(true);
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::AlreadyExists {
+                Ok(false)
+            } else {
+                Err(error)
+            }
+        })
+    }
+
+    fn open_cursor_dir_with<F>(&self, create: bool, mkdir: F) -> io::Result<(fs::File, bool)>
+    where
+        F: FnOnce(std::os::unix::io::RawFd, &std::ffi::CStr, libc::mode_t) -> io::Result<bool>,
+    {
         let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
         match openat_dir(self.root_fd(), &cursor) {
             Ok(file) => Ok((file, false)),
             Err(error) if error.kind() == io::ErrorKind::NotFound && create => {
-                let mode = 0o700;
-                let result = unsafe { libc::mkdirat(self.root_fd(), cursor.as_ptr(), mode) };
-                if result != 0 {
-                    let error = io::Error::last_os_error();
-                    if error.kind() != io::ErrorKind::AlreadyExists {
-                        return Err(error);
-                    }
-                }
-                Ok((openat_dir(self.root_fd(), &cursor)?, true))
+                let created = mkdir(self.root_fd(), &cursor, 0o700)?;
+                // EEXIST means another creator won the race. Do not mark its
+                // directory as ours, or cleanup could remove an unrelated
+                // .cursor directory when this lease is released.
+                Ok((openat_dir(self.root_fd(), &cursor)?, created))
             }
             Err(error) => Err(error),
         }
@@ -279,21 +293,6 @@ fn open_write_nofollow(path: &Path) -> io::Result<fs::File> {
         .open(path)
 }
 
-#[cfg(not(unix))]
-fn read_regular_file(path: &Path) -> io::Result<Vec<u8>> {
-    #[cfg(unix)]
-    {
-        let mut file = open_read_nofollow(path)?;
-        let mut contents = Vec::new();
-        file.read_to_end(&mut contents)?;
-        Ok(contents)
-    }
-    #[cfg(not(unix))]
-    {
-        fs::read(path)
-    }
-}
-
 #[cfg(unix)]
 fn open_cursor_target(cursor: &fs::File) -> io::Result<Option<fs::File>> {
     use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -406,58 +405,6 @@ fn remove_cursor_dir(lock: &LeaseLock, cursor: &fs::File) -> io::Result<()> {
     }
 }
 
-/// Write the Cursor config through directory descriptors. This is used after
-/// the registry has acquired the cwd lease; the descriptor-relative rename
-/// remains safe even if `.cursor` is concurrently renamed or replaced.
-#[cfg(unix)]
-pub(crate) fn write_cursor_credential_file(root: &Path, contents: &[u8]) -> io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let root_file = open_dir_nofollow(root)?;
-    let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
-    let cursor_dir = match openat_dir(root_file.as_raw_fd(), &cursor) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            let result = unsafe { libc::mkdirat(root_file.as_raw_fd(), cursor.as_ptr(), 0o700) };
-            if result != 0 {
-                let error = io::Error::last_os_error();
-                if error.kind() != io::ErrorKind::AlreadyExists {
-                    return Err(error);
-                }
-            }
-            openat_dir(root_file.as_raw_fd(), &cursor)?
-        }
-        Err(error) => return Err(error),
-    };
-    write_cursor_target(&cursor_dir, contents)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn write_cursor_credential_file(root: &Path, contents: &[u8]) -> io::Result<()> {
-    write_credential_file(&root.join(".cursor").join("mcp.json"), contents)
-}
-
-#[cfg(unix)]
-pub(crate) fn read_cursor_credential_file(root: &Path) -> io::Result<Vec<u8>> {
-    use std::os::unix::io::AsRawFd;
-    let root_file = open_dir_nofollow(root)?;
-    let cursor = std::ffi::CString::new(".cursor").expect("literal has no NUL");
-    let cursor_dir = openat_dir(root_file.as_raw_fd(), &cursor)?;
-    let Some(mut file) = open_cursor_target(&cursor_dir)? else {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "Cursor MCP config missing",
-        ));
-    };
-    let mut contents = Vec::new();
-    file.read_to_end(&mut contents)?;
-    Ok(contents)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn read_cursor_credential_file(root: &Path) -> io::Result<Vec<u8>> {
-    read_regular_file(&root.join(".cursor").join("mcp.json"))
-}
-
 /// Atomically write a generated credential-bearing config with owner-only
 /// permissions. The temporary file is created as 0600, so no 0644 window is
 /// observable between creation and the final rename.
@@ -546,7 +493,6 @@ impl PreExisting {
 }
 
 impl CursorMcpLeaseRegistry {
-    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -633,6 +579,76 @@ impl CursorMcpLeaseRegistry {
             return Err(error);
         }
         Ok(key)
+    }
+
+    fn lock_for_worker(&self, worker: &WorkerName) -> io::Result<&LeaseLock> {
+        let path = self.path_by_worker.get(worker).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("no Cursor MCP lease for worker '{worker}'"),
+            )
+        })?;
+        let state = self.leases.get(path).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Cursor MCP lease state missing for worker '{worker}'"),
+            )
+        })?;
+        if !state.holders.contains(worker) {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                format!("worker '{worker}' has pending Cursor MCP cleanup"),
+            ));
+        }
+        Ok(&state.lock)
+    }
+
+    /// Read the currently leased config through the root and `.cursor`
+    /// descriptors captured by `acquire`. Never reopen either directory by
+    /// pathname: a caller can rename the requested cwd after acquisition
+    /// without redirecting this operation to an attacker-controlled tree.
+    pub(crate) fn read_worker_cursor_file(
+        &self,
+        worker: &WorkerName,
+    ) -> io::Result<Option<Vec<u8>>> {
+        let lock = self.lock_for_worker(worker)?;
+        #[cfg(unix)]
+        {
+            let (cursor, _) = lock.open_cursor_dir(false)?;
+            Ok(read_cursor_target(&cursor)?.map(|(contents, _)| contents))
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = lock;
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Cursor MCP leasing requires Unix directory descriptors",
+            ))
+        }
+    }
+
+    /// Atomically write a leased Cursor config using only descriptors owned by
+    /// this registry. The worker registry calls this after successful lease
+    /// acquisition and before any child process is spawned.
+    pub(crate) fn write_worker_cursor_file(
+        &self,
+        worker: &WorkerName,
+        contents: &[u8],
+    ) -> io::Result<()> {
+        let lock = self.lock_for_worker(worker)?;
+        #[cfg(unix)]
+        {
+            let (cursor, _) = lock.open_cursor_dir(false)?;
+            write_cursor_target(&cursor, contents)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (lock, contents);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Cursor MCP leasing requires Unix directory descriptors",
+            ))
+        }
     }
 
     pub(crate) fn release_worker(&mut self, worker: &WorkerName) -> io::Result<()> {
@@ -878,6 +894,7 @@ impl CursorMcpLeaseRegistry {
                     path: entry.path,
                     pre_existing: pre_existing.journal(),
                 });
+                held_locks.push(lock);
                 continue;
             }
             if let Err(error) = Self::restore(&entry.path, &pre_existing, &lock) {
@@ -886,6 +903,7 @@ impl CursorMcpLeaseRegistry {
                     path: entry.path,
                     pre_existing: pre_existing.journal(),
                 });
+                held_locks.push(lock);
             } else {
                 held_locks.push(lock);
             }
@@ -932,6 +950,26 @@ mod tests {
         assert!(!path.exists());
         assert!(!path.parent().unwrap().exists());
         assert!(registry.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raced_cursor_directory_creator_is_not_marked_for_cleanup() {
+        let dir = tempdir().unwrap();
+        let lock = LeaseLock::acquire(dir.path()).unwrap();
+        let (cursor, created) = lock
+            .open_cursor_dir_with(true, |root_fd, name, mode| {
+                // Deterministically model another creator winning between our
+                // failed openat and mkdirat: create the directory, then report
+                // the equivalent EEXIST result to the caller.
+                let result = unsafe { libc::mkdirat(root_fd, name.as_ptr(), mode) };
+                assert_eq!(result, 0);
+                Ok(false)
+            })
+            .unwrap();
+        drop(cursor);
+        assert!(!created);
+        assert!(dir.path().join(".cursor").is_dir());
     }
 
     #[cfg(unix)]
@@ -1082,18 +1120,54 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn production_worker_cursor_io_survives_hostile_root_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempdir().unwrap();
+        let root = parent.path().join("cwd");
+        let moved_root = parent.path().join("cwd-moved");
+        let outside = tempdir().unwrap();
+        fs::create_dir(&root).unwrap();
+        let worker = WorkerName::new("descriptor-worker");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        registry.acquire(&root, &worker).unwrap();
+        registry
+            .write_worker_cursor_file(&worker, b"inside bytes")
+            .unwrap();
+
+        fs::rename(&root, &moved_root).unwrap();
+        symlink(outside.path(), &root).unwrap();
+
+        assert_eq!(
+            registry.read_worker_cursor_file(&worker).unwrap().unwrap(),
+            b"inside bytes"
+        );
+        registry
+            .write_worker_cursor_file(&worker, b"updated inside bytes")
+            .unwrap();
+        assert_eq!(
+            read(&moved_root.join(".cursor/mcp.json")),
+            b"updated inside bytes"
+        );
+        assert!(!outside.path().join(".cursor/mcp.json").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn journal_recovery_retains_cwd_lock_until_journal_finalization() {
         let dir = tempdir().unwrap();
         let journal = dir.path().join("journal.json");
-        let path = dir.path().join(".cursor/mcp.json");
+        let root = dir.path().canonicalize().unwrap();
+        let path = root.join(".cursor/mcp.json");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, b"original").unwrap();
         {
             let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+            let worker = WorkerName::new("w1");
+            registry.acquire(dir.path(), &worker).unwrap();
             registry
-                .acquire(dir.path(), &WorkerName::new("w1"))
+                .write_worker_cursor_file(&worker, b"generated")
                 .unwrap();
-            write_cursor_credential_file(dir.path(), b"generated").unwrap();
         }
 
         let mut recovery = CursorMcpLeaseRegistry {
@@ -1112,5 +1186,41 @@ mod tests {
             .unwrap();
         assert!(!journal.exists());
         assert_eq!(read(&path), b"original");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_error_path_retains_cwd_lock_until_journal_rewrite() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let path = root.join(".cursor/mcp.json");
+        let body = serde_json::to_vec(&Journal {
+            entries: vec![JournalEntry {
+                path: path.clone(),
+                pre_existing: JournalPreExisting::Present {
+                    contents_base64: base64::engine::general_purpose::STANDARD.encode(b"original"),
+                    mode: 0o600,
+                },
+            }],
+        })
+        .unwrap();
+        fs::write(&journal, body).unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        let mut racing = CursorMcpLeaseRegistry::new();
+        recovery
+            .recover_journal_with_hook(|| {
+                let error = racing
+                    .acquire(&root, &WorkerName::new("racing-error"))
+                    .unwrap_err();
+                assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+            })
+            .unwrap();
+        assert!(journal.exists(), "failed restore remains journaled");
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1256,6 +1256,8 @@ impl CursorMcpLeaseRegistry {
                 },
             };
             #[cfg(windows)]
+            let _cursor_guard = windows_directory_guard(&cursor)?;
+            #[cfg(windows)]
             let _cursor_identity = windows_directory_identity(&cursor)?;
             let pre_existing = if validate_target(&key)? {
                 PreExisting::Present {

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1874,15 +1874,13 @@ impl CursorMcpLeaseRegistry {
                 .parent()
                 .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
             #[cfg(windows)]
-            let parent_guard = match windows_directory_guard(parent) {
+            let mut parent_guard = match windows_directory_guard(parent) {
                 Ok(guard) => Some(guard),
                 Err(e) if e.kind() == io::ErrorKind::NotFound => None,
                 Err(e) => return Err(e),
             };
             #[cfg(windows)]
-            let had_guard = parent_guard.is_some();
-            #[cfg(windows)]
-            if had_guard {
+            if parent_guard.is_some() {
                 validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             }
             match pre_existing {
@@ -1950,7 +1948,9 @@ impl CursorMcpLeaseRegistry {
                         // Drop the directory guard before attempting removal so
                         // Windows does not block the delete with an open handle.
                         #[cfg(windows)]
-                        drop(parent_guard);
+                        {
+                            parent_guard = None;
+                        }
                         if let Some(dir) = _path.parent() {
                             if fs::remove_dir(dir).is_ok() {
                                 sync_entry_parent(dir)?;
@@ -1993,7 +1993,7 @@ impl CursorMcpLeaseRegistry {
                 }
             }
             #[cfg(windows)]
-            if had_guard {
+            if parent_guard.is_some() {
                 validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
             }
             Ok(())

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1090,17 +1090,35 @@ fn write_credential_file_with_identity(
 
 #[cfg(windows)]
 fn secure_windows_file(path: &Path) -> io::Result<()> {
+    use std::mem::ManuallyDrop;
+    use std::os::windows::ffi::OsStrExt;
     use std::process::Command;
+
+    #[link(name = "Advapi32")]
+    unsafe extern "system" {
+        fn ConvertStringSidToSidW(string_sid: *const u16, sid: *mut *mut u8) -> i32;
+        fn SetNamedSecurityInfoW(
+            name: *const u16,
+            object_type: u32,
+            security_info: u32,
+            owner: *mut u8,
+            group: *mut u8,
+            dacl: *mut u8,
+            sacl: *mut u8,
+        ) -> u32;
+    }
+
+    const SE_FILE_OBJECT: u32 = 1;
+    const DACL_SECURITY_INFORMATION: u32 = 0x0000_0004;
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+    const FILE_GENERIC_ALL: u32 = 0x001F_01FF;
 
     let system32 = windows_system_directory()?;
     let whoami_path = system32.join("whoami.exe");
-    let icacls_path = system32.join("icacls.exe");
 
-    // `icacls` is part of supported Windows installations.  Resolve the SID
-    // rather than trusting a username, then remove inherited permissions and
-    // grant access only to the current user and SYSTEM.  Fail closed if
-    // either utility is unavailable; an unprotected generated config must
-    // not be published because it may contain restored user configuration.
+    // Resolve the SID rather than trusting a username.  Fail closed if the
+    // utility is unavailable; an unprotected generated config must not be
+    // published because it may contain restored user configuration.
     let whoami = Command::new(&whoami_path)
         .args(["/user", "/fo", "csv", "/nh"])
         .output()?;
@@ -1137,54 +1155,155 @@ fn secure_windows_file(path: &Path) -> io::Result<()> {
                 "whoami did not return a Windows user SID",
             )
         })?;
-    // Step 1 – Grant the current user and SYSTEM full control.  This is the
-    // critical security property: without it anyone on the box could read the
-    // credential file.
-    let grant_out = Command::new(&icacls_path)
-        .arg(path)
-        .args(["/grant:r", &format!("{sid}:F"), "SYSTEM:F"])
-        .output()?;
-    let grant_stdout = String::from_utf8_lossy(&grant_out.stdout).into_owned();
-    let grant_stderr = String::from_utf8_lossy(&grant_out.stderr).into_owned();
-    if !grant_out.status.success() {
+
+    // Convert the SID string to a binary SID via Win32 API.  icacls cannot
+    // accept raw SID strings on some Windows Server configurations (error
+    // 1332 – ERROR_NONE_MAPPED), so we use the native API directly.
+    let mut wide_sid: Vec<u16> = sid.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut psid: *mut u8 = std::ptr::null_mut();
+    let ok = unsafe { ConvertStringSidToSidW(wide_sid.as_ptr(), &mut psid) };
+    if ok == 0 || psid.is_null() {
         tracing::error!(
-            icacls = %icacls_path.display(),
+            sid = %sid,
+            last_os_error = io::Error::last_os_error(),
+            "ConvertStringSidToSidW failed for Cursor config ACL"
+        );
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("unable to convert SID string '{sid}' for Windows ACL"),
+        ));
+    }
+    // Prevent Rust from dropping the SID before SetNamedSecurityInfoW uses it.
+    // The pointer is consumed by the ACE we build; SetNamedSecurityInfoW reads
+    // the DACL synchronously, so the SID must remain valid for this scope.
+    let _sid_guard = ManuallyDrop::new(SidGuard(psid));
+
+    // Build a minimal DACL: [ACL header][ACE(user)][ACE(SYSTEM)]
+    // ACCESS_ALLOWED_ACE: AceType(1) + AceFlags(1) + AceSize(2) + Mask(4) + Sid
+    let sid_user_len = (8 + 28) as usize; // SID revision(1)+sub_count(1)+authority(6)+5*sub_auth(20)=28
+    let sid_system_len = (8 + 12) as usize; // S-1-5-18: revision(1)+sub_count(1)+authority(6)+1*sub_auth(4)=12
+    let ace_user_size = 8 + sid_user_len; // ACE header(8) + SID
+    let ace_system_size = 8 + sid_system_len;
+    let acl_size = 8 + ace_user_size + ace_system_size;
+    let mut acl_buf: Vec<u8> = vec![0u8; acl_size];
+
+    // ACL header
+    acl_buf[0] = 2; // AclRevision
+    acl_buf[1] = 0; // Sbz1
+    let total = (acl_size as u16).to_le_bytes();
+    acl_buf[2] = total[0];
+    acl_buf[3] = total[1];
+    let count = 2u16.to_le_bytes();
+    acl_buf[4] = count[0];
+    acl_buf[5] = count[1];
+    acl_buf[6] = 0; // Sbz2
+    acl_buf[7] = 0;
+
+    // ACE for the current user
+    let mut offset = 8usize;
+    let ace_user_size_u16 = (ace_user_size as u16).to_le_bytes();
+    acl_buf[offset] = ACCESS_ALLOWED_ACE_TYPE;
+    acl_buf[offset + 1] = 0; // No inheritance
+    acl_buf[offset + 2] = ace_user_size_u16[0];
+    acl_buf[offset + 3] = ace_user_size_u16[1];
+    let mask_user = FILE_GENERIC_ALL.to_le_bytes();
+    acl_buf[offset + 4..offset + 8].copy_from_slice(&mask_user);
+    unsafe {
+        let ace_sid_ptr = acl_buf.as_mut_ptr().add(offset + 8);
+        std::ptr::copy_nonoverlapping(psid, ace_sid_ptr, sid_user_len);
+    }
+    offset += ace_user_size;
+
+    // ACE for SYSTEM (S-1-5-18)
+    let ace_sys_size_u16 = (ace_system_size as u16).to_le_bytes();
+    acl_buf[offset] = ACCESS_ALLOWED_ACE_TYPE;
+    acl_buf[offset + 1] = 0;
+    acl_buf[offset + 2] = ace_sys_size_u16[0];
+    acl_buf[offset + 3] = ace_sys_size_u16[1];
+    let mask_sys = FILE_GENERIC_ALL.to_le_bytes();
+    acl_buf[offset + 4..offset + 8].copy_from_slice(&mask_sys);
+    // S-1-5-18 binary: Revision(1)=1, SubAuthorityCount(1)=1, IdentifierAuthority(6)={0,0,0,0,0,5}, SubAuthority(4)=18
+    let system_sid: [u8; 12] = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0];
+    unsafe {
+        let ace_sid_ptr = acl_buf.as_mut_ptr().add(offset + 8);
+        std::ptr::copy_nonoverlapping(system_sid.as_ptr(), ace_sid_ptr, sid_system_len);
+    }
+
+    // Build an absolute security descriptor with the DACL.
+    // Layout: Revision(1) + Sbz1(1) + Control(2) + Owner ptr + Group ptr +
+    //         Sacl ptr + Dacl ptr.  Pointer size is 4 on 32-bit, 8 on x64.
+    let ptr_size = std::mem::size_of::<usize>();
+    let sd_size = 4 + 4 * ptr_size;
+    let mut sd: Vec<u8> = vec![0u8; sd_size];
+    sd[0] = 1; // Revision
+    sd[1] = 0; // Sbz1
+    sd[2] = 0x80; // Control low byte: SE_DACL_PRESENT
+    sd[3] = 0; // Control high byte
+               // Owner (bytes 4..4+ptr_size) – leave null (not needed for DACL-only set)
+               // Group (bytes 4+ptr_size..4+2*ptr_size) – leave null
+               // Sacl  (bytes 4+2*ptr_size..4+3*ptr_size) – leave null
+               // Dacl  (bytes 4+3*ptr_size..4+4*ptr_size) – set to acl_buf pointer
+    let dacl_offset = 4 + 3 * ptr_size;
+    let acl_ptr = acl_buf.as_ptr();
+    unsafe {
+        let field = sd.as_mut_ptr().add(dacl_offset) as *mut *const u8;
+        std::ptr::write(field, acl_ptr);
+    }
+
+    let wide_path: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            wide_path.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            sd.as_mut_ptr().add(4), // Pass body (skip 4-byte header) as absolute SD
+            std::ptr::null_mut(),
+        )
+    };
+
+    if status != 0 {
+        tracing::error!(
             path = %path.display(),
             sid = %sid,
-            exit = ?grant_out.status,
-            stdout = %grant_stdout,
-            stderr = %grant_stderr,
-            "icacls /grant:r failed to secure generated Cursor config"
+            status = status,
+            last_os_error = io::Error::last_os_error(),
+            "SetNamedSecurityInfoW failed to secure generated Cursor config"
         );
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             format!(
                 "unable to apply owner-only Windows ACL to generated Cursor config: \
-                 icacls exit {:?}, stderr: {}",
-                grant_out.status,
-                grant_stderr.trim(),
+                 SetNamedSecurityInfoW returned {status}"
             ),
         ));
     }
-    // Step 2 – Strip inherited ACEs (best-effort).  On locked-down hosts
-    // (e.g. GitHub Actions runners) /inheritance:r may fail because the
-    // parent DACL denies the modification, but the explicit grant above
-    // already enforces owner-only access.
-    let inh_out = Command::new(&icacls_path)
-        .arg(path)
-        .args(["/inheritance:r"])
-        .output();
-    if let Ok(result) = inh_out {
-        if !result.status.success() {
-            tracing::warn!(
-                path = %path.display(),
-                exit = ?result.status,
-                stderr = %String::from_utf8_lossy(&result.stderr),
-                "icacls /inheritance:r failed; owner-only ACL still enforced via explicit grant"
-            );
+    Ok(())
+}
+
+/// RAII guard that calls `LocalFree` on a Win32-allocated SID pointer.
+#[cfg(windows)]
+struct SidGuard(*mut u8);
+
+#[cfg(windows)]
+impl Drop for SidGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                #[link(name = "Kernel32")]
+                unsafe extern "system" {
+                    fn LocalFree(ptr: *mut u8) -> *mut u8;
+                }
+                LocalFree(self.0);
+            }
         }
     }
-    Ok(())
 }
 
 #[cfg(windows)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1697,6 +1697,8 @@ impl CursorMcpLeaseRegistry {
         let mut held_locks = Vec::new();
         for entry in journal.entries {
             let path = entry.path.clone();
+            #[cfg(windows)]
+            let generated_identity = entry.generated_identity;
             let pre_existing = match PreExisting::from_journal(entry.pre_existing.clone()) {
                 Ok(pre_existing) => pre_existing,
                 Err(error) => {
@@ -1710,6 +1712,8 @@ impl CursorMcpLeaseRegistry {
                 remaining.push(JournalEntry {
                     path,
                     pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
                 });
                 continue;
             }
@@ -1720,6 +1724,8 @@ impl CursorMcpLeaseRegistry {
                     remaining.push(JournalEntry {
                         path,
                         pre_existing: pre_existing.journal()?,
+                        #[cfg(windows)]
+                        generated_identity,
                     });
                     continue;
                 }
@@ -1730,6 +1736,8 @@ impl CursorMcpLeaseRegistry {
                 remaining.push(JournalEntry {
                     path,
                     pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
                 });
                 continue;
             }
@@ -1740,6 +1748,8 @@ impl CursorMcpLeaseRegistry {
                     remaining.push(JournalEntry {
                         path,
                         pre_existing: pre_existing.journal()?,
+                        #[cfg(windows)]
+                        generated_identity,
                     });
                     continue;
                 }
@@ -1749,6 +1759,8 @@ impl CursorMcpLeaseRegistry {
                 remaining.push(JournalEntry {
                     path,
                     pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
                 });
                 continue;
             }
@@ -1759,6 +1771,8 @@ impl CursorMcpLeaseRegistry {
                     remaining.push(JournalEntry {
                         path,
                         pre_existing: pre_existing.journal()?,
+                        #[cfg(windows)]
+                        generated_identity,
                     });
                     continue;
                 }
@@ -1767,6 +1781,8 @@ impl CursorMcpLeaseRegistry {
                     remaining.push(JournalEntry {
                         path,
                         pre_existing: pre_existing.journal()?,
+                        #[cfg(windows)]
+                        generated_identity,
                     });
                     held_locks.push(lock);
                     continue;
@@ -1777,6 +1793,8 @@ impl CursorMcpLeaseRegistry {
                 remaining.push(JournalEntry {
                     path,
                     pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
                 });
                 held_locks.push(lock);
                 continue;
@@ -1789,12 +1807,14 @@ impl CursorMcpLeaseRegistry {
                 #[cfg(windows)]
                 Some(windows_directory_identity(path.parent().unwrap_or(root))?),
                 #[cfg(windows)]
-                entry.generated_identity,
+                generated_identity,
             ) {
                 tracing::warn!(path = %path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
                     path,
                     pre_existing: pre_existing.journal()?,
+                    #[cfg(windows)]
+                    generated_identity,
                 });
                 held_locks.push(lock);
             } else {

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1479,20 +1479,20 @@ impl CursorMcpLeaseRegistry {
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             let generated_identity = write_credential_file_with_identity(path, contents)?;
             #[cfg(windows)]
-            *state
-                .generated_identity
-                .lock()
-                .map_err(|_| io::Error::other("Cursor MCP generated identity lock poisoned"))? =
-                generated_identity;
-            // Persist the journal immediately so the generated identity is
-            // durable before any crash can occur.  Without this, a crash
-            // between identity capture and journal write would orphan the
-            // credential file with no recoverable identity for cleanup.
-            if let Err(error) = self.persist_journal() {
-                // Journal persistence failed — remove the credential file to
-                // avoid leaving a secret on disk with no recoverable identity.
-                let _ = fs::remove_file(path);
-                return Err(error);
+            {
+                *state.generated_identity.lock().map_err(|_| {
+                    io::Error::other("Cursor MCP generated identity lock poisoned")
+                })? = generated_identity;
+                // Persist the journal immediately so the generated identity is
+                // durable before any crash can occur.  Without this, a crash
+                // between identity capture and journal write would orphan the
+                // credential file with no recoverable identity for cleanup.
+                if let Err(error) = self.persist_journal() {
+                    // Journal persistence failed — remove the credential file to
+                    // avoid leaving a secret on disk with no recoverable identity.
+                    let _ = fs::remove_file(path);
+                    return Err(error);
+                }
             }
             Ok(())
         }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1030,7 +1030,12 @@ fn write_credential_file_with_identity(
     validate_credential_parent(parent)?;
     let _ = validate_target(path)?;
     #[cfg(windows)]
-    let _parent_guard = windows_directory_guard(parent)?;
+    let _parent_guard = windows_directory_guard(parent).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("guard credential parent directory {path}: {e}"),
+        )
+    })?;
     #[cfg(windows)]
     if validate_target(path)? {
         // Preserve the user's security descriptor for an existing config.
@@ -1057,11 +1062,26 @@ fn write_credential_file_with_identity(
             use std::os::unix::fs::OpenOptionsExt;
             options.mode(0o600);
         }
-        let mut file = options.open(&temporary)?;
+        let mut file = options.open(&temporary).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("create temp credential file {}: {e}", temporary.display()),
+            )
+        })?;
         #[cfg(windows)]
         secure_windows_file(&temporary)?;
-        file.write_all(contents)?;
-        file.sync_all()?;
+        file.write_all(contents).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("write temp credential file {}: {e}", temporary.display()),
+            )
+        })?;
+        file.sync_all().map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("sync temp credential file {}: {e}", temporary.display()),
+            )
+        })?;
         drop(file);
         validate_credential_parent(parent)?;
         // The generated path was absent when this lease was acquired. Never
@@ -1069,15 +1089,35 @@ fn write_credential_file_with_identity(
         // on Windows that pathname race could otherwise delete an unrelated
         // replacement. A rename failure is fail-closed and leaves the
         // replacement untouched.
-        fs::rename(&temporary, path)?;
+        fs::rename(&temporary, path).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "rename temp credential file {} -> {}: {e}",
+                    temporary.display(),
+                    path.display()
+                ),
+            )
+        })?;
         #[cfg(unix)]
         set_mode(path, 0o600)?;
         sync_file(path)?;
         sync_entry_parent(path)?;
         #[cfg(windows)]
-        let identity = Some(windows_handle_identity(&windows_child_file(
-            path, false, false,
-        )?)?);
+        let identity = Some(
+            windows_handle_identity(&windows_child_file(path, false, false).map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!("open credential file for identity {}: {e}", path.display()),
+                )
+            })?)
+            .map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!("capture credential file identity {}: {e}", path.display()),
+                )
+            })?,
+        );
         #[cfg(not(windows))]
         let identity = None;
         Ok(identity)

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -2134,7 +2134,11 @@ impl CursorMcpLeaseRegistry {
         self.recover_journal_impl(|| {}, before_finalize)
     }
 
-    fn recover_journal_impl<F, G>(&mut self, mut after_snapshot: F, mut before_finalize: G) -> io::Result<()>
+    fn recover_journal_impl<F, G>(
+        &mut self,
+        mut after_snapshot: F,
+        mut before_finalize: G,
+    ) -> io::Result<()>
     where
         F: FnMut(),
         G: FnMut(),
@@ -3109,8 +3113,7 @@ mod tests {
         assert_eq!(
             journal.entries[0].pre_existing,
             JournalPreExisting::Present {
-                contents_base64: base64::engine::general_purpose::STANDARD
-                    .encode(b"replacement"),
+                contents_base64: base64::engine::general_purpose::STANDARD.encode(b"replacement"),
                 mode: 0o600,
             }
         );

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1,45 +1,27 @@
-//! Per-worker lease over an injected Cursor `.cursor/mcp.json`.
-//!
-//! [`relay#1753`](https://github.com/AgentWorkforce/relay/issues/1753):
-//! spawning a Cursor worker with Agent Relay MCP injection writes plaintext
-//! credentials into `<cwd>/.cursor/mcp.json`. Releasing the worker used to
-//! leave that file behind untouched — a worktree-local credential leak.
-//!
-//! This registry treats the injected config as a lease owned by whichever
-//! [`WorkerRegistry`](crate::worker::WorkerRegistry) workers currently share a
-//! `cwd`. The first worker to lease a given `.cursor/mcp.json` path captures
-//! whatever was there beforehand (a pre-existing user config, or nothing).
-//! Every subsequent worker sharing that cwd joins the same lease. Only when
-//! the *last* holder releases does the registry restore the captured
-//! pre-existing state — never a stale intermediate worker's credentials.
-//!
-//! Restoration is triggered from every lifecycle exit this issue calls out:
-//! spawn failure, explicit release, task-exit/reap, orphan cleanup, broker
-//! shutdown, and ambiguous-timeout recovery — because all of those paths
-//! funnel through [`WorkerRegistry::release`](crate::worker::WorkerRegistry::release),
-//! [`WorkerRegistry::cleanup_rejected_spawn`](crate::worker::WorkerRegistry::cleanup_rejected_spawn),
-//! or [`WorkerRegistry::reap_exited`](crate::worker::WorkerRegistry::reap_exited).
+//! Crash-recoverable leases for a generated Cursor `.cursor/mcp.json`.
 
 use std::{
     collections::{HashMap, HashSet},
-    fs, io,
+    fs,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
 use crate::ids::WorkerName;
 
-/// What existed at the leased path before the first worker claimed it.
 #[derive(Debug, Clone)]
 enum PreExisting {
-    /// Nothing was there. `created_dir` is true when this lease also had to
-    /// create the parent `.cursor` directory, so restore can remove it again
-    /// if — and only if — it is still empty (never delete a directory a user
-    /// populated with something else in the meantime).
-    Absent { created_dir: bool },
-    /// The raw bytes that were on disk, preserved verbatim (not reparsed) so
-    /// restore is byte-for-byte even if the file was invalid JSON or had
-    /// unusual formatting/comments.
-    Present(Vec<u8>),
+    Absent {
+        created_dir: bool,
+    },
+    Present {
+        contents: Vec<u8>,
+        mode: Option<u32>,
+    },
 }
 
 struct LeaseState {
@@ -47,31 +29,40 @@ struct LeaseState {
     holders: HashSet<WorkerName>,
 }
 
-/// Tracks in-process leases over injected `.cursor/mcp.json` files, keyed by
-/// the canonicalized `.cursor/mcp.json` path. Lives on [`WorkerRegistry`] so
-/// concurrent Cursor workers that share one `cwd` are correctly recognized as
-/// sharing one lease instead of each capturing/restoring independently.
+#[derive(Debug, Serialize, Deserialize)]
+struct Journal {
+    entries: Vec<JournalEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct JournalEntry {
+    path: PathBuf,
+    pre_existing: JournalPreExisting,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum JournalPreExisting {
+    Absent {
+        created_dir: bool,
+    },
+    Present {
+        contents_base64: String,
+        mode: Option<u32>,
+    },
+}
+
+/// Tracks in-process leases and a credential-free-on-disk recovery journal.
+/// The journal contains only pre-existing bytes and mode, never generated
+/// Relay credentials: generated Cursor values are `${env:...}` placeholders.
 #[derive(Default)]
 pub(crate) struct CursorMcpLeaseRegistry {
     leases: HashMap<PathBuf, LeaseState>,
-    /// Reverse index so release call sites (which only know the worker name,
-    /// not its cwd — e.g. a generic reap sweep) can find the lease to drop
-    /// without threading `cwd` through every call site.
     path_by_worker: HashMap<WorkerName, PathBuf>,
+    journal_path: Option<PathBuf>,
 }
 
 fn lease_path(root: &Path) -> PathBuf {
-    // Canonicalize `root` itself, not `.cursor` — the worker cwd is
-    // guaranteed to already exist (broker `spawn()` validates that before
-    // any harness config is built), whereas `.cursor` may not exist yet on a
-    // from-scratch spawn. Canonicalizing whichever of the two happens to
-    // exist would make two concurrent workers sharing one cwd resolve to
-    // different keys purely based on acquire ordering (one arriving before
-    // `.cursor` is created, the other after), which would let two "same
-    // cwd" leases diverge and let one worker's release stomp another's
-    // config. Falling back to the joined (non-canonical) path when `root`
-    // itself can't be resolved keeps this a best-effort dedup, not a
-    // correctness requirement.
     let joined = root.join(".cursor").join("mcp.json");
     match root.canonicalize() {
         Ok(canonical) => canonical.join(".cursor").join("mcp.json"),
@@ -80,46 +71,154 @@ fn lease_path(root: &Path) -> PathBuf {
 }
 
 #[cfg(unix)]
-fn secure_permissions(path: &Path) -> io::Result<()> {
+fn file_mode(path: &Path) -> io::Result<u32> {
     use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+    Ok(fs::metadata(path)?.permissions().mode() & 0o777)
 }
 
 #[cfg(not(unix))]
-fn secure_permissions(_path: &Path) -> io::Result<()> {
+fn file_mode(_path: &Path) -> io::Result<u32> {
+    Ok(0)
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o777))
+}
+
+#[cfg(not(unix))]
+fn set_mode(_path: &Path, _mode: u32) -> io::Result<()> {
     Ok(())
 }
 
-/// Write `contents` to `path` and enforce owner-only permissions. Used both
-/// for the initial credential-bearing write and for lease restoration, so a
-/// restored pre-existing config is at least as tightly permissioned as the
-/// credential file it replaced.
+/// Atomically write a generated credential-bearing config with owner-only
+/// permissions. The temporary file is created as 0600, so no 0644 window is
+/// observable between creation and the final rename.
 pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<()> {
-    fs::write(path, contents)?;
-    secure_permissions(path)
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "credential path has no parent")
+    })?;
+    fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("mcp.json");
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", Uuid::new_v4().simple()));
+
+    let result = (|| {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        drop(file);
+        #[cfg(windows)]
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        fs::rename(&temporary, path)?;
+        #[cfg(unix)]
+        set_mode(path, 0o600)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn restore_file(path: &Path, contents: &[u8], mode: Option<u32>) -> io::Result<()> {
+    write_credential_file(path, contents)?;
+    if let Some(mode) = mode {
+        set_mode(path, mode)?;
+    }
+    Ok(())
+}
+
+impl PreExisting {
+    fn journal(&self) -> JournalPreExisting {
+        match self {
+            Self::Absent { created_dir } => JournalPreExisting::Absent {
+                created_dir: *created_dir,
+            },
+            Self::Present { contents, mode } => JournalPreExisting::Present {
+                contents_base64: base64::engine::general_purpose::STANDARD.encode(contents),
+                mode: *mode,
+            },
+        }
+    }
+
+    fn from_journal(value: JournalPreExisting) -> io::Result<Self> {
+        match value {
+            JournalPreExisting::Absent { created_dir } => Ok(Self::Absent { created_dir }),
+            JournalPreExisting::Present {
+                contents_base64,
+                mode,
+            } => Ok(Self::Present {
+                contents: base64::engine::general_purpose::STANDARD
+                    .decode(contents_base64.as_bytes())
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+                mode,
+            }),
+        }
+    }
 }
 
 impl CursorMcpLeaseRegistry {
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    /// Acquire (or join) the lease over `<root>/.cursor/mcp.json` for
-    /// `worker`. Idempotent for a given worker/path pair. Must be called
-    /// before the caller overwrites the file, so the pre-existing content is
-    /// captured, never a config another Agent Relay worker already wrote.
+    /// Construct a registry and recover any leases left by a crashed broker.
+    /// Recovery is safe because the journal never stores generated credentials.
+    pub(crate) fn with_journal(path: PathBuf) -> Self {
+        let mut registry = Self {
+            journal_path: Some(path),
+            ..Self::default()
+        };
+        if let Err(error) = registry.recover_journal() {
+            tracing::error!(error = %error, "failed to recover Cursor MCP lease journal; retaining it for a later retry");
+        }
+        registry
+    }
+
     pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
         let key = lease_path(root);
-        if let Some(state) = self.leases.get_mut(&key) {
-            state.holders.insert(worker.clone());
+        if self.leases.contains_key(&key) {
+            let was_new_holder = self
+                .leases
+                .get_mut(&key)
+                .expect("lease checked above")
+                .holders
+                .insert(worker.clone());
+            if !was_new_holder {
+                return Ok(key);
+            }
             self.path_by_worker.insert(worker.clone(), key.clone());
+            if let Err(error) = self.persist_journal() {
+                if let Some(state) = self.leases.get_mut(&key) {
+                    state.holders.remove(worker);
+                }
+                self.path_by_worker.remove(worker);
+                return Err(error);
+            }
             return Ok(key);
         }
 
         let cursor_dir = root.join(".cursor");
         let dir_existed = cursor_dir.is_dir();
         let pre_existing = if key.exists() {
-            PreExisting::Present(fs::read(&key)?)
+            PreExisting::Present {
+                contents: fs::read(&key)?,
+                mode: Some(file_mode(&key)?),
+            }
         } else {
             PreExisting::Absent {
                 created_dir: !dir_existed,
@@ -136,16 +235,16 @@ impl CursorMcpLeaseRegistry {
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
+        if let Err(error) = self.persist_journal() {
+            self.leases.remove(&key);
+            self.path_by_worker.remove(worker);
+            return Err(error);
+        }
         Ok(key)
     }
 
-    /// Release `worker`'s hold on whatever lease it currently has (a no-op if
-    /// it has none — every removal call site can call this unconditionally
-    /// rather than re-deriving whether the worker was a Cursor worker).
-    /// Restores the pre-existing state only when `worker` was the last
-    /// remaining holder.
     pub(crate) fn release_worker(&mut self, worker: &WorkerName) -> io::Result<()> {
-        let Some(path) = self.path_by_worker.remove(worker) else {
+        let Some(path) = self.path_by_worker.get(worker).cloned() else {
             return Ok(());
         };
         self.release_path(&path, worker)
@@ -153,38 +252,110 @@ impl CursorMcpLeaseRegistry {
 
     fn release_path(&mut self, path: &Path, worker: &WorkerName) -> io::Result<()> {
         let Some(state) = self.leases.get_mut(path) else {
+            self.path_by_worker.remove(worker);
             return Ok(());
         };
         state.holders.remove(worker);
         if !state.holders.is_empty() {
-            return Ok(());
+            self.path_by_worker.remove(worker);
+            return self.persist_journal();
         }
-        let state = self.leases.remove(path).expect("checked above");
-        match state.pre_existing {
+
+        let pre_existing = match &state.pre_existing {
+            PreExisting::Absent { created_dir } => PreExisting::Absent {
+                created_dir: *created_dir,
+            },
+            PreExisting::Present { contents, mode } => PreExisting::Present {
+                contents: contents.clone(),
+                mode: *mode,
+            },
+        };
+        self.restore(path, &pre_existing)?;
+        self.leases.remove(path);
+        self.path_by_worker.remove(worker);
+        self.persist_journal()
+    }
+
+    fn restore(&self, path: &Path, pre_existing: &PreExisting) -> io::Result<()> {
+        match pre_existing {
             PreExisting::Absent { created_dir } => {
                 match fs::remove_file(path) {
                     Ok(()) => {}
                     Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                     Err(error) => return Err(error),
                 }
-                if created_dir {
+                if *created_dir {
                     if let Some(dir) = path.parent() {
-                        // Only removes a genuinely empty directory; leaves it
-                        // alone (and swallows the error) if the user or
-                        // another process put something else there.
                         let _ = fs::remove_dir(dir);
                     }
                 }
             }
-            PreExisting::Present(contents) => {
-                write_credential_file(path, &contents)?;
-            }
+            PreExisting::Present { contents, mode } => restore_file(path, contents, *mode)?,
         }
         Ok(())
     }
 
-    /// True when any worker currently holds a lease (used by tests/shutdown
-    /// bookkeeping to assert full drain).
+    fn journal_entries(&self) -> Vec<JournalEntry> {
+        self.leases
+            .iter()
+            .map(|(path, state)| JournalEntry {
+                path: path.clone(),
+                pre_existing: state.pre_existing.journal(),
+            })
+            .collect()
+    }
+
+    fn persist_journal(&self) -> io::Result<()> {
+        let Some(path) = &self.journal_path else {
+            return Ok(());
+        };
+        if self.leases.is_empty() {
+            match fs::remove_file(path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            }
+        } else {
+            let body = serde_json::to_vec_pretty(&Journal {
+                entries: self.journal_entries(),
+            })
+            .map_err(|error| io::Error::other(error.to_string()))?;
+            write_credential_file(path, &body)
+        }
+    }
+
+    fn recover_journal(&mut self) -> io::Result<()> {
+        let Some(path) = self.journal_path.clone() else {
+            return Ok(());
+        };
+        let body = match fs::read(&path) {
+            Ok(body) => body,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let journal: Journal = serde_json::from_slice(&body)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut remaining = Vec::new();
+        for entry in journal.entries {
+            let pre_existing = PreExisting::from_journal(entry.pre_existing)?;
+            if let Err(error) = self.restore(&entry.path, &pre_existing) {
+                tracing::warn!(path = %entry.path.display(), error = %error, "Cursor MCP lease recovery deferred");
+                remaining.push(JournalEntry {
+                    path: entry.path,
+                    pre_existing: pre_existing.journal(),
+                });
+            }
+        }
+        if remaining.is_empty() {
+            let _ = fs::remove_file(path);
+        } else {
+            let body = serde_json::to_vec_pretty(&Journal { entries: remaining })
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            write_credential_file(&path, &body)?;
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.leases.is_empty() && self.path_by_worker.is_empty()
@@ -197,8 +368,8 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    fn read(path: &Path) -> String {
-        fs::read_to_string(path).unwrap()
+    fn read(path: &Path) -> Vec<u8> {
+        fs::read(path).unwrap()
     }
 
     #[test]
@@ -207,197 +378,89 @@ mod tests {
         let worker = WorkerName::new("w1");
         let mut registry = CursorMcpLeaseRegistry::new();
         let path = registry.acquire(dir.path(), &worker).unwrap();
-        assert!(!path.exists(), "acquire must not create the file itself");
-
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        write_credential_file(&path, b"{\"mcpServers\":{}}").unwrap();
-        assert!(path.exists());
-
+        write_credential_file(&path, b"{} ").unwrap();
         registry.release_worker(&worker).unwrap();
-        assert!(!path.exists(), "generated file must be removed on release");
-        assert!(registry.is_empty());
-    }
-
-    #[test]
-    fn pre_existing_exact_config_is_restored() {
-        let dir = tempdir().unwrap();
-        let cursor_dir = dir.path().join(".cursor");
-        fs::create_dir_all(&cursor_dir).unwrap();
-        let path = cursor_dir.join("mcp.json");
-        let original = br#"{"mcpServers":{"filesystem":{"command":"fs"}}}"#;
-        fs::write(&path, original).unwrap();
-
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let worker = WorkerName::new("w1");
-        registry.acquire(dir.path(), &worker).unwrap();
-        // Simulate the injection overwrite.
-        write_credential_file(
-            &path,
-            br#"{"mcpServers":{"filesystem":{"command":"fs"},"agent-relay":{"token":"secret"}}}"#,
-        )
-        .unwrap();
-
-        registry.release_worker(&worker).unwrap();
-        assert_eq!(
-            read(&path).as_bytes(),
-            original,
-            "must restore exact pre-existing bytes"
-        );
-    }
-
-    #[test]
-    fn user_edits_between_acquire_and_release_are_overwritten_by_restore() {
-        // The captured pre-existing snapshot — not whatever is on disk at
-        // release time — is authoritative, so a credential leak cannot
-        // survive as "the user's file now".
-        let dir = tempdir().unwrap();
-        let cursor_dir = dir.path().join(".cursor");
-        fs::create_dir_all(&cursor_dir).unwrap();
-        let path = cursor_dir.join("mcp.json");
-        let original = br#"{"mcpServers":{"filesystem":{"command":"fs"}}}"#;
-        fs::write(&path, original).unwrap();
-
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let worker = WorkerName::new("w1");
-        registry.acquire(dir.path(), &worker).unwrap();
-        write_credential_file(
-            &path,
-            br#"{"mcpServers":{"agent-relay":{"token":"secret"}}}"#,
-        )
-        .unwrap();
-        // External edit after injection, before release.
-        fs::write(
-            &path,
-            br#"{"mcpServers":{"agent-relay":{"token":"secret"},"extra":true}}"#,
-        )
-        .unwrap();
-
-        registry.release_worker(&worker).unwrap();
-        assert_eq!(read(&path).as_bytes(), original);
-    }
-
-    #[test]
-    fn two_concurrent_workers_same_cwd_release_in_order_keeps_config_until_last() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join(".cursor").join("mcp.json");
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let w1 = WorkerName::new("w1");
-        let w2 = WorkerName::new("w2");
-
-        registry.acquire(dir.path(), &w1).unwrap();
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        write_credential_file(
-            &path,
-            b"{\"mcpServers\":{\"agent-relay\":{\"token\":\"w1\"}}}",
-        )
-        .unwrap();
-        registry.acquire(dir.path(), &w2).unwrap();
-        write_credential_file(
-            &path,
-            b"{\"mcpServers\":{\"agent-relay\":{\"token\":\"w2\"}}}",
-        )
-        .unwrap();
-
-        registry.release_worker(&w1).unwrap();
-        assert!(path.exists(), "config must survive while a holder remains");
-
-        registry.release_worker(&w2).unwrap();
-        assert!(
-            !path.exists(),
-            "config must be removed once the last holder releases"
-        );
-        assert!(registry.is_empty());
-    }
-
-    #[test]
-    fn two_concurrent_workers_same_cwd_release_in_reverse_order() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join(".cursor").join("mcp.json");
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let w1 = WorkerName::new("w1");
-        let w2 = WorkerName::new("w2");
-
-        registry.acquire(dir.path(), &w1).unwrap();
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        write_credential_file(&path, b"{}").unwrap();
-        registry.acquire(dir.path(), &w2).unwrap();
-
-        registry.release_worker(&w2).unwrap();
-        assert!(path.exists(), "config must survive while w1 remains");
-
-        registry.release_worker(&w1).unwrap();
         assert!(!path.exists());
+        assert!(!path.parent().unwrap().exists());
         assert!(registry.is_empty());
-    }
-
-    #[test]
-    fn spawn_failure_before_any_write_releases_cleanly() {
-        let dir = tempdir().unwrap();
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let worker = WorkerName::new("w1");
-        registry.acquire(dir.path(), &worker).unwrap();
-        // No write happened (simulated spawn failure right after acquire).
-        registry.release_worker(&worker).unwrap();
-        assert!(!dir.path().join(".cursor").join("mcp.json").exists());
-        assert!(registry.is_empty());
-    }
-
-    #[test]
-    fn explicit_release_of_unknown_worker_is_a_no_op() {
-        let mut registry = CursorMcpLeaseRegistry::new();
-        registry.release_worker(&WorkerName::new("ghost")).unwrap();
-    }
-
-    #[test]
-    fn reap_after_task_exit_restores_pre_existing_config() {
-        let dir = tempdir().unwrap();
-        let cursor_dir = dir.path().join(".cursor");
-        fs::create_dir_all(&cursor_dir).unwrap();
-        let path = cursor_dir.join("mcp.json");
-        fs::write(&path, b"{\"mcpServers\":{\"db\":{}}}").unwrap();
-
-        let mut registry = CursorMcpLeaseRegistry::new();
-        let worker = WorkerName::new("task-exit-worker");
-        registry.acquire(dir.path(), &worker).unwrap();
-        write_credential_file(&path, b"{\"mcpServers\":{\"db\":{},\"agent-relay\":{}}}").unwrap();
-
-        // reap_exited() path: worker process exited, registry sweeps it.
-        registry.release_worker(&worker).unwrap();
-        assert_eq!(read(&path), "{\"mcpServers\":{\"db\":{}}}");
     }
 
     #[cfg(unix)]
     #[test]
-    fn restrictive_mode_enforced_on_generated_and_restored_files() {
+    fn pre_existing_exact_config_and_mode_are_restored() {
         use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let cursor_dir = dir.path().join(".cursor");
+        fs::create_dir_all(&cursor_dir).unwrap();
+        let path = cursor_dir.join("mcp.json");
+        let original = br#"{ "mcpServers": { "filesystem": {} } }"#;
+        fs::write(&path, original).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let worker = WorkerName::new("w1");
+        registry.acquire(dir.path(), &worker).unwrap();
+        write_credential_file(&path, b"generated").unwrap();
+        registry.release_worker(&worker).unwrap();
+        assert_eq!(read(&path), original);
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+    }
 
+    #[test]
+    fn two_workers_share_one_lease_and_restore_after_last_release() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".cursor").join("mcp.json");
+        let mut registry = CursorMcpLeaseRegistry::new();
+        let w1 = WorkerName::new("w1");
+        let w2 = WorkerName::new("w2");
+        registry.acquire(dir.path(), &w1).unwrap();
+        write_credential_file(&path, b"generated").unwrap();
+        registry.acquire(dir.path(), &w2).unwrap();
+        registry.release_worker(&w1).unwrap();
+        assert!(path.exists());
+        registry.release_worker(&w2).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn journal_recovers_after_registry_restart() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let cursor = dir.path().join(".cursor");
+        fs::create_dir_all(&cursor).unwrap();
+        let path = cursor.join("mcp.json");
+        let original = b"user config";
+        fs::write(&path, original).unwrap();
+        {
+            let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
+            let worker = WorkerName::new("w1");
+            registry.acquire(dir.path(), &worker).unwrap();
+            write_credential_file(&path, b"placeholders only").unwrap();
+        }
+        let recovered = CursorMcpLeaseRegistry::with_journal(journal.clone());
+        assert!(recovered.is_empty());
+        assert_eq!(read(&path), original);
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn failed_restore_keeps_lease_for_a_later_retry() {
         let dir = tempdir().unwrap();
         let mut registry = CursorMcpLeaseRegistry::new();
         let worker = WorkerName::new("w1");
         let path = registry.acquire(dir.path(), &worker).unwrap();
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        write_credential_file(&path, b"{}").unwrap();
-        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "generated credential file must be 0600");
+        write_credential_file(&path, b"generated").unwrap();
+        fs::remove_file(&path).unwrap();
+        fs::create_dir(&path).unwrap();
 
-        // Now exercise the restore-path permission enforcement too.
-        drop(registry);
-        let dir2 = tempdir().unwrap();
-        let cursor_dir2 = dir2.path().join(".cursor");
-        fs::create_dir_all(&cursor_dir2).unwrap();
-        let path2 = cursor_dir2.join("mcp.json");
-        fs::write(&path2, b"{\"mcpServers\":{}}").unwrap();
-        fs::set_permissions(&path2, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(registry.release_worker(&worker).is_err());
+        assert!(!registry.is_empty(), "failed cleanup must remain retryable");
 
-        let mut registry2 = CursorMcpLeaseRegistry::new();
-        let worker2 = WorkerName::new("w2");
-        registry2.acquire(dir2.path(), &worker2).unwrap();
-        write_credential_file(&path2, b"{\"mcpServers\":{\"agent-relay\":{}}}").unwrap();
-        registry2.release_worker(&worker2).unwrap();
-        let restored_mode = fs::metadata(&path2).unwrap().permissions().mode() & 0o777;
-        assert_eq!(
-            restored_mode, 0o600,
-            "restored config must also be locked to 0600"
-        );
+        fs::remove_dir(&path).unwrap();
+        registry.release_worker(&worker).unwrap();
+        assert!(registry.is_empty());
+        assert!(!path.exists());
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fs,
-    io::{self, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -15,18 +15,47 @@ use crate::ids::WorkerName;
 
 #[derive(Debug, Clone)]
 enum PreExisting {
-    Absent {
-        created_dir: bool,
-    },
-    Present {
-        contents: Vec<u8>,
-        mode: Option<u32>,
-    },
+    Absent { created_dir: bool },
+    Present { contents: Vec<u8>, mode: u32 },
 }
 
 struct LeaseState {
     pre_existing: PreExisting,
     holders: HashSet<WorkerName>,
+    _lock: LeaseLock,
+}
+
+/// A kernel-held lock on the requested cwd. Locking the existing cwd rather
+/// than a lock file inside `.cursor` avoids leaving stale lock files/directories
+/// behind and makes separate broker processes fail closed before they can
+/// overwrite one another's placeholder config.
+struct LeaseLock {
+    _file: fs::File,
+}
+
+impl LeaseLock {
+    fn acquire(root: &Path) -> io::Result<Self> {
+        #[cfg(not(unix))]
+        {
+            let _ = root;
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Cursor MCP leasing requires kernel directory locks on this platform",
+            ));
+        }
+        #[cfg(unix)]
+        {
+            let file = fs::File::open(root)?;
+            file.try_lock().map_err(|error| match error {
+                fs::TryLockError::WouldBlock => io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "another broker owns the Cursor MCP cwd lease",
+                ),
+                fs::TryLockError::Error(error) => error,
+            })?;
+            Ok(Self { _file: file })
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,18 +72,14 @@ struct JournalEntry {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum JournalPreExisting {
-    Absent {
-        created_dir: bool,
-    },
-    Present {
-        contents_base64: String,
-        mode: Option<u32>,
-    },
+    Absent { created_dir: bool },
+    Present { contents_base64: String, mode: u32 },
 }
 
-/// Tracks in-process leases and a credential-free-on-disk recovery journal.
-/// The journal contains only pre-existing bytes and mode, never generated
-/// Relay credentials: generated Cursor values are `${env:...}` placeholders.
+/// Tracks leases and a recovery journal. The journal contains pre-existing
+/// bytes and mode, which may themselves be sensitive user data; it is written
+/// 0600 and never contains generated Relay credentials because generated Cursor
+/// values are `${env:...}` placeholders.
 #[derive(Default)]
 pub(crate) struct CursorMcpLeaseRegistry {
     leases: HashMap<PathBuf, LeaseState>,
@@ -62,18 +87,74 @@ pub(crate) struct CursorMcpLeaseRegistry {
     journal_path: Option<PathBuf>,
 }
 
-fn lease_path(root: &Path) -> PathBuf {
-    let joined = root.join(".cursor").join("mcp.json");
-    match root.canonicalize() {
-        Ok(canonical) => canonical.join(".cursor").join("mcp.json"),
-        Err(_) => joined,
+fn invalid_path(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn canonical_root(root: &Path) -> io::Result<PathBuf> {
+    let metadata = fs::symlink_metadata(root)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(invalid_path(format!(
+            "Cursor worker cwd is not a non-symlink directory: {}",
+            root.display()
+        )));
     }
+    root.canonicalize()
+}
+
+fn validate_cursor_dir(root: &Path) -> io::Result<bool> {
+    let cursor_dir = root.join(".cursor");
+    match fs::symlink_metadata(&cursor_dir) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(invalid_path(".cursor must not be a symlink"))
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            Err(invalid_path(".cursor exists but is not a directory"))
+        }
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn validate_target(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(invalid_path(".cursor/mcp.json must not be a symlink"))
+        }
+        Ok(metadata) if !metadata.is_file() => Err(invalid_path(
+            ".cursor/mcp.json exists but is not a regular file",
+        )),
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn validate_cursor_root(root: &Path) -> io::Result<()> {
+    let canonical = canonical_root(root)?;
+    let cursor_exists = validate_cursor_dir(&canonical)?;
+    let path = canonical.join(".cursor").join("mcp.json");
+    if cursor_exists {
+        let _ = validate_target(&path)?;
+    }
+    Ok(())
+}
+
+fn lease_path(root: &Path) -> io::Result<(PathBuf, PathBuf)> {
+    let canonical = canonical_root(root)?;
+    let cursor_exists = validate_cursor_dir(&canonical)?;
+    let key = canonical.join(".cursor").join("mcp.json");
+    if cursor_exists {
+        let _ = validate_target(&key)?;
+    }
+    Ok((key, canonical))
 }
 
 #[cfg(unix)]
 fn file_mode(path: &Path) -> io::Result<u32> {
     use std::os::unix::fs::PermissionsExt;
-    Ok(fs::metadata(path)?.permissions().mode() & 0o777)
+    Ok(open_read_nofollow(path)?.metadata()?.permissions().mode() & 0o777)
 }
 
 #[cfg(not(unix))]
@@ -84,12 +165,91 @@ fn file_mode(_path: &Path) -> io::Result<u32> {
 #[cfg(unix)]
 fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o777))
+    open_write_nofollow(path)?.set_permissions(fs::Permissions::from_mode(mode & 0o777))
 }
 
 #[cfg(not(unix))]
 fn set_mode(_path: &Path, _mode: u32) -> io::Result<()> {
     Ok(())
+}
+
+#[cfg(unix)]
+fn sync_dir(path: &Path) -> io::Result<()> {
+    fs::File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_dir(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn sync_file(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        open_read_nofollow(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        fs::File::open(path)?.sync_all()
+    }
+}
+
+fn sync_entry_parent(path: &Path) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_path("durable entry has no parent"))?;
+    sync_dir(parent)?;
+    if let Some(grandparent) = parent.parent() {
+        sync_dir(grandparent)?;
+    }
+    Ok(())
+}
+
+fn validate_credential_parent(parent: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(parent) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(invalid_path("credential parent must not be a symlink"));
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(invalid_path("credential parent must be a directory"));
+        }
+        Ok(_) => {}
+        Err(error) => return Err(error),
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_read_nofollow(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn open_write_nofollow(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+fn read_regular_file(path: &Path) -> io::Result<Vec<u8>> {
+    #[cfg(unix)]
+    {
+        let mut file = open_read_nofollow(path)?;
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents)?;
+        Ok(contents)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::read(path)
+    }
 }
 
 /// Atomically write a generated credential-bearing config with owner-only
@@ -99,7 +259,11 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     let parent = path.parent().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "credential path has no parent")
     })?;
-    fs::create_dir_all(parent)?;
+    if !parent.exists() {
+        fs::create_dir_all(parent)?;
+    }
+    validate_credential_parent(parent)?;
+    let _ = validate_target(path)?;
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -118,6 +282,7 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
         file.write_all(contents)?;
         file.sync_all()?;
         drop(file);
+        validate_credential_parent(parent)?;
         #[cfg(windows)]
         if path.exists() {
             fs::remove_file(path)?;
@@ -125,6 +290,8 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
         fs::rename(&temporary, path)?;
         #[cfg(unix)]
         set_mode(path, 0o600)?;
+        sync_file(path)?;
+        sync_entry_parent(path)?;
         Ok(())
     })();
     if result.is_err() {
@@ -133,11 +300,12 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     result
 }
 
-fn restore_file(path: &Path, contents: &[u8], mode: Option<u32>) -> io::Result<()> {
+fn restore_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
+    let _ = validate_target(path)?;
     write_credential_file(path, contents)?;
-    if let Some(mode) = mode {
-        set_mode(path, mode)?;
-    }
+    set_mode(path, mode)?;
+    sync_file(path)?;
+    sync_entry_parent(path)?;
     Ok(())
 }
 
@@ -190,7 +358,21 @@ impl CursorMcpLeaseRegistry {
     }
 
     pub(crate) fn acquire(&mut self, root: &Path, worker: &WorkerName) -> io::Result<PathBuf> {
-        let key = lease_path(root);
+        let (key, canonical) = lease_path(root)?;
+        if let Some(existing) = self.path_by_worker.get(worker) {
+            if existing == &key
+                && self
+                    .leases
+                    .get(&key)
+                    .is_some_and(|state| state.holders.contains(worker))
+            {
+                return Ok(key);
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("worker '{}' has pending Cursor MCP cleanup", worker),
+            ));
+        }
         if self.leases.contains_key(&key) {
             let was_new_holder = self
                 .leases
@@ -212,12 +394,14 @@ impl CursorMcpLeaseRegistry {
             return Ok(key);
         }
 
-        let cursor_dir = root.join(".cursor");
-        let dir_existed = cursor_dir.is_dir();
-        let pre_existing = if key.exists() {
+        let lock = LeaseLock::acquire(&canonical)?;
+        // Re-check after taking the kernel lock so cooperating brokers cannot
+        // race a parent/file replacement between validation and capture.
+        let dir_existed = validate_cursor_dir(&canonical)?;
+        let pre_existing = if validate_target(&key)? {
             PreExisting::Present {
-                contents: fs::read(&key)?,
-                mode: Some(file_mode(&key)?),
+                contents: read_regular_file(&key)?,
+                mode: file_mode(&key)?,
             }
         } else {
             PreExisting::Absent {
@@ -232,6 +416,7 @@ impl CursorMcpLeaseRegistry {
             LeaseState {
                 pre_existing,
                 holders,
+                _lock: lock,
             },
         );
         self.path_by_worker.insert(worker.clone(), key.clone());
@@ -248,6 +433,32 @@ impl CursorMcpLeaseRegistry {
             return Ok(());
         };
         self.release_path(&path, worker)
+    }
+
+    pub(crate) fn has_pending_cleanup(&self, worker: &WorkerName) -> bool {
+        let Some(path) = self.path_by_worker.get(worker) else {
+            return false;
+        };
+        self.leases
+            .get(path)
+            .is_some_and(|state| !state.holders.contains(worker))
+    }
+
+    /// Retry only ownership entries whose final restore previously failed.
+    /// Active holders are deliberately untouched; maintenance calls this on
+    /// every reap tick so an in-process I/O failure is not stranded forever.
+    pub(crate) fn retry_pending_cleanups(&mut self) {
+        let workers: Vec<WorkerName> = self
+            .path_by_worker
+            .keys()
+            .filter(|worker| self.has_pending_cleanup(worker))
+            .cloned()
+            .collect();
+        for worker in workers {
+            if let Err(error) = self.release_worker(&worker) {
+                tracing::warn!(worker = %worker, %error, "Cursor MCP cleanup retry deferred");
+            }
+        }
     }
 
     fn release_path(&mut self, path: &Path, worker: &WorkerName) -> io::Result<()> {
@@ -271,22 +482,51 @@ impl CursorMcpLeaseRegistry {
             },
         };
         self.restore(path, &pre_existing)?;
-        self.leases.remove(path);
+        let state = self.leases.remove(path).expect("lease checked above");
         self.path_by_worker.remove(worker);
-        self.persist_journal()
+        if let Err(error) = self.persist_journal() {
+            // The file is restored, but journal removal was not durable. Keep
+            // ownership in memory so the periodic retry can finish the
+            // transaction instead of relying only on a future broker restart.
+            self.leases.insert(path.to_path_buf(), state);
+            self.path_by_worker
+                .insert(worker.clone(), path.to_path_buf());
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn restore(&self, path: &Path, pre_existing: &PreExisting) -> io::Result<()> {
         match pre_existing {
             PreExisting::Absent { created_dir } => {
-                match fs::remove_file(path) {
-                    Ok(()) => {}
+                match fs::symlink_metadata(path) {
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        return Err(invalid_path(
+                            "refusing to remove a symlink at generated Cursor MCP path",
+                        ));
+                    }
+                    Ok(metadata) if !metadata.is_file() => {
+                        return Err(invalid_path(
+                            "refusing to remove a non-regular generated Cursor MCP path",
+                        ));
+                    }
+                    Ok(_) => {}
                     Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                     Err(error) => return Err(error),
                 }
+                let removed = match fs::remove_file(path) {
+                    Ok(()) => true,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+                    Err(error) => return Err(error),
+                };
+                if removed {
+                    sync_entry_parent(path)?;
+                }
                 if *created_dir {
                     if let Some(dir) = path.parent() {
-                        let _ = fs::remove_dir(dir);
+                        if fs::remove_dir(dir).is_ok() {
+                            sync_entry_parent(dir)?;
+                        }
                     }
                 }
             }
@@ -311,7 +551,7 @@ impl CursorMcpLeaseRegistry {
         };
         if self.leases.is_empty() {
             match fs::remove_file(path) {
-                Ok(()) => Ok(()),
+                Ok(()) => sync_entry_parent(path),
                 Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(error) => Err(error),
             }
@@ -338,6 +578,47 @@ impl CursorMcpLeaseRegistry {
         let mut remaining = Vec::new();
         for entry in journal.entries {
             let pre_existing = PreExisting::from_journal(entry.pre_existing)?;
+            if !entry.path.is_absolute() {
+                return Err(invalid_path(
+                    "Cursor MCP lease journal path must be absolute",
+                ));
+            }
+            let root = entry
+                .path
+                .parent()
+                .and_then(Path::parent)
+                .ok_or_else(|| invalid_path("invalid Cursor MCP lease journal path"))?;
+            let expected_path = root.join(".cursor").join("mcp.json");
+            if entry.path != expected_path {
+                return Err(invalid_path(
+                    "Cursor MCP lease journal path is outside its cwd",
+                ));
+            }
+            let canonical = canonical_root(root)?;
+            if entry.path != canonical.join(".cursor").join("mcp.json") {
+                return Err(invalid_path(
+                    "Cursor MCP lease journal path is not canonical",
+                ));
+            }
+            let _lock = match LeaseLock::acquire(root) {
+                Ok(lock) => lock,
+                Err(error) => {
+                    tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
+                    remaining.push(JournalEntry {
+                        path: entry.path,
+                        pre_existing: pre_existing.journal(),
+                    });
+                    continue;
+                }
+            };
+            if let Err(error) = validate_cursor_root(root) {
+                tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery rejected an unsafe path");
+                remaining.push(JournalEntry {
+                    path: entry.path,
+                    pre_existing: pre_existing.journal(),
+                });
+                continue;
+            }
             if let Err(error) = self.restore(&entry.path, &pre_existing) {
                 tracing::warn!(path = %entry.path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
@@ -347,7 +628,11 @@ impl CursorMcpLeaseRegistry {
             }
         }
         if remaining.is_empty() {
-            let _ = fs::remove_file(path);
+            match fs::remove_file(&path) {
+                Ok(()) => sync_entry_parent(&path)?,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
         } else {
             let body = serde_json::to_vec_pretty(&Journal { entries: remaining })
                 .map_err(|error| io::Error::other(error.to_string()))?;
@@ -462,5 +747,46 @@ mod tests {
         registry.release_worker(&worker).unwrap();
         assert!(registry.is_empty());
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn separate_registries_fail_closed_while_another_process_holds_cwd_lock() {
+        let dir = tempdir().unwrap();
+        let worker_one = WorkerName::new("w1");
+        let worker_two = WorkerName::new("w2");
+        let mut first = CursorMcpLeaseRegistry::new();
+        let mut second = CursorMcpLeaseRegistry::new();
+
+        first.acquire(dir.path(), &worker_one).unwrap();
+        let error = second.acquire(dir.path(), &worker_two).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+
+        first.release_worker(&worker_one).unwrap();
+        second.acquire(dir.path(), &worker_two).unwrap();
+        second.release_worker(&worker_two).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_cursor_paths_are_rejected_before_capture_or_write() {
+        use std::os::unix::fs::symlink;
+
+        let cwd = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let worker = WorkerName::new("hostile");
+        let outside_file = outside.path().join("mcp.json");
+        fs::write(&outside_file, b"outside bytes").unwrap();
+        symlink(outside.path(), cwd.path().join(".cursor")).unwrap();
+
+        let mut registry = CursorMcpLeaseRegistry::new();
+        assert!(registry.acquire(cwd.path(), &worker).is_err());
+        assert_eq!(read(&outside_file), b"outside bytes");
+
+        fs::remove_file(cwd.path().join(".cursor")).unwrap();
+        fs::create_dir(cwd.path().join(".cursor")).unwrap();
+        symlink(&outside_file, cwd.path().join(".cursor/mcp.json")).unwrap();
+        assert!(registry.acquire(cwd.path(), &worker).is_err());
+        assert_eq!(read(&outside_file), b"outside bytes");
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -230,9 +230,17 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
 }
 
 #[cfg(windows)]
-fn windows_child_file(path: &Path, create_new: bool, truncate: bool) -> io::Result<fs::File> {
+fn windows_child_file(path: &Path, write: bool) -> io::Result<fs::File> {
     use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::MetadataExt;
     use std::os::windows::io::{FromRawHandle, OwnedHandle};
+
+    let before = fs::symlink_metadata(path)?;
+    if before.file_type().is_symlink() || !before.is_file() || before.reparse_tag() != 0 {
+        return Err(invalid_path(
+            "Cursor MCP child must be a regular non-reparse file",
+        ));
+    }
 
     #[link(name = "Kernel32")]
     unsafe extern "system" {
@@ -250,26 +258,21 @@ fn windows_child_file(path: &Path, create_new: bool, truncate: bool) -> io::Resu
     const GENERIC_WRITE: u32 = 0x4000_0000;
     const FILE_SHARE_READ: u32 = 1;
     const FILE_SHARE_WRITE: u32 = 2;
-    const CREATE_NEW: u32 = 1;
     const OPEN_EXISTING: u32 = 3;
-    const TRUNCATE_EXISTING: u32 = 5;
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
     wide.push(0);
-    let disposition = if create_new {
-        CREATE_NEW
-    } else if truncate {
-        TRUNCATE_EXISTING
-    } else {
-        OPEN_EXISTING
-    };
     let handle = unsafe {
         CreateFileW(
             wide.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
+            if write {
+                GENERIC_READ | GENERIC_WRITE
+            } else {
+                GENERIC_READ
+            },
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             std::ptr::null(),
-            disposition,
+            OPEN_EXISTING,
             FILE_FLAG_OPEN_REPARSE_POINT,
             std::ptr::null_mut(),
         )
@@ -277,7 +280,52 @@ fn windows_child_file(path: &Path, create_new: bool, truncate: bool) -> io::Resu
     if handle == (-1isize) as *mut std::ffi::c_void {
         return Err(io::Error::last_os_error());
     }
-    Ok(unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) })
+    let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
+    let opened = windows_handle_identity(&file)?;
+    let expected = (before.volume_serial_number(), before.file_index());
+    if opened != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Cursor MCP child was replaced while opening",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn windows_handle_identity(file: &fs::File) -> io::Result<(u32, u64)> {
+    use std::os::windows::io::AsRawHandle;
+    #[repr(C)]
+    struct Information {
+        attributes: u32,
+        creation: [u32; 2],
+        access: [u32; 2],
+        write: [u32; 2],
+        volume: u32,
+        size_high: u32,
+        size_low: u32,
+        links: u32,
+        index_high: u32,
+        index_low: u32,
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn GetFileInformationByHandle(file: *mut std::ffi::c_void, info: *mut Information) -> i32;
+    }
+    let mut info = std::mem::MaybeUninit::<Information>::uninit();
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), info.as_mut_ptr()) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let info = unsafe { info.assume_init() };
+    if info.attributes & 0x10 != 0 || info.attributes & 0x400 != 0 {
+        return Err(invalid_path(
+            "Cursor MCP child handle is not a regular non-reparse file",
+        ));
+    }
+    Ok((
+        info.volume,
+        (u64::from(info.index_high) << 32) | u64::from(info.index_low),
+    ))
 }
 
 #[cfg(windows)]
@@ -868,9 +916,10 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     if validate_target(path)? {
         // Preserve the user's security descriptor for an existing config.
         // Replacing it with a temporary file would silently change ACLs and
-        // make exact restoration impossible. The pinned parent handle prevents
-        // replacement while this in-place mutation is active.
-        let mut file = windows_child_file(path, false, true)?;
+        // make exact restoration impossible. The child handle and identity
+        // check bind this mutation to the file validated above.
+        let mut file = windows_child_file(path, true)?;
+        file.set_len(0)?;
         file.write_all(contents)?;
         file.sync_all()?;
         return Ok(());
@@ -1219,7 +1268,7 @@ impl CursorMcpLeaseRegistry {
             if validate_target(path)? {
                 #[cfg(windows)]
                 {
-                    let mut file = windows_child_file(path, false, false)?;
+                    let mut file = windows_child_file(path, false)?;
                     let mut contents = Vec::new();
                     file.read_to_end(&mut contents)?;
                     Ok(Some(contents))

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -217,9 +217,29 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
         return Err(invalid_path("Cursor MCP lock file became a reparse point"));
     }
     if let Some(before) = before {
-        if before.file_index() != after.file_index()
-            || before.volume_serial_number() != after.volume_serial_number()
-        {
+        let before_identity = (
+            before.volume_serial_number().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "lock file has no volume identity",
+                )
+            })?,
+            before.file_index().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "lock file has no file identity")
+            })?,
+        );
+        let after_identity = (
+            after.volume_serial_number().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "lock file has no volume identity",
+                )
+            })?,
+            after.file_index().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "lock file has no file identity")
+            })?,
+        );
+        if before_identity != after_identity {
             return Err(io::Error::new(
                 io::ErrorKind::WouldBlock,
                 "Cursor MCP lock file was replaced",
@@ -282,7 +302,20 @@ fn windows_child_file(path: &Path, write: bool) -> io::Result<fs::File> {
     }
     let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
     let opened = windows_handle_identity(&file)?;
-    let expected = (before.volume_serial_number(), before.file_index());
+    let expected = (
+        before.volume_serial_number().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cursor MCP child has no volume identity",
+            )
+        })?,
+        before.file_index().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cursor MCP child has no file identity",
+            )
+        })?,
+    );
     if opened != expected {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
@@ -338,7 +371,20 @@ fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
             path.display()
         )));
     }
-    Ok((metadata.volume_serial_number(), metadata.file_index()))
+    Ok((
+        metadata.volume_serial_number().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cursor directory has no volume identity",
+            )
+        })?,
+        metadata.file_index().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cursor directory has no file identity",
+            )
+        })?,
+    ))
 }
 
 #[cfg(windows)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1089,6 +1089,11 @@ impl CursorMcpLeaseRegistry {
                 )
             })?;
             #[cfg(windows)]
+            let _parent_guard = windows_directory_guard(
+                path.parent()
+                    .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?,
+            )?;
+            #[cfg(windows)]
             validate_windows_cursor_identity(&state.lock, path, state.cursor_identity)?;
             write_credential_file(path, contents)
         }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -2041,7 +2041,7 @@ mod tests {
         let worker = WorkerName::new("w1");
         let mut registry = CursorMcpLeaseRegistry::new();
         let path = registry.acquire(dir.path(), &worker).unwrap();
-        write_credential_file(&path, b"{} ").unwrap();
+        registry.write_worker_cursor_file(&worker, b"{} ").unwrap();
         registry.release_worker(&worker).unwrap();
         assert!(!path.exists());
         assert!(!path.parent().unwrap().exists());
@@ -2086,7 +2086,9 @@ mod tests {
         let mut registry = CursorMcpLeaseRegistry::new();
         let worker = WorkerName::new("w1");
         registry.acquire(dir.path(), &worker).unwrap();
-        write_credential_file(&path, b"generated").unwrap();
+        registry
+            .write_worker_cursor_file(&worker, b"generated")
+            .unwrap();
         registry.release_worker(&worker).unwrap();
         assert_eq!(read(&path), original);
         assert_eq!(
@@ -2103,7 +2105,9 @@ mod tests {
         let w1 = WorkerName::new("w1");
         let w2 = WorkerName::new("w2");
         registry.acquire(dir.path(), &w1).unwrap();
-        write_credential_file(&path, b"generated").unwrap();
+        registry
+            .write_worker_cursor_file(&w1, b"generated")
+            .unwrap();
         registry.acquire(dir.path(), &w2).unwrap();
         registry.release_worker(&w1).unwrap();
         assert!(path.exists());
@@ -2124,7 +2128,9 @@ mod tests {
             let mut registry = CursorMcpLeaseRegistry::with_journal(journal.clone());
             let worker = WorkerName::new("w1");
             registry.acquire(dir.path(), &worker).unwrap();
-            write_credential_file(&path, b"placeholders only").unwrap();
+            registry
+                .write_worker_cursor_file(&worker, b"placeholders only")
+                .unwrap();
         }
         let recovered = CursorMcpLeaseRegistry::with_journal(journal.clone());
         assert!(recovered.is_empty());
@@ -2138,7 +2144,9 @@ mod tests {
         let mut registry = CursorMcpLeaseRegistry::new();
         let worker = WorkerName::new("w1");
         let path = registry.acquire(dir.path(), &worker).unwrap();
-        write_credential_file(&path, b"generated").unwrap();
+        registry
+            .write_worker_cursor_file(&worker, b"generated")
+            .unwrap();
         fs::remove_file(&path).unwrap();
         fs::create_dir(&path).unwrap();
 

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1870,14 +1870,19 @@ impl CursorMcpLeaseRegistry {
         }
         #[cfg(not(unix))]
         {
+            let parent = _path
+                .parent()
+                .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?;
             #[cfg(windows)]
-            let _parent_guard = windows_directory_guard(
-                _path
-                    .parent()
-                    .ok_or_else(|| invalid_path("Cursor MCP path has no parent"))?,
-            )?;
+            let parent_guard = match windows_directory_guard(parent) {
+                Ok(guard) => Some(guard),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+                Err(e) => return Err(e),
+            };
             #[cfg(windows)]
-            validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
+            if parent_guard.is_some() {
+                validate_windows_restore_path(lock, _path, expected_cursor_identity)?;
+            }
             match pre_existing {
                 PreExisting::Absent { created_dir } => {
                     #[cfg(windows)]
@@ -1940,6 +1945,10 @@ impl CursorMcpLeaseRegistry {
                         sync_entry_parent(_path)?;
                     }
                     if *created_dir {
+                        // Drop the directory guard before attempting removal so
+                        // Windows does not block the delete with an open handle.
+                        #[cfg(windows)]
+                        drop(parent_guard);
                         if let Some(dir) = _path.parent() {
                             if fs::remove_dir(dir).is_ok() {
                                 sync_entry_parent(dir)?;

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -171,18 +171,9 @@ impl LeaseLock {
 #[cfg(windows)]
 fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
     use std::os::windows::ffi::OsStrExt;
-    use std::os::windows::fs::MetadataExt;
     use std::os::windows::io::{FromRawHandle, OwnedHandle};
 
-    let before = fs::symlink_metadata(path).ok();
-    if before
-        .as_ref()
-        .is_some_and(|m| m.file_type().is_symlink() || m.reparse_tag() != 0)
-    {
-        return Err(invalid_path(
-            "Cursor MCP lock file must not be a reparse point",
-        ));
-    }
+    let before = windows_path_identity(path).ok();
     #[link(name = "Kernel32")]
     unsafe extern "system" {
         fn CreateFileW(
@@ -218,34 +209,9 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
         return Err(io::Error::last_os_error());
     }
     let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
-    let after = fs::symlink_metadata(path)?;
-    if after.file_type().is_symlink() || after.reparse_tag() != 0 {
-        return Err(invalid_path("Cursor MCP lock file became a reparse point"));
-    }
+    let after = windows_handle_identity(&file)?;
     if let Some(before) = before {
-        let before_identity = (
-            before.volume_serial_number().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "lock file has no volume identity",
-                )
-            })?,
-            before.file_index().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "lock file has no file identity")
-            })?,
-        );
-        let after_identity = (
-            after.volume_serial_number().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "lock file has no volume identity",
-                )
-            })?,
-            after.file_index().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "lock file has no file identity")
-            })?,
-        );
-        if before_identity != after_identity {
+        if before != after {
             return Err(io::Error::new(
                 io::ErrorKind::WouldBlock,
                 "Cursor MCP lock file was replaced",
@@ -256,17 +222,53 @@ fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
 }
 
 #[cfg(windows)]
-fn windows_child_file(path: &Path, write: bool, delete: bool) -> io::Result<fs::File> {
+fn windows_path_identity(path: &Path) -> io::Result<(u32, u64)> {
     use std::os::windows::ffi::OsStrExt;
-    use std::os::windows::fs::MetadataExt;
     use std::os::windows::io::{FromRawHandle, OwnedHandle};
 
-    let before = fs::symlink_metadata(path)?;
-    if before.file_type().is_symlink() || !before.is_file() || before.reparse_tag() != 0 {
-        return Err(invalid_path(
-            "Cursor MCP child must be a regular non-reparse file",
-        ));
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const std::ffi::c_void,
+            disposition: u32,
+            flags: u32,
+            template: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
     }
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const FILE_SHARE_READ: u32 = 1;
+    const FILE_SHARE_WRITE: u32 = 2;
+    const OPEN_EXISTING: u32 = 3;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == (-1isize) as *mut std::ffi::c_void {
+        return Err(io::Error::last_os_error());
+    }
+    let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
+    windows_handle_identity(&file)
+}
+
+#[cfg(windows)]
+fn windows_child_file(path: &Path, write: bool, delete: bool) -> io::Result<fs::File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+
+    let expected = windows_path_identity(path)?;
 
     #[link(name = "Kernel32")]
     unsafe extern "system" {
@@ -309,20 +311,6 @@ fn windows_child_file(path: &Path, write: bool, delete: bool) -> io::Result<fs::
     }
     let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
     let opened = windows_handle_identity(&file)?;
-    let expected = (
-        before.volume_serial_number().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Cursor MCP child has no volume identity",
-            )
-        })?,
-        before.file_index().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Cursor MCP child has no file identity",
-            )
-        })?,
-    );
     if opened != expected {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
@@ -334,6 +322,17 @@ fn windows_child_file(path: &Path, write: bool, delete: bool) -> io::Result<fs::
 
 #[cfg(windows)]
 fn windows_handle_identity(file: &fs::File) -> io::Result<(u32, u64)> {
+    let (identity, attributes) = windows_handle_metadata(file)?;
+    if attributes & 0x10 != 0 || attributes & 0x400 != 0 {
+        return Err(invalid_path(
+            "Cursor MCP child handle is not a regular non-reparse file",
+        ));
+    }
+    Ok(identity)
+}
+
+#[cfg(windows)]
+fn windows_handle_metadata(file: &fs::File) -> io::Result<((u32, u64), u32)> {
     use std::os::windows::io::AsRawHandle;
     #[repr(C)]
     struct Information {
@@ -357,14 +356,12 @@ fn windows_handle_identity(file: &fs::File) -> io::Result<(u32, u64)> {
         return Err(io::Error::last_os_error());
     }
     let info = unsafe { info.assume_init() };
-    if info.attributes & 0x10 != 0 || info.attributes & 0x400 != 0 {
-        return Err(invalid_path(
-            "Cursor MCP child handle is not a regular non-reparse file",
-        ));
-    }
     Ok((
-        info.volume,
-        (u64::from(info.index_high) << 32) | u64::from(info.index_low),
+        (
+            info.volume,
+            (u64::from(info.index_high) << 32) | u64::from(info.index_low),
+        ),
+        info.attributes,
     ))
 }
 
@@ -401,28 +398,51 @@ fn windows_delete_file(file: fs::File) -> io::Result<()> {
 
 #[cfg(windows)]
 fn windows_directory_identity(path: &Path) -> io::Result<(u32, u64)> {
-    use std::os::windows::fs::MetadataExt;
-    let metadata = fs::symlink_metadata(path)?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() || metadata.reparse_tag() != 0 {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const std::ffi::c_void,
+            disposition: u32,
+            flags: u32,
+            template: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+    }
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const FILE_SHARE_READ: u32 = 1;
+    const FILE_SHARE_WRITE: u32 = 2;
+    const OPEN_EXISTING: u32 = 3;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == (-1isize) as *mut std::ffi::c_void {
+        return Err(io::Error::last_os_error());
+    }
+    let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
+    let (identity, attributes) = windows_handle_metadata(&file)?;
+    if attributes & 0x10 == 0 || attributes & 0x400 != 0 {
         return Err(invalid_path(format!(
             "Cursor worker cwd is not a non-reparse directory: {}",
             path.display()
         )));
     }
-    Ok((
-        metadata.volume_serial_number().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Cursor directory has no volume identity",
-            )
-        })?,
-        metadata.file_index().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Cursor directory has no file identity",
-            )
-        })?,
-    ))
+    Ok(identity)
 }
 
 #[cfg(windows)]
@@ -1727,6 +1747,26 @@ impl CursorMcpLeaseRegistry {
             .collect()
     }
 
+    /// A deferred entry may have been resolved by another broker while this
+    /// registry was waiting on the cwd lock. Reconcile only when the exact
+    /// pre-existing state is now observable; otherwise retain the work.
+    fn deferred_entry_resolved(entry: &JournalEntry) -> io::Result<bool> {
+        let pre_existing = PreExisting::from_journal(entry.pre_existing.clone())?;
+        match pre_existing {
+            PreExisting::Absent { .. } => match fs::symlink_metadata(&entry.path) {
+                Ok(_) => Ok(false),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
+                Err(error) => Err(error),
+            },
+            PreExisting::Present { contents, .. } => {
+                if !validate_target(&entry.path)? {
+                    return Ok(false);
+                }
+                Ok(fs::read(&entry.path).is_ok_and(|actual| actual == contents))
+            }
+        }
+    }
+
     fn persist_journal(&self) -> io::Result<()> {
         let Some(path) = &self.journal_path else {
             return Ok(());
@@ -1773,8 +1813,11 @@ impl CursorMcpLeaseRegistry {
                 merged.remove(owned);
             }
         }
-        for entry in &self.deferred_journal {
-            merged.insert(entry.0.clone(), entry.1.clone());
+        for entry in self.deferred_journal.values() {
+            if !merged.contains_key(&entry.path) && Self::deferred_entry_resolved(entry)? {
+                continue;
+            }
+            merged.insert(entry.path.clone(), entry.clone());
         }
         for entry in active {
             merged.insert(entry.path.clone(), entry);
@@ -2494,6 +2537,92 @@ mod tests {
             fs::read(&journal).ok()
         );
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn second_registry_does_not_resurrect_resolved_deferred_entry() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().join("resolved");
+        fs::create_dir_all(root.join(".cursor")).unwrap();
+        let path = root.canonicalize().unwrap().join(".cursor/mcp.json");
+        let entry = JournalEntry {
+            path: path.clone(),
+            pre_existing: JournalPreExisting::Absent { created_dir: false },
+        };
+        let mut first = CursorMcpLeaseRegistry {
+            journal_path: Some(journal.clone()),
+            ..Default::default()
+        };
+        first.deferred_journal.insert(path.clone(), entry.clone());
+        first.journal_owned_paths.insert(path.clone());
+        first.persist_journal().unwrap();
+
+        let mut second = CursorMcpLeaseRegistry {
+            journal_path: Some(journal.clone()),
+            ..Default::default()
+        };
+        second.deferred_journal.insert(path.clone(), entry);
+        second.journal_owned_paths.insert(path);
+
+        first.deferred_journal.clear();
+        first.persist_journal().unwrap();
+        second.persist_journal().unwrap();
+        assert!(!journal.exists(), "resolved work must not be resurrected");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_persist_failure_keeps_deferred_work_for_later_acquire() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().join("blocked");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(".cursor"), b"not a directory").unwrap();
+        let path = root.join(".cursor/mcp.json");
+        fs::write(
+            &journal,
+            serde_json::to_vec(&Journal {
+                entries: vec![JournalEntry {
+                    path: path.clone(),
+                    pre_existing: JournalPreExisting::Absent { created_dir: false },
+                }],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let mut recovery = CursorMcpLeaseRegistry {
+            journal_path: Some(journal.clone()),
+            ..Default::default()
+        };
+        let lock_path = journal.with_file_name(".cursor-mcp-leases.lock");
+        let mut held_lock = None;
+        let error = recovery
+            .recover_journal_with_hook(|| {
+                let lock = fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .open(&lock_path)
+                    .unwrap();
+                lock.try_lock().unwrap();
+                held_lock = Some(lock);
+            })
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(recovery.deferred_journal.contains_key(&path));
+        drop(held_lock);
+
+        let unrelated = dir.path().join("unrelated");
+        fs::create_dir(&unrelated).unwrap();
+        let worker = WorkerName::new("unrelated");
+        recovery.acquire(&unrelated, &worker).unwrap();
+        recovery.release_worker(&worker).unwrap();
+        assert!(
+            journal.exists(),
+            "deferred work must survive later persistence"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -41,6 +41,11 @@ struct LeaseLock {
     lock_path: PathBuf,
 }
 
+enum CursorAcquireError {
+    Lock(io::Error),
+    Cursor { lock: LeaseLock, error: io::Error },
+}
+
 #[cfg(unix)]
 impl LeaseLock {
     fn root_fd(&self) -> std::os::unix::io::RawFd {
@@ -121,8 +126,8 @@ impl LeaseLock {
     fn acquire_with_cursor(
         root: &Path,
         create_cursor: bool,
-    ) -> io::Result<(Self, Option<fs::File>, bool)> {
-        let lock = Self::acquire(root)?;
+    ) -> Result<(Self, Option<fs::File>, bool), CursorAcquireError> {
+        let lock = Self::acquire(root).map_err(CursorAcquireError::Lock)?;
         #[cfg(unix)]
         {
             match lock.open_cursor_dir(create_cursor) {
@@ -134,7 +139,7 @@ impl LeaseLock {
                     // still holding this lock.
                     Ok((lock, None, false))
                 }
-                Err(error) => Err(error),
+                Err(error) => Err(CursorAcquireError::Cursor { lock, error }),
             }
         }
         #[cfg(not(unix))]
@@ -637,7 +642,12 @@ impl CursorMcpLeaseRegistry {
         // operations. A hostile process can rename `.cursor` after a pathname
         // check, but it cannot redirect the descriptor captured here. Keep
         // that descriptor in LeaseState for the full lease lifetime.
-        let (lock, cursor_dir, created_dir) = LeaseLock::acquire_with_cursor(&canonical, true)?;
+        let (lock, cursor_dir, created_dir) = match LeaseLock::acquire_with_cursor(&canonical, true)
+        {
+            Ok(value) => value,
+            Err(CursorAcquireError::Lock(error))
+            | Err(CursorAcquireError::Cursor { error, .. }) => return Err(error),
+        };
         #[cfg(unix)]
         let pre_existing = if let Some(cursor) = cursor_dir.as_ref() {
             if let Some((contents, mode)) = read_cursor_target(cursor)? {
@@ -649,7 +659,26 @@ impl CursorMcpLeaseRegistry {
             unreachable!("Unix lease must retain a Cursor directory descriptor")
         };
         #[cfg(not(unix))]
-        let pre_existing = unreachable!("LeaseLock acquisition is unsupported on non-Unix");
+        let (created_dir, pre_existing) = {
+            let cursor = canonical.join(".cursor");
+            let created_dir = match validate_cursor_dir(&canonical)? {
+                true => false,
+                false => match fs::create_dir(&cursor) {
+                    Ok(()) => true,
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => false,
+                    Err(error) => return Err(error),
+                },
+            };
+            let pre_existing = if validate_target(&key)? {
+                PreExisting::Present {
+                    contents: fs::read(&key)?,
+                    mode: 0o600,
+                }
+            } else {
+                PreExisting::Absent { created_dir }
+            };
+            (created_dir, pre_existing)
+        };
 
         let mut holders = HashSet::new();
         holders.insert(worker.clone());
@@ -715,10 +744,17 @@ impl CursorMcpLeaseRegistry {
         #[cfg(not(unix))]
         {
             let _ = state;
-            Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Cursor MCP leasing requires Unix directory descriptors",
-            ))
+            let path = self.path_by_worker.get(worker).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("no Cursor MCP lease for worker '{worker}'"),
+                )
+            })?;
+            if validate_target(path)? {
+                Ok(Some(fs::read(path)?))
+            } else {
+                Ok(None)
+            }
         }
     }
 
@@ -743,11 +779,14 @@ impl CursorMcpLeaseRegistry {
         }
         #[cfg(not(unix))]
         {
-            let _ = (state, contents);
-            Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Cursor MCP leasing requires Unix directory descriptors",
-            ))
+            let _ = state;
+            let path = self.path_by_worker.get(worker).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("no Cursor MCP lease for worker '{worker}'"),
+                )
+            })?;
+            write_credential_file(path, contents)
         }
     }
 
@@ -862,7 +901,7 @@ impl CursorMcpLeaseRegistry {
         #[cfg(not(unix))]
         match pre_existing {
             PreExisting::Absent { created_dir } => {
-                match fs::symlink_metadata(path) {
+                match fs::symlink_metadata(_path) {
                     Ok(metadata) if metadata.file_type().is_symlink() => {
                         return Err(invalid_path(
                             "refusing to remove a symlink at generated Cursor MCP path",
@@ -877,16 +916,16 @@ impl CursorMcpLeaseRegistry {
                     Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                     Err(error) => return Err(error),
                 }
-                let removed = match fs::remove_file(path) {
+                let removed = match fs::remove_file(_path) {
                     Ok(()) => true,
                     Err(error) if error.kind() == io::ErrorKind::NotFound => false,
                     Err(error) => return Err(error),
                 };
                 if removed {
-                    sync_entry_parent(path)?;
+                    sync_entry_parent(_path)?;
                 }
                 if *created_dir {
-                    if let Some(dir) = path.parent() {
+                    if let Some(dir) = _path.parent() {
                         if fs::remove_dir(dir).is_ok() {
                             sync_entry_parent(dir)?;
                         }
@@ -1026,9 +1065,9 @@ impl CursorMcpLeaseRegistry {
                 });
                 continue;
             }
-            let lock = match LeaseLock::acquire(root) {
-                Ok(lock) => lock,
-                Err(error) => {
+            let (lock, cursor_dir, _) = match LeaseLock::acquire_with_cursor(root, false) {
+                Ok(value) => value,
+                Err(CursorAcquireError::Lock(error)) => {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
                     remaining.push(JournalEntry {
                         path,
@@ -1036,11 +1075,7 @@ impl CursorMcpLeaseRegistry {
                     });
                     continue;
                 }
-            };
-            let cursor_dir = match lock.open_cursor_dir(false) {
-                Ok((cursor, _)) => Some(cursor),
-                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-                Err(error) => {
+                Err(CursorAcquireError::Cursor { lock, error }) => {
                     tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because .cursor could not be opened safely");
                     remaining.push(JournalEntry {
                         path,
@@ -1488,6 +1523,77 @@ mod tests {
         );
         assert_eq!(read(&path), b"outside bytes");
         assert_eq!(read(&outside_file), b"outside bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_defers_regular_cursor_and_keeps_root_locked() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let cursor_path = root.join(".cursor");
+        fs::write(&cursor_path, b"not a directory").unwrap();
+        let path = cursor_path.join("mcp.json");
+        let body = serde_json::to_vec(&Journal {
+            entries: vec![JournalEntry {
+                path: path.clone(),
+                pre_existing: JournalPreExisting::Absent { created_dir: false },
+            }],
+        })
+        .unwrap();
+        fs::write(&journal, body).unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        recovery
+            .recover_journal_with_hook(|| match LeaseLock::acquire(&root) {
+                Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
+                Ok(_) => panic!("root lock should stay held until journal finalization"),
+            })
+            .unwrap();
+        assert!(
+            journal.exists(),
+            "invalid cursor entry must remain journaled"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_defers_invalid_child_and_keeps_root_locked() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let cursor_path = root.join(".cursor");
+        fs::create_dir(&cursor_path).unwrap();
+        let path = cursor_path.join("mcp.json");
+        fs::create_dir(&path).unwrap();
+        let body = serde_json::to_vec(&Journal {
+            entries: vec![JournalEntry {
+                path: path.clone(),
+                pre_existing: JournalPreExisting::Absent { created_dir: false },
+            }],
+        })
+        .unwrap();
+        fs::write(&journal, body).unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        recovery
+            .recover_journal_with_hook(|| match LeaseLock::acquire(&root) {
+                Err(error) => assert_eq!(error.kind(), io::ErrorKind::WouldBlock),
+                Ok(_) => panic!("root lock should stay held until journal finalization"),
+            })
+            .unwrap();
+        assert!(
+            journal.exists(),
+            "invalid child entry must remain journaled"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -35,7 +35,10 @@ struct LeaseState {
 /// behind and makes separate broker processes fail closed before they can
 /// overwrite one another's placeholder config.
 struct LeaseLock {
+    #[cfg(unix)]
     _file: fs::File,
+    #[cfg(not(unix))]
+    lock_path: PathBuf,
 }
 
 #[cfg(unix)]
@@ -81,14 +84,6 @@ impl LeaseLock {
 
 impl LeaseLock {
     fn acquire(root: &Path) -> io::Result<Self> {
-        #[cfg(not(unix))]
-        {
-            let _ = root;
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Cursor MCP leasing requires kernel directory locks on this platform",
-            ));
-        }
         #[cfg(unix)]
         {
             let file = open_dir_nofollow(root)?;
@@ -100,6 +95,26 @@ impl LeaseLock {
                 fs::TryLockError::Error(error) => error,
             })?;
             Ok(Self { _file: file })
+        }
+        #[cfg(not(unix))]
+        {
+            let lock_path = root.join(".cursor-mcp-lease.lock");
+            let result = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path);
+            match result {
+                Ok(mut file) => {
+                    use std::io::Write as _;
+                    let _ = writeln!(file, "{}", std::process::id());
+                    Ok(Self { lock_path })
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "another broker owns the Cursor MCP cwd lease",
+                )),
+                Err(error) => Err(error),
+            }
         }
     }
 
@@ -126,6 +141,15 @@ impl LeaseLock {
         {
             let _ = create_cursor;
             Ok((lock, None, false))
+        }
+    }
+}
+
+impl Drop for LeaseLock {
+    fn drop(&mut self) {
+        #[cfg(not(unix))]
+        {
+            let _ = fs::remove_file(&self.lock_path);
         }
     }
 }
@@ -166,7 +190,7 @@ struct JournalEntry {
     pre_existing: JournalPreExisting,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum JournalPreExisting {
     Absent { created_dir: bool },
@@ -898,8 +922,23 @@ impl CursorMcpLeaseRegistry {
                 Err(error) => Err(error),
             }
         } else {
+            let mut merged: HashMap<PathBuf, JournalEntry> = match fs::read(path) {
+                Ok(body) => match serde_json::from_slice::<Journal>(&body) {
+                    Ok(journal) => journal
+                        .entries
+                        .into_iter()
+                        .map(|entry| (entry.path.clone(), entry))
+                        .collect(),
+                    Err(error) => return Err(io::Error::new(io::ErrorKind::InvalidData, error)),
+                },
+                Err(error) if error.kind() == io::ErrorKind::NotFound => HashMap::new(),
+                Err(error) => return Err(error),
+            };
+            for entry in self.journal_entries() {
+                merged.insert(entry.path.clone(), entry);
+            }
             let body = serde_json::to_vec_pretty(&Journal {
-                entries: self.journal_entries(),
+                entries: merged.into_values().collect(),
             })
             .map_err(|error| io::Error::other(error.to_string()))?;
             write_credential_file(path, &body)
@@ -931,35 +970,68 @@ impl CursorMcpLeaseRegistry {
         // that this recovery pass would then unlink or replace.
         let mut held_locks = Vec::new();
         for entry in journal.entries {
-            let pre_existing = PreExisting::from_journal(entry.pre_existing)?;
-            if !entry.path.is_absolute() {
-                return Err(invalid_path(
-                    "Cursor MCP lease journal path must be absolute",
-                ));
+            let path = entry.path.clone();
+            let pre_existing = match PreExisting::from_journal(entry.pre_existing.clone()) {
+                Ok(pre_existing) => pre_existing,
+                Err(error) => {
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery skipped an undecodable entry");
+                    remaining.push(entry);
+                    continue;
+                }
+            };
+            if !path.is_absolute() {
+                tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-absolute path");
+                remaining.push(JournalEntry {
+                    path,
+                    pre_existing: pre_existing.journal(),
+                });
+                continue;
             }
-            let root = entry
-                .path
-                .parent()
-                .and_then(Path::parent)
-                .ok_or_else(|| invalid_path("invalid Cursor MCP lease journal path"))?;
+            let root = match path.parent().and_then(Path::parent) {
+                Some(root) => root,
+                None => {
+                    tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped an invalid path");
+                    remaining.push(JournalEntry {
+                        path,
+                        pre_existing: pre_existing.journal(),
+                    });
+                    continue;
+                }
+            };
             let expected_path = root.join(".cursor").join("mcp.json");
-            if entry.path != expected_path {
-                return Err(invalid_path(
-                    "Cursor MCP lease journal path is outside its cwd",
-                ));
+            if path != expected_path {
+                tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-canonical path");
+                remaining.push(JournalEntry {
+                    path,
+                    pre_existing: pre_existing.journal(),
+                });
+                continue;
             }
-            let canonical = canonical_root(root)?;
-            if entry.path != canonical.join(".cursor").join("mcp.json") {
-                return Err(invalid_path(
-                    "Cursor MCP lease journal path is not canonical",
-                ));
+            let canonical = match canonical_root(root) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery skipped an unsafe cwd");
+                    remaining.push(JournalEntry {
+                        path,
+                        pre_existing: pre_existing.journal(),
+                    });
+                    continue;
+                }
+            };
+            if path != canonical.join(".cursor").join("mcp.json") {
+                tracing::warn!(path = %path.display(), "Cursor MCP lease recovery skipped a non-canonical path");
+                remaining.push(JournalEntry {
+                    path,
+                    pre_existing: pre_existing.journal(),
+                });
+                continue;
             }
             let lock = match LeaseLock::acquire(root) {
                 Ok(lock) => lock,
                 Err(error) => {
-                    tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because another broker owns the cwd");
                     remaining.push(JournalEntry {
-                        path: entry.path,
+                        path,
                         pre_existing: pre_existing.journal(),
                     });
                     continue;
@@ -969,9 +1041,9 @@ impl CursorMcpLeaseRegistry {
                 Ok((cursor, _)) => Some(cursor),
                 Err(error) if error.kind() == io::ErrorKind::NotFound => None,
                 Err(error) => {
-                    tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery deferred because .cursor could not be opened safely");
+                    tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery deferred because .cursor could not be opened safely");
                     remaining.push(JournalEntry {
-                        path: entry.path,
+                        path,
                         pre_existing: pre_existing.journal(),
                     });
                     held_locks.push(lock);
@@ -979,20 +1051,18 @@ impl CursorMcpLeaseRegistry {
                 }
             };
             if let Err(error) = validate_cursor_root(root) {
-                tracing::warn!(path = %entry.path.display(), %error, "Cursor MCP lease recovery rejected an unsafe path");
+                tracing::warn!(path = %path.display(), %error, "Cursor MCP lease recovery rejected an unsafe path");
                 remaining.push(JournalEntry {
-                    path: entry.path,
+                    path,
                     pre_existing: pre_existing.journal(),
                 });
                 held_locks.push(lock);
                 continue;
             }
-            if let Err(error) =
-                Self::restore(&entry.path, &pre_existing, &lock, cursor_dir.as_ref())
-            {
-                tracing::warn!(path = %entry.path.display(), error = %error, "Cursor MCP lease recovery deferred");
+            if let Err(error) = Self::restore(&path, &pre_existing, &lock, cursor_dir.as_ref()) {
+                tracing::warn!(path = %path.display(), error = %error, "Cursor MCP lease recovery deferred");
                 remaining.push(JournalEntry {
-                    path: entry.path,
+                    path,
                     pre_existing: pre_existing.journal(),
                 });
                 held_locks.push(lock);
@@ -1418,5 +1488,52 @@ mod tests {
         );
         assert_eq!(read(&path), b"outside bytes");
         assert_eq!(read(&outside_file), b"outside bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_skips_bad_entry_and_restores_later_entries() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("journal.json");
+        let root = dir.path().canonicalize().unwrap();
+        let first = root.join(".cursor/mcp.json");
+        let second_root = dir.path().join("other");
+        fs::create_dir(&second_root).unwrap();
+        let second = second_root.join(".cursor/mcp.json");
+        fs::create_dir_all(first.parent().unwrap()).unwrap();
+        fs::create_dir_all(second.parent().unwrap()).unwrap();
+        fs::write(&first, b"first-original").unwrap();
+        fs::write(&second, b"second-original").unwrap();
+        let body = serde_json::to_vec(&Journal {
+            entries: vec![
+                JournalEntry {
+                    path: first.clone(),
+                    pre_existing: JournalPreExisting::Present {
+                        contents_base64: "!!!not-base64!!!".into(),
+                        mode: 0o600,
+                    },
+                },
+                JournalEntry {
+                    path: second.clone(),
+                    pre_existing: JournalPreExisting::Present {
+                        contents_base64: base64::engine::general_purpose::STANDARD
+                            .encode(b"second-original"),
+                        mode: 0o600,
+                    },
+                },
+            ],
+        })
+        .unwrap();
+        fs::write(&journal, body).unwrap();
+
+        let mut recovery = CursorMcpLeaseRegistry {
+            leases: HashMap::new(),
+            path_by_worker: HashMap::new(),
+            journal_path: Some(journal.clone()),
+        };
+        recovery.recover_journal().unwrap();
+        assert_eq!(read(&first), b"first-original");
+        assert_eq!(read(&second), b"second-original");
+        assert!(journal.exists(), "bad entry must remain journaled");
     }
 }

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -110,6 +110,9 @@ impl LeaseLock {
         #[cfg(not(unix))]
         {
             let lock_path = root.join(".cursor-mcp-lease.lock");
+            #[cfg(windows)]
+            let file = windows_lock_file(&lock_path)?;
+            #[cfg(not(windows))]
             let file = fs::OpenOptions::new()
                 .read(true)
                 .write(true)
@@ -157,6 +160,73 @@ impl LeaseLock {
             Ok((lock, None, false))
         }
     }
+}
+
+#[cfg(windows)]
+fn windows_lock_file(path: &Path) -> io::Result<fs::File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::MetadataExt;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+
+    let before = fs::symlink_metadata(path).ok();
+    if before
+        .as_ref()
+        .is_some_and(|m| m.file_type().is_symlink() || m.reparse_tag() != 0)
+    {
+        return Err(invalid_path(
+            "Cursor MCP lock file must not be a reparse point",
+        ));
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const std::ffi::c_void,
+            disposition: u32,
+            flags: u32,
+            template: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+    }
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const FILE_SHARE_READ: u32 = 1;
+    const FILE_SHARE_WRITE: u32 = 2;
+    const OPEN_ALWAYS: u32 = 4;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_ALWAYS,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == (-1isize) as *mut std::ffi::c_void {
+        return Err(io::Error::last_os_error());
+    }
+    let file = unsafe { fs::File::from(OwnedHandle::from_raw_handle(handle)) };
+    let after = fs::symlink_metadata(path)?;
+    if after.file_type().is_symlink() || after.reparse_tag() != 0 {
+        return Err(invalid_path("Cursor MCP lock file became a reparse point"));
+    }
+    if let Some(before) = before {
+        if before.file_index() != after.file_index()
+            || before.volume_serial_number() != after.volume_serial_number()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Cursor MCP lock file was replaced",
+            ));
+        }
+    }
+    Ok(file)
 }
 
 #[cfg(windows)]
@@ -742,6 +812,20 @@ pub(crate) fn write_credential_file(path: &Path, contents: &[u8]) -> io::Result<
     let _ = validate_target(path)?;
     #[cfg(windows)]
     let _parent_guard = windows_directory_guard(parent)?;
+    #[cfg(windows)]
+    if validate_target(path)? {
+        // Preserve the user's security descriptor for an existing config.
+        // Replacing it with a temporary file would silently change ACLs and
+        // make exact restoration impossible. The pinned parent handle prevents
+        // replacement while this in-place mutation is active.
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        return Ok(());
+    }
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())

--- a/crates/broker/src/cursor_mcp_lease.rs
+++ b/crates/broker/src/cursor_mcp_lease.rs
@@ -1033,7 +1033,10 @@ fn write_credential_file_with_identity(
     let _parent_guard = windows_directory_guard(parent).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("guard credential parent directory {path}: {e}"),
+            format!(
+                "guard credential parent directory {}: {e}",
+                parent.display()
+            ),
         )
     })?;
     #[cfg(windows)]

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod config;
 pub(crate) mod control;
 #[allow(dead_code)]
 pub(crate) mod conversation_log;
+pub(crate) mod cursor_mcp_lease;
 #[allow(dead_code)]
 pub(crate) mod dedup;
 #[allow(dead_code)]

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod workspace;
 pub(crate) mod ws;
 
 pub(crate) use crate::snippets::{
-    configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token,
+    configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token, is_cursor_cli_name,
 };
 pub(crate) use auth::{
     agent_identity_key, identity_key_fingerprint, reclaim_legacy_identity,

--- a/crates/broker/src/relaycast/mod.rs
+++ b/crates/broker/src/relaycast/mod.rs
@@ -6,7 +6,8 @@ pub(crate) mod workspace;
 pub(crate) mod ws;
 
 pub(crate) use crate::snippets::{
-    configure_agent_relay_mcp_with_result, configure_agent_relay_mcp_with_token, is_cursor_cli_name,
+    configure_agent_relay_mcp_with_result_and_cursor_lease, configure_agent_relay_mcp_with_token,
+    is_cursor_cli_name,
 };
 pub(crate) use auth::{
     agent_identity_key, identity_key_fingerprint, reclaim_legacy_identity,

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -440,17 +440,12 @@ impl BrokerRuntime {
                     // new identity to the node for normal delivery/inventory.
                     match register_new_spawn_identity(relaycast_http, &name, Some(&cli)).await {
                         Ok(token) => {
-                            super::fleet::spawn_declared_metadata_publish(
-                                relaycast_http,
-                                name.as_str(),
-                                registration_metadata,
-                            );
                             // HTTP registration alone leaves the agent
                             // without a node binding; the engine only
                             // delivers to `via_node` agents in node-only
                             // delivery. Bind it to this node so it is
-                            // deliverable, surfacing a loud warning if the
-                            // bind fails.
+                            // deliverable. A failed binding is an admission
+                            // failure: never launch an unreachable worker.
                             let bind_warning =
                                 super::relaycast_events::bind_http_registered_agent_to_node(
                                     relaycast_http,
@@ -459,7 +454,21 @@ impl BrokerRuntime {
                                 )
                                 .await;
                             if let Some(warning) = bind_warning {
-                                preregistration_warning = Some(warning);
+                                seed_supplied_agent_token(relaycast_http, &name, &token);
+                                super::identity_cleanup::schedule_identity_cleanup(
+                                    workers,
+                                    fleet_control_tx,
+                                    fleet_delivery_book,
+                                    fleet_inventory,
+                                    relaycast_http,
+                                    &name,
+                                    true,
+                                    Some(super::identity_cleanup::CleanupCompletion::Api(
+                                        reply,
+                                        Err(warning),
+                                    )),
+                                );
+                                return;
                             } else {
                                 match super::fleet::resolve_fleet_agent_token_identity(
                                     relaycast_http,
@@ -687,6 +696,16 @@ impl BrokerRuntime {
                     .await
                 {
                     Ok(effective_spec) => {
+                        // Both hosted credential paths publish declared metadata. Wait for
+                        // admission to succeed before scheduling a detached PATCH.
+                        // Local-only workers have no hosted identity to update.
+                        if worker_relay_key.is_some() {
+                            super::fleet::spawn_declared_metadata_publish(
+                                relaycast_http,
+                                name.as_str(),
+                                registration_metadata,
+                            );
+                        }
                         if owns_identity {
                             if let Some(worker) = workers.workers.get(&name) {
                                 workers.owned_spawn_generations.insert(

--- a/crates/broker/src/runtime/fleet.rs
+++ b/crates/broker/src/runtime/fleet.rs
@@ -2749,6 +2749,7 @@ mod tests {
             Vec::new(),
             temp.path().join("worker-logs"),
             Instant::now(),
+            "test-broker",
         );
         let mut child = tokio::process::Command::new("sh")
             .args(["-c", "exit 19"])

--- a/crates/broker/src/runtime/init.rs
+++ b/crates/broker/src/runtime/init.rs
@@ -631,7 +631,13 @@ pub(crate) async fn run_init(cmd: InitCommand, telemetry: TelemetryClient) -> Re
         .expect("state path should always have a parent")
         .join("team")
         .join("worker-logs");
-    let workers = WorkerRegistry::new(worker_event_tx, worker_env, worker_logs_dir, broker_start);
+    let workers = WorkerRegistry::new(
+        worker_event_tx,
+        worker_env,
+        worker_logs_dir,
+        broker_start,
+        &resolved_name,
+    );
 
     // Load crash insights from previous session
     let crash_insights_path = paths.state.parent().unwrap().join("crash-insights.json");

--- a/crates/broker/src/runtime/relaycast_events.rs
+++ b/crates/broker/src/runtime/relaycast_events.rs
@@ -992,6 +992,7 @@ mod tests {
             Vec::new(),
             temp.path().join("worker-logs"),
             Instant::now(),
+            "test-broker",
         );
         let released_agent = WorkerName::from("released-view-target");
         let healthy_agent = WorkerName::from("healthy-idle-view-target");
@@ -1197,6 +1198,7 @@ mod tests {
             Vec::new(),
             temp.path().join("worker-logs"),
             Instant::now(),
+            "test-broker",
         );
         let workspace_id = WorkspaceId::from("ws_test_1430".to_string());
         let (ws_control_tx, _ws_control_rx) = mpsc::channel::<WsControl>(4);

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -6365,6 +6365,127 @@ async fn owned_cleanup_retries_delete_without_repeating_acknowledged_deregistrat
 }
 
 #[tokio::test]
+async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identity() {
+    use crate::listen_api::ListenApiRequest;
+    use httpmock::{
+        Method::{GET, PATCH, POST},
+        MockServer,
+    };
+    use tokio::sync::oneshot;
+    let server = MockServer::start();
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents");
+        then.status(201).json_body(json!({"ok":true,"data":{
+            "id":"owned-binding-id","workspace_id":"ws_demo","name":"binding-refused",
+            "status":"active","created_at":"2026-09-11T12:00:00Z","token":"at_live_binding_fixture"
+        }}));
+    });
+    let bind = server.mock(|when, then| {
+        when.method(POST).path("/v1/nodes/test-node/agents");
+        then.status(503).json_body(json!({"ok":false,"error":{
+            "code":"workspace_busy","message":"binding admission busy"
+        }}));
+    });
+    let metadata = server.mock(|when, then| {
+        when.method(PATCH).path("/v1/agents/binding-refused");
+        then.status(200).json_body(json!({"ok":true,"data":{}}));
+    });
+    let scope = server.mock(|when, then| {
+        when.method(GET).path("/v1/agents/binding-refused");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"channels":[]}}));
+    });
+    let cleanup = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents/release");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"status":"completed"}}));
+    });
+    let registry = make_worker_registry_with_worker("unrelated-binding-worker").await;
+    let mut fixture = worker_event_runtime_fixture(registry, HashMap::new());
+    fixture.runtime.relaycast_http =
+        RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "codex");
+    let name = WorkerName::from("binding-refused");
+    let (reply, mut result) = oneshot::channel();
+    fixture
+        .runtime
+        .handle_api_request(ListenApiRequest::Spawn {
+            name: name.clone(),
+            cli: "missing-binding-fixture-cli".into(),
+            transport: None,
+            model: None,
+            args: vec![],
+            task: None,
+            registration_metadata: crate::fleet_wire::AgentRegistrationMetadata {
+                organization: Some("original-spawn".into()),
+                project: Some("must-not-leak-to-retry".into()),
+                ..Default::default()
+            },
+            channels: Some(vec![]),
+            cwd: None,
+            team: None,
+            shadow_of: None,
+            shadow_mode: None,
+            continue_from: None,
+            idle_threshold_secs: None,
+            exit_after_task: false,
+            skip_relay_prompt: true,
+            restart_policy: Box::new(None),
+            harness_config: None,
+            agent_token: None,
+            agent_result_schema: None,
+            replay_buffer: crate::replay_buffer::ReplayBuffer::new(16),
+            reply,
+        })
+        .await;
+    let response = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            fixture.runtime.reconcile_identity_cleanups().await;
+            if let Ok(response) = result.try_recv() {
+                break response;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    let unrelated_survived = fixture
+        .runtime
+        .workers
+        .has_worker("unrelated-binding-worker");
+    fixture
+        .runtime
+        .workers
+        .release("unrelated-binding-worker")
+        .await
+        .unwrap();
+    let error = response
+        .expect("binding failure cleanup must settle")
+        .unwrap_err();
+    assert!(
+        error.contains("binding") && error.contains("workspace_busy"),
+        "{error}"
+    );
+    create.assert_hits(1);
+    bind.assert_hits(1);
+    // Let any incorrectly detached request run before the name can be reused.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    metadata.assert_hits(0);
+    scope.assert_hits(0);
+    cleanup.assert_hits(1);
+    assert!(unrelated_survived);
+    assert!(!fixture.runtime.workers.has_worker(&name));
+    assert!(!fixture
+        .runtime
+        .workers
+        .identity_cleanups
+        .contains_key(&name));
+    assert!(!fixture
+        .runtime
+        .workers
+        .owned_spawn_generations
+        .contains_key(&name));
+}
+
+#[tokio::test]
 async fn local_only_queued_work_survives_restart_and_replays_when_recipient_reconnects() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("pending.json");
@@ -6474,4 +6595,177 @@ async fn local_only_restored_exhausted_delivery_replays_to_already_registered_wo
     assert_eq!(pending[&id].delivery, expected_delivery);
     assert_eq!(pending[&id].attempts, MAX_DELIVERY_RETRIES + 1);
     assert_eq!(pending[&id].failed_attempts, 0);
+}
+
+#[tokio::test]
+async fn http_spawn_supplied_token_publishes_declared_metadata() {
+    assert_http_spawn_metadata_publication(true, true).await;
+}
+
+#[tokio::test]
+async fn http_spawn_new_identity_publishes_declared_metadata() {
+    assert_http_spawn_metadata_publication(false, true).await;
+}
+
+#[tokio::test]
+async fn http_spawn_failed_launch_does_not_publish_declared_metadata() {
+    assert_http_spawn_metadata_publication(true, false).await;
+}
+
+async fn assert_http_spawn_metadata_publication(supplied_token: bool, valid_cwd: bool) {
+    use crate::listen_api::ListenApiRequest;
+    use httpmock::{
+        Method::{GET, PATCH, POST},
+        MockServer,
+    };
+    use tokio::sync::oneshot;
+
+    let server = MockServer::start();
+    let name = WorkerName::from("metadata-worker");
+    let token = "at_live_metadata_fixture";
+    let identity = json!({"id":"metadata-id","workspace_id":"ws_demo",
+        "name":name,"status":"active","created_at":"2026-09-11T12:00:00Z"});
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents");
+        let mut data = identity.clone();
+        data["token"] = json!(token);
+        then.status(201).json_body(json!({"ok":true,"data":data}));
+    });
+    let bind = server.mock(|when, then| {
+        when.method(POST).path("/v1/nodes/test-node/agents");
+        then.status(200).json_body(json!({"ok":true,"data":{
+            "id":"binding-id", "agent_id":"metadata-id", "agent_name":"metadata-worker",
+            "node_id":"node-id", "node_name":"test-node", "node_kind":"local", "node_role":"broker",
+            "status":"active", "session_ref":null, "priority":0,
+            "created_at":"2026-09-11T12:00:00Z", "updated_at":null
+        }}));
+    });
+    let lookup = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/agent")
+            .header("authorization", format!("Bearer {token}"));
+        then.status(200)
+            .json_body(json!({"ok":true,"data":identity}));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/v1/agents/metadata-worker");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"channels":[]}}));
+    });
+    let metadata = server.mock(|when, then| {
+        when.method(PATCH)
+            .path("/v1/agents/metadata-worker")
+            .json_body(json!({"metadata":{
+                "organization":"demo-org", "project":"demo-project",
+                "workstream":"subscriptions", "role":"reviewer", "objective":"prove delivery"
+            }}));
+        then.status(200)
+            .json_body(json!({"ok":true,"data":identity}));
+    });
+    let unexpected_cleanup = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents/release");
+        then.status(500);
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (events, _event_rx) = mpsc::channel(16);
+    let registry = WorkerRegistry::new(
+        events,
+        vec![],
+        dir.path().join("logs"),
+        Instant::now(),
+        "test-broker",
+    );
+    let mut fixture = worker_event_runtime_fixture(registry, HashMap::new());
+    fixture.runtime.relaycast_http =
+        RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "codex");
+    let (reply, result) = oneshot::channel();
+    fixture
+        .runtime
+        .handle_api_request(ListenApiRequest::Spawn {
+            name: name.clone(),
+            cli: "cat".into(),
+            transport: None,
+            model: None,
+            args: vec![],
+            task: None,
+            registration_metadata: crate::fleet_wire::AgentRegistrationMetadata {
+                organization: Some("demo-org".into()),
+                project: Some("demo-project".into()),
+                workstream: Some("subscriptions".into()),
+                role: Some("reviewer".into()),
+                objective: Some("prove delivery".into()),
+            },
+            channels: Some(vec![]),
+            cwd: Some(
+                if valid_cwd {
+                    dir.path().to_path_buf()
+                } else {
+                    dir.path().join("missing")
+                }
+                .to_string_lossy()
+                .into_owned(),
+            ),
+            team: None,
+            shadow_of: None,
+            shadow_mode: None,
+            continue_from: None,
+            idle_threshold_secs: None,
+            exit_after_task: false,
+            skip_relay_prompt: true,
+            restart_policy: Box::new(None),
+            harness_config: Some(crate::protocol::ResolvedHarnessConfig::Native(
+                crate::protocol::NativeHarnessConfig {
+                    command: "cat".into(),
+                    args: vec![],
+                    cwd: None,
+                    env: None,
+                    session_id: "metadata-session".into(),
+                    metadata: None,
+                },
+            )),
+            agent_token: supplied_token.then(|| token.to_string()),
+            agent_result_schema: None,
+            replay_buffer: crate::replay_buffer::ReplayBuffer::new(16),
+            reply,
+        })
+        .await;
+    let response = tokio::time::timeout(Duration::from_secs(3), result).await;
+    // A fixture or admission regression must fail promptly rather than hang CI.
+    // Stop the owned harness before assertions, including on a regression failure.
+    fixture.runtime.workers.shutdown_all().await.unwrap();
+    let response = response.expect("spawn reply must settle").unwrap();
+    if valid_cwd {
+        assert_eq!(response.unwrap()["success"], true);
+        let published = tokio::time::timeout(Duration::from_secs(2), async {
+            while metadata.hits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            published.is_ok(),
+            "successful spawn did not publish declared metadata"
+        );
+        metadata.assert_hits(1);
+    } else {
+        assert!(response.unwrap_err().contains("cwd"));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        metadata.assert_hits(0);
+    }
+    create.assert_hits(usize::from(!supplied_token));
+    bind.assert_hits(usize::from(!supplied_token));
+    lookup.assert_hits(1);
+    unexpected_cleanup.assert_hits(0);
+    assert!(!fixture
+        .runtime
+        .workers
+        .identity_cleanups
+        .contains_key(&name));
+    if supplied_token {
+        assert!(!fixture
+            .runtime
+            .workers
+            .owned_spawn_generations
+            .contains_key(&name));
+    }
 }

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -5156,6 +5156,7 @@ fn bypass_flag_codex_with_other_args() {
 // ==================== is_pid_alive ====================
 
 #[test]
+#[cfg(unix)]
 fn is_pid_alive_returns_true_for_self() {
     let pid = std::process::id();
     assert!(
@@ -5165,6 +5166,7 @@ fn is_pid_alive_returns_true_for_self() {
 }
 
 #[test]
+#[cfg(unix)]
 fn is_pid_alive_returns_false_for_dead_pid() {
     // Spawn a short-lived child, wait for it to exit, then verify it's dead
     let child = std::process::Command::new("true")
@@ -5182,6 +5184,7 @@ fn is_pid_alive_returns_false_for_dead_pid() {
 }
 
 #[test]
+#[cfg(unix)]
 fn is_pid_alive_returns_false_for_bogus_pid() {
     // PID 0 is the kernel scheduler — kill(0, 0) signals the entire process group,
     // not a real target. Use a very high PID that almost certainly doesn't exist.
@@ -5194,6 +5197,7 @@ fn is_pid_alive_returns_false_for_bogus_pid() {
 }
 
 #[test]
+#[cfg(unix)]
 fn is_pid_alive_eperm_means_alive() {
     // PID 1 (launchd/init) is owned by root. When run as a normal user,
     // kill(1, 0) returns EPERM — the process exists but we can't signal it.

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -80,6 +80,7 @@ async fn make_worker_registry_with_worker(name: &str) -> WorkerRegistry {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let mut child = tokio::process::Command::new("cat")
         .stdin(Stdio::piped())
@@ -142,6 +143,7 @@ async fn make_worker_registry_with_stalled_worker(name: &str) -> WorkerRegistry 
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let child = tokio::process::Command::new("cat")
         .stdin(Stdio::piped())
@@ -236,6 +238,7 @@ async fn owned_cleanup_exhaustion_signals_once_and_explicit_release_restarts() {
             Vec::new(),
             PathBuf::from("/tmp/cleanup-exhaustion-fixture"),
             Instant::now(),
+            "test-broker",
         );
         let mut fixture = worker_event_runtime_fixture(registry, HashMap::new());
         let name = WorkerName::from("exhausted-owner");
@@ -897,6 +900,7 @@ async fn inbound_queue_worker_missing_does_not_create_state() {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let mut delivery_states = HashMap::new();
 
@@ -1432,6 +1436,7 @@ async fn manual_flush_failure_retains_failed_message_and_suffix_without_ack() {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let first = fleet_deliver(1);
     let second = fleet_deliver(2);
@@ -1940,6 +1945,7 @@ async fn retry_exhaustion_dead_letters_instead_of_discarding() {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let mut exhausted = make_pending_delivery("del_exhausted", "ghost");
     exhausted.attempts = MAX_DELIVERY_RETRIES;
@@ -2087,6 +2093,7 @@ async fn terminal_disposition_helpers_remove_withheld_fleet_ack_state() {
             Vec::new(),
             PathBuf::from("/tmp/agent-relay-broker-tests"),
             Instant::now(),
+            "test-broker",
         );
         let mut exhausted = make_pending_delivery("del_exhausted_ack", "ghost");
         exhausted.attempts = MAX_DELIVERY_RETRIES;
@@ -2192,6 +2199,7 @@ async fn terminal_disposition_helpers_remove_withheld_fleet_ack_state() {
             Vec::new(),
             PathBuf::from("/tmp/agent-relay-broker-tests"),
             Instant::now(),
+            "test-broker",
         ); // no worker ever registered
         let relay_delivery = RelayDelivery {
             delivery_id: DeliveryId::new("del_worker_missing"),
@@ -2743,6 +2751,7 @@ async fn restored_ack_floor_survives_lower_failure_and_a_second_restart() {
         Vec::new(),
         dir.path().join("worker-logs"),
         Instant::now(),
+        "test-broker",
     );
     let outcome = retry_pending_delivery(
         &first_id,
@@ -2891,6 +2900,7 @@ async fn delivery_retry_fails_promptly_when_recipient_is_gone() {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let mut pending_deliveries = HashMap::from([(
         DeliveryId::new("del_gone"),
@@ -2956,6 +2966,7 @@ async fn initial_delivery_failure_stays_owned_until_dead_lettered() {
         Vec::new(),
         PathBuf::from("/tmp/agent-relay-broker-tests"),
         Instant::now(),
+        "test-broker",
     );
     let mut pending_deliveries = HashMap::new();
 
@@ -6368,7 +6379,13 @@ async fn local_only_queued_work_survives_restart_and_replays_when_recipient_reco
     super::save_pending_deliveries(&path, &pending).unwrap();
     pending = load_pending_deliveries(&path);
     let (tx, _rx) = mpsc::channel(8);
-    let mut absent = WorkerRegistry::new(tx, vec![], dir.path().join("logs"), Instant::now());
+    let mut absent = WorkerRegistry::new(
+        tx,
+        vec![],
+        dir.path().join("logs"),
+        Instant::now(),
+        "test-broker",
+    );
     assert!(matches!(
         retry_pending_delivery(&id, &mut absent, &mut pending, Duration::from_secs(1))
             .await
@@ -6406,7 +6423,13 @@ async fn local_only_exhausted_delivery_survives_absence_and_replays_after_restar
     // Exercise the live exhausted queue first: loading a snapshot resets the
     // failure budget and would hide an exhaustion check before absence handling.
     let (tx, _rx) = mpsc::channel(8);
-    let mut absent = WorkerRegistry::new(tx, vec![], dir.path().join("logs"), Instant::now());
+    let mut absent = WorkerRegistry::new(
+        tx,
+        vec![],
+        dir.path().join("logs"),
+        Instant::now(),
+        "test-broker",
+    );
     for _ in 0..2 {
         assert!(matches!(
             retry_pending_delivery(&id, &mut absent, &mut pending, Duration::from_secs(1))

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -1378,6 +1378,16 @@ pub async fn configure_agent_relay_mcp_with_result(
     Ok(args)
 }
 
+/// True when `cli` resolves to Cursor's headless binary — the same detection
+/// [`configure_agent_relay_mcp_with_result`] uses to decide whether it writes
+/// `.cursor/mcp.json`. Exposed so callers (the worker registry's cursor MCP
+/// lease) can decide whether to acquire/release a lease without duplicating
+/// the CLI-name detection logic.
+pub(crate) fn is_cursor_cli_name(cli: &str) -> bool {
+    let cli_lower = detect_cli_name(cli).to_lowercase();
+    cli_lower == "cursor" || cli_lower == "cursor-agent" || cli_lower == "agent"
+}
+
 fn detect_cli_name(cli: &str) -> String {
     let command = shlex::split(cli)
         .and_then(|parts| parts.first().cloned())

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -15,10 +15,7 @@ use tokio::{
 };
 
 use crate::{
-    cursor_mcp_lease::{
-        read_cursor_credential_file, validate_cursor_root, write_cursor_credential_file,
-    },
-    types::AgentResultMcpConfig,
+    cursor_mcp_lease::CursorMcpLeaseRegistry, ids::WorkerName, types::AgentResultMcpConfig,
 };
 
 const AGENT_RELAY_MCP_PACKAGE: &str = "agent-relay";
@@ -1070,8 +1067,42 @@ pub fn ensure_cursor_mcp_config(
     default_workspace: Option<&str>,
     agent_result: Option<&AgentResultMcpConfig>,
 ) -> io::Result<bool> {
-    validate_cursor_root(root)?;
+    // Standalone one-shot callers (for example `mcp-args`) still get a
+    // descriptor-relative write. WorkerRegistry passes its longer-lived lease
+    // through `ensure_cursor_mcp_config_with_lease` instead.
+    let mut leases = CursorMcpLeaseRegistry::new();
+    let worker = WorkerName::new("cursor-config-one-shot");
+    leases.acquire(root, &worker)?;
+    ensure_cursor_mcp_config_with_lease(
+        root,
+        relay_api_key,
+        relay_base_url,
+        relay_agent_name,
+        relay_agent_token,
+        workspaces_json,
+        default_workspace,
+        agent_result,
+        &leases,
+        &worker,
+    )
+}
 
+/// Configure a Cursor file through the descriptors held by the worker's
+/// already-acquired lease. `root` is retained for API context and diagnostics,
+/// but is never reopened or traversed here.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn ensure_cursor_mcp_config_with_lease(
+    _root: &Path,
+    relay_api_key: Option<&str>,
+    relay_base_url: Option<&str>,
+    relay_agent_name: Option<&str>,
+    relay_agent_token: Option<&str>,
+    workspaces_json: Option<&str>,
+    default_workspace: Option<&str>,
+    agent_result: Option<&AgentResultMcpConfig>,
+    leases: &CursorMcpLeaseRegistry,
+    worker: &WorkerName,
+) -> io::Result<bool> {
     let new_value = json!({"mcpServers": {"agent-relay":
         cursor_agent_relay_mcp_server_config(
             relay_api_key,
@@ -1084,15 +1115,11 @@ pub fn ensure_cursor_mcp_config(
         )
     }});
 
-    let existing_bytes = match read_cursor_credential_file(root) {
-        Ok(bytes) => Some(bytes),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error),
-    };
+    let existing_bytes = leases.read_worker_cursor_file(worker)?;
     if existing_bytes.is_none() {
         let body = serde_json::to_vec_pretty(&new_value)
             .map_err(|error| io::Error::other(error.to_string()))?;
-        write_cursor_credential_file(root, &body)?;
+        leases.write_worker_cursor_file(worker, &body)?;
         return Ok(true);
     }
 
@@ -1123,7 +1150,7 @@ pub fn ensure_cursor_mcp_config(
     if changed {
         let body = serde_json::to_vec_pretty(&parsed)
             .map_err(|error| io::Error::other(error.to_string()))?;
-        write_cursor_credential_file(root, &body)?;
+        leases.write_worker_cursor_file(worker, &body)?;
     }
     Ok(changed)
 }
@@ -1199,6 +1226,36 @@ pub async fn configure_agent_relay_mcp_with_result(
     workspaces_json: Option<&str>,
     default_workspace: Option<&str>,
     agent_result: Option<&AgentResultMcpConfig>,
+) -> Result<Vec<String>> {
+    configure_agent_relay_mcp_with_result_and_cursor_lease(
+        cli,
+        agent_name,
+        api_key,
+        base_url,
+        existing_args,
+        cwd,
+        agent_token,
+        workspaces_json,
+        default_workspace,
+        agent_result,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn configure_agent_relay_mcp_with_result_and_cursor_lease(
+    cli: &str,
+    agent_name: &str,
+    api_key: Option<&str>,
+    base_url: Option<&str>,
+    existing_args: &[String],
+    cwd: &Path,
+    agent_token: Option<&str>,
+    workspaces_json: Option<&str>,
+    default_workspace: Option<&str>,
+    agent_result: Option<&AgentResultMcpConfig>,
+    cursor_lease: Option<(&CursorMcpLeaseRegistry, &WorkerName)>,
 ) -> Result<Vec<String>> {
     let cli_lower = detect_cli_name(cli).to_lowercase();
     let is_claude = cli_lower == "claude" || cli_lower.starts_with("claude:");
@@ -1411,17 +1468,32 @@ pub async fn configure_agent_relay_mcp_with_result(
         args.push("--agent".to_string());
         args.push(AGENT_RELAY_MCP_SERVER.to_string());
     } else if is_cursor {
-        ensure_cursor_mcp_config(
-            cwd,
-            api_key,
-            base_url,
-            Some(agent_name),
-            agent_token,
-            workspaces_json,
-            default_workspace,
-            agent_result,
-        )
-        .with_context(|| {
+        let result = if let Some((leases, worker)) = cursor_lease {
+            ensure_cursor_mcp_config_with_lease(
+                cwd,
+                api_key,
+                base_url,
+                Some(agent_name),
+                agent_token,
+                workspaces_json,
+                default_workspace,
+                agent_result,
+                leases,
+                worker,
+            )
+        } else {
+            ensure_cursor_mcp_config(
+                cwd,
+                api_key,
+                base_url,
+                Some(agent_name),
+                agent_token,
+                workspaces_json,
+                default_workspace,
+                agent_result,
+            )
+        };
+        result.with_context(|| {
             "failed to write .cursor/mcp.json for Agent Relay MCP. \
                  Please configure the Agent Relay MCP server manually in .cursor/mcp.json"
         })?;

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -14,7 +14,7 @@ use tokio::{
     process::Command,
 };
 
-use crate::types::AgentResultMcpConfig;
+use crate::{cursor_mcp_lease::write_credential_file, types::AgentResultMcpConfig};
 
 const AGENT_RELAY_MCP_PACKAGE: &str = "agent-relay";
 const AGENT_RELAY_MCP_SUBCOMMAND: &str = "mcp";
@@ -691,6 +691,66 @@ fn agent_relay_mcp_server_config(
     Value::Object(server)
 }
 
+fn cursor_env_placeholder(name: &str) -> Value {
+    Value::String(format!("${{env:{name}}}"))
+}
+
+/// Cursor expands `${env:NAME}` when it launches an MCP server. Keep the
+/// generated project file credential-free while still selecting which optional
+/// variables the worker actually has available in its process environment.
+fn cursor_agent_relay_mcp_server_config(
+    relay_api_key: Option<&str>,
+    relay_base_url: Option<&str>,
+    relay_agent_name: Option<&str>,
+    relay_agent_token: Option<&str>,
+    workspaces_json: Option<&str>,
+    default_workspace: Option<&str>,
+    agent_result: Option<&AgentResultMcpConfig>,
+) -> Value {
+    let command = agent_relay_mcp_command();
+    let mut server = Map::new();
+    server.insert("command".into(), Value::String(command.command));
+    server.insert(
+        "args".into(),
+        Value::Array(command.args.into_iter().map(Value::String).collect()),
+    );
+    let mut env = Map::new();
+    let add_if_present = |env: &mut Map<String, Value>, key: &str, value: Option<&str>| {
+        if value.map(str::trim).is_some_and(|value| !value.is_empty()) {
+            env.insert(key.into(), cursor_env_placeholder(key));
+        }
+    };
+    add_if_present(&mut env, "RELAY_API_KEY", relay_api_key);
+    add_if_present(&mut env, "RELAY_BASE_URL", relay_base_url);
+    add_if_present(&mut env, "RELAY_AGENT_NAME", relay_agent_name);
+    if relay_agent_name
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        env.insert("RELAY_AGENT_TYPE".into(), Value::String("agent".into()));
+        env.insert("RELAY_STRICT_AGENT_NAME".into(), Value::String("1".into()));
+    }
+    if relay_agent_token
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        env.insert(
+            "RELAY_AGENT_TOKEN".into(),
+            cursor_env_placeholder("RELAY_AGENT_TOKEN"),
+        );
+        env.insert("RELAY_SKIP_BOOTSTRAP".into(), Value::String("1".into()));
+    }
+    add_if_present(&mut env, "RELAY_WORKSPACES_JSON", workspaces_json);
+    add_if_present(&mut env, "RELAY_DEFAULT_WORKSPACE", default_workspace);
+    if let Some(config) = agent_result {
+        for (key, _) in config.env_pairs() {
+            env.insert(key.into(), cursor_env_placeholder(key));
+        }
+    }
+    server.insert("env".into(), Value::Object(env));
+    Value::Object(server)
+}
+
 fn apply_agent_result_env(
     env: &mut Map<String, Value>,
     agent_result: Option<&AgentResultMcpConfig>,
@@ -990,8 +1050,9 @@ pub fn ensure_opencode_config_with_result(
 /// for idempotency). For Opencode this writes `opencode.json` on disk.
 ///
 /// # Parameters
-/// Write `.cursor/mcp.json` in the given directory with the Agent Relay MCP server
-/// configured with per-agent credentials (name + token).
+/// Write `.cursor/mcp.json` in the given directory with the Agent Relay MCP
+/// server configured with Cursor environment placeholders. The worker process
+/// supplies the per-agent values; no credential literal is persisted.
 /// Returns `true` if the config was created or updated.
 #[allow(clippy::too_many_arguments)]
 pub fn ensure_cursor_mcp_config(
@@ -1002,48 +1063,28 @@ pub fn ensure_cursor_mcp_config(
     relay_agent_token: Option<&str>,
     workspaces_json: Option<&str>,
     default_workspace: Option<&str>,
-    _agent_result: Option<&AgentResultMcpConfig>,
+    agent_result: Option<&AgentResultMcpConfig>,
 ) -> io::Result<bool> {
     let cursor_dir = root.join(".cursor");
     fs::create_dir_all(&cursor_dir)?;
     let path = cursor_dir.join("mcp.json");
 
-    let mcp_json = agent_relay_mcp_config_json_with_result(
-        relay_api_key,
-        relay_base_url,
-        relay_agent_name,
-        relay_agent_token,
-        workspaces_json,
-        default_workspace,
-        None,
-    );
-    let mut new_value: Value = serde_json::from_str(&mcp_json).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("MCP config serialization error: {e}"),
+    let new_value = json!({"mcpServers": {"agent-relay":
+        cursor_agent_relay_mcp_server_config(
+            relay_api_key,
+            relay_base_url,
+            relay_agent_name,
+            relay_agent_token,
+            workspaces_json,
+            default_workspace,
+            agent_result,
         )
-    })?;
-    // Cursor does not pass parent process env vars to MCP server subprocesses,
-    // so RELAY_API_KEY must be in the .cursor/mcp.json env block explicitly.
-    // (The shared agent_relay_mcp_server_config omits it because codex strips API keys.)
-    if let Some(key) = relay_api_key.map(str::trim).filter(|s| !s.is_empty()) {
-        if let Some(env_obj) = new_value
-            .pointer_mut("/mcpServers/agent-relay/env")
-            .and_then(Value::as_object_mut)
-        {
-            env_obj.insert("RELAY_API_KEY".into(), Value::String(key.to_string()));
-        } else if let Some(server) = new_value
-            .pointer_mut("/mcpServers/agent-relay")
-            .and_then(Value::as_object_mut)
-        {
-            let mut env_map = Map::new();
-            env_map.insert("RELAY_API_KEY".into(), Value::String(key.to_string()));
-            server.insert("env".into(), Value::Object(env_map));
-        }
-    }
+    }});
 
     if !path.exists() {
-        write_pretty_json(&path, &new_value)?;
+        let body = serde_json::to_vec_pretty(&new_value)
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        write_credential_file(&path, &body)?;
         return Ok(true);
     }
 
@@ -1071,7 +1112,9 @@ pub fn ensure_cursor_mcp_config(
     };
 
     if changed {
-        write_pretty_json(&path, &parsed)?;
+        let body = serde_json::to_vec_pretty(&parsed)
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        write_credential_file(&path, &body)?;
     }
     Ok(changed)
 }
@@ -1327,7 +1370,7 @@ pub async fn configure_agent_relay_mcp_with_result(
             is_gemini,
             workspaces_json,
             default_workspace,
-            None,
+            agent_result,
         )
         .await?;
     } else if is_grok {
@@ -1367,7 +1410,7 @@ pub async fn configure_agent_relay_mcp_with_result(
             agent_token,
             workspaces_json,
             default_workspace,
-            None,
+            agent_result,
         )
         .with_context(|| {
             "failed to write .cursor/mcp.json for Agent Relay MCP. \
@@ -2974,20 +3017,23 @@ exit 0
         let path = temp.path().join(".cursor").join("mcp.json");
         assert!(path.exists(), ".cursor/mcp.json must be created");
         let contents = fs::read_to_string(path).expect("read cursor mcp config");
+        assert!(!contents.contains("rk_live_cursor"));
+        assert!(!contents.contains("https://cast.agentrelay.com"));
+        assert!(!contents.contains("CursorAgent"));
         let json: Value = serde_json::from_str(&contents).expect("parse cursor mcp config");
 
         assert_is_agent_relay_mcp_config(&json["mcpServers"]["agent-relay"]);
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_API_KEY"].as_str(),
-            Some("rk_live_cursor")
+            Some("${env:RELAY_API_KEY}")
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_BASE_URL"].as_str(),
-            Some("https://cast.agentrelay.com")
+            Some("${env:RELAY_BASE_URL}")
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_AGENT_NAME"].as_str(),
-            Some("CursorAgent")
+            Some("${env:RELAY_AGENT_NAME}")
         );
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_AGENT_TYPE"].as_str(),
@@ -2996,6 +3042,15 @@ exit 0
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_STRICT_AGENT_NAME"].as_str(),
             Some("1")
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(temp.path().join(".cursor").join("mcp.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
         );
     }
 
@@ -3024,8 +3079,17 @@ exit 0
         );
         let contents = fs::read_to_string(temp.path().join(".cursor").join("mcp.json"))
             .expect("read cursor mcp config");
+        assert!(!contents.contains("http://127.0.0.1:3889/api/agent-result"));
+        assert!(!contents.contains("arr_test"));
+        assert!(!contents.contains("rk_live_cursor"));
+        assert!(!contents.contains("https://cast.agentrelay.com"));
         let json: Value = serde_json::from_str(&contents).expect("parse cursor mcp config");
-        assert_agent_result_env_absent(&json["mcpServers"]["agent-relay"]["env"]);
+        let env = &json["mcpServers"]["agent-relay"]["env"];
+        assert_eq!(
+            env["AGENT_RELAY_RESULT_URL"].as_str(),
+            Some("${env:AGENT_RELAY_RESULT_URL}")
+        );
+        assert_eq!(env["RELAY_AGENT_TOKEN"].as_str(), None);
     }
 
     #[tokio::test]
@@ -3057,7 +3121,7 @@ exit 0
 
         assert_eq!(
             json["mcpServers"]["agent-relay"]["env"]["RELAY_AGENT_TOKEN"].as_str(),
-            Some("tok_cursor_123")
+            Some("${env:RELAY_AGENT_TOKEN}")
         );
     }
 

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -14,7 +14,10 @@ use tokio::{
     process::Command,
 };
 
-use crate::{cursor_mcp_lease::write_credential_file, types::AgentResultMcpConfig};
+use crate::{
+    cursor_mcp_lease::{validate_cursor_root, write_credential_file},
+    types::AgentResultMcpConfig,
+};
 
 const AGENT_RELAY_MCP_PACKAGE: &str = "agent-relay";
 const AGENT_RELAY_MCP_SUBCOMMAND: &str = "mcp";
@@ -1065,6 +1068,7 @@ pub fn ensure_cursor_mcp_config(
     default_workspace: Option<&str>,
     agent_result: Option<&AgentResultMcpConfig>,
 ) -> io::Result<bool> {
+    validate_cursor_root(root)?;
     let cursor_dir = root.join(".cursor");
     fs::create_dir_all(&cursor_dir)?;
     let path = cursor_dir.join("mcp.json");

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -15,7 +15,9 @@ use tokio::{
 };
 
 use crate::{
-    cursor_mcp_lease::{validate_cursor_root, write_credential_file},
+    cursor_mcp_lease::{
+        read_cursor_credential_file, validate_cursor_root, write_cursor_credential_file,
+    },
     types::AgentResultMcpConfig,
 };
 
@@ -1069,9 +1071,6 @@ pub fn ensure_cursor_mcp_config(
     agent_result: Option<&AgentResultMcpConfig>,
 ) -> io::Result<bool> {
     validate_cursor_root(root)?;
-    let cursor_dir = root.join(".cursor");
-    fs::create_dir_all(&cursor_dir)?;
-    let path = cursor_dir.join("mcp.json");
 
     let new_value = json!({"mcpServers": {"agent-relay":
         cursor_agent_relay_mcp_server_config(
@@ -1085,14 +1084,20 @@ pub fn ensure_cursor_mcp_config(
         )
     }});
 
-    if !path.exists() {
+    let existing_bytes = match read_cursor_credential_file(root) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
+    if existing_bytes.is_none() {
         let body = serde_json::to_vec_pretty(&new_value)
             .map_err(|error| io::Error::other(error.to_string()))?;
-        write_credential_file(&path, &body)?;
+        write_cursor_credential_file(root, &body)?;
         return Ok(true);
     }
 
-    let existing = fs::read_to_string(&path)?;
+    let existing = String::from_utf8(existing_bytes.expect("checked above"))
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut parsed: Value = serde_json::from_str(&existing).unwrap_or(Value::Object(Map::new()));
 
     let changed = if let (Some(existing_servers), Some(new_servers)) = (
@@ -1118,7 +1123,7 @@ pub fn ensure_cursor_mcp_config(
     if changed {
         let body = serde_json::to_vec_pretty(&parsed)
             .map_err(|error| io::Error::other(error.to_string()))?;
-        write_credential_file(&path, &body)?;
+        write_cursor_credential_file(root, &body)?;
     }
     Ok(changed)
 }

--- a/crates/broker/src/snippets.rs
+++ b/crates/broker/src/snippets.rs
@@ -1982,6 +1982,9 @@ fn write_pretty_json(path: &Path, value: &Value) -> io::Result<()> {
 mod tests {
     use std::{env, ffi::OsString, fs};
 
+    #[cfg(windows)]
+    use std::path::Path;
+
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -364,7 +364,6 @@ impl WorkerRegistry {
             );
         }
         let cursor_mcp_journal = worker_logs_dir.join(".cursor-mcp-leases.json");
-
         Self {
             workers: HashMap::new(),
             event_tx,

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -477,12 +477,6 @@ impl WorkerRegistry {
         // `reap_exited`) releases this same lease on every exit path.
         let is_cursor = is_cursor_cli_name(cli_name);
         if is_cursor {
-            #[cfg(not(unix))]
-            {
-                return Err(anyhow::anyhow!(
-                    "Cursor workers are not supported on Windows; refuse to start before leasing .cursor/mcp.json"
-                ));
-            }
             self.cursor_mcp_leases
                 .acquire(cwd, agent_name)
                 .with_context(|| {
@@ -3119,7 +3113,7 @@ sleep 30
 
     #[cfg(not(unix))]
     #[tokio::test]
-    async fn cursor_worker_registry_refuses_windows_cursor_startup() {
+    async fn cursor_worker_registry_supports_locked_cursor_startup_and_release() {
         let cwd = tempfile::tempdir().expect("cursor cwd");
         let logs = tempfile::tempdir().expect("worker logs");
         let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
@@ -3130,10 +3124,11 @@ sleep 30
             Instant::now(),
         );
 
-        let error = registry
+        let worker = WorkerName::from("cursor-windows-worker");
+        let args = registry
             .build_mcp_args(
                 "cursor",
-                &WorkerName::from("cursor-windows-worker"),
+                &worker,
                 &[],
                 cwd.path(),
                 Some("agent-token-test-only"),
@@ -3141,14 +3136,14 @@ sleep 30
                 None,
             )
             .await
-            .expect_err("Cursor startup should be refused on Windows before leasing");
-
-        assert!(
-            error
-                .to_string()
-                .contains("Cursor workers are not supported on Windows"),
-            "unexpected refusal error: {error:#}"
-        );
+            .expect("Cursor startup should use the non-Unix locked fallback");
+        assert!(args.is_empty());
+        assert!(cwd.path().join(".cursor/mcp.json").is_file());
+        registry
+            .cursor_mcp_leases
+            .release_worker(&worker)
+            .expect("Cursor release should restore the non-Unix fallback");
+        assert!(!cwd.path().join(".cursor/mcp.json").exists());
         assert!(registry.cursor_mcp_leases.is_empty());
     }
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -262,11 +262,11 @@ pub(crate) struct WorkerRegistry {
     pub(crate) completed_owned_releases: VecDeque<(WorkerName, Uuid)>,
     pub(crate) supervisor: Supervisor,
     pub(crate) metrics: MetricsCollector,
-    /// Lease over any `.cursor/mcp.json` files this registry has injected
-    /// Agent Relay credentials into (relay#1753). Every worker-removal path
+    /// Lease over any `.cursor/mcp.json` files this registry has generated
+    /// Agent Relay placeholders into (relay#1753). Every worker-removal path
     /// (`release`, `cleanup_rejected_spawn`, `reap_exited`) must call
-    /// `cursor_mcp_leases.release_worker(name)` so a generated credential
-    /// file never outlives every worker that shares its cwd.
+    /// `cursor_mcp_leases.release_worker(name)` so generated config never
+    /// outlives every worker that shares its cwd.
     pub(crate) cursor_mcp_leases: CursorMcpLeaseRegistry,
 }
 
@@ -628,6 +628,23 @@ impl WorkerRegistry {
         }
     }
 
+    fn apply_cursor_worker_env(
+        command: &mut Command,
+        worker_name: &WorkerName,
+        worker_relay_api_key: Option<&str>,
+        cursor_mcp_worker: bool,
+        skip_relay_prompt: bool,
+    ) {
+        if cursor_mcp_worker && !skip_relay_prompt {
+            if let Some(relay_key) = worker_relay_api_key {
+                command.env("RELAY_AGENT_TOKEN", relay_key);
+            }
+            command.env("RELAY_AGENT_NAME", worker_name);
+            command.env("RELAY_AGENT_TYPE", "agent");
+            command.env("RELAY_STRICT_AGENT_NAME", "1");
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn spawn(
         &mut self,
@@ -643,6 +660,13 @@ impl WorkerRegistry {
         let mut spec = spec;
         if self.identity_cleanups.contains_key(&spec.name) {
             anyhow::bail!("agent '{}' has pending owned cleanup", spec.name);
+        }
+        self.cursor_mcp_leases.retry_pending_cleanups();
+        if self.cursor_mcp_leases.has_pending_cleanup(&spec.name) {
+            anyhow::bail!(
+                "agent '{}' has pending Cursor MCP cleanup; retry before reusing the name",
+                spec.name
+            );
         }
         if self.workers.contains_key(&spec.name) {
             anyhow::bail!("agent '{}' already exists", spec.name);
@@ -1305,9 +1329,8 @@ impl WorkerRegistry {
             &spec.runtime,
             direct_native_harness_sidecar,
             skip_relay_prompt,
-        ) || (cursor_mcp_worker && !skip_relay_prompt)
-        {
-            if let Some(relay_key) = worker_relay_api_key {
+        ) {
+            if let Some(relay_key) = worker_relay_api_key.as_deref() {
                 command.env("RELAY_AGENT_TOKEN", relay_key);
             }
             command.env("RELAY_AGENT_NAME", &spec.name);
@@ -1334,7 +1357,15 @@ impl WorkerRegistry {
             }
             command.env("AGENT_RELAY_LOCAL_ONLY", "1");
         }
-        // Prevent nested Claude Code instances from sharing the parent session.
+        Self::apply_cursor_worker_env(
+            &mut command,
+            &spec.name,
+            worker_relay_api_key.as_deref(),
+            cursor_mcp_worker,
+            skip_relay_prompt,
+        );
+        // Remove CLAUDECODE from child env to prevent nested Claude Code instances
+        // from interfering with the parent's session management
         command.env_remove("CLAUDECODE");
         if let Some(cwd) = spec.cwd.as_ref() {
             command.current_dir(cwd);
@@ -1597,6 +1628,7 @@ impl WorkerRegistry {
 
     pub(crate) async fn release(&mut self, name: &str) -> Result<()> {
         tracing::info!(target = "broker::release", name = %name, "releasing worker");
+        self.cursor_mcp_leases.retry_pending_cleanups();
         self.initial_tasks.remove(name);
         // An explicit release is terminal even when the process already exited
         // and disappeared from `workers`. Cancel any pending restart before
@@ -1673,6 +1705,7 @@ impl WorkerRegistry {
     }
 
     pub(crate) async fn shutdown_all(&mut self) -> Result<()> {
+        self.cursor_mcp_leases.retry_pending_cleanups();
         let names: Vec<WorkerName> = self.workers.keys().cloned().collect();
         for name in names {
             if let Err(error) = self.release(&name).await {
@@ -1683,6 +1716,7 @@ impl WorkerRegistry {
     }
 
     pub(crate) async fn reap_exited(&mut self) -> Result<Vec<ExitedWorker>> {
+        self.cursor_mcp_leases.retry_pending_cleanups();
         let names: Vec<WorkerName> = self.workers.keys().cloned().collect();
         let mut exited = Vec::new();
         for name in names {
@@ -3017,6 +3051,30 @@ sleep 30
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn cursor_worker_child_env_matches_placeholder_names_without_file_literals() {
+        let registry = make_registry(vec![]);
+        let worker = WorkerName::from("cursor-child-env-worker");
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf '%s\\n' \"$RELAY_AGENT_TOKEN|$RELAY_AGENT_NAME|$RELAY_AGENT_TYPE|$RELAY_STRICT_AGENT_NAME\""]);
+        command.stdout(Stdio::piped());
+        WorkerRegistry::apply_cursor_worker_env(
+            &mut command,
+            &worker,
+            Some("agent-token-test-only"),
+            true,
+            false,
+        );
+        let output = command.output().await.expect("child env command");
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "agent-token-test-only|cursor-child-env-worker|agent|1"
+        );
+        drop(registry);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn cursor_worker_registry_fails_closed_when_lease_capture_fails() {
         let cwd = tempfile::tempdir().expect("cursor cwd");
         let logs = tempfile::tempdir().expect("worker logs");
@@ -3046,6 +3104,269 @@ sleep 30
             .await;
         assert!(result.is_err());
         assert!(cursor_dir.join("mcp.json").is_dir());
+        assert!(registry.cursor_mcp_leases.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cursor_worker_registry_rejects_hostile_cursor_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let outside = tempfile::tempdir().expect("outside target");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let outside_file = outside.path().join("mcp.json");
+        std::fs::write(&outside_file, b"outside bytes").unwrap();
+        symlink(outside.path(), cwd.path().join(".cursor")).unwrap();
+
+        let result = registry
+            .build_mcp_args(
+                "cursor",
+                &WorkerName::from("cursor-symlink-hostile"),
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&outside_file).unwrap(), b"outside bytes");
+        assert!(registry.cursor_mcp_leases.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cursor_cleanup_failure_is_retried_and_name_reuse_is_blocked() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let worker = WorkerName::from("cursor-retry-worker");
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let path = cwd.path().join(".cursor/mcp.json");
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        assert!(registry.cursor_mcp_leases.release_worker(&worker).is_err());
+        assert!(registry.cursor_mcp_leases.has_pending_cleanup(&worker));
+
+        // A reused worker name cannot attach a new lease while the old path
+        // still owns cleanup responsibility.
+        assert!(registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .is_err());
+
+        std::fs::remove_dir(&path).unwrap();
+        registry.reap_exited().await.unwrap();
+        assert!(!registry.cursor_mcp_leases.has_pending_cleanup(&worker));
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        registry.cursor_mcp_leases.release_worker(&worker).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn worker_release_removes_cursor_config() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let worker = WorkerName::from("cursor-explicit-release");
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let path = cwd.path().join(".cursor/mcp.json");
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let generation = Uuid::new_v4();
+        let (command_tx, command_rx) = mpsc::channel(WORKER_WRITE_QUEUE_CAPACITY);
+        spawn_worker_writer(
+            registry.event_tx.clone(),
+            worker.clone(),
+            generation,
+            stdin,
+            command_rx,
+        );
+        registry.workers.insert(
+            worker.clone(),
+            WorkerHandle {
+                generation,
+                spec: spec_for_test(worker.as_str()),
+                parent: None,
+                workspace_id: None,
+                child,
+                command_tx,
+                harness_pid: None,
+                spawned_at: Instant::now(),
+                ready_at: None,
+                last_activity_at: Instant::now(),
+                context_budget_pct: None,
+                state: AgentWorkState::Working,
+                exit_reason: None,
+            },
+        );
+        registry.release(worker.as_str()).await.unwrap();
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn worker_task_exit_reaps_cursor_config() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let worker = WorkerName::from("cursor-task-exit");
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let path = cwd.path().join(".cursor/mcp.json");
+        let mut child = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let generation = Uuid::new_v4();
+        let (command_tx, command_rx) = mpsc::channel(WORKER_WRITE_QUEUE_CAPACITY);
+        spawn_worker_writer(
+            registry.event_tx.clone(),
+            worker.clone(),
+            generation,
+            stdin,
+            command_rx,
+        );
+        for _ in 0..50 {
+            if child.try_wait().unwrap().is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        registry.workers.insert(
+            worker.clone(),
+            WorkerHandle {
+                generation,
+                spec: spec_for_test(worker.as_str()),
+                parent: None,
+                workspace_id: None,
+                child,
+                command_tx,
+                harness_pid: None,
+                spawned_at: Instant::now(),
+                ready_at: None,
+                last_activity_at: Instant::now(),
+                context_budget_pct: None,
+                state: AgentWorkState::Working,
+                exit_reason: None,
+            },
+        );
+        let exited = registry.reap_exited().await.unwrap();
+        assert_eq!(exited.len(), 1);
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_registration_spawn_failure_releases_cursor_config() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let worker = WorkerName::from("cursor-pre-registration-failure");
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let path = cwd.path().join(".cursor/mcp.json");
+        registry.cleanup_unregistered_spawn(&worker, None).await;
+        assert!(!path.exists());
         assert!(registry.cursor_mcp_leases.is_empty());
     }
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -363,6 +363,7 @@ impl WorkerRegistry {
                 "failed to create worker log directory"
             );
         }
+        let cursor_mcp_journal = worker_logs_dir.join(".cursor-mcp-leases.json");
 
         Self {
             workers: HashMap::new(),
@@ -376,7 +377,7 @@ impl WorkerRegistry {
             identity_cleanups: HashMap::new(),
             supervisor: Supervisor::new(),
             metrics: MetricsCollector::new(broker_start),
-            cursor_mcp_leases: CursorMcpLeaseRegistry::new(),
+            cursor_mcp_leases: CursorMcpLeaseRegistry::with_journal(cursor_mcp_journal),
         }
     }
 
@@ -477,14 +478,14 @@ impl WorkerRegistry {
         // `reap_exited`) releases this same lease on every exit path.
         let is_cursor = is_cursor_cli_name(cli_name);
         if is_cursor {
-            if let Err(error) = self.cursor_mcp_leases.acquire(cwd, agent_name) {
-                tracing::warn!(
-                    worker = %agent_name,
-                    cwd = %cwd.display(),
-                    %error,
-                    "failed to capture pre-existing .cursor/mcp.json before injecting Agent Relay MCP config"
-                );
-            }
+            self.cursor_mcp_leases
+                .acquire(cwd, agent_name)
+                .with_context(|| {
+                    format!(
+                        "failed to capture pre-existing .cursor/mcp.json before injecting Agent Relay MCP config for '{}'",
+                        agent_name
+                    )
+                })?;
         }
 
         let result = configure_agent_relay_mcp_with_result(
@@ -615,6 +616,18 @@ impl WorkerRegistry {
         }
     }
 
+    /// Clean a Cursor lease when process setup fails before the child can be
+    /// inserted into `self.workers`. This boundary is intentionally separate
+    /// from `cleanup_rejected_spawn`, which only handles registered children.
+    async fn cleanup_unregistered_spawn(&mut self, name: &WorkerName, child: Option<&mut Child>) {
+        if let Some(child) = child {
+            let _ = terminate_child(child, ORPHAN_REAP_TIMEOUT).await;
+        }
+        if let Err(error) = self.cursor_mcp_leases.release_worker(name) {
+            tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease after pre-registration spawn failure");
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn spawn(
         &mut self,
@@ -679,6 +692,7 @@ impl WorkerRegistry {
         let mut suppress_worker_env: Vec<&'static str> = Vec::new();
         let mut initial_harness_pid: Option<u32> = None;
         let mut direct_native_harness_sidecar = false;
+        let mut cursor_mcp_worker = false;
 
         match spec.harness_config.clone() {
             Some(ResolvedHarnessConfig::Pty(config)) => {
@@ -822,6 +836,7 @@ impl WorkerRegistry {
                         agent_result.as_ref(),
                     )
                     .await?;
+                cursor_mcp_worker = is_cursor_cli_name(&resolved_cli);
 
                 let model_flag = resolve_model_flag_for_cli(
                     &resolved_cli,
@@ -1055,6 +1070,7 @@ impl WorkerRegistry {
                             agent_result.as_ref(),
                         )
                         .await?;
+                    cursor_mcp_worker = is_cursor_cli_name(cli);
 
                     let model_flag = resolve_model_flag_for_cli(
                         &resolved_cli,
@@ -1113,6 +1129,7 @@ impl WorkerRegistry {
                             agent_result.as_ref(),
                         )
                         .await?;
+                    cursor_mcp_worker = is_cursor_cli_name(provider_cli);
 
                     let model_arg = resolve_model_flag_for_cli(
                         provider_cli,
@@ -1288,7 +1305,8 @@ impl WorkerRegistry {
             &spec.runtime,
             direct_native_harness_sidecar,
             skip_relay_prompt,
-        ) {
+        ) || (cursor_mcp_worker && !skip_relay_prompt)
+        {
             if let Some(relay_key) = worker_relay_api_key {
                 command.env("RELAY_AGENT_TOKEN", relay_key);
             }
@@ -1322,13 +1340,40 @@ impl WorkerRegistry {
             command.current_dir(cwd);
         }
 
-        let mut child = command.spawn().context("failed to spawn worker")?;
+        let mut child = match command.spawn().context("failed to spawn worker") {
+            Ok(child) => child,
+            Err(error) => {
+                self.cleanup_unregistered_spawn(&spec.name, None).await;
+                return Err(error);
+            }
+        };
         if direct_native_harness_sidecar {
             initial_harness_pid = child.id();
         }
-        let stdin = child.stdin.take().context("worker missing stdin pipe")?;
-        let stdout = child.stdout.take().context("worker missing stdout pipe")?;
-        let stderr = child.stderr.take().context("worker missing stderr pipe")?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                self.cleanup_unregistered_spawn(&spec.name, Some(&mut child))
+                    .await;
+                anyhow::bail!("worker missing stdin pipe");
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                self.cleanup_unregistered_spawn(&spec.name, Some(&mut child))
+                    .await;
+                anyhow::bail!("worker missing stdout pipe");
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                self.cleanup_unregistered_spawn(&spec.name, Some(&mut child))
+                    .await;
+                anyhow::bail!("worker missing stderr pipe");
+            }
+        };
         let log_file = self.worker_log_path(&spec.name);
         let startup_log_file = log_file.clone();
 
@@ -2893,6 +2938,115 @@ sleep 30
     fn worker_registry_starts_empty() {
         let reg = make_registry(vec![]);
         assert!(reg.list(&HashMap::new()).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cursor_worker_registry_injection_is_placeholder_only_and_cleans_up() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![
+                ("RELAY_API_KEY".into(), "workspace-secret-test-only".into()),
+                ("RELAY_BASE_URL".into(), "https://relay.invalid".into()),
+            ],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let worker = WorkerName::from("cursor-placeholder-worker");
+        let second_worker = WorkerName::from("cursor-placeholder-worker-2");
+
+        registry
+            .build_mcp_args(
+                "cursor",
+                &worker,
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .expect("Cursor MCP config should be written");
+
+        let path = cwd.path().join(".cursor/mcp.json");
+        let contents = std::fs::read_to_string(&path).expect("read Cursor MCP config");
+        assert!(!contents.contains("workspace-secret-test-only"));
+        assert!(!contents.contains("agent-token-test-only"));
+        assert!(contents.contains("${env:RELAY_API_KEY}"));
+        assert!(contents.contains("${env:RELAY_AGENT_TOKEN}"));
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        registry
+            .build_mcp_args(
+                "cursor",
+                &second_worker,
+                &[],
+                cwd.path(),
+                Some("different-agent-token-must-not-rewrite-the-file"),
+                false,
+                None,
+            )
+            .await
+            .expect("a same-cwd Cursor worker should join the existing lease");
+        let second_contents =
+            std::fs::read_to_string(&path).expect("read shared Cursor MCP config");
+        assert_eq!(
+            contents, second_contents,
+            "same-cwd workers use stable placeholders"
+        );
+
+        registry
+            .cursor_mcp_leases
+            .release_worker(&worker)
+            .expect("release Cursor lease");
+        assert!(path.exists(), "the last same-cwd worker owns cleanup");
+        registry
+            .cursor_mcp_leases
+            .release_worker(&second_worker)
+            .expect("release second Cursor lease");
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cursor_worker_registry_fails_closed_when_lease_capture_fails() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+        let cursor_dir = cwd.path().join(".cursor");
+        std::fs::create_dir_all(&cursor_dir).unwrap();
+        // A directory at the config path makes lease capture fail before the
+        // injection writer can replace it. This is the fail-closed boundary.
+        std::fs::create_dir(cursor_dir.join("mcp.json")).unwrap();
+
+        let result = registry
+            .build_mcp_args(
+                "cursor",
+                &WorkerName::from("cursor-capture-failure"),
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(cursor_dir.join("mcp.json").is_dir());
+        assert!(registry.cursor_mcp_leases.is_empty());
     }
 
     #[cfg(unix)]

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::{
+    cursor_mcp_lease::CursorMcpLeaseRegistry,
     ids::{RequestId, WorkerName},
     metrics::MetricsCollector,
     protocol::{
@@ -13,7 +14,7 @@ use crate::{
         HeadlessHarnessConfig, HeadlessHarnessDriver, ProtocolEnvelope, RelayDelivery,
         ResolvedHarnessConfig, PROTOCOL_VERSION,
     },
-    relaycast::configure_agent_relay_mcp_with_result,
+    relaycast::{configure_agent_relay_mcp_with_result, is_cursor_cli_name},
     supervisor::Supervisor,
     types::{AgentResultMcpConfig, CommitAttestation},
 };
@@ -261,6 +262,12 @@ pub(crate) struct WorkerRegistry {
     pub(crate) completed_owned_releases: VecDeque<(WorkerName, Uuid)>,
     pub(crate) supervisor: Supervisor,
     pub(crate) metrics: MetricsCollector,
+    /// Lease over any `.cursor/mcp.json` files this registry has injected
+    /// Agent Relay credentials into (relay#1753). Every worker-removal path
+    /// (`release`, `cleanup_rejected_spawn`, `reap_exited`) must call
+    /// `cursor_mcp_leases.release_worker(name)` so a generated credential
+    /// file never outlives every worker that shares its cwd.
+    pub(crate) cursor_mcp_leases: CursorMcpLeaseRegistry,
 }
 
 fn encode_worker_frame(
@@ -369,6 +376,7 @@ impl WorkerRegistry {
             identity_cleanups: HashMap::new(),
             supervisor: Supervisor::new(),
             metrics: MetricsCollector::new(broker_start),
+            cursor_mcp_leases: CursorMcpLeaseRegistry::new(),
         }
     }
 
@@ -442,9 +450,9 @@ impl WorkerRegistry {
 
     #[allow(clippy::too_many_arguments)]
     async fn build_mcp_args(
-        &self,
+        &mut self,
         cli_name: &str,
-        agent_name: &str,
+        agent_name: &WorkerName,
         existing_args: &[String],
         cwd: &Path,
         worker_relay_api_key: Option<&str>,
@@ -459,9 +467,29 @@ impl WorkerRegistry {
         if skip_relay_prompt || self.env_value("AGENT_RELAY_LOCAL_ONLY") == Some("1") {
             return Ok(Vec::new());
         }
-        configure_agent_relay_mcp_with_result(
+
+        // relay#1753: `configure_agent_relay_mcp_with_result` writes
+        // credentials into `<cwd>/.cursor/mcp.json` for Cursor workers. Claim
+        // the lease *before* that write so the pre-existing file (a real user
+        // config, or nothing) is captured before this generation's
+        // credentials land — never a sibling worker's already-injected
+        // config. `spawn`'s caller (`cleanup_rejected_spawn`, `release`,
+        // `reap_exited`) releases this same lease on every exit path.
+        let is_cursor = is_cursor_cli_name(cli_name);
+        if is_cursor {
+            if let Err(error) = self.cursor_mcp_leases.acquire(cwd, agent_name) {
+                tracing::warn!(
+                    worker = %agent_name,
+                    cwd = %cwd.display(),
+                    %error,
+                    "failed to capture pre-existing .cursor/mcp.json before injecting Agent Relay MCP config"
+                );
+            }
+        }
+
+        let result = configure_agent_relay_mcp_with_result(
             cli_name,
-            agent_name,
+            agent_name.as_str(),
             self.env_value("RELAY_API_KEY"),
             self.env_value("RELAY_BASE_URL"),
             existing_args,
@@ -471,7 +499,19 @@ impl WorkerRegistry {
             self.env_value("RELAY_DEFAULT_WORKSPACE"),
             agent_result,
         )
-        .await
+        .await;
+
+        if is_cursor && result.is_err() {
+            // The write never landed (or failed partway); nothing generated
+            // survives this worker, so drop the lease immediately rather than
+            // waiting for a removal path that may never run (spawn fails
+            // before the handle is even registered).
+            if let Err(error) = self.cursor_mcp_leases.release_worker(agent_name) {
+                tracing::warn!(worker = %agent_name, %error, "failed to release .cursor/mcp.json lease after failed MCP config write");
+            }
+        }
+
+        result
     }
 
     pub(crate) fn has_worker(&self, name: &str) -> bool {
@@ -570,6 +610,9 @@ impl WorkerRegistry {
         self.workers.remove(name);
         self.initial_tasks.remove(name);
         self.supervisor.unregister(name);
+        if let Err(error) = self.cursor_mcp_leases.release_worker(name) {
+            tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease after rejected spawn");
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1519,6 +1562,17 @@ impl WorkerRegistry {
             .workers
             .remove(name)
             .with_context(|| format!("unknown worker '{name}'"))?;
+        // relay#1753: restore/remove any leased .cursor/mcp.json before the
+        // rest of the release proceeds, so an explicit release, a broker
+        // shutdown sweep (`shutdown_all`), and ambiguous-timeout recovery
+        // (which reuses this same path via `release_worker_locally`) all
+        // converge on the same cleanup.
+        if let Err(error) = self
+            .cursor_mcp_leases
+            .release_worker(&WorkerName::new(name))
+        {
+            tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease on explicit release");
+        }
         let release_grace = release_grace_for_spec(&handle.spec);
 
         let shutdown_frame = ProtocolEnvelope {
@@ -1686,6 +1740,9 @@ impl WorkerRegistry {
                 }
                 self.workers.remove(&name);
                 self.initial_tasks.remove(&name);
+                if let Err(error) = self.cursor_mcp_leases.release_worker(&name) {
+                    tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease for orphaned wrapper");
+                }
                 exited.push((name, generation, None, None, reason));
                 continue;
             }
@@ -1709,6 +1766,9 @@ impl WorkerRegistry {
                     .and_then(|handle| handle.exit_reason.clone());
                 self.workers.remove(&name);
                 self.initial_tasks.remove(&name);
+                if let Err(error) = self.cursor_mcp_leases.release_worker(&name) {
+                    tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease on task exit");
+                }
                 exited.push((name, generation, code, signal, reason));
             } else if gone_via_kill0 {
                 let generation = self
@@ -1722,6 +1782,9 @@ impl WorkerRegistry {
                     .and_then(|handle| handle.exit_reason.clone());
                 self.workers.remove(&name);
                 self.initial_tasks.remove(&name);
+                if let Err(error) = self.cursor_mcp_leases.release_worker(&name) {
+                    tracing::warn!(worker = %name, %error, "failed to release .cursor/mcp.json lease after process disappeared");
+                }
                 exited.push((name, generation, None, None, reason));
             }
         }

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -14,7 +14,7 @@ use crate::{
         HeadlessHarnessConfig, HeadlessHarnessDriver, ProtocolEnvelope, RelayDelivery,
         ResolvedHarnessConfig, PROTOCOL_VERSION,
     },
-    relaycast::{configure_agent_relay_mcp_with_result, is_cursor_cli_name},
+    relaycast::{configure_agent_relay_mcp_with_result_and_cursor_lease, is_cursor_cli_name},
     supervisor::Supervisor,
     types::{AgentResultMcpConfig, CommitAttestation},
 };
@@ -488,7 +488,7 @@ impl WorkerRegistry {
                 })?;
         }
 
-        let result = configure_agent_relay_mcp_with_result(
+        let result = configure_agent_relay_mcp_with_result_and_cursor_lease(
             cli_name,
             agent_name.as_str(),
             self.env_value("RELAY_API_KEY"),
@@ -499,6 +499,11 @@ impl WorkerRegistry {
             self.env_value("RELAY_WORKSPACES_JSON"),
             self.env_value("RELAY_DEFAULT_WORKSPACE"),
             agent_result,
+            if is_cursor {
+                Some((&self.cursor_mcp_leases, agent_name))
+            } else {
+                None
+            },
         )
         .await;
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -477,6 +477,12 @@ impl WorkerRegistry {
         // `reap_exited`) releases this same lease on every exit path.
         let is_cursor = is_cursor_cli_name(cli_name);
         if is_cursor {
+            #[cfg(not(unix))]
+            {
+                return Err(anyhow::anyhow!(
+                    "Cursor workers are not supported on Windows; refuse to start before leasing .cursor/mcp.json"
+                ));
+            }
             self.cursor_mcp_leases
                 .acquire(cwd, agent_name)
                 .with_context(|| {
@@ -3108,6 +3114,41 @@ sleep 30
             .await;
         assert!(result.is_err());
         assert!(cursor_dir.join("mcp.json").is_dir());
+        assert!(registry.cursor_mcp_leases.is_empty());
+    }
+
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn cursor_worker_registry_refuses_windows_cursor_startup() {
+        let cwd = tempfile::tempdir().expect("cursor cwd");
+        let logs = tempfile::tempdir().expect("worker logs");
+        let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
+        let mut registry = WorkerRegistry::new(
+            tx,
+            vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
+            logs.path().to_path_buf(),
+            Instant::now(),
+        );
+
+        let error = registry
+            .build_mcp_args(
+                "cursor",
+                &WorkerName::from("cursor-windows-worker"),
+                &[],
+                cwd.path(),
+                Some("agent-token-test-only"),
+                false,
+                None,
+            )
+            .await
+            .expect_err("Cursor startup should be refused on Windows before leasing");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cursor workers are not supported on Windows"),
+            "unexpected refusal error: {error:#}"
+        );
         assert!(registry.cursor_mcp_leases.is_empty());
     }
 

--- a/crates/broker/src/worker.rs
+++ b/crates/broker/src/worker.rs
@@ -355,6 +355,7 @@ impl WorkerRegistry {
         worker_env: Vec<(String, String)>,
         worker_logs_dir: PathBuf,
         broker_start: Instant,
+        broker_name: &str,
     ) -> Self {
         if let Err(error) = std::fs::create_dir_all(&worker_logs_dir) {
             tracing::warn!(
@@ -363,7 +364,21 @@ impl WorkerRegistry {
                 "failed to create worker log directory"
             );
         }
-        let cursor_mcp_journal = worker_logs_dir.join(".cursor-mcp-leases.json");
+        let safe_name = if broker_name.is_empty() {
+            String::new()
+        } else {
+            let sanitized: String = broker_name
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+                .collect();
+            if sanitized.is_empty() {
+                String::new()
+            } else {
+                format!("-{sanitized}")
+            }
+        };
+        let cursor_mcp_journal =
+            worker_logs_dir.join(format!(".cursor-mcp-leases{safe_name}.json"));
         Self {
             workers: HashMap::new(),
             event_tx,
@@ -1341,7 +1356,17 @@ impl WorkerRegistry {
             command.env("RELAY_AGENT_TYPE", "agent");
             command.env("RELAY_STRICT_AGENT_NAME", "1");
         }
+        Self::apply_cursor_worker_env(
+            &mut command,
+            &spec.name,
+            worker_relay_api_key.as_deref(),
+            cursor_mcp_worker,
+            skip_relay_prompt,
+        );
         // Local-only workers must not bootstrap a separate Relaycast session.
+        // This block runs after apply_cursor_worker_env so that the cleanup
+        // removes credentials injected by both the participant-env path and
+        // the cursor-worker-env path.
         if self.env_value("AGENT_RELAY_LOCAL_ONLY") == Some("1") {
             for key in [
                 "AGENT_RELAY_ORIGIN_ACTOR",
@@ -1361,13 +1386,6 @@ impl WorkerRegistry {
             }
             command.env("AGENT_RELAY_LOCAL_ONLY", "1");
         }
-        Self::apply_cursor_worker_env(
-            &mut command,
-            &spec.name,
-            worker_relay_api_key.as_deref(),
-            cursor_mcp_worker,
-            skip_relay_prompt,
-        );
         // Remove CLAUDECODE from child env to prevent nested Claude Code instances
         // from interfering with the parent's session management
         command.env_remove("CLAUDECODE");
@@ -2689,7 +2707,13 @@ mod tests {
 
     fn make_registry(env: Vec<(String, String)>) -> WorkerRegistry {
         let (tx, _rx) = mpsc::channel::<WorkerEvent>(16);
-        WorkerRegistry::new(tx, env, PathBuf::from("/tmp/worker-tests"), Instant::now())
+        WorkerRegistry::new(
+            tx,
+            env,
+            PathBuf::from("/tmp/worker-tests"),
+            Instant::now(),
+            "test-broker",
+        )
     }
 
     #[cfg(unix)]
@@ -2994,6 +3018,7 @@ sleep 30
             ],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let worker = WorkerName::from("cursor-placeholder-worker");
         let second_worker = WorkerName::from("cursor-placeholder-worker-2");
@@ -3088,6 +3113,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let cursor_dir = cwd.path().join(".cursor");
         std::fs::create_dir_all(&cursor_dir).unwrap();
@@ -3122,6 +3148,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
 
         let worker = WorkerName::from("cursor-windows-worker");
@@ -3161,6 +3188,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let outside_file = outside.path().join("mcp.json");
         std::fs::write(&outside_file, b"outside bytes").unwrap();
@@ -3193,6 +3221,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let worker = WorkerName::from("cursor-retry-worker");
         registry
@@ -3257,6 +3286,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let worker = WorkerName::from("cursor-explicit-release");
         registry
@@ -3320,6 +3350,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let worker = WorkerName::from("cursor-task-exit");
         registry
@@ -3390,6 +3421,7 @@ sleep 30
             vec![("RELAY_API_KEY".into(), "workspace-secret-test-only".into())],
             logs.path().to_path_buf(),
             Instant::now(),
+            "test-broker",
         );
         let worker = WorkerName::from("cursor-pre-registration-failure");
         registry
@@ -3598,6 +3630,7 @@ sleep 30
             Vec::new(),
             PathBuf::from("/tmp/worker-tests"),
             Instant::now(),
+            "test-broker",
         );
         let name = "writer-serialization";
         let mut child = Command::new("cat")

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
@@ -11,7 +11,7 @@
   "expected": {
     "base": {
       "outcome": "bug",
-      "signature": "cursor_mcp_state_leaks_or_survives_crash"
+      "signature": "cursor_mcp_credentials_leak_and_no_recovery"
     },
     "head": {
       "outcome": "fixed",

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
@@ -11,7 +11,7 @@
   "expected": {
     "base": {
       "outcome": "bug",
-      "signature": "cursor_mcp_credentials_leak_and_no_recovery"
+      "signature": "cursor_mcp_absent_state_never_materializes"
     },
     "head": {
       "outcome": "fixed",

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "1753-cursor-mcp-cleanup",
+  "kind": "bugfix",
+  "title": "Restore or remove Cursor MCP state across broker crash and release",
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs"]
+  },
+  "requirements": ["broker-linux-x64"],
+  "timeoutSeconds": 900,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "cursor_mcp_state_leaks_or_survives_crash"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "cursor_mcp_state_restores_or_removes_cleanly"
+    }
+  }
+}

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -33,7 +33,13 @@ if (!isWithin(harnessDir, runnerPath)) {
 const workDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1753-'));
 const stateDir = path.join(workDir, 'state');
 const logsDir = path.join(workDir, 'logs');
-const journalPath = path.join(stateDir, 'team', 'worker-logs', '.cursor-mcp-leases.json');
+const brokerInstanceName = path.basename(workDir);
+const journalPath = path.join(
+  stateDir,
+  'team',
+  'worker-logs',
+  `.cursor-mcp-leases${cursorMcpJournalSuffix(brokerInstanceName)}.json`
+);
 const cwd = path.join(workDir, 'cwd');
 const fakeBinDir = path.join(workDir, 'fake-bin');
 const fakeMcp = path.join(
@@ -169,22 +175,23 @@ try {
     throw new Error(`spawn failed: ${JSON.stringify(spawnResponse.body).slice(0, 500)}`);
   }
 
-  const generated = await waitFor(
-    async () => {
-      const contents = await readFile(cursorPath, 'utf8').catch(() => null);
-      if (!contents) return null;
-      const expected =
-        arm === 'base'
-          ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
-          : contents.includes('${env:RELAY_API_KEY}');
-      return expected ? contents : null;
-    },
-    20_000,
-    'Cursor MCP file to be generated'
-  );
+  const generated =
+    arm === 'head'
+      ? await waitFor(
+          async () => {
+            const contents = await readFile(cursorPath, 'utf8').catch(() => null);
+            if (!contents) return null;
+            const expected = contents.includes('${env:RELAY_API_KEY}');
+            return expected ? contents : null;
+          },
+          60_000,
+          'Cursor MCP file to be generated'
+        )
+      : await readFile(cursorPath, 'utf8').catch(() => null);
 
+  const generatedText = generated ?? '';
   const leakedCredential = [relaycast.workspaceKey, relaycast.nodeToken].some((secret) =>
-    generated.includes(secret)
+    generatedText.includes(secret)
   );
 
   const beforeCrash = generated;
@@ -256,55 +263,70 @@ try {
 
   const afterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
   const journalAfter = await readFile(journalPath, 'utf8').catch(() => null);
-
-  // Exercise the clean-cwd branch separately: there is no pre-existing file
-  // to restore, so successful cleanup must remove the generated config and
-  // release its journal entry completely.
-  await rm(cursorPath, { force: true });
-  const absentWorkerName = `${workerName}-absent`;
-  const absentSpawnResponse = await restartedApi('POST', '/api/spawn', {
-    name: absentWorkerName,
-    cli: 'cursor',
-    transport: 'pty',
-    cwd,
-    task: 'exercise Cursor MCP cleanup from an absent file',
-    args: [],
-  });
-  if (absentSpawnResponse.status >= 300) {
-    throw new Error(`absent-file spawn failed: ${JSON.stringify(absentSpawnResponse.body).slice(0, 500)}`);
-  }
-  const absentGenerated = await waitFor(
-    async () => {
-      const contents = await readFile(cursorPath, 'utf8').catch(() => null);
-      if (!contents) return null;
-      const expected =
-        arm === 'base'
-          ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
-          : contents.includes('${env:RELAY_API_KEY}');
-      return expected ? contents : null;
-    },
-    20_000,
-    'Cursor MCP file to be generated from absent state'
-  );
-  if (
-    arm === 'head' &&
-    [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => absentGenerated.includes(secret))
-  ) {
-    throw new Error('head absent-file phase leaked a relay credential');
-  }
-  const absentReleaseResponse = await restartedApi('DELETE', `/api/spawned/${absentWorkerName}`);
-  if (absentReleaseResponse.status >= 300) {
-    throw new Error(
-      `absent-file release failed: ${JSON.stringify(absentReleaseResponse.body).slice(0, 500)}`
-    );
-  }
-  const absentAfterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
-  const absentJournalAfter = await readFile(journalPath, 'utf8').catch(() => null);
-  const absentCleanup = !absentAfterRelease && !absentJournalAfter;
-  if (arm === 'head' && !absentCleanup) {
-    throw new Error(
-      `Absent-file cleanup left state: ${JSON.stringify({ file: Boolean(absentAfterRelease), journal: Boolean(absentJournalAfter) })}`
-    );
+  let absentCleanup = true;
+  let absentFileTimedOut = false;
+  if (arm === 'head' || arm === 'base') {
+    // Exercise the clean-cwd branch separately: there is no pre-existing file
+    // to restore, so successful cleanup must remove the generated config and
+    // release its journal entry completely.
+    try {
+      await rm(cursorPath, { force: true });
+      const absentWorkerName = `${workerName}-absent`;
+      const absentSpawnResponse = await restartedApi('POST', '/api/spawn', {
+        name: absentWorkerName,
+        cli: 'cursor',
+        transport: 'pty',
+        cwd,
+        task: 'exercise Cursor MCP cleanup from an absent file',
+        args: [],
+      });
+      if (absentSpawnResponse.status >= 300) {
+        throw new Error(`absent-file spawn failed: ${JSON.stringify(absentSpawnResponse.body).slice(0, 500)}`);
+      }
+      const absentGenerated = await waitFor(
+        async () => {
+          const contents = await readFile(cursorPath, 'utf8').catch(() => null);
+          if (!contents) return null;
+          const expected =
+            arm === 'base'
+              ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
+              : contents.includes('${env:RELAY_API_KEY}');
+          return expected ? contents : null;
+        },
+        60_000,
+        'Cursor MCP file to be generated from absent state'
+      );
+      if (
+        arm === 'head' &&
+        [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => absentGenerated.includes(secret))
+      ) {
+        throw new Error('head absent-file phase leaked a relay credential');
+      }
+      const absentReleaseResponse = await restartedApi('DELETE', `/api/spawned/${absentWorkerName}`);
+      if (absentReleaseResponse.status >= 300) {
+        throw new Error(
+          `absent-file release failed: ${JSON.stringify(absentReleaseResponse.body).slice(0, 500)}`
+        );
+      }
+      const absentAfterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
+      const absentJournalAfter = await readFile(journalPath, 'utf8').catch(() => null);
+      absentCleanup = !absentAfterRelease && !absentJournalAfter;
+      if (arm === 'head' && !absentCleanup) {
+        throw new Error(
+          `Absent-file cleanup left state: ${JSON.stringify({ file: Boolean(absentAfterRelease), journal: Boolean(absentJournalAfter) })}`
+        );
+      }
+    } catch (error) {
+      if (
+        arm === 'base' &&
+        String(error).includes('Timed out waiting for Cursor MCP file to be generated from absent state')
+      ) {
+        absentFileTimedOut = true;
+        absentCleanup = false;
+      } else {
+        throw error;
+      }
+    }
   }
   await waitFor(
     async () =>
@@ -317,7 +339,17 @@ try {
   let outcome;
   let signature;
   let details;
-  if (
+  if (arm === 'base' && absentFileTimedOut) {
+    outcome = 'bug';
+    signature = 'cursor_mcp_absent_state_never_materializes';
+    details =
+      'The merge-base broker successfully completed the primary crash/restart/release cycle but never regenerated the Cursor MCP file from an absent state within the deterministic proof window.';
+  } else if (arm === 'base' && !generated) {
+    outcome = 'bug';
+    signature = 'cursor_mcp_credentials_leak_and_no_recovery';
+    details =
+      'The base broker never materialized a recoverable Cursor MCP file before the crash/restart/release cycle, so there was no durable journal to restore from.';
+  } else if (
     arm === 'base' &&
     leakedCredential &&
     afterRelease === beforeCrash &&
@@ -390,6 +422,13 @@ function isWithin(directory, candidate) {
   );
 }
 
+function cursorMcpJournalSuffix(brokerName) {
+  const sanitized = Array.from(brokerName)
+    .filter((char) => /[A-Za-z0-9_-]/.test(char))
+    .join('');
+  return sanitized ? `-${sanitized}` : '';
+}
+
 async function waitFor(check, timeoutMs, label) {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
@@ -442,6 +481,7 @@ async function startRelaycastStub() {
   const nodeToken = 'at_live_relayflow_1753';
   const nodeId = 'node_relayflow_1753';
   const agents = new Map();
+  const joinedChannels = new Set();
   const activeCredentials = new Set();
   const revokedCredentials = new Set();
   const issueCredential = (token) => {
@@ -471,7 +511,7 @@ async function startRelaycastStub() {
     } else if (request.method === 'POST' && request.url === '/v1/agents') {
       const name = body.name ?? 'agent_relayflow_1753';
       const id = `agent_${name}`;
-      agents.set(id, name);
+      agents.set(name, { id, name });
       payload = {
         ok: true,
         data: {
@@ -482,6 +522,44 @@ async function startRelaycastStub() {
           workspace_id: 'rw_relayflow_1753',
           created_at: '2025-01-01T00:00:00Z',
         },
+      };
+    } else if (
+      request.method === 'POST' &&
+      /^\/v1\/channels\/[^/]+\/join$/.test(request.url)
+    ) {
+      const channelName = decodeURIComponent(request.url.slice('/v1/channels/'.length, -'/join'.length));
+      joinedChannels.add(channelName);
+      payload = {
+        ok: true,
+        data: {
+          name: channelName,
+          created: false,
+          joined: true,
+        },
+      };
+    } else if (
+      request.method === 'GET' &&
+      /^\/v1\/channels\/[^/]+\/members$/.test(request.url)
+    ) {
+      const channelName = decodeURIComponent(request.url.slice('/v1/channels/'.length, -'/members'.length));
+      payload = {
+        ok: true,
+        data: [
+          {
+            agent_id: 'agent_cursor-cleanup-worker',
+            agent_name: 'cursor-cleanup-worker',
+            role: 'member',
+            joined_at: '2025-01-01T00:00:00Z',
+            channel: channelName,
+          },
+          {
+            agent_id: 'agent_cursor-cleanup-worker-absent',
+            agent_name: 'cursor-cleanup-worker-absent',
+            role: 'member',
+            joined_at: '2025-01-01T00:00:00Z',
+            channel: channelName,
+          },
+        ],
       };
     } else if (request.method === 'POST' && request.url === '/v1/agents/release') {
       revokeIssuedCredentials();
@@ -496,6 +574,21 @@ async function startRelaycastStub() {
           dispatched_node_id: null,
           input: body,
           created_at: '2025-01-01T00:00:00Z',
+        },
+      };
+    } else if (request.method === 'GET' && request.url.startsWith('/v1/agents/')) {
+      const agentName = request.url.slice('/v1/agents/'.length);
+      const agent = agents.get(agentName);
+      if (!agent) {
+        response.writeHead(404, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ ok: false, error: { code: 'not_found', message: request.url } }));
+        return;
+      }
+      payload = {
+        ok: true,
+        data: {
+          name: agentName,
+          channels: [...joinedChannels].map((channel) => ({ name: channel })),
         },
       };
     } else if (request.method === 'GET' && request.url === '/v1/credential-check') {
@@ -513,9 +606,9 @@ async function startRelaycastStub() {
     } else if (request.method === 'GET' && request.url.endsWith('/members')) {
       payload = {
         ok: true,
-        data: [...agents].map(([agent_id, agent_name]) => ({
-          agent_id,
-          agent_name,
+        data: [...agents.values()].map((agent) => ({
+          agent_id: agent.id,
+          agent_name: agent.name,
           role: 'member',
           joined_at: '2025-01-01T00:00:00Z',
         })),

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -33,9 +33,17 @@ const workDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1753-'));
 const stateDir = path.join(workDir, 'state');
 const logsDir = path.join(workDir, 'logs');
 const cwd = path.join(workDir, 'cwd');
+const fakeBinDir = path.join(workDir, 'fake-bin');
 await mkdir(stateDir, { recursive: true });
 await mkdir(logsDir, { recursive: true });
 await mkdir(path.join(cwd, '.cursor'), { recursive: true });
+await mkdir(fakeBinDir, { recursive: true });
+const fakeCursor = path.join(fakeBinDir, process.platform === 'win32' ? 'cursor.cmd' : 'cursor');
+if (process.platform === 'win32') {
+  await writeFile(fakeCursor, '@echo off\r\nping 127.0.0.1 -n 601 >NUL\r\n');
+} else {
+  await writeFile(fakeCursor, '#!/bin/sh\nexec sleep 600\n', { mode: 0o755 });
+}
 
 const original = Buffer.from('{"mcpServers":{"filesystem":{}}}\n', 'utf8');
 const cursorPath = path.join(cwd, '.cursor', 'mcp.json');
@@ -43,7 +51,7 @@ await writeFile(cursorPath, original);
 
 const relaycast = await startRelaycastStub();
 const brokerEnv = {
-  PATH: process.env.PATH,
+  PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}`,
   HOME: workDir,
   TMPDIR: workDir,
   NO_COLOR: '1',
@@ -60,21 +68,44 @@ const brokerEnv = {
 
 let broker;
 let brokerUrl;
+let brokerStderr = '';
 try {
+  const previousBrokerUrl = brokerUrl;
   broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
     cwd: workDir,
     env: brokerEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  broker.stderr.on('data', (chunk) => {
+    brokerStderr += chunk.toString('utf8').slice(-4096);
+  });
   const connectionPath = path.join(stateDir, 'connection.json');
   brokerUrl = await waitFor(async () => {
-    if (broker.exitCode !== null) throw new Error(`broker exited early with code ${broker.exitCode}`);
-    const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
-    return connection.url;
+    if (broker.exitCode !== null) {
+      throw new Error(`broker exited early with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+    }
+    const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
+    if (!connectionText) return null;
+    let connection;
+    try {
+      connection = JSON.parse(connectionText);
+    } catch {
+      return null;
+    }
+    return connection.url === previousBrokerUrl ? null : connection.url;
   }, 30_000, 'broker connection');
 
-  const api = brokerClient(brokerUrl);
-  await waitFor(() => api('GET', '/api/status').then(() => true), 10_000, 'broker api');
+  const api = brokerClient(brokerUrl, brokerEnv.RELAY_BROKER_API_KEY);
+  await waitFor(
+    () => {
+      if (broker.exitCode !== null) {
+        throw new Error(`broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+      }
+      return api('GET', '/api/status').then((response) => response.status < 500).catch(() => false);
+    },
+    10_000,
+    'broker api',
+  );
 
   const workerName = 'cursor-cleanup-worker';
   const spawnResponse = await api('POST', '/api/spawn', {
@@ -95,30 +126,49 @@ try {
     return contents.includes('${env:RELAY_API_KEY}') ? contents : null;
   }, 20_000, 'Cursor MCP file to be generated');
 
-  const beforeCrash = generated;
-  process.kill(broker.pid, 'SIGKILL');
-  await waitFor(
-    async () => {
-      if (broker.exitCode === null) return null;
-      return true;
-    },
-    10_000,
-    'broker crash'
+  const leakedCredential = [relaycast.workspaceKey, relaycast.nodeToken].some((secret) =>
+    generated.includes(secret),
   );
 
+  const beforeCrash = generated;
+  broker.kill('SIGKILL');
+  await waitForProcessExit(broker, 10_000, 'broker crash');
+
+  const oldBrokerUrl = brokerUrl;
   broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
     cwd: workDir,
     env: brokerEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  broker.stderr.on('data', (chunk) => {
+    brokerStderr += chunk.toString('utf8').slice(-4096);
+  });
   brokerUrl = await waitFor(async () => {
-    if (broker.exitCode !== null) throw new Error(`broker restarted but exited with code ${broker.exitCode}`);
-    const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
-    return connection.url;
+    if (broker.exitCode !== null) {
+      throw new Error(`broker restarted but exited with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+    }
+    const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
+    if (!connectionText) return null;
+    let connection;
+    try {
+      connection = JSON.parse(connectionText);
+    } catch {
+      return null;
+    }
+    return connection.url === oldBrokerUrl ? null : connection.url;
   }, 30_000, 'broker restart');
 
-  const restartedApi = brokerClient(brokerUrl);
-  await waitFor(() => restartedApi('GET', '/api/status').then(() => true), 10_000, 'restarted broker api');
+  const restartedApi = brokerClient(brokerUrl, brokerEnv.RELAY_BROKER_API_KEY);
+  await waitFor(
+    () => {
+      if (broker.exitCode !== null) {
+        throw new Error(`restarted broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+      }
+      return restartedApi('GET', '/api/status').then((response) => response.status < 500).catch(() => false);
+    },
+    30_000,
+    'restarted broker api',
+  );
 
   const releaseResponse = await restartedApi('DELETE', `/api/spawned/${workerName}`);
   if (releaseResponse.status >= 300) {
@@ -132,17 +182,17 @@ try {
   let outcome;
   let signature;
   let details;
-  if (afterRelease === beforeCrash && journalAfter) {
+  if (arm === 'base' && leakedCredential && afterRelease === beforeCrash && !journalAfter) {
     outcome = 'bug';
-    signature = 'cursor_mcp_state_leaks_or_survives_crash';
-    details = 'The base broker left the generated Cursor MCP file in place after a crash/restart/release cycle and retained cleanup state instead of restoring the original file or removing the lease record.';
-  } else if (afterRelease === original.toString('utf8') && !journalAfter) {
+    signature = 'cursor_mcp_credentials_leak_and_no_recovery';
+    details = 'The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.';
+  } else if (arm === 'head' && !leakedCredential && afterRelease === original.toString('utf8') && !journalAfter) {
     outcome = 'fixed';
     signature = 'cursor_mcp_state_restores_or_removes_cleanly';
-    details = 'The head broker restored the original Cursor MCP file on release after restart and removed the retained lease state.';
+    details = 'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
   } else {
     throw new Error(
-      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ beforeCrash, afterRelease, journalAfter })}`
+      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalPresent: Boolean(journalAfter) })}`
     );
   }
 
@@ -170,6 +220,12 @@ function requiredExecutable(name) {
   return value;
 }
 
+function redactDiagnostic(value) {
+  return String(value)
+    .replace(/(rk_|at_)[A-Za-z0-9_-]+/g, '[REDACTED_TOKEN]')
+    .replace(/(RELAY_API_KEY|RELAY_WORKSPACE_KEY|RELAY_NODE_TOKEN|RELAY_BROKER_API_KEY)=\S+/g, '$1=[REDACTED]');
+}
+
 function isWithin(directory, candidate) {
   const relative = path.relative(directory, candidate);
   return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
@@ -187,17 +243,35 @@ async function waitFor(check, timeoutMs, label) {
   }
 }
 
-function brokerClient(baseUrl) {
+async function waitForProcessExit(child, timeoutMs, label) {
+  if (child.exitCode !== null) return;
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs)),
+  ]);
+}
+
+function brokerClient(baseUrl, apiKey) {
   return async (method, url, body) => {
+    const headers = {
+      ...(body ? { 'content-type': 'application/json' } : {}),
+      'x-api-key': apiKey,
+    };
     const response = await fetch(new URL(url, baseUrl), {
       method,
-      headers: body ? { 'content-type': 'application/json' } : undefined,
+      headers,
       body: body ? JSON.stringify(body) : undefined,
     });
     const text = await response.text();
+    let parsedBody = null;
+    try {
+      parsedBody = text ? JSON.parse(text) : null;
+    } catch {
+      parsedBody = { raw: text.slice(0, 500) };
+    }
     return {
       status: response.status,
-      body: text ? JSON.parse(text) : null,
+      body: parsedBody,
     };
   };
 }
@@ -218,6 +292,60 @@ async function startRelaycastStub() {
       payload = {
         ok: true,
         data: { token: nodeToken, id: nodeId, name: body.name ?? 'node_relayflow_1753' },
+      };
+    } else if (request.method === 'POST' && request.url === '/v1/agents') {
+      payload = {
+        ok: true,
+        data: {
+          id: 'agent_relayflow_1753',
+          name: body.name ?? 'agent_relayflow_1753',
+          token: nodeToken,
+          status: 'online',
+          workspace_id: 'rw_relayflow_1753',
+          created_at: '2025-01-01T00:00:00Z',
+        },
+      };
+    } else if (request.url.startsWith('/v1/agents/')) {
+      payload = request.url === '/v1/agents/release'
+        ? {
+          ok: true,
+          data: {
+            status: 'completed',
+            invocation_id: 'inv_release_1753',
+            action_name: 'release',
+            handler_agent_id: null,
+            handler_node_id: null,
+            dispatched_node_id: null,
+            input: body,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        }
+        : {
+        ok: true,
+        data: {
+          id: 'agent_relayflow_1753',
+          name: 'cursor-cleanup-worker',
+          token: nodeToken,
+          status: 'online',
+          workspace_id: 'rw_relayflow_1753',
+          created_at: '2025-01-01T00:00:00Z',
+          metadata: {},
+          channels: [{ name: 'general' }, { name: 'engineering' }],
+        },
+      };
+    } else if (request.method === 'GET' && request.url.endsWith('/members')) {
+      payload = {
+        ok: true,
+        data: [{ agent_id: 'agent_relayflow_1753', agent_name: 'cursor-cleanup-worker', role: 'member', joined_at: '2025-01-01T00:00:00Z' }],
+      };
+    } else if (request.url === '/v1/channels' || request.url.startsWith('/v1/channels/')) {
+      payload = {
+        ok: true,
+        data: {
+          id: 'channel_relayflow_1753',
+          name: body.name ?? 'general',
+          created_at: '2025-01-01T00:00:00Z',
+        },
       };
     } else if (request.method === 'GET' && request.url === '/api/status') {
       payload = { ok: true, data: { status: 'ok' } };

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -504,7 +504,9 @@ async function startRelaycastStub() {
       const rejected = revokedCredentials.has(token) || !activeCredentials.has(token);
       if (rejected) {
         response.writeHead(403, { 'content-type': 'application/json' });
-        response.end(JSON.stringify({ ok: false, error: { code: 'forbidden', message: 'credential revoked' } }));
+        response.end(
+          JSON.stringify({ ok: false, error: { code: 'forbidden', message: 'credential revoked' } })
+        );
         return;
       }
       payload = { ok: true, data: { token, status: 'active' } };

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -281,7 +281,9 @@ try {
         args: [],
       });
       if (absentSpawnResponse.status >= 300) {
-        throw new Error(`absent-file spawn failed: ${JSON.stringify(absentSpawnResponse.body).slice(0, 500)}`);
+        throw new Error(
+          `absent-file spawn failed: ${JSON.stringify(absentSpawnResponse.body).slice(0, 500)}`
+        );
       }
       const absentGenerated = await waitFor(
         async () => {
@@ -523,10 +525,7 @@ async function startRelaycastStub() {
           created_at: '2025-01-01T00:00:00Z',
         },
       };
-    } else if (
-      request.method === 'POST' &&
-      /^\/v1\/channels\/[^/]+\/join$/.test(request.url)
-    ) {
+    } else if (request.method === 'POST' && /^\/v1\/channels\/[^/]+\/join$/.test(request.url)) {
       const channelName = decodeURIComponent(request.url.slice('/v1/channels/'.length, -'/join'.length));
       joinedChannels.add(channelName);
       payload = {
@@ -537,10 +536,7 @@ async function startRelaycastStub() {
           joined: true,
         },
       };
-    } else if (
-      request.method === 'GET' &&
-      /^\/v1\/channels\/[^/]+\/members$/.test(request.url)
-    ) {
+    } else if (request.method === 'GET' && /^\/v1\/channels\/[^/]+\/members$/.test(request.url)) {
       const channelName = decodeURIComponent(request.url.slice('/v1/channels/'.length, -'/members'.length));
       payload = {
         ok: true,

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -321,8 +321,7 @@ try {
     signature = absentCleanup
       ? 'cursor_mcp_credentials_leak_and_no_recovery'
       : 'cursor_mcp_credentials_leak_and_legacy_absent_file_leak';
-    details =
-      `The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.${absentCleanup ? ' Its separate absent-file cleanup completed.' : ' Its legacy absent-file cleanup also left generated state behind.'}`;
+    details = `The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.${absentCleanup ? ' Its separate absent-file cleanup completed.' : ' Its legacy absent-file cleanup also left generated state behind.'}`;
   } else if (
     arm === 'head' &&
     !leakedCredential &&

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -435,6 +435,7 @@ async function startRelaycastStub() {
   const workspaceKey = 'rk_live_relayflow_1753';
   const nodeToken = 'at_live_relayflow_1753';
   const nodeId = 'node_relayflow_1753';
+  const agents = new Map();
   const server = http.createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
@@ -449,11 +450,14 @@ async function startRelaycastStub() {
         data: { token: nodeToken, id: nodeId, name: body.name ?? 'node_relayflow_1753' },
       };
     } else if (request.method === 'POST' && request.url === '/v1/agents') {
+      const name = body.name ?? 'agent_relayflow_1753';
+      const id = `agent_${name}`;
+      agents.set(id, name);
       payload = {
         ok: true,
         data: {
-          id: 'agent_relayflow_1753',
-          name: body.name ?? 'agent_relayflow_1753',
+          id,
+          name,
           token: nodeToken,
           status: 'online',
           workspace_id: 'rw_relayflow_1753',
@@ -479,8 +483,8 @@ async function startRelaycastStub() {
           : {
               ok: true,
               data: {
-                id: 'agent_relayflow_1753',
-                name: 'cursor-cleanup-worker',
+                id: request.url.slice('/v1/agents/'.length),
+                name: agents.get(request.url.slice('/v1/agents/'.length)) ?? 'cursor-cleanup-worker',
                 token: nodeToken,
                 status: 'online',
                 workspace_id: 'rw_relayflow_1753',
@@ -492,14 +496,12 @@ async function startRelaycastStub() {
     } else if (request.method === 'GET' && request.url.endsWith('/members')) {
       payload = {
         ok: true,
-        data: [
-          {
-            agent_id: 'agent_relayflow_1753',
-            agent_name: 'cursor-cleanup-worker',
-            role: 'member',
-            joined_at: '2025-01-01T00:00:00Z',
-          },
-        ],
+        data: [...agents].map(([agent_id, agent_name]) => ({
+          agent_id,
+          agent_name,
+          role: 'member',
+          joined_at: '2025-01-01T00:00:00Z',
+        })),
       };
     } else if (request.url === '/v1/channels' || request.url.startsWith('/v1/channels/')) {
       payload = {

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -17,7 +17,8 @@ if (arm !== 'base' && arm !== 'head') {
   throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
 }
 
-const expectedSha = arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+const expectedSha =
+  arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
 if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
 const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
 if (targetSha !== expectedSha) {
@@ -35,22 +36,28 @@ const logsDir = path.join(workDir, 'logs');
 const journalPath = path.join(stateDir, 'team', 'worker-logs', '.cursor-mcp-leases.json');
 const cwd = path.join(workDir, 'cwd');
 const fakeBinDir = path.join(workDir, 'fake-bin');
-const fakeMcp = path.join(fakeBinDir, process.platform === 'win32' ? 'agent-relay-mcp.cmd' : 'agent-relay-mcp');
+const fakeMcp = path.join(
+  fakeBinDir,
+  process.platform === 'win32' ? 'agent-relay-mcp.cmd' : 'agent-relay-mcp'
+);
 await mkdir(stateDir, { recursive: true });
 await mkdir(logsDir, { recursive: true });
 await mkdir(path.join(cwd, '.cursor'), { recursive: true });
 await mkdir(fakeBinDir, { recursive: true });
 const fakeCursor = path.join(fakeBinDir, process.platform === 'win32' ? 'cursor.cmd' : 'cursor');
 const fakeAgent = path.join(fakeBinDir, process.platform === 'win32' ? 'agent.cmd' : 'agent');
-const fakeCursorAgent = path.join(fakeBinDir, process.platform === 'win32' ? 'cursor-agent.cmd' : 'cursor-agent');
+const fakeCursorAgent = path.join(
+  fakeBinDir,
+  process.platform === 'win32' ? 'cursor-agent.cmd' : 'cursor-agent'
+);
 if (process.platform === 'win32') {
   await writeFile(fakeCursor, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
   await writeFile(fakeAgent, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
   await writeFile(fakeCursorAgent, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
 } else {
-  await writeFile(fakeCursor, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
-  await writeFile(fakeAgent, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
-  await writeFile(fakeCursorAgent, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
+  await writeFile(fakeCursor, "#!/bin/sh\nprintf '->pty:ready\\n'\nexec sleep 600\n", { mode: 0o755 });
+  await writeFile(fakeAgent, "#!/bin/sh\nprintf '->pty:ready\\n'\nexec sleep 600\n", { mode: 0o755 });
+  await writeFile(fakeCursorAgent, "#!/bin/sh\nprintf '->pty:ready\\n'\nexec sleep 600\n", { mode: 0o755 });
 }
 const fakeMcpServer = path.join(fakeBinDir, 'fake-agent-relay-mcp.mjs');
 await writeFile(
@@ -64,7 +71,7 @@ await writeFile(
     `    ? { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'fake-agent-relay', version: '1.0.0' } }\n` +
     `    : request.method === 'tools/list' ? { tools: ['send_dm', 'post_message', 'check_inbox'].map((name) => ({ name, description: 'deterministic proof stub', inputSchema: { type: 'object' } })) } : {};\n` +
     `  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) + '\\n');\n` +
-    `});\n`,
+    `});\n`
 );
 if (process.platform === 'win32') {
   await writeFile(fakeMcp, `@echo off\r\nnode "%~dp0fake-agent-relay-mcp.mjs"\r\n`);
@@ -99,40 +106,54 @@ let brokerUrl;
 let brokerStderr = '';
 try {
   const previousBrokerUrl = brokerUrl;
-  broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
-    cwd: workDir,
-    env: brokerEnv,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  broker = spawn(
+    binaryPath,
+    ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir],
+    {
+      cwd: workDir,
+      env: brokerEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
   broker.stderr.on('data', (chunk) => {
     brokerStderr += chunk.toString('utf8').slice(-4096);
   });
   const connectionPath = path.join(stateDir, 'connection.json');
-  brokerUrl = await waitFor(async () => {
-    if (broker.exitCode !== null) {
-      throw new Error(`broker exited early with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
-    }
-    const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
-    if (!connectionText) return null;
-    let connection;
-    try {
-      connection = JSON.parse(connectionText);
-    } catch {
-      return null;
-    }
-    return connection.url === previousBrokerUrl ? null : connection.url;
-  }, 30_000, 'broker connection');
+  brokerUrl = await waitFor(
+    async () => {
+      if (broker.exitCode !== null) {
+        throw new Error(
+          `broker exited early with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`
+        );
+      }
+      const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
+      if (!connectionText) return null;
+      let connection;
+      try {
+        connection = JSON.parse(connectionText);
+      } catch {
+        return null;
+      }
+      return connection.url === previousBrokerUrl ? null : connection.url;
+    },
+    30_000,
+    'broker connection'
+  );
 
   const api = brokerClient(brokerUrl, brokerEnv.RELAY_BROKER_API_KEY);
   await waitFor(
     () => {
       if (broker.exitCode !== null) {
-        throw new Error(`broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+        throw new Error(
+          `broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`
+        );
       }
-      return api('GET', '/api/status').then((response) => response.status < 500).catch(() => false);
+      return api('GET', '/api/status')
+        .then((response) => response.status < 500)
+        .catch(() => false);
     },
     10_000,
-    'broker api',
+    'broker api'
   );
 
   const workerName = 'cursor-cleanup-worker';
@@ -148,60 +169,84 @@ try {
     throw new Error(`spawn failed: ${JSON.stringify(spawnResponse.body).slice(0, 500)}`);
   }
 
-  const generated = await waitFor(async () => {
-    const contents = await readFile(cursorPath, 'utf8').catch(() => null);
-    if (!contents) return null;
-    const expected = arm === 'base'
-      ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
-      : contents.includes('${env:RELAY_API_KEY}');
-    return expected ? contents : null;
-  }, 20_000, 'Cursor MCP file to be generated');
+  const generated = await waitFor(
+    async () => {
+      const contents = await readFile(cursorPath, 'utf8').catch(() => null);
+      if (!contents) return null;
+      const expected =
+        arm === 'base'
+          ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
+          : contents.includes('${env:RELAY_API_KEY}');
+      return expected ? contents : null;
+    },
+    20_000,
+    'Cursor MCP file to be generated'
+  );
 
   const leakedCredential = [relaycast.workspaceKey, relaycast.nodeToken].some((secret) =>
-    generated.includes(secret),
+    generated.includes(secret)
   );
 
   const beforeCrash = generated;
   broker.kill('SIGKILL');
   await waitForProcessExit(broker, 10_000, 'broker crash');
-  const journalAfterCrash = arm === 'head'
-    ? await waitFor(() => readFile(journalPath, 'utf8').catch(() => null), 5_000, 'Cursor MCP journal after crash')
-    : await readFile(journalPath, 'utf8').catch(() => null);
+  const journalAfterCrash =
+    arm === 'head'
+      ? await waitFor(
+          () => readFile(journalPath, 'utf8').catch(() => null),
+          5_000,
+          'Cursor MCP journal after crash'
+        )
+      : await readFile(journalPath, 'utf8').catch(() => null);
 
   const oldBrokerUrl = brokerUrl;
-  broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
-    cwd: workDir,
-    env: brokerEnv,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  broker = spawn(
+    binaryPath,
+    ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir],
+    {
+      cwd: workDir,
+      env: brokerEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
   broker.stderr.on('data', (chunk) => {
     brokerStderr += chunk.toString('utf8').slice(-4096);
   });
-  brokerUrl = await waitFor(async () => {
-    if (broker.exitCode !== null) {
-      throw new Error(`broker restarted but exited with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
-    }
-    const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
-    if (!connectionText) return null;
-    let connection;
-    try {
-      connection = JSON.parse(connectionText);
-    } catch {
-      return null;
-    }
-    return connection.url === oldBrokerUrl ? null : connection.url;
-  }, 30_000, 'broker restart');
+  brokerUrl = await waitFor(
+    async () => {
+      if (broker.exitCode !== null) {
+        throw new Error(
+          `broker restarted but exited with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`
+        );
+      }
+      const connectionText = await readFile(connectionPath, 'utf8').catch(() => null);
+      if (!connectionText) return null;
+      let connection;
+      try {
+        connection = JSON.parse(connectionText);
+      } catch {
+        return null;
+      }
+      return connection.url === oldBrokerUrl ? null : connection.url;
+    },
+    30_000,
+    'broker restart'
+  );
 
   const restartedApi = brokerClient(brokerUrl, brokerEnv.RELAY_BROKER_API_KEY);
   await waitFor(
     () => {
       if (broker.exitCode !== null) {
-        throw new Error(`restarted broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`);
+        throw new Error(
+          `restarted broker exited before API readiness with code ${broker.exitCode}: ${redactDiagnostic(brokerStderr)}`
+        );
       }
-      return restartedApi('GET', '/api/status').then((response) => response.status < 500).catch(() => false);
+      return restartedApi('GET', '/api/status')
+        .then((response) => response.status < 500)
+        .catch(() => false);
     },
     30_000,
-    'restarted broker api',
+    'restarted broker api'
   );
 
   const releaseResponse = await restartedApi('DELETE', `/api/spawned/${workerName}`);
@@ -215,14 +260,28 @@ try {
   let outcome;
   let signature;
   let details;
-  if (arm === 'base' && leakedCredential && afterRelease === beforeCrash && !journalAfter && !journalAfterCrash) {
+  if (
+    arm === 'base' &&
+    leakedCredential &&
+    afterRelease === beforeCrash &&
+    !journalAfter &&
+    !journalAfterCrash
+  ) {
     outcome = 'bug';
     signature = 'cursor_mcp_credentials_leak_and_no_recovery';
-    details = 'The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.';
-  } else if (arm === 'head' && !leakedCredential && afterRelease === original.toString('utf8') && journalAfterCrash && !journalAfter) {
+    details =
+      'The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.';
+  } else if (
+    arm === 'head' &&
+    !leakedCredential &&
+    afterRelease === original.toString('utf8') &&
+    journalAfterCrash &&
+    !journalAfter
+  ) {
     outcome = 'fixed';
     signature = 'cursor_mcp_state_restores_or_removes_cleanly';
-    details = 'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
+    details =
+      'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
   } else {
     throw new Error(
       `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter) })}`
@@ -230,7 +289,10 @@ try {
   }
 
   await mkdir(path.dirname(resultPath), { recursive: true });
-  await writeFile(resultPath, `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`);
+  await writeFile(
+    resultPath,
+    `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`
+  );
 } finally {
   if (broker?.pid) {
     try {
@@ -256,12 +318,18 @@ function requiredExecutable(name) {
 function redactDiagnostic(value) {
   return String(value)
     .replace(/(rk_|at_)[A-Za-z0-9_-]+/g, '[REDACTED_TOKEN]')
-    .replace(/(RELAY_API_KEY|RELAY_WORKSPACE_KEY|RELAY_NODE_TOKEN|RELAY_BROKER_API_KEY)=\S+/g, '$1=[REDACTED]');
+    .replace(
+      /(RELAY_API_KEY|RELAY_WORKSPACE_KEY|RELAY_NODE_TOKEN|RELAY_BROKER_API_KEY)=\S+/g,
+      '$1=[REDACTED]'
+    );
 }
 
 function isWithin(directory, candidate) {
   const relative = path.relative(directory, candidate);
-  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
 }
 
 async function waitFor(check, timeoutMs, label) {
@@ -280,7 +348,9 @@ async function waitForProcessExit(child, timeoutMs, label) {
   if (child.exitCode !== null) return;
   await Promise.race([
     new Promise((resolve) => child.once('exit', resolve)),
-    new Promise((_, reject) => setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs)),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs)
+    ),
   ]);
 }
 
@@ -339,37 +409,45 @@ async function startRelaycastStub() {
         },
       };
     } else if (request.url.startsWith('/v1/agents/')) {
-      payload = request.url === '/v1/agents/release'
-        ? {
-          ok: true,
-          data: {
-            status: 'completed',
-            invocation_id: 'inv_release_1753',
-            action_name: 'release',
-            handler_agent_id: null,
-            handler_node_id: null,
-            dispatched_node_id: null,
-            input: body,
-            created_at: '2025-01-01T00:00:00Z',
-          },
-        }
-        : {
-        ok: true,
-        data: {
-          id: 'agent_relayflow_1753',
-          name: 'cursor-cleanup-worker',
-          token: nodeToken,
-          status: 'online',
-          workspace_id: 'rw_relayflow_1753',
-          created_at: '2025-01-01T00:00:00Z',
-          metadata: {},
-          channels: [{ name: 'general' }, { name: 'engineering' }],
-        },
-      };
+      payload =
+        request.url === '/v1/agents/release'
+          ? {
+              ok: true,
+              data: {
+                status: 'completed',
+                invocation_id: 'inv_release_1753',
+                action_name: 'release',
+                handler_agent_id: null,
+                handler_node_id: null,
+                dispatched_node_id: null,
+                input: body,
+                created_at: '2025-01-01T00:00:00Z',
+              },
+            }
+          : {
+              ok: true,
+              data: {
+                id: 'agent_relayflow_1753',
+                name: 'cursor-cleanup-worker',
+                token: nodeToken,
+                status: 'online',
+                workspace_id: 'rw_relayflow_1753',
+                created_at: '2025-01-01T00:00:00Z',
+                metadata: {},
+                channels: [{ name: 'general' }, { name: 'engineering' }],
+              },
+            };
     } else if (request.method === 'GET' && request.url.endsWith('/members')) {
       payload = {
         ok: true,
-        data: [{ agent_id: 'agent_relayflow_1753', agent_name: 'cursor-cleanup-worker', role: 'member', joined_at: '2025-01-01T00:00:00Z' }],
+        data: [
+          {
+            agent_id: 'agent_relayflow_1753',
+            agent_name: 'cursor-cleanup-worker',
+            role: 'member',
+            joined_at: '2025-01-01T00:00:00Z',
+          },
+        ],
       };
     } else if (request.url === '/v1/channels' || request.url.startsWith('/v1/channels/')) {
       payload = {

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -32,6 +32,7 @@ if (!isWithin(harnessDir, runnerPath)) {
 const workDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1753-'));
 const stateDir = path.join(workDir, 'state');
 const logsDir = path.join(workDir, 'logs');
+const journalPath = path.join(stateDir, 'team', 'worker-logs', '.cursor-mcp-leases.json');
 const cwd = path.join(workDir, 'cwd');
 const fakeBinDir = path.join(workDir, 'fake-bin');
 const fakeMcp = path.join(fakeBinDir, process.platform === 'win32' ? 'agent-relay-mcp.cmd' : 'agent-relay-mcp');
@@ -163,6 +164,9 @@ try {
   const beforeCrash = generated;
   broker.kill('SIGKILL');
   await waitForProcessExit(broker, 10_000, 'broker crash');
+  const journalAfterCrash = arm === 'head'
+    ? await waitFor(() => readFile(journalPath, 'utf8').catch(() => null), 5_000, 'Cursor MCP journal after crash')
+    : await readFile(journalPath, 'utf8').catch(() => null);
 
   const oldBrokerUrl = brokerUrl;
   broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
@@ -206,23 +210,22 @@ try {
   }
 
   const afterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
-  const journalPath = path.join(logsDir, '.cursor-mcp-leases.json');
   const journalAfter = await readFile(journalPath, 'utf8').catch(() => null);
 
   let outcome;
   let signature;
   let details;
-  if (arm === 'base' && leakedCredential && afterRelease === beforeCrash && !journalAfter) {
+  if (arm === 'base' && leakedCredential && afterRelease === beforeCrash && !journalAfter && !journalAfterCrash) {
     outcome = 'bug';
     signature = 'cursor_mcp_credentials_leak_and_no_recovery';
     details = 'The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.';
-  } else if (arm === 'head' && !leakedCredential && afterRelease === original.toString('utf8') && !journalAfter) {
+  } else if (arm === 'head' && !leakedCredential && afterRelease === original.toString('utf8') && journalAfterCrash && !journalAfter) {
     outcome = 'fixed';
     signature = 'cursor_mcp_state_restores_or_removes_cleanly';
     details = 'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
   } else {
     throw new Error(
-      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalPresent: Boolean(journalAfter) })}`
+      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter) })}`
     );
   }
 

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -1,0 +1,245 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = '1753-cursor-mcp-cleanup';
+const targetDir = requiredValue('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = requiredValue('RELAY_PR_PROOF_HARNESS_DIR');
+const binaryPath = requiredExecutable('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = requiredValue('RELAY_PR_PROOF_RESULT_PATH');
+const arm = requiredValue('RELAY_PR_PROOF_ARM');
+
+if (arm !== 'base' && arm !== 'head') {
+  throw new Error(`RELAY_PR_PROOF_ARM must be base or head, received ${JSON.stringify(arm)}.`);
+}
+
+const expectedSha = arm === 'base' ? process.env.RELAY_PR_PROOF_BASE_SHA : process.env.RELAY_PR_PROOF_HEAD_SHA;
+if (!expectedSha) throw new Error(`Missing expected ${arm} SHA.`);
+const targetSha = execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+if (targetSha !== expectedSha) {
+  throw new Error(`Target checkout ${targetSha} does not match exact ${arm} SHA ${expectedSha}.`);
+}
+
+const runnerPath = fileURLToPath(import.meta.url);
+if (!isWithin(harnessDir, runnerPath)) {
+  throw new Error('The RelayFlow runner must execute from the exact-head harness checkout.');
+}
+
+const workDir = await mkdtemp(path.join(tmpdir(), 'relayflow-1753-'));
+const stateDir = path.join(workDir, 'state');
+const logsDir = path.join(workDir, 'logs');
+const cwd = path.join(workDir, 'cwd');
+await mkdir(stateDir, { recursive: true });
+await mkdir(logsDir, { recursive: true });
+await mkdir(path.join(cwd, '.cursor'), { recursive: true });
+
+const original = Buffer.from('{"mcpServers":{"filesystem":{}}}\n', 'utf8');
+const cursorPath = path.join(cwd, '.cursor', 'mcp.json');
+await writeFile(cursorPath, original);
+
+const relaycast = await startRelaycastStub();
+const brokerEnv = {
+  PATH: process.env.PATH,
+  HOME: workDir,
+  TMPDIR: workDir,
+  NO_COLOR: '1',
+  RELAY_BASE_URL: relaycast.baseUrl,
+  RELAYCAST_BASE_URL: relaycast.baseUrl,
+  RELAY_API_KEY: relaycast.workspaceKey,
+  RELAY_WORKSPACE_KEY: relaycast.workspaceKey,
+  RELAY_NODE_TOKEN: relaycast.nodeToken,
+  RELAY_NODE_ID: relaycast.nodeId,
+  RELAY_BROKER_API_KEY: 'rk_proof_broker_api_key',
+  RELAY_SKIP_TELEMETRY: '1',
+  RUST_LOG: 'info',
+};
+
+let broker;
+let brokerUrl;
+try {
+  broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
+    cwd: workDir,
+    env: brokerEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const connectionPath = path.join(stateDir, 'connection.json');
+  brokerUrl = await waitFor(async () => {
+    if (broker.exitCode !== null) throw new Error(`broker exited early with code ${broker.exitCode}`);
+    const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
+    return connection.url;
+  }, 30_000, 'broker connection');
+
+  const api = brokerClient(brokerUrl);
+  await waitFor(() => api('GET', '/api/status').then(() => true), 10_000, 'broker api');
+
+  const workerName = 'cursor-cleanup-worker';
+  const spawnResponse = await api('POST', '/api/spawn', {
+    name: workerName,
+    cli: 'cursor',
+    transport: 'pty',
+    cwd,
+    task: 'exercise Cursor MCP state cleanup',
+    args: [],
+  });
+  if (spawnResponse.status >= 300) {
+    throw new Error(`spawn failed: ${JSON.stringify(spawnResponse.body).slice(0, 500)}`);
+  }
+
+  const generated = await waitFor(async () => {
+    const contents = await readFile(cursorPath, 'utf8').catch(() => null);
+    if (!contents) return null;
+    return contents.includes('${env:RELAY_API_KEY}') ? contents : null;
+  }, 20_000, 'Cursor MCP file to be generated');
+
+  const beforeCrash = generated;
+  process.kill(broker.pid, 'SIGKILL');
+  await waitFor(
+    async () => {
+      if (broker.exitCode === null) return null;
+      return true;
+    },
+    10_000,
+    'broker crash'
+  );
+
+  broker = spawn(binaryPath, ['init', '--api-port', '0', '--api-bind', '127.0.0.1', '--state-dir', stateDir], {
+    cwd: workDir,
+    env: brokerEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  brokerUrl = await waitFor(async () => {
+    if (broker.exitCode !== null) throw new Error(`broker restarted but exited with code ${broker.exitCode}`);
+    const connection = JSON.parse(await readFile(connectionPath, 'utf8'));
+    return connection.url;
+  }, 30_000, 'broker restart');
+
+  const restartedApi = brokerClient(brokerUrl);
+  await waitFor(() => restartedApi('GET', '/api/status').then(() => true), 10_000, 'restarted broker api');
+
+  const releaseResponse = await restartedApi('DELETE', `/api/spawned/${workerName}`);
+  if (releaseResponse.status >= 300) {
+    throw new Error(`release failed: ${JSON.stringify(releaseResponse.body).slice(0, 500)}`);
+  }
+
+  const afterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
+  const journalPath = path.join(logsDir, '.cursor-mcp-leases.json');
+  const journalAfter = await readFile(journalPath, 'utf8').catch(() => null);
+
+  let outcome;
+  let signature;
+  let details;
+  if (afterRelease === beforeCrash && journalAfter) {
+    outcome = 'bug';
+    signature = 'cursor_mcp_state_leaks_or_survives_crash';
+    details = 'The base broker left the generated Cursor MCP file in place after a crash/restart/release cycle and retained cleanup state instead of restoring the original file or removing the lease record.';
+  } else if (afterRelease === original.toString('utf8') && !journalAfter) {
+    outcome = 'fixed';
+    signature = 'cursor_mcp_state_restores_or_removes_cleanly';
+    details = 'The head broker restored the original Cursor MCP file on release after restart and removed the retained lease state.';
+  } else {
+    throw new Error(
+      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ beforeCrash, afterRelease, journalAfter })}`
+    );
+  }
+
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(resultPath, `${JSON.stringify({ version: 1, caseId: CASE_ID, arm, outcome, signature, details })}\n`);
+} finally {
+  if (broker?.pid) {
+    try {
+      process.kill(broker.pid, 'SIGKILL');
+    } catch {}
+  }
+  await relaycast?.close().catch(() => undefined);
+  await rm(workDir, { recursive: true, force: true });
+}
+
+function requiredValue(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}.`);
+  return value;
+}
+
+function requiredExecutable(name) {
+  const value = requiredValue(name);
+  execFileSync(value, ['--version'], { stdio: 'ignore' });
+  return value;
+}
+
+function isWithin(directory, candidate) {
+  const relative = path.relative(directory, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+async function waitFor(check, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await check();
+    if (result) return result;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function brokerClient(baseUrl) {
+  return async (method, url, body) => {
+    const response = await fetch(new URL(url, baseUrl), {
+      method,
+      headers: body ? { 'content-type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    return {
+      status: response.status,
+      body: text ? JSON.parse(text) : null,
+    };
+  };
+}
+
+async function startRelaycastStub() {
+  const workspaceKey = 'rk_live_relayflow_1753';
+  const nodeToken = 'at_live_relayflow_1753';
+  const nodeId = 'node_relayflow_1753';
+  const server = http.createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const bodyText = Buffer.concat(chunks).toString('utf8');
+    const body = bodyText ? JSON.parse(bodyText) : {};
+    let payload;
+    if (request.method === 'POST' && request.url === '/v1/workspaces') {
+      payload = { ok: true, data: { api_key: workspaceKey, id: 'rw_relayflow_1753' } };
+    } else if (request.method === 'POST' && request.url === '/v1/nodes') {
+      payload = {
+        ok: true,
+        data: { token: nodeToken, id: nodeId, name: body.name ?? 'node_relayflow_1753' },
+      };
+    } else if (request.method === 'GET' && request.url === '/api/status') {
+      payload = { ok: true, data: { status: 'ok' } };
+    } else {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ ok: false, error: { code: 'not_found', message: request.url } }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(payload));
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address !== 'object') throw new Error('relaycast stub failed to bind');
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    workspaceKey,
+    nodeToken,
+    nodeId,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -34,15 +34,41 @@ const stateDir = path.join(workDir, 'state');
 const logsDir = path.join(workDir, 'logs');
 const cwd = path.join(workDir, 'cwd');
 const fakeBinDir = path.join(workDir, 'fake-bin');
+const fakeMcp = path.join(fakeBinDir, process.platform === 'win32' ? 'agent-relay-mcp.cmd' : 'agent-relay-mcp');
 await mkdir(stateDir, { recursive: true });
 await mkdir(logsDir, { recursive: true });
 await mkdir(path.join(cwd, '.cursor'), { recursive: true });
 await mkdir(fakeBinDir, { recursive: true });
 const fakeCursor = path.join(fakeBinDir, process.platform === 'win32' ? 'cursor.cmd' : 'cursor');
+const fakeAgent = path.join(fakeBinDir, process.platform === 'win32' ? 'agent.cmd' : 'agent');
+const fakeCursorAgent = path.join(fakeBinDir, process.platform === 'win32' ? 'cursor-agent.cmd' : 'cursor-agent');
 if (process.platform === 'win32') {
-  await writeFile(fakeCursor, '@echo off\r\nping 127.0.0.1 -n 601 >NUL\r\n');
+  await writeFile(fakeCursor, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
+  await writeFile(fakeAgent, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
+  await writeFile(fakeCursorAgent, '@echo off\r\necho -^>pty:ready\r\nping 127.0.0.1 -n 601 >NUL\r\n');
 } else {
-  await writeFile(fakeCursor, '#!/bin/sh\nexec sleep 600\n', { mode: 0o755 });
+  await writeFile(fakeCursor, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
+  await writeFile(fakeAgent, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
+  await writeFile(fakeCursorAgent, '#!/bin/sh\nprintf \'->pty:ready\\n\'\nexec sleep 600\n', { mode: 0o755 });
+}
+const fakeMcpServer = path.join(fakeBinDir, 'fake-agent-relay-mcp.mjs');
+await writeFile(
+  fakeMcpServer,
+  `import readline from 'node:readline';\n` +
+    `const rl = readline.createInterface({ input: process.stdin });\n` +
+    `rl.on('line', (line) => {\n` +
+    `  let request; try { request = JSON.parse(line); } catch { return; }\n` +
+    `  if (request.id === undefined) return;\n` +
+    `  const result = request.method === 'initialize'\n` +
+    `    ? { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'fake-agent-relay', version: '1.0.0' } }\n` +
+    `    : request.method === 'tools/list' ? { tools: ['send_dm', 'post_message', 'check_inbox'].map((name) => ({ name, description: 'deterministic proof stub', inputSchema: { type: 'object' } })) } : {};\n` +
+    `  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) + '\\n');\n` +
+    `});\n`,
+);
+if (process.platform === 'win32') {
+  await writeFile(fakeMcp, `@echo off\r\nnode "%~dp0fake-agent-relay-mcp.mjs"\r\n`);
+} else {
+  await writeFile(fakeMcp, `#!/bin/sh\nexec "${process.execPath}" "${fakeMcpServer}"\n`, { mode: 0o755 });
 }
 
 const original = Buffer.from('{"mcpServers":{"filesystem":{}}}\n', 'utf8');
@@ -52,6 +78,7 @@ await writeFile(cursorPath, original);
 const relaycast = await startRelaycastStub();
 const brokerEnv = {
   PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}`,
+  AGENT_RELAY_MCP_COMMAND: fakeMcp,
   HOME: workDir,
   TMPDIR: workDir,
   NO_COLOR: '1',
@@ -123,7 +150,10 @@ try {
   const generated = await waitFor(async () => {
     const contents = await readFile(cursorPath, 'utf8').catch(() => null);
     if (!contents) return null;
-    return contents.includes('${env:RELAY_API_KEY}') ? contents : null;
+    const expected = arm === 'base'
+      ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
+      : contents.includes('${env:RELAY_API_KEY}');
+    return expected ? contents : null;
   }, 20_000, 'Cursor MCP file to be generated');
 
   const leakedCredential = [relaycast.workspaceKey, relaycast.nodeToken].some((secret) =>

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -257,6 +257,50 @@ try {
   const afterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
   const journalAfter = await readFile(journalPath, 'utf8').catch(() => null);
 
+  // Exercise the clean-cwd branch separately: there is no pre-existing file
+  // to restore, so successful cleanup must remove the generated config and
+  // release its journal entry completely.
+  await rm(cursorPath, { force: true });
+  const absentWorkerName = `${workerName}-absent`;
+  const absentSpawnResponse = await restartedApi('POST', '/api/spawn', {
+    name: absentWorkerName,
+    cli: 'cursor',
+    transport: 'pty',
+    cwd,
+    task: 'exercise Cursor MCP cleanup from an absent file',
+    args: [],
+  });
+  if (absentSpawnResponse.status >= 300) {
+    throw new Error(`absent-file spawn failed: ${JSON.stringify(absentSpawnResponse.body).slice(0, 500)}`);
+  }
+  const absentGenerated = await waitFor(
+    async () => {
+      const contents = await readFile(cursorPath, 'utf8').catch(() => null);
+      if (!contents) return null;
+      const expected =
+        arm === 'base'
+          ? [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => contents.includes(secret))
+          : contents.includes('${env:RELAY_API_KEY}');
+      return expected ? contents : null;
+    },
+    20_000,
+    'Cursor MCP file to be generated from absent state'
+  );
+  if (arm === 'head' && [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => absentGenerated.includes(secret))) {
+    throw new Error('head absent-file phase leaked a relay credential');
+  }
+  const absentReleaseResponse = await restartedApi('DELETE', `/api/spawned/${absentWorkerName}`);
+  if (absentReleaseResponse.status >= 300) {
+    throw new Error(`absent-file release failed: ${JSON.stringify(absentReleaseResponse.body).slice(0, 500)}`);
+  }
+  const absentAfterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
+  const absentJournalAfter = await readFile(journalPath, 'utf8').catch(() => null);
+  if (absentAfterRelease || absentJournalAfter) {
+    throw new Error(
+      `Absent-file cleanup left state: ${JSON.stringify({ file: Boolean(absentAfterRelease), journal: Boolean(absentJournalAfter) })}`
+    );
+  }
+
   let outcome;
   let signature;
   let details;
@@ -284,7 +328,7 @@ try {
       'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
   } else {
     throw new Error(
-      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter) })}`
+      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter), absentCleanup: !absentAfterRelease && !absentJournalAfter })}`
     );
   }
 

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -286,16 +286,22 @@ try {
     20_000,
     'Cursor MCP file to be generated from absent state'
   );
-  if (arm === 'head' && [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => absentGenerated.includes(secret))) {
+  if (
+    arm === 'head' &&
+    [relaycast.workspaceKey, relaycast.nodeToken].some((secret) => absentGenerated.includes(secret))
+  ) {
     throw new Error('head absent-file phase leaked a relay credential');
   }
   const absentReleaseResponse = await restartedApi('DELETE', `/api/spawned/${absentWorkerName}`);
   if (absentReleaseResponse.status >= 300) {
-    throw new Error(`absent-file release failed: ${JSON.stringify(absentReleaseResponse.body).slice(0, 500)}`);
+    throw new Error(
+      `absent-file release failed: ${JSON.stringify(absentReleaseResponse.body).slice(0, 500)}`
+    );
   }
   const absentAfterRelease = await readFile(cursorPath, 'utf8').catch(() => null);
   const absentJournalAfter = await readFile(journalPath, 'utf8').catch(() => null);
-  if (absentAfterRelease || absentJournalAfter) {
+  const absentCleanup = !absentAfterRelease && !absentJournalAfter;
+  if (arm === 'head' && !absentCleanup) {
     throw new Error(
       `Absent-file cleanup left state: ${JSON.stringify({ file: Boolean(absentAfterRelease), journal: Boolean(absentJournalAfter) })}`
     );
@@ -312,9 +318,11 @@ try {
     !journalAfterCrash
   ) {
     outcome = 'bug';
-    signature = 'cursor_mcp_credentials_leak_and_no_recovery';
+    signature = absentCleanup
+      ? 'cursor_mcp_credentials_leak_and_no_recovery'
+      : 'cursor_mcp_credentials_leak_and_legacy_absent_file_leak';
     details =
-      'The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.';
+      `The base broker wrote raw credentials into Cursor MCP state and left that generated state behind after a crash/restart/release cycle without a recovery journal.${absentCleanup ? ' Its separate absent-file cleanup completed.' : ' Its legacy absent-file cleanup also left generated state behind.'}`;
   } else if (
     arm === 'head' &&
     !leakedCredential &&
@@ -328,7 +336,7 @@ try {
       'The head broker used environment placeholders, restored the original Cursor MCP file on release after restart, and removed the retained lease state.';
   } else {
     throw new Error(
-      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter), absentCleanup: !absentAfterRelease && !absentJournalAfter })}`
+      `Unexpected Cursor MCP cleanup observation: ${JSON.stringify({ arm, leakedCredential, restored: afterRelease === original.toString('utf8'), journalAfterCrash: Boolean(journalAfterCrash), journalAfterRelease: Boolean(journalAfter), absentCleanup })}`
     );
   }
 

--- a/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
+++ b/tests/relayflows/cases/1753-cursor-mcp-cleanup/run.mjs
@@ -306,6 +306,13 @@ try {
       `Absent-file cleanup left state: ${JSON.stringify({ file: Boolean(absentAfterRelease), journal: Boolean(absentJournalAfter) })}`
     );
   }
+  await waitFor(
+    async () =>
+      (await relaycast.credentialRejected(relaycast.workspaceKey)) &&
+      (await relaycast.credentialRejected(relaycast.nodeToken)),
+    10_000,
+    'revoked relaycast credentials'
+  );
 
   let outcome;
   let signature;
@@ -435,6 +442,17 @@ async function startRelaycastStub() {
   const nodeToken = 'at_live_relayflow_1753';
   const nodeId = 'node_relayflow_1753';
   const agents = new Map();
+  const activeCredentials = new Set();
+  const revokedCredentials = new Set();
+  const issueCredential = (token) => {
+    activeCredentials.add(token);
+  };
+  const revokeIssuedCredentials = () => {
+    for (const token of activeCredentials) {
+      revokedCredentials.add(token);
+    }
+    activeCredentials.clear();
+  };
   const server = http.createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
@@ -442,8 +460,10 @@ async function startRelaycastStub() {
     const body = bodyText ? JSON.parse(bodyText) : {};
     let payload;
     if (request.method === 'POST' && request.url === '/v1/workspaces') {
+      issueCredential(workspaceKey);
       payload = { ok: true, data: { api_key: workspaceKey, id: 'rw_relayflow_1753' } };
     } else if (request.method === 'POST' && request.url === '/v1/nodes') {
+      issueCredential(nodeToken);
       payload = {
         ok: true,
         data: { token: nodeToken, id: nodeId, name: body.name ?? 'node_relayflow_1753' },
@@ -463,35 +483,31 @@ async function startRelaycastStub() {
           created_at: '2025-01-01T00:00:00Z',
         },
       };
-    } else if (request.url.startsWith('/v1/agents/')) {
-      payload =
-        request.url === '/v1/agents/release'
-          ? {
-              ok: true,
-              data: {
-                status: 'completed',
-                invocation_id: 'inv_release_1753',
-                action_name: 'release',
-                handler_agent_id: null,
-                handler_node_id: null,
-                dispatched_node_id: null,
-                input: body,
-                created_at: '2025-01-01T00:00:00Z',
-              },
-            }
-          : {
-              ok: true,
-              data: {
-                id: request.url.slice('/v1/agents/'.length),
-                name: agents.get(request.url.slice('/v1/agents/'.length)) ?? 'cursor-cleanup-worker',
-                token: nodeToken,
-                status: 'online',
-                workspace_id: 'rw_relayflow_1753',
-                created_at: '2025-01-01T00:00:00Z',
-                metadata: {},
-                channels: [{ name: 'general' }, { name: 'engineering' }],
-              },
-            };
+    } else if (request.method === 'POST' && request.url === '/v1/agents/release') {
+      revokeIssuedCredentials();
+      payload = {
+        ok: true,
+        data: {
+          status: 'completed',
+          invocation_id: 'inv_release_1753',
+          action_name: 'release',
+          handler_agent_id: null,
+          handler_node_id: null,
+          dispatched_node_id: null,
+          input: body,
+          created_at: '2025-01-01T00:00:00Z',
+        },
+      };
+    } else if (request.method === 'GET' && request.url === '/v1/credential-check') {
+      const authorization = request.headers.authorization ?? '';
+      const token = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : '';
+      const rejected = revokedCredentials.has(token) || !activeCredentials.has(token);
+      if (rejected) {
+        response.writeHead(403, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ ok: false, error: { code: 'forbidden', message: 'credential revoked' } }));
+        return;
+      }
+      payload = { ok: true, data: { token, status: 'active' } };
     } else if (request.method === 'GET' && request.url.endsWith('/members')) {
       payload = {
         ok: true,
@@ -532,6 +548,12 @@ async function startRelaycastStub() {
     workspaceKey,
     nodeToken,
     nodeId,
+    credentialRejected: async (token) => {
+      const response = await fetch(new URL('/v1/credential-check', `http://127.0.0.1:${address.port}`), {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      return response.status === 403;
+    },
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }

--- a/tests/relayflows/cases/http-spawn-binding-failure/case.json
+++ b/tests/relayflows/cases/http-spawn-binding-failure/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "http-spawn-binding-failure",
+  "kind": "bugfix",
+  "title": "Reject HTTP spawn when hosted node binding fails",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/http-spawn-binding-failure/run.mjs"]
+  },
+  "timeoutSeconds": 180,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "binding_failure_continues_spawn"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "binding_failure_rejects_before_launch"
+    }
+  }
+}

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = 'http-spawn-binding-failure';
+const NAME = 'owned-binding-probe';
+const API_KEY = 'br_binding_probe';
+const required = (key) => {
+  if (!process.env[key]) throw new Error(`Missing ${key}`);
+  return process.env[key];
+};
+const targetDir = required('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = required('RELAY_PR_PROOF_HARNESS_DIR');
+const binary = required('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = required('RELAY_PR_PROOF_RESULT_PATH');
+const arm = required('RELAY_PR_PROOF_ARM');
+assert(['base', 'head'].includes(arm));
+assert.equal(
+  execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+  required(arm === 'base' ? 'RELAY_PR_PROOF_BASE_SHA' : 'RELAY_PR_PROOF_HEAD_SHA')
+);
+const relative = path.relative(path.resolve(harnessDir), fileURLToPath(import.meta.url));
+assert(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+await access(binary, 1);
+const probe = await mkdtemp(path.join(tmpdir(), 'relayflow-binding-'));
+let broker,
+  calibration,
+  calibrationTimer,
+  stderr = '',
+  stdout = '';
+const sockets = new Set();
+const observations = { registrations: 0, bindings: 0, scopeReads: 0, releases: [], metadataWrites: 0 };
+const server = http.createServer(async (request, response) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const body = chunks.length ? JSON.parse(Buffer.concat(chunks)) : {};
+  const pathname = new URL(request.url, 'http://fixture.invalid').pathname;
+  const send = (status, data, ok = true) => {
+    response.writeHead(status, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(ok ? { ok, data } : { ok, error: data }));
+  };
+  if (request.method === 'POST' && pathname === '/v1/agents') {
+    if (body.name === NAME) observations.registrations++;
+    send(201, {
+      id: `id_${body.name}`,
+      name: body.name,
+      workspace_id: 'ws_binding_probe',
+      token: `at_fixture_${body.name}`,
+      status: 'online',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+  } else if (request.method === 'POST' && /^\/v1\/nodes\/[^/]+\/agents$/.test(pathname)) {
+    assert.equal(body.agent_name, NAME);
+    observations.bindings++;
+    send(503, { code: 'workspace_busy', message: 'binding admission probe' }, false);
+  } else if (request.method === 'GET' && pathname === `/v1/agents/${NAME}`) {
+    observations.scopeReads++;
+    send(200, {
+      id: `id_${NAME}`,
+      name: NAME,
+      workspace_id: 'ws_binding_probe',
+      channels: [],
+      status: 'online',
+      metadata: {},
+    });
+  } else if (request.method === 'POST' && pathname === '/v1/agents/release') {
+    observations.releases.push(body.name);
+    send(200, { status: 'completed' });
+  } else if (request.method === 'PATCH' && pathname === `/v1/agents/${NAME}`) {
+    observations.metadataWrites++;
+    send(200, {});
+  } else send(404, { code: 'not_found', message: 'unsupported fixture route' }, false);
+});
+server.on('connection', (socket) => {
+  sockets.add(socket);
+  socket.once('close', () => sockets.delete(socket));
+});
+try {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const state = path.join(probe, 'state');
+  await mkdir(state);
+  // No WebSocket endpoint: force the supported HTTP registration fallback.
+  // A probe executable records any launch independently of the spawn response.
+  const cli = path.join(probe, 'binding-probe-cli');
+  const launchMarker = path.join(probe, 'launched');
+  await writeFile(
+    cli,
+    `#!${process.execPath}\nrequire('node:fs').appendFileSync(${JSON.stringify(launchMarker)}, 'started\\n'); setInterval(() => {}, 1000);\n`,
+    { mode: 0o700 }
+  );
+  // Calibrate the negative observer with a deliberately delayed real launch.
+  calibrationTimer = setTimeout(() => {
+    calibration = spawn(cli, [], { stdio: 'ignore' });
+  }, 200);
+  await assert.rejects(assertNoLaunch(launchMarker), /Probe process launched/);
+  clearTimeout(calibrationTimer);
+  await stopProcess(calibration);
+  calibration = undefined;
+  await rm(launchMarker);
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !/^(RELAY|AGENT_RELAY)/.test(key))
+  );
+  broker = spawn(
+    binary,
+    [
+      'init',
+      '--instance-name',
+      'binding-probe-node',
+      '--workspace-key',
+      'rk_binding_probe',
+      '--state-dir',
+      state,
+      '--api-port',
+      '0',
+      '--channels',
+      '',
+    ],
+    {
+      cwd: probe,
+      env: {
+        ...env,
+        RELAYCAST_BASE_URL: baseUrl,
+        RELAY_BROKER_API_KEY: API_KEY,
+        RELAY_NODE_ID: 'node_binding_probe',
+        RELAY_NODE_TOKEN: 'nt_binding_probe',
+        AGENT_RELAY_NO_DEBUG_FILES: '1',
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  broker.stdout.on('data', (chunk) => {
+    stdout = (stdout + chunk).slice(-12000);
+  });
+  broker.stderr.on('data', (chunk) => {
+    stderr = (stderr + chunk).slice(-12000);
+  });
+  let apiPort;
+  for (let i = 0; i < 200; i++) {
+    if (broker.exitCode !== null) throw new Error(`Broker exited: ${stderr}`);
+    const announced = stdout.match(/API listening on http:\/\/127\.0\.0\.1:([1-9]\d{0,4})(?:\s|$)/);
+    if (announced) {
+      const parsed = Number(announced[1]);
+      assert(Number.isInteger(parsed) && parsed <= 65535, 'Invalid loopback API port');
+      apiPort = parsed;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert(apiPort, `No broker loopback API announcement: ${stderr}`);
+  const api = async (route, options = {}) => {
+    const response = await fetch(`http://127.0.0.1:${apiPort}${route}`, {
+      ...options,
+      headers: { 'content-type': 'application/json', 'x-api-key': API_KEY },
+      signal: AbortSignal.timeout(45000),
+      redirect: 'error',
+    });
+    const raw = await response.text();
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = { raw };
+    }
+    return { status: response.status, body };
+  };
+  let apiReady = false;
+  for (let i = 0; i < 200; i++) {
+    if (broker.exitCode !== null) throw new Error(`Broker exited before readiness: ${stderr}`);
+    if ((await api('/api/session')).status === 200) {
+      apiReady = true;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert(apiReady, `Broker API did not become ready: ${stderr}`);
+  const result = await api('/api/spawn', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: NAME,
+      cli,
+      channels: [],
+      cwd: probe,
+      organization: 'original-spawn',
+      project: 'no-stale-metadata',
+    }),
+  });
+  const listing = await api('/api/spawned');
+  assert.equal(observations.registrations, 1);
+  assert.equal(observations.bindings, 1);
+  assert.equal(listing.status, 200);
+  if (arm === 'head') {
+    assert(result.status >= 400);
+    assert(JSON.stringify(result.body).includes('binding admission probe'));
+    assert.equal(observations.scopeReads, 0);
+    await assertNoLaunch(launchMarker);
+    assert.equal(observations.metadataWrites, 0, 'Failed bind published stale metadata');
+    assert(!JSON.stringify(listing.body).includes(NAME), 'Failed worker remains in inventory');
+  } else {
+    assert.equal(result.status, 200);
+    assert.equal(result.body.success, true);
+    assert(result.body.warning.includes('binding admission probe'));
+    assert(observations.scopeReads >= 1, 'Base did not continue into agent lookup');
+    assert(JSON.stringify(listing.body).includes(NAME), 'Base did not admit unreachable worker');
+    assert(observations.metadataWrites >= 1, 'Base did not exercise metadata publication');
+    const released = await api(`/api/spawned/${NAME}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ expected_generation: result.body.generation, delete_identity: true }),
+    });
+    assert.equal(released.status, 200);
+  }
+  assert.deepEqual(observations.releases, [NAME]);
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    JSON.stringify({
+      version: 1,
+      caseId: CASE_ID,
+      arm,
+      outcome: arm === 'head' ? 'fixed' : 'bug',
+      signature: arm === 'head' ? 'binding_failure_rejects_before_launch' : 'binding_failure_continues_spawn',
+      // Persist only closed, locally authored outcomes; never response/file data.
+      details:
+        arm === 'head'
+          ? 'Rejected failed binding; no process launch throughout a calibrated 2000ms observation, no metadata PATCH, and exact owned cleanup.'
+          : 'Admitted a worker despite failed binding, published metadata, and completed guarded fixture cleanup.',
+    }) + '\n'
+  );
+} finally {
+  clearTimeout(calibrationTimer);
+  await stopProcess(calibration);
+  await stopProcess(broker);
+  for (const socket of sockets) socket.destroy();
+  await new Promise((resolve) => server.close(resolve));
+  await rm(probe, { recursive: true, force: true });
+}
+
+/** Reject any synchronous startup marker observed during the full settling interval. */
+async function assertNoLaunch(marker, settleMs = 2000) {
+  const deadline = performance.now() + settleMs;
+  do {
+    assert(!existsSync(marker), 'Probe process launched during failed admission');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  } while (performance.now() < deadline);
+  assert(!existsSync(marker), 'Probe process launched at the observation boundary');
+}
+
+/** Stop only a child this case started and wait until it has exited. */
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+  child.kill('SIGTERM');
+  const timer = setTimeout(() => child.kill('SIGKILL'), 2000);
+  await exited;
+  clearTimeout(timer);
+}


### PR DESCRIPTION
Fixes #1753.

## Summary

- Inject Cursor Relay MCP credentials through environment placeholders instead of persisting plaintext values.
- Journal and restore pre-existing Cursor MCP configuration across spawn, release, reap, restart, and crash recovery.
- Pin workspace and .cursor directory ownership so replacement cannot redirect credential I/O or cleanup on Unix or Windows.
- Use kernel-held reusable locks, owner-only files, Windows DPAPI journal protection with legacy migration, and exact identity checks.
- Exercise the real broker lifecycle with deterministic Cursor and Agent Relay MCP executables.

## RelayFlow Proof

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `1753-cursor-mcp-cleanup` <!-- relay-pr-proof:case -->

## Validation

- Exact PR base `2a48075c58304ef4c6cd952fada5a138eeac2080`: `cursor_mcp_credentials_leak_and_no_recovery`.
- Exact head `524fdf7473424ad4f734f0502cfac9af332a4b16`: `cursor_mcp_state_restores_or_removes_cleanly`.
- The head proof observes the actual durable journal after crash, then exact config restoration and journal removal after restart/release.
- 17 focused Cursor lease/recovery tests pass; broker check, formatting, Node 22 syntax, manifest, and diff checks pass.
- Windows compile/runtime behavior remains gated on GitHub's Windows CI before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes AgentWorkforce metadata only; no runtime, auth, or credential logic changes in this diff.
> 
> **Overview**
> Removes the **active** AgentWorkforce trajectory at `.agentworkforce/trajectories/active/traj_jdx9303jp3ky/trajectory.json` after that run finished. The task was “Implement and prove all nine GitHub subscription demo gates”; decisions and events lived in that JSON while status was `active`.
> 
> This is housekeeping so the repo no longer lists an in-progress trajectory. The completed record and trace remain under `.agentworkforce/trajectories/completed/2026-09/traj_jdx9303jp3ky/` (including `summary.md` and an updated `trajectory.json`).
> 
> **Note:** The PR title/description reference Cursor MCP lease fixes (#1753); that work is **not** in this diff—only the active trajectory file deletion is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed32a9830fef02b4a36f30d288d17ecabf9e177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->