### PR TITLE
fix(ci): probe every harness-driver tarball before verify install

### DIFF
--- a/.github/workflows/verify-publish-sdk.yml
+++ b/.github/workflows/verify-publish-sdk.yml
@@ -119,19 +119,22 @@ jobs:
             done
 
             # Even when `npm view` succeeds, the tarball may still 404 from
-            # the CDN edge that npm install hits. Probe the tarball URL of
-            # the matching broker directly.
+            # the CDN edge that npm install hits. Probe every package's
+            # tarball URL directly — the v12.0.0 publish passed a broker-only
+            # probe and then 404'd on the harness driver's own tarball.
             if [ "${#missing[@]}" -eq 0 ]; then
-              TARBALL_URL=$(npm view "${EXPECTED_BROKER}@$VERSION" dist.tarball 2>/dev/null || true)
-              if [ -z "$TARBALL_URL" ]; then
-                missing+=("${EXPECTED_BROKER}@$VERSION (no tarball url)")
-              else
+              for pkg in "${PACKAGES[@]}"; do
+                TARBALL_URL=$(npm view "$pkg" dist.tarball 2>/dev/null || true)
+                if [ -z "$TARBALL_URL" ]; then
+                  missing+=("$pkg (no tarball url)")
+                  continue
+                fi
                 STATUS=$(curl -sS -o /dev/null -w "%{http_code}" -I \
                   --connect-timeout 5 --max-time 15 "$TARBALL_URL" || echo "000")
                 if [ "$STATUS" != "200" ]; then
-                  missing+=("${EXPECTED_BROKER}@$VERSION (tarball HTTP $STATUS)")
+                  missing+=("$pkg (tarball HTTP $STATUS)")
                 fi
-              fi
+              done
             fi
 
             if [ "${#missing[@]}" -eq 0 ]; then
@@ -157,7 +160,21 @@ jobs:
           cd "$SCRATCH"
           npm init -y --silent >/dev/null
           echo "Installing ${{ steps.spec.outputs.spec }}"
-          npm install --no-audit --no-fund "${{ steps.spec.outputs.spec }}"
+          # A probe from this runner can hit a warm CDN edge while npm's
+          # fetch hits a cold one, so retry the install on transient 404s.
+          for i in 1 2 3 4 5; do
+            if npm install --no-audit --no-fund "${{ steps.spec.outputs.spec }}"; then
+              break
+            fi
+            if [ "$i" -eq 5 ]; then
+              echo "FAIL: npm install did not succeed after $i attempts"
+              exit 1
+            fi
+            WAIT=$((15 * i))
+            echo "install attempt $i failed, clearing npm cache and retrying in ${WAIT}s"
+            npm cache clean --force >/dev/null 2>&1 || true
+            sleep "$WAIT"
+          done
           echo ""
           echo "=== installed @agent-relay/ packages ==="
           ls node_modules/@agent-relay/


### PR DESCRIPTION
## Summary

The v12.0.0 publish ([run 34467504522](https://github.com/AgentWorkforce/relay/actions/runs/34467504522)) shipped every package, but all four **Verify Published Harness Driver** jobs went red:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@agent-relay/harness-driver/-/harness-driver-12.0.0.tgz
```

`harness-driver@12.0.0` was published at 11:04:17; the scratch install ran at 11:07:52. The registry wait gate passed because it only probed the **broker's** tarball URL, never the harness driver's own tarball, so the install hit a CDN edge that did not have it yet. The tarball resolves (HTTP 200) and a clean install succeeds now — this was a false negative, not a bad release.

## Changes

- Wait gate probes the tarball URL of every waited package (harness driver, sdk, matching broker), not just the broker.
- Scratch install retries up to 5 times with linear backoff and an npm cache clean between attempts, since a probe and npm's own fetch can hit different edges.

CI-only; no changelog entry.

## Verification

- YAML parses; `actionlint` passes.
- Ran the new probe loop locally: `12.0.0` → nothing missing; `99.0.0` → all three packages flagged `(no tarball url)`.
- Not reproduced: the CDN propagation lag itself. The next publish run is the real proof.

## RelayFlow Proof

- Change type: `non-functional` <!-- relay-pr-proof:type -->
- RelayFlow case: `n/a` <!-- relay-pr-proof:case -->

Only `.github/workflows/verify-publish-sdk.yml` changes; it runs after publish and does not change any shipped package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mFU2Jim9xGff7gBC8Fg24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes to wait/retry logic; no runtime, auth, or publish behavior changes.
> 
> **Overview**
> Hardens **Verify Published Harness Driver** against npm registry/CDN propagation flakes that caused false failures after v12.0.0 (wait gate passed on the broker tarball while `harness-driver` still 404’d).
> 
> The **registry wait** step now HTTP-probes **`dist.tarball` for every waited package** (`harness-driver`, `@agent-relay/sdk`, and the matrix broker), not only the broker. The **scratch `npm install`** step retries up to **5 times** with linear backoff, **`npm cache clean --force`** between attempts, so a warm CDN edge on curl does not mask a cold edge on npm’s fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787a4effdebc6989d017d05d60da81f509ddaf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
