### PR TITLE
fix: reject agent spawn when hosted node binding fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- HTTP agent spawn rejects failed Relaycast node binding and cleans up the newly registered identity before admitting an unreachable worker.
+- HTTP agent spawn rejects failed Relaycast node binding, cleans up the newly registered identity, and publishes declared metadata for successful spawns using either new or supplied tokens.
 
 - `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
 - `fleet spawn --sandbox` dispatches with only its temporary launcher token after Cloud target selection, avoiding the SDK's dual-credential rejection while keeping workspace-key authority limited to launcher registration and release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP agent spawn rejects failed Relaycast node binding and cleans up the newly registered identity before admitting an unreachable worker.
+
 - `agent-relay node up` retries the narrowly transient Relaycast `workspace_busy` admission response while keeping unrelated rate limits terminal and preserving bounded startup diagnostics.
 - `fleet spawn --sandbox` dispatches with only its temporary launcher token after Cloud target selection, avoiding the SDK's dual-credential rejection while keeping workspace-key authority limited to launcher registration and release.
 

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -423,11 +423,6 @@ impl BrokerRuntime {
                     // new identity to the node for normal delivery/inventory.
                     match register_new_spawn_identity(relaycast_http, &name, Some(&cli)).await {
                         Ok(token) => {
-                            super::fleet::spawn_declared_metadata_publish(
-                                relaycast_http,
-                                name.as_str(),
-                                registration_metadata,
-                            );
                             // HTTP registration alone leaves the agent
                             // without a node binding; the engine only
                             // delivers to `via_node` agents in node-only
@@ -458,6 +453,13 @@ impl BrokerRuntime {
                                 );
                                 return;
                             } else {
+                                // A failed bind releases this name during cleanup. Do not
+                                // leave a detached name-based PATCH that could hit a retry.
+                                super::fleet::spawn_declared_metadata_publish(
+                                    relaycast_http,
+                                    name.as_str(),
+                                    registration_metadata,
+                                );
                                 match super::fleet::resolve_fleet_agent_token_identity(
                                     relaycast_http,
                                     fleet_delivery_book,

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -470,13 +470,6 @@ impl BrokerRuntime {
                                 );
                                 return;
                             } else {
-                                // A failed bind releases this name during cleanup. Do not
-                                // leave a detached name-based PATCH that could hit a retry.
-                                super::fleet::spawn_declared_metadata_publish(
-                                    relaycast_http,
-                                    name.as_str(),
-                                    registration_metadata,
-                                );
                                 match super::fleet::resolve_fleet_agent_token_identity(
                                     relaycast_http,
                                     fleet_delivery_book,
@@ -703,6 +696,16 @@ impl BrokerRuntime {
                     .await
                 {
                     Ok(effective_spec) => {
+                        // Both hosted credential paths publish declared metadata. Wait for
+                        // admission to succeed before scheduling a detached PATCH.
+                        // Local-only workers have no hosted identity to update.
+                        if worker_relay_key.is_some() {
+                            super::fleet::spawn_declared_metadata_publish(
+                                relaycast_http,
+                                name.as_str(),
+                                registration_metadata,
+                            );
+                        }
                         if owns_identity {
                             if let Some(worker) = workers.workers.get(&name) {
                                 workers.owned_spawn_generations.insert(

--- a/crates/broker/src/runtime/api.rs
+++ b/crates/broker/src/runtime/api.rs
@@ -386,7 +386,6 @@ impl BrokerRuntime {
                         return;
                     }
                 };
-                let mut preregistration_warning: Option<String> = None;
                 // Caller-supplied agent_token is authoritative. In fleet mode it
                 // was minted by the node control connection, and the worker must
                 // receive that exact token before its harness starts.
@@ -433,8 +432,8 @@ impl BrokerRuntime {
                             // without a node binding; the engine only
                             // delivers to `via_node` agents in node-only
                             // delivery. Bind it to this node so it is
-                            // deliverable, surfacing a loud warning if the
-                            // bind fails.
+                            // deliverable. A failed binding is an admission
+                            // failure: never launch an unreachable worker.
                             let bind_warning =
                                 super::relaycast_events::bind_http_registered_agent_to_node(
                                     relaycast_http,
@@ -443,7 +442,21 @@ impl BrokerRuntime {
                                 )
                                 .await;
                             if let Some(warning) = bind_warning {
-                                preregistration_warning = Some(warning);
+                                seed_supplied_agent_token(relaycast_http, &name, &token);
+                                super::identity_cleanup::schedule_identity_cleanup(
+                                    workers,
+                                    fleet_control_tx,
+                                    fleet_delivery_book,
+                                    fleet_inventory,
+                                    relaycast_http,
+                                    &name,
+                                    true,
+                                    Some(super::identity_cleanup::CleanupCompletion::Api(
+                                        reply,
+                                        Err(warning),
+                                    )),
+                                );
+                                return;
                             } else {
                                 match super::fleet::resolve_fleet_agent_token_identity(
                                     relaycast_http,
@@ -764,7 +777,7 @@ impl BrokerRuntime {
                                 "pid":pid,
                                 "source":"http_api",
                                 "pre_registered": worker_relay_key.is_some(),
-                                "registration_warning": preregistration_warning.clone(),
+                                "registration_warning": null,
                             }),
                         )
                         .await;
@@ -794,7 +807,7 @@ impl BrokerRuntime {
                             "channels": effective_spec.channels,
                             "sessionId": effective_spec.session_id.clone(),
                             "pre_registered": worker_relay_key.is_some(),
-                            "warning": preregistration_warning,
+                            "warning": null,
                         })));
                     }
                     Err(e) => {

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -6352,7 +6352,7 @@ async fn owned_cleanup_retries_delete_without_repeating_acknowledged_deregistrat
 async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identity() {
     use crate::listen_api::ListenApiRequest;
     use httpmock::{
-        Method::{GET, POST},
+        Method::{GET, PATCH, POST},
         MockServer,
     };
     use tokio::sync::oneshot;
@@ -6369,6 +6369,10 @@ async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identit
         then.status(503).json_body(json!({"ok":false,"error":{
             "code":"workspace_busy","message":"binding admission busy"
         }}));
+    });
+    let metadata = server.mock(|when, then| {
+        when.method(PATCH).path("/v1/agents/binding-refused");
+        then.status(200).json_body(json!({"ok":true,"data":{}}));
     });
     let scope = server.mock(|when, then| {
         when.method(GET).path("/v1/agents/binding-refused");
@@ -6395,7 +6399,11 @@ async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identit
             model: None,
             args: vec![],
             task: None,
-            registration_metadata: Default::default(),
+            registration_metadata: crate::fleet_wire::AgentRegistrationMetadata {
+                organization: Some("original-spawn".into()),
+                project: Some("must-not-leak-to-retry".into()),
+                ..Default::default()
+            },
             channels: Some(vec![]),
             cwd: None,
             team: None,
@@ -6442,6 +6450,9 @@ async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identit
     );
     create.assert_hits(1);
     bind.assert_hits(1);
+    // Let any incorrectly detached request run before the name can be reused.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    metadata.assert_hits(0);
     scope.assert_hits(0);
     cleanup.assert_hits(1);
     assert!(unrelated_survived);

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -6606,7 +6606,12 @@ async fn assert_http_spawn_metadata_publication(supplied_token: bool, valid_cwd:
     });
     let bind = server.mock(|when, then| {
         when.method(POST).path("/v1/nodes/test-node/agents");
-        then.status(200).json_body(json!({"ok":true,"data":{}}));
+        then.status(200).json_body(json!({"ok":true,"data":{
+            "id":"binding-id", "agent_id":"metadata-id", "agent_name":"metadata-worker",
+            "node_id":"node-id", "node_name":"test-node", "node_kind":"local", "node_role":"broker",
+            "status":"active", "session_ref":null, "priority":0,
+            "created_at":"2026-09-11T12:00:00Z", "updated_at":null
+        }}));
     });
     let lookup = server.mock(|when, then| {
         when.method(GET)
@@ -6691,9 +6696,11 @@ async fn assert_http_spawn_metadata_publication(supplied_token: bool, valid_cwd:
             reply,
         })
         .await;
-    let response = result.await.unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(3), result).await;
+    // A fixture or admission regression must fail promptly rather than hang CI.
     // Stop the owned harness before assertions, including on a regression failure.
     fixture.runtime.workers.shutdown_all().await.unwrap();
+    let response = response.expect("spawn reply must settle").unwrap();
     if valid_cwd {
         assert_eq!(response.unwrap()["success"], true);
         let published = tokio::time::timeout(Duration::from_secs(2), async {

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -6347,3 +6347,113 @@ async fn owned_cleanup_retries_delete_without_repeating_acknowledged_deregistrat
         .contains_key(&name));
     fixture.runtime.workers.release("unrelated").await.unwrap();
 }
+
+#[tokio::test]
+async fn http_spawn_binding_failure_stops_before_launch_and_cleans_owned_identity() {
+    use crate::listen_api::ListenApiRequest;
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
+    use tokio::sync::oneshot;
+    let server = MockServer::start();
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents");
+        then.status(201).json_body(json!({"ok":true,"data":{
+            "id":"owned-binding-id","workspace_id":"ws_demo","name":"binding-refused",
+            "status":"active","created_at":"2026-09-11T12:00:00Z","token":"at_live_binding_fixture"
+        }}));
+    });
+    let bind = server.mock(|when, then| {
+        when.method(POST).path("/v1/nodes/test-node/agents");
+        then.status(503).json_body(json!({"ok":false,"error":{
+            "code":"workspace_busy","message":"binding admission busy"
+        }}));
+    });
+    let scope = server.mock(|when, then| {
+        when.method(GET).path("/v1/agents/binding-refused");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"channels":[]}}));
+    });
+    let cleanup = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents/release");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"status":"completed"}}));
+    });
+    let registry = make_worker_registry_with_worker("unrelated-binding-worker").await;
+    let mut fixture = worker_event_runtime_fixture(registry, HashMap::new());
+    fixture.runtime.relaycast_http =
+        RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "codex");
+    let name = WorkerName::from("binding-refused");
+    let (reply, mut result) = oneshot::channel();
+    fixture
+        .runtime
+        .handle_api_request(ListenApiRequest::Spawn {
+            name: name.clone(),
+            cli: "missing-binding-fixture-cli".into(),
+            transport: None,
+            model: None,
+            args: vec![],
+            task: None,
+            registration_metadata: Default::default(),
+            channels: Some(vec![]),
+            cwd: None,
+            team: None,
+            shadow_of: None,
+            shadow_mode: None,
+            continue_from: None,
+            idle_threshold_secs: None,
+            exit_after_task: false,
+            skip_relay_prompt: true,
+            restart_policy: Box::new(None),
+            harness_config: None,
+            agent_token: None,
+            agent_result_schema: None,
+            replay_buffer: crate::replay_buffer::ReplayBuffer::new(16),
+            reply,
+        })
+        .await;
+    let response = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            fixture.runtime.reconcile_identity_cleanups().await;
+            if let Ok(response) = result.try_recv() {
+                break response;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    let unrelated_survived = fixture
+        .runtime
+        .workers
+        .has_worker("unrelated-binding-worker");
+    fixture
+        .runtime
+        .workers
+        .release("unrelated-binding-worker")
+        .await
+        .unwrap();
+    let error = response
+        .expect("binding failure cleanup must settle")
+        .unwrap_err();
+    assert!(
+        error.contains("binding") && error.contains("workspace_busy"),
+        "{error}"
+    );
+    create.assert_hits(1);
+    bind.assert_hits(1);
+    scope.assert_hits(0);
+    cleanup.assert_hits(1);
+    assert!(unrelated_survived);
+    assert!(!fixture.runtime.workers.has_worker(&name));
+    assert!(!fixture
+        .runtime
+        .workers
+        .identity_cleanups
+        .contains_key(&name));
+    assert!(!fixture
+        .runtime
+        .workers
+        .owned_spawn_generations
+        .contains_key(&name));
+}

--- a/crates/broker/src/runtime/tests.rs
+++ b/crates/broker/src/runtime/tests.rs
@@ -6569,3 +6569,163 @@ async fn local_only_restored_exhausted_delivery_replays_to_already_registered_wo
     assert_eq!(pending[&id].attempts, MAX_DELIVERY_RETRIES + 1);
     assert_eq!(pending[&id].failed_attempts, 0);
 }
+
+#[tokio::test]
+async fn http_spawn_supplied_token_publishes_declared_metadata() {
+    assert_http_spawn_metadata_publication(true, true).await;
+}
+
+#[tokio::test]
+async fn http_spawn_new_identity_publishes_declared_metadata() {
+    assert_http_spawn_metadata_publication(false, true).await;
+}
+
+#[tokio::test]
+async fn http_spawn_failed_launch_does_not_publish_declared_metadata() {
+    assert_http_spawn_metadata_publication(true, false).await;
+}
+
+async fn assert_http_spawn_metadata_publication(supplied_token: bool, valid_cwd: bool) {
+    use crate::listen_api::ListenApiRequest;
+    use httpmock::{
+        Method::{GET, PATCH, POST},
+        MockServer,
+    };
+    use tokio::sync::oneshot;
+
+    let server = MockServer::start();
+    let name = WorkerName::from("metadata-worker");
+    let token = "at_live_metadata_fixture";
+    let identity = json!({"id":"metadata-id","workspace_id":"ws_demo",
+        "name":name,"status":"active","created_at":"2026-09-11T12:00:00Z"});
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents");
+        let mut data = identity.clone();
+        data["token"] = json!(token);
+        then.status(201).json_body(json!({"ok":true,"data":data}));
+    });
+    let bind = server.mock(|when, then| {
+        when.method(POST).path("/v1/nodes/test-node/agents");
+        then.status(200).json_body(json!({"ok":true,"data":{}}));
+    });
+    let lookup = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/agent")
+            .header("authorization", format!("Bearer {token}"));
+        then.status(200)
+            .json_body(json!({"ok":true,"data":identity}));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/v1/agents/metadata-worker");
+        then.status(200)
+            .json_body(json!({"ok":true,"data":{"channels":[]}}));
+    });
+    let metadata = server.mock(|when, then| {
+        when.method(PATCH)
+            .path("/v1/agents/metadata-worker")
+            .json_body(json!({"metadata":{
+                "organization":"demo-org", "project":"demo-project",
+                "workstream":"subscriptions", "role":"reviewer", "objective":"prove delivery"
+            }}));
+        then.status(200)
+            .json_body(json!({"ok":true,"data":identity}));
+    });
+    let unexpected_cleanup = server.mock(|when, then| {
+        when.method(POST).path("/v1/agents/release");
+        then.status(500);
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (events, _event_rx) = mpsc::channel(16);
+    let registry = WorkerRegistry::new(events, vec![], dir.path().join("logs"), Instant::now());
+    let mut fixture = worker_event_runtime_fixture(registry, HashMap::new());
+    fixture.runtime.relaycast_http =
+        RelaycastHttpClient::new(Some(server.base_url()), "rk_live_test", "broker", "codex");
+    let (reply, result) = oneshot::channel();
+    fixture
+        .runtime
+        .handle_api_request(ListenApiRequest::Spawn {
+            name: name.clone(),
+            cli: "cat".into(),
+            transport: None,
+            model: None,
+            args: vec![],
+            task: None,
+            registration_metadata: crate::fleet_wire::AgentRegistrationMetadata {
+                organization: Some("demo-org".into()),
+                project: Some("demo-project".into()),
+                workstream: Some("subscriptions".into()),
+                role: Some("reviewer".into()),
+                objective: Some("prove delivery".into()),
+            },
+            channels: Some(vec![]),
+            cwd: Some(
+                if valid_cwd {
+                    dir.path().to_path_buf()
+                } else {
+                    dir.path().join("missing")
+                }
+                .to_string_lossy()
+                .into_owned(),
+            ),
+            team: None,
+            shadow_of: None,
+            shadow_mode: None,
+            continue_from: None,
+            idle_threshold_secs: None,
+            exit_after_task: false,
+            skip_relay_prompt: true,
+            restart_policy: Box::new(None),
+            harness_config: Some(crate::protocol::ResolvedHarnessConfig::Native(
+                crate::protocol::NativeHarnessConfig {
+                    command: "cat".into(),
+                    args: vec![],
+                    cwd: None,
+                    env: None,
+                    session_id: "metadata-session".into(),
+                    metadata: None,
+                },
+            )),
+            agent_token: supplied_token.then(|| token.to_string()),
+            agent_result_schema: None,
+            replay_buffer: crate::replay_buffer::ReplayBuffer::new(16),
+            reply,
+        })
+        .await;
+    let response = result.await.unwrap();
+    // Stop the owned harness before assertions, including on a regression failure.
+    fixture.runtime.workers.shutdown_all().await.unwrap();
+    if valid_cwd {
+        assert_eq!(response.unwrap()["success"], true);
+        let published = tokio::time::timeout(Duration::from_secs(2), async {
+            while metadata.hits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            published.is_ok(),
+            "successful spawn did not publish declared metadata"
+        );
+        metadata.assert_hits(1);
+    } else {
+        assert!(response.unwrap_err().contains("cwd"));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        metadata.assert_hits(0);
+    }
+    create.assert_hits(usize::from(!supplied_token));
+    bind.assert_hits(usize::from(!supplied_token));
+    lookup.assert_hits(1);
+    unexpected_cleanup.assert_hits(0);
+    assert!(!fixture
+        .runtime
+        .workers
+        .identity_cleanups
+        .contains_key(&name));
+    if supplied_token {
+        assert!(!fixture
+            .runtime
+            .workers
+            .owned_spawn_generations
+            .contains_key(&name));
+    }
+}

--- a/tests/relayflows/cases/http-spawn-binding-failure/case.json
+++ b/tests/relayflows/cases/http-spawn-binding-failure/case.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "id": "http-spawn-binding-failure",
+  "kind": "bugfix",
+  "title": "Reject HTTP spawn when hosted node binding fails",
+  "requirements": ["broker-linux-x64"],
+  "runner": {
+    "command": ["node", "tests/relayflows/cases/http-spawn-binding-failure/run.mjs"]
+  },
+  "timeoutSeconds": 180,
+  "expected": {
+    "base": {
+      "outcome": "bug",
+      "signature": "binding_failure_continues_spawn"
+    },
+    "head": {
+      "outcome": "fixed",
+      "signature": "binding_failure_rejects_before_launch"
+    }
+  }
+}

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -31,7 +31,8 @@ const probe = await mkdtemp(path.join(tmpdir(), 'relayflow-binding-'));
 let broker,
   calibration,
   calibrationTimer,
-  stderr = '';
+  stderr = '',
+  stdout = '';
 const sockets = new Set();
 const observations = { registrations: 0, bindings: 0, scopeReads: 0, releases: [], metadataWrites: 0 };
 const server = http.createServer(async (request, response) => {
@@ -131,16 +132,19 @@ try {
         AGENT_RELAY_NO_DEBUG_FILES: '1',
         AGENT_RELAY_TELEMETRY_DISABLED: '1',
       },
-      stdio: ['ignore', 'ignore', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     }
   );
+  broker.stdout.on('data', (chunk) => {
+    stdout = (stdout + chunk).slice(-12000);
+  });
   broker.stderr.on('data', (chunk) => {
     stderr = (stderr + chunk).slice(-12000);
   });
   let apiPort;
   for (let i = 0; i < 200; i++) {
     if (broker.exitCode !== null) throw new Error(`Broker exited: ${stderr}`);
-    const announced = stderr.match(/API listening on http:\/\/127\.0\.0\.1:([1-9]\d{0,4})(?:\s|$)/);
+    const announced = stdout.match(/API listening on http:\/\/127\.0\.0\.1:([1-9]\d{0,4})(?:\s|$)/);
     if (announced) {
       const parsed = Number(announced[1]);
       assert(Number.isInteger(parsed) && parsed <= 65535, 'Invalid loopback API port');

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -162,7 +162,7 @@ try {
     assert.equal(result.status, 200);
     assert.equal(result.body.success, true);
     assert(result.body.warning.includes('binding admission probe'));
-    assert.equal(observations.scopeReads, 1);
+    assert(observations.scopeReads >= 1, 'Base did not continue into agent lookup');
     assert(JSON.stringify(listing.body).includes(NAME), 'Base did not admit unreachable worker');
     const released = await api(`/api/spawned/${NAME}`, {
       method: 'DELETE',

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -142,8 +142,25 @@ try {
       signal: AbortSignal.timeout(45000),
       redirect: 'error',
     });
-    return { status: response.status, body: await response.json() };
+    const raw = await response.text();
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = { raw };
+    }
+    return { status: response.status, body };
   };
+  let apiReady = false;
+  for (let i = 0; i < 200; i++) {
+    if (broker.exitCode !== null) throw new Error(`Broker exited before readiness: ${stderr}`);
+    if ((await api('/api/session')).status === 200) {
+      apiReady = true;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert(apiReady, `Broker API did not become ready: ${stderr}`);
   const result = await api('/api/spawn', {
     method: 'POST',
     body: JSON.stringify({ name: NAME, cli, channels: [], cwd: probe }),

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawn } from 'node:child_process';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import http from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -28,9 +29,11 @@ assert(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
 await access(binary, 1);
 const probe = await mkdtemp(path.join(tmpdir(), 'relayflow-binding-'));
 let broker,
+  calibration,
+  calibrationTimer,
   stderr = '';
 const sockets = new Set();
-const observations = { registrations: 0, bindings: 0, scopeReads: 0, releases: [], launches: 0 };
+const observations = { registrations: 0, bindings: 0, scopeReads: 0, releases: [], metadataWrites: 0 };
 const server = http.createServer(async (request, response) => {
   const chunks = [];
   for await (const chunk of request) chunks.push(chunk);
@@ -67,8 +70,8 @@ const server = http.createServer(async (request, response) => {
   } else if (request.method === 'POST' && pathname === '/v1/agents/release') {
     observations.releases.push(body.name);
     send(200, { status: 'completed' });
-  } else if (pathname === '/probe-launch') {
-    observations.launches++;
+  } else if (request.method === 'PATCH' && pathname === `/v1/agents/${NAME}`) {
+    observations.metadataWrites++;
     send(200, {});
   } else send(404, { code: 'not_found', message: 'unsupported fixture route' }, false);
 });
@@ -84,11 +87,21 @@ try {
   // No WebSocket endpoint: force the supported HTTP registration fallback.
   // A probe executable records any launch independently of the spawn response.
   const cli = path.join(probe, 'binding-probe-cli');
+  const launchMarker = path.join(probe, 'launched');
   await writeFile(
     cli,
-    `#!${process.execPath}\nfetch('${baseUrl}/probe-launch'); setInterval(() => {}, 1000);\n`,
+    `#!${process.execPath}\nrequire('node:fs').appendFileSync(${JSON.stringify(launchMarker)}, 'started\\n'); setInterval(() => {}, 1000);\n`,
     { mode: 0o700 }
   );
