### PR TITLE
docs(changelog): mark pending release as minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Agent Relay will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Major]
+## [Unreleased - Minor]
 
 ### Added
 
@@ -31,13 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Node startup recovery and shutdown require a persisted process and runtime-lock identity for the selected state directory, preserving unrelated agents.
 
-### Breaking Changes
+### Changed
 
-- `up` and `node up` refuse startup outside macOS and Linux because broker ownership cannot be verified on other platforms. Legacy brokers without a verifiable identity no longer support automatic shutdown or recovery.
-
-### Migration Guidance
-
-- Run nodes on macOS or Linux (including WSL) with `ps` and `lsof` available. Manually verify and stop legacy brokers before removing their retained state and restarting to create a verifiable identity.
+- `up` and `node up` refuse startup outside macOS and Linux (including WSL, with `ps` and `lsof` available) because broker ownership cannot be verified elsewhere. Brokers started by earlier versions have no verifiable identity and are not shut down or recovered automatically; stop them manually and restart once to create one.
 
 ## [12.0.0] - 2026-09-10
 


### PR DESCRIPTION
## Summary

Marks the pending release as **Minor** (next version 12.1.0 instead of 13.0.0).

The only SemVer-major entry under `[Unreleased]` came from #1736: `up` / `node up` now refuse to start outside macOS and Linux, and brokers started by earlier versions lose automatic shutdown/recovery. Native Windows CLI `up` is undocumented and not believed to be in real use (SDK harness-driver users on Windows don't go through `up` and are unaffected), so the maintainer decision is to ship this as minor.

## Changes

- `CHANGELOG.md`: heading `[Unreleased - Major]` → `[Unreleased - Minor]`.
- Folded the `Breaking Changes` + `Migration Guidance` entries into one `Changed` bullet that keeps the platform restriction and the manual legacy-broker stop step.

No code changes. This deliberately lowers the release level, overriding the changelog's monotonic rule, by maintainer decision.

## Release notes

- Generated release notes won't flag #1736 as breaking: publish.yml reads `!` only from the commit subject, and the squash subject is `fix(cli): …`.
- When publishing, pick `version=minor` in the Publish Package workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mFU2Jim9xGff7gBC8Fg24


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relay/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only semver and changelog restructuring; no code paths or dependencies change.
> 
> **Overview**
> Reclassifies the pending release from **major (13.0.0)** to **minor (12.1.0)** by updating `CHANGELOG.md` only—no runtime or API changes.
> 
> The `[Unreleased - Major]` heading becomes `[Unreleased - Minor]`, and the former **Breaking Changes** / **Migration Guidance** blocks are merged into one **Changed** bullet that still documents `up` / `node up` platform limits and manual cleanup for legacy brokers without an explicit breaking section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef63104c81757607638856de070115ace1fdee1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->