+  // Calibrate the negative observer with a deliberately delayed real launch.
+  calibrationTimer = setTimeout(() => {
+    calibration = spawn(cli, [], { stdio: 'ignore' });
+  }, 200);
+  await assert.rejects(assertNoLaunch(launchMarker), /Probe process launched/);
+  clearTimeout(calibrationTimer);
+  await stopProcess(calibration);
+  calibration = undefined;
+  await rm(launchMarker);
   const env = Object.fromEntries(
     Object.entries(process.env).filter(([key]) => !/^(RELAY|AGENT_RELAY)/.test(key))
   );
@@ -124,19 +137,21 @@ try {
   broker.stderr.on('data', (chunk) => {
     stderr = (stderr + chunk).slice(-12000);
   });
-  let connection;
+  let apiPort;
   for (let i = 0; i < 200; i++) {
     if (broker.exitCode !== null) throw new Error(`Broker exited: ${stderr}`);
-    try {
-      connection = JSON.parse(await readFile(path.join(state, 'connection.json'), 'utf8'));
+    const announced = stderr.match(/API listening on http:\/\/127\.0\.0\.1:([1-9]\d{0,4})(?:\s|$)/);
+    if (announced) {
+      const parsed = Number(announced[1]);
+      assert(Number.isInteger(parsed) && parsed <= 65535, 'Invalid loopback API port');
+      apiPort = parsed;
       break;
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 100));
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  assert(connection, `No broker API: ${stderr}`);
+  assert(apiPort, `No broker loopback API announcement: ${stderr}`);
   const api = async (route, options = {}) => {
-    const response = await fetch(`http://127.0.0.1:${connection.port}${route}`, {
+    const response = await fetch(`http://127.0.0.1:${apiPort}${route}`, {
       ...options,
       headers: { 'content-type': 'application/json', 'x-api-key': API_KEY },
       signal: AbortSignal.timeout(45000),
@@ -163,7 +178,14 @@ try {
   assert(apiReady, `Broker API did not become ready: ${stderr}`);
   const result = await api('/api/spawn', {
     method: 'POST',
-    body: JSON.stringify({ name: NAME, cli, channels: [], cwd: probe }),
+    body: JSON.stringify({
+      name: NAME,
+      cli,
+      channels: [],
+      cwd: probe,
+      organization: 'original-spawn',
+      project: 'no-stale-metadata',
+    }),
   });
   const listing = await api('/api/spawned');
   assert.equal(observations.registrations, 1);
@@ -173,7 +195,8 @@ try {
     assert(result.status >= 400);
     assert(JSON.stringify(result.body).includes('binding admission probe'));
     assert.equal(observations.scopeReads, 0);
-    assert.equal(observations.launches, 0);
+    await assertNoLaunch(launchMarker);
+    assert.equal(observations.metadataWrites, 0, 'Failed bind published stale metadata');
     assert(!JSON.stringify(listing.body).includes(NAME), 'Failed worker remains in inventory');
   } else {
     assert.equal(result.status, 200);
@@ -181,6 +204,7 @@ try {
     assert(result.body.warning.includes('binding admission probe'));
     assert(observations.scopeReads >= 1, 'Base did not continue into agent lookup');
     assert(JSON.stringify(listing.body).includes(NAME), 'Base did not admit unreachable worker');
+    assert(observations.metadataWrites >= 1, 'Base did not exercise metadata publication');
     const released = await api(`/api/spawned/${NAME}`, {
       method: 'DELETE',
       body: JSON.stringify({ expected_generation: result.body.generation, delete_identity: true }),
@@ -197,10 +221,16 @@ try {
       arm,
       outcome: arm === 'head' ? 'fixed' : 'bug',
       signature: arm === 'head' ? 'binding_failure_rejects_before_launch' : 'binding_failure_continues_spawn',
-      details: JSON.stringify({ status: result.status, observations }),
+      // Persist only closed, locally authored outcomes; never response/file data.
+      details:
+        arm === 'head'
+          ? 'Rejected failed binding; no process launch throughout a calibrated 2000ms observation, no metadata PATCH, and exact owned cleanup.'
+          : 'Admitted a worker despite failed binding, published metadata, and completed guarded fixture cleanup.',
     }) + '\n'
   );
 } finally {
+  clearTimeout(calibrationTimer);
+  await stopProcess(calibration);
   if (broker && broker.exitCode === null) {
     const exited = new Promise((resolve) => broker.once('exit', resolve));
     broker.kill('SIGTERM');
@@ -211,4 +241,24 @@ try {
   for (const socket of sockets) socket.destroy();
   await new Promise((resolve) => server.close(resolve));
   await rm(probe, { recursive: true, force: true });
+}
+
+/** Reject any synchronous startup marker observed during the full settling interval. */
+async function assertNoLaunch(marker, settleMs = 2000) {
+  const deadline = performance.now() + settleMs;
+  do {
+    assert(!existsSync(marker), 'Probe process launched during failed admission');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  } while (performance.now() < deadline);
+  assert(!existsSync(marker), 'Probe process launched at the observation boundary');
+}
+
+/** Stop only a child this case started and wait until it has exited. */
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+  child.kill('SIGTERM');
+  const timer = setTimeout(() => child.kill('SIGKILL'), 2000);
+  await exited;
+  clearTimeout(timer);
 }

--- a/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
+++ b/tests/relayflows/cases/http-spawn-binding-failure/run.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CASE_ID = 'http-spawn-binding-failure';
+const NAME = 'owned-binding-probe';
+const API_KEY = 'br_binding_probe';
+const required = (key) => {
+  if (!process.env[key]) throw new Error(`Missing ${key}`);
+  return process.env[key];
+};
+const targetDir = required('RELAY_PR_PROOF_TARGET_DIR');
+const harnessDir = required('RELAY_PR_PROOF_HARNESS_DIR');
+const binary = required('RELAY_PR_PROOF_BROKER_BINARY');
+const resultPath = required('RELAY_PR_PROOF_RESULT_PATH');
+const arm = required('RELAY_PR_PROOF_ARM');
+assert(['base', 'head'].includes(arm));
+assert.equal(
+  execFileSync('git', ['-C', targetDir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+  required(arm === 'base' ? 'RELAY_PR_PROOF_BASE_SHA' : 'RELAY_PR_PROOF_HEAD_SHA')
+);
+const relative = path.relative(path.resolve(harnessDir), fileURLToPath(import.meta.url));
+assert(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+await access(binary, 1);
+const probe = await mkdtemp(path.join(tmpdir(), 'relayflow-binding-'));
+let broker,
+  stderr = '';
+const sockets = new Set();
+const observations = { registrations: 0, bindings: 0, scopeReads: 0, releases: [], launches: 0 };
+const server = http.createServer(async (request, response) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const body = chunks.length ? JSON.parse(Buffer.concat(chunks)) : {};
+  const pathname = new URL(request.url, 'http://fixture.invalid').pathname;
+  const send = (status, data, ok = true) => {
+    response.writeHead(status, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(ok ? { ok, data } : { ok, error: data }));
+  };
+  if (request.method === 'POST' && pathname === '/v1/agents') {
+    if (body.name === NAME) observations.registrations++;
+    send(201, {
+      id: `id_${body.name}`,
+      name: body.name,
+      workspace_id: 'ws_binding_probe',
+      token: `at_fixture_${body.name}`,
+      status: 'online',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+  } else if (request.method === 'POST' && /^\/v1\/nodes\/[^/]+\/agents$/.test(pathname)) {
+    assert.equal(body.agent_name, NAME);
+    observations.bindings++;
+    send(503, { code: 'workspace_busy', message: 'binding admission probe' }, false);
+  } else if (request.method === 'GET' && pathname === `/v1/agents/${NAME}`) {
+    observations.scopeReads++;
+    send(200, {
+      id: `id_${NAME}`,
+      name: NAME,
+      workspace_id: 'ws_binding_probe',
+      channels: [],
+      status: 'online',
+      metadata: {},
+    });
+  } else if (request.method === 'POST' && pathname === '/v1/agents/release') {
+    observations.releases.push(body.name);
+    send(200, { status: 'completed' });
+  } else if (pathname === '/probe-launch') {
+    observations.launches++;
+    send(200, {});
+  } else send(404, { code: 'not_found', message: 'unsupported fixture route' }, false);
+});
+server.on('connection', (socket) => {
+  sockets.add(socket);
+  socket.once('close', () => sockets.delete(socket));
+});
+try {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const state = path.join(probe, 'state');
+  await mkdir(state);
+  // No WebSocket endpoint: force the supported HTTP registration fallback.
+  // A probe executable records any launch independently of the spawn response.
+  const cli = path.join(probe, 'binding-probe-cli');
+  await writeFile(
+    cli,
+    `#!${process.execPath}\nfetch('${baseUrl}/probe-launch'); setInterval(() => {}, 1000);\n`,
+    { mode: 0o700 }
+  );
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !/^(RELAY|AGENT_RELAY)/.test(key))
+  );
+  broker = spawn(
+    binary,
+    [
+      'init',
+      '--instance-name',
+      'binding-probe-node',
+      '--workspace-key',
+      'rk_binding_probe',
+      '--state-dir',
+      state,
+      '--api-port',
+      '0',
+      '--channels',
+      '',
+    ],
+    {
+      cwd: probe,
+      env: {
+        ...env,
+        RELAYCAST_BASE_URL: baseUrl,
+        RELAY_BROKER_API_KEY: API_KEY,
+        RELAY_NODE_ID: 'node_binding_probe',
+        RELAY_NODE_TOKEN: 'nt_binding_probe',
+        AGENT_RELAY_NO_DEBUG_FILES: '1',
+        AGENT_RELAY_TELEMETRY_DISABLED: '1',
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    }
+  );
+  broker.stderr.on('data', (chunk) => {
+    stderr = (stderr + chunk).slice(-12000);
+  });
+  let connection;
+  for (let i = 0; i < 200; i++) {
+    if (broker.exitCode !== null) throw new Error(`Broker exited: ${stderr}`);
+    try {
+      connection = JSON.parse(await readFile(path.join(state, 'connection.json'), 'utf8'));
+      break;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  assert(connection, `No broker API: ${stderr}`);
+  const api = async (route, options = {}) => {
+    const response = await fetch(`http://127.0.0.1:${connection.port}${route}`, {
+      ...options,
+      headers: { 'content-type': 'application/json', 'x-api-key': API_KEY },
+      signal: AbortSignal.timeout(45000),
+      redirect: 'error',
+    });
+    return { status: response.status, body: await response.json() };
+  };
+  const result = await api('/api/spawn', {
+    method: 'POST',
+    body: JSON.stringify({ name: NAME, cli, channels: [], cwd: probe }),
+  });
+  const listing = await api('/api/spawned');
+  assert.equal(observations.registrations, 1);
+  assert.equal(observations.bindings, 1);
+  assert.equal(listing.status, 200);
+  if (arm === 'head') {
+    assert(result.status >= 400);
+    assert(JSON.stringify(result.body).includes('binding admission probe'));
+    assert.equal(observations.scopeReads, 0);
+    assert.equal(observations.launches, 0);
+    assert(!JSON.stringify(listing.body).includes(NAME), 'Failed worker remains in inventory');
+  } else {
+    assert.equal(result.status, 200);
+    assert.equal(result.body.success, true);
+    assert(result.body.warning.includes('binding admission probe'));
+    assert.equal(observations.scopeReads, 1);
+    assert(JSON.stringify(listing.body).includes(NAME), 'Base did not admit unreachable worker');
+    const released = await api(`/api/spawned/${NAME}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ expected_generation: result.body.generation, delete_identity: true }),
+    });
+    assert.equal(released.status, 200);
+  }
+  assert.deepEqual(observations.releases, [NAME]);
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(
+    resultPath,
+    JSON.stringify({
+      version: 1,
+      caseId: CASE_ID,
+      arm,
+      outcome: arm === 'head' ? 'fixed' : 'bug',
+      signature: arm === 'head' ? 'binding_failure_rejects_before_launch' : 'binding_failure_continues_spawn',
+      details: JSON.stringify({ status: result.status, observations }),
+    }) + '\n'
+  );
+} finally {
+  if (broker && broker.exitCode === null) {
+    const exited = new Promise((resolve) => broker.once('exit', resolve));
+    broker.kill('SIGTERM');
+    const timer = setTimeout(() => broker.kill('SIGKILL'), 3000);
+    await exited;
+    clearTimeout(timer);
+  }
+  for (const socket of sockets) socket.destroy();
+  await new Promise((resolve) => server.close(resolve));
+  await rm(probe, { recursive: true, force: true });
+}


### PR DESCRIPTION
HTTP registration could report a successful spawn after Relaycast refused its node binding, leaving an admitted worker that could not receive node deliveries. This change rejects the spawn before channel setup or worker admission and uses the existing guarded cleanup path for the newly owned identity. Declared metadata is published only after binding succeeds, so failed-binding cleanup cannot leave a detached name-based PATCH targeting a later same-name retry.

Validation: the metadata regression fails on the previous head and passes with the repair; the full broker library suite passes (1,101 passed, four ignored), and Clippy passes. The executable RelayFlow case reproduces successful admission despite failed binding on base, versus rejection/no worker/zero metadata PATCHes/exact owned cleanup on head. Its probe writes a startup marker synchronously, verifies the observer using a deliberately delayed real launch, and checks for no launch throughout a full2,000ms settling interval. Both arms pass locally. The API origin remains fixed to loopback with a validated startup port and redirects disabled; result artifacts contain only locally authored outcome descriptions.

This is a narrow admission fix and synthetic regression proof, not a passing hosted delivery or Nango-to-chief demo. A successful REST binding still does not establish provider ownership; that separate reproduced gap is tracked in #1758. PR1743 overload retries and PR1755 owned-cleanup improvements retain their separate scope.

- Change type: `bugfix` <!-- relay-pr-proof:type -->
- RelayFlow case: `http-spawn-binding-failure` <!-- relay-pr-proof:case -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP spawn admission and identity cleanup in the broker runtime; behavior is narrower and test-backed, but failed spawns now release identities that previously lingered as admitted workers.
> 
> **Overview**
> HTTP agent spawn no longer continues when Relaycast **node binding** fails after create-only registration. The broker treats a failed bind as an admission error, returns the bind failure to the caller, and runs the existing **owned-identity cleanup** instead of launching a worker that could not receive node deliveries.
> 
> **Declared metadata** (`organization`, `project`, etc.) is published only after admission succeeds, for both newly registered and supplied-token hosted spawns. Metadata PATCH is skipped for failed binds and failed launches, so a detached name-based update cannot race a later retry on the same agent name.
> 
> Coverage adds broker unit tests for bind-failure cleanup and metadata timing, plus a RelayFlow case that contrasts pre-fix “spawn despite bind failure” with rejection before process launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c76047d9d8330ceb61dca4783898cb2fdb90a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